### PR TITLE
Use MBNI webpage to determine R package name

### DIFF
--- a/workers/Dockerfile.base
+++ b/workers/Dockerfile.base
@@ -36,6 +36,7 @@ WORKDIR /home/user
 ENV R_LIBS "/usr/local/lib/R/site-library"
 
 COPY workers/r_dependencies.R .
+COPY workers/install_ensg_pkgs.R .
 
 RUN Rscript r_dependencies.R
 

--- a/workers/Dockerfile.base
+++ b/workers/Dockerfile.base
@@ -6,8 +6,6 @@ FROM ubuntu:16.04
 RUN \
   apt-get update -qq && \
   apt-get install -y lsb-release && \
-  echo "deb http://archive.ubuntu.com/ubuntu $(lsb_release -sc) multiverse\n" \
-      >> /etc/apt/sources.list.d/added_repos.list && \
   echo "deb http://cran.cnr.berkeley.edu/bin/linux/ubuntu $(lsb_release -sc)/" \
       >> /etc/apt/sources.list.d/added_repos.list && \
   apt-key adv --keyserver keyserver.ubuntu.com --recv-keys E084DAB9 && \

--- a/workers/data_refinery_workers/processors/array_express.py
+++ b/workers/data_refinery_workers/processors/array_express.py
@@ -39,9 +39,9 @@ def _prepare_files(job_context: Dict) -> Dict:
 
 
 def _create_ensg_pkg_map() -> Dict:
-    """Read the text file that was generated when ionstalling ensg R
-    packages and return a map whose key is chip name and value is the
-    corresponding BrainArray ensg package name.
+    """Reads the text file that was generated when installing ensg R
+    packages, and returns a map whose keys are chip names and values are
+    the corresponding BrainArray ensg package name.
     """
     ensg_pkg_filename = "/home/user/r_ensg_probe_pkgs.txt"
     chip2pkg = dict()

--- a/workers/data_refinery_workers/processors/array_express.py
+++ b/workers/data_refinery_workers/processors/array_express.py
@@ -72,7 +72,7 @@ def _determine_brainarray_package(job_context: Dict) -> Dict:
     # Related: https://github.com/data-refinery/data-refinery/issues/85
     # Related: https://github.com/data-refinery/data-refinery/issues/141
     package_name_without_version = package_name.replace("v1", "").replace("v2", "")
-    job_context["brainarray_package"] = package_name_without_version + "hsentrezgprobe"
+    job_context["brainarray_package"] = package_name_without_version + "ensgprobe"
     return job_context
 
 
@@ -128,7 +128,7 @@ def _create_result_objects(job_context: Dict) -> Dict:
     scan_version_parts = []
     for version_part in ro.r("packageVersion('SCAN.UPC')")[0]:
         scan_version_parts.append(str(version_part))
-    scan_version = ".".join(scan_version_parts) 
+    scan_version = ".".join(scan_version_parts)
     result.program_version = scan_version
     result.time_start = job_context['time_start']
     result.time_end = job_context['time_end']
@@ -154,7 +154,7 @@ def _create_result_objects(job_context: Dict) -> Dict:
         failure_reason = "Exception caught while moving file to S3"
         job_context["job"].failure_reason = failure_reason
         job_context["success"] = False
-        return job_context        
+        return job_context
 
     logger.info("Created %s", result)
     job_context["success"] = True

--- a/workers/data_refinery_workers/processors/array_express.py
+++ b/workers/data_refinery_workers/processors/array_express.py
@@ -38,6 +38,25 @@ def _prepare_files(job_context: Dict) -> Dict:
     return job_context
 
 
+def _create_ensg_pkg_map() -> Dict:
+    """Read the text file that was generated when ionstalling ensg R
+    packages and return a map whose key is chip name and value is the
+    corresponding BrainArray ensg package name.
+    """
+    ensg_pkg_filename = "/home/user/r_ensg_probe_pkgs.txt"
+    chip2pkg = dict()
+    with open(ensg_pkg_filename) as file_handler:
+        for line in file_handler:
+            tokens = line.strip("\n").split("\t")
+            # tokens[0] is (normalized) chip name,
+            # tokens[1] is the package's URL in this format:
+            # http://mbni.org/customcdf/<version>/ensg.download/<pkg>_22.0.0.tar.gz
+            pkg_name = tokens[1].split("/")[-1].split("_")[0]
+            chip2pkg[tokens[0]] = pkg_name
+
+    return chip2pkg
+
+
 def _determine_brainarray_package(job_context: Dict) -> Dict:
     """Determines the right brainarray package to use for the file.
 
@@ -58,6 +77,7 @@ def _determine_brainarray_package(job_context: Dict) -> Dict:
 
     # header is a list of vectors. [0][0] contains the package name.
     punctuation_table = str.maketrans(dict.fromkeys(string.punctuation))
+    # Normalize header[0][0]
     package_name = header[0][0].translate(punctuation_table).lower()
 
     # Headers can contain the version "v1" or "v2", which doesn't
@@ -66,13 +86,18 @@ def _determine_brainarray_package(job_context: Dict) -> Dict:
     # and we can monitor what packages are added to it and modify
     # accordingly. So far "v1" and "v2" are the only known versions
     # which must be accomodated in this way.
-
-    # XXX: This may need to be made Organism-specific! hsentrezgprobe is for Homo Sapiens(?)
-    # XXX: TODO: We also expect this to be replaced with `ensg`
-    # Related: https://github.com/data-refinery/data-refinery/issues/85
     # Related: https://github.com/data-refinery/data-refinery/issues/141
     package_name_without_version = package_name.replace("v1", "").replace("v2", "")
-    job_context["brainarray_package"] = package_name_without_version + "ensgprobe"
+    chip_pkg_map = _create_ensg_pkg_map()
+    try:
+        job_context["brainarray_package"] = chip_pkg_map[package_name_without_version]
+    except KeyError as e:
+        error_template = ("Unable to find ensg package name from input file {0}"
+                          " (cdfName: {1}) while running AFFY_TO_PCL due to error: {2}")
+        error_message = error_template.format(input_file, header[0][0], str(e))
+        logger.error(error_message, processor_job=job_context["job"].id)
+        job_context["job"].failure_reason = error_message
+        job_context["success"] = False
     return job_context
 
 

--- a/workers/install_ensg_pkgs.R
+++ b/workers/install_ensg_pkgs.R
@@ -1,0 +1,45 @@
+install.packages("xml2")
+library("xml2")
+ensg_url <- "http://brainarray.mbni.med.umich.edu/Brainarray/Database/CustomCDF/22.0.0/ensg.asp"
+html_content <- read_html(ensg_url)
+
+# The second table in the html is the main table that lists all packages.
+data_table = xml_find_all(html_content, ".//table")[[2]]
+
+# Extract data rows from the second table:
+data_rows <- xml_children(data_table)[3:xml_length(data_table)]
+
+# These two global variables will be modified by save_chip_pkg():
+chips <- c()
+pkg_urls <- c()
+
+# This function parses a data row in the table and save chip name and
+# the URL of "P" R source package to chips and pkg_urls repectively.
+save_chip_pkg <- function(row) {
+    # Column #3: "Chip"
+    chip_name <- xml_text(xml_child(row, 3))
+    # Convert chip_name to lower case, then normalize it by removing
+    # "-", "_" and " " characters.
+    chip_name <- gsub("[-_ ]", "", tolower(chip_name))
+
+    # Column #16: "R Source Packages (C and P)".
+    # We need the URL of "P", which is the second URL.
+    source_pkgs <- xml_child(row, 16)
+    probe_pkg_url <- xml_attr(xml_child(source_pkgs, 2), "href")
+
+    if (nzchar(chip_name) && nzchar(probe_pkg_url)) {
+        chips <<- c(chips, chip_name)
+        pkg_urls <<- c(pkg_urls, probe_pkg_url)
+    }
+}
+
+# Extract data of interest out of each row
+lapply(data_rows, save_chip_pkg)
+
+# Write chips and pkg_urls to a tab-delimited file
+output_filename <- paste("/home/user/r_ensg_probe_pkgs.txt", sep="/")
+write.table(list(chips, pkg_urls), file=output_filename, quote=FALSE,
+            row.names=FALSE, col.names=FALSE, sep="\t")
+
+# Install these ensg packages
+lapply(pkg_urls, devtools::install_url)

--- a/workers/install_ensg_pkgs.R
+++ b/workers/install_ensg_pkgs.R
@@ -3,7 +3,7 @@ library("xml2")
 ensg_url <- "http://brainarray.mbni.med.umich.edu/Brainarray/Database/CustomCDF/22.0.0/ensg.asp"
 html_content <- read_html(ensg_url)
 
-# The second table in the html is the main table that lists all packages.
+# The second table in the html is the main table that lists all ensg packages.
 data_table <- xml_find_all(html_content, ".//table")[[2]]
 
 # Extract data rows from the second table:
@@ -13,8 +13,8 @@ data_rows <- xml_children(data_table)[3:xml_length(data_table)]
 chips <- c()
 pkg_urls <- c()
 
-# This function parses a data row in the table and save chip name and
-# the URL of "P" R source package to chips and pkg_urls repectively.
+# This function parses a data row in the table and saves chip names and
+# the URLs of "P" R source package to chips and pkg_urls repectively.
 save_chip_pkg <- function(row) {
     # Column #3: "Chip"
     chip_name <- xml_text(xml_child(row, 3))

--- a/workers/install_ensg_pkgs.R
+++ b/workers/install_ensg_pkgs.R
@@ -14,7 +14,7 @@ chips <- c()
 pkg_urls <- c()
 
 # This function parses a data row in the table and saves chip names and
-# the URLs of "P" R source package to chips and pkg_urls repectively.
+# URLs of "P" R source package to chips and pkg_urls respectively.
 save_chip_pkg <- function(row) {
     # Column #3: "Chip"
     chip_name <- xml_text(xml_child(row, 3))

--- a/workers/install_ensg_pkgs.R
+++ b/workers/install_ensg_pkgs.R
@@ -4,7 +4,7 @@ ensg_url <- "http://brainarray.mbni.med.umich.edu/Brainarray/Database/CustomCDF/
 html_content <- read_html(ensg_url)
 
 # The second table in the html is the main table that lists all packages.
-data_table = xml_find_all(html_content, ".//table")[[2]]
+data_table <- xml_find_all(html_content, ".//table")[[2]]
 
 # Extract data rows from the second table:
 data_rows <- xml_children(data_table)[3:xml_length(data_table)]

--- a/workers/install_ensg_pkgs.R
+++ b/workers/install_ensg_pkgs.R
@@ -37,7 +37,7 @@ save_chip_pkg <- function(row) {
 lapply(data_rows, save_chip_pkg)
 
 # Write chips and pkg_urls to a tab-delimited file
-output_filename <- paste("/home/user/r_ensg_probe_pkgs.txt", sep="/")
+output_filename <- "/home/user/r_ensg_probe_pkgs.txt"
 write.table(list(chips, pkg_urls), file=output_filename, quote=FALSE,
             row.names=FALSE, col.names=FALSE, sep="\t")
 

--- a/workers/r_dependencies.R
+++ b/workers/r_dependencies.R
@@ -18,7 +18,7 @@ devtools::install_version('pkgconfig', version='2.0.1')
 
 # Bioconductor packages, installed by devtools::install_url()
 
-# install_url() requires biocLite.R
+# devtools::install_url() requires biocLite.R
 source('https://bioconductor.org/biocLite.R')
 
 # Helper function that installs a list of packages based on input URL
@@ -58,19 +58,8 @@ annotation_pkgs <- c(
 )
 install_with_url(annotation_url, annotation_pkgs)
 
-###############################################################################
-# Use devtools::install_url() to install BrainArray pacakges whose urls match
-# this pattern:
-# http://mbni.org/customcdf/22.0.0/ensg.download/*probe_22.0.0.tar.gz
-
-# Use xml2 to parse the html file
-mbni_url <- "http://mbni.org/customcdf/22.0.0/ensg.download/"
-install.packages("xml2")
-html_file <- xml2::download_html(mbni_url)
-html_content <- xml2::read_html(html_file)
-anchors <- xml2::xml_text(xml2::xml_find_all(html_content, ".//a"))
-probe_pkgs <- anchors[grep("probe_22.0.0.tar.gz", anchors)]
-install_with_url(mbni_url, probe_pkgs)
+# Invoke another R script to install BrainArray ensg packages
+source("install_ensg_pkgs.R")
 
 # Install Bioconductor platform design (pd) packages
 experiment_url <- 'https://bioconductor.org/packages/release/data/experiment/src/contrib/'


### PR DESCRIPTION
## Issue Number

#85 

## Purpose/Implementation Notes

Instead of hard coding the species name (such as `hs`) in BrainArray packages, this PR parses an MBNI  
webpage and saves all chip names and corresponding R package URLS in an external file before installing them. `array_express.py` will then read this file to get the package name.

## Types of changes

What types of changes does your code introduce?

<!-- Remove any which your PR isn't -->
- New feature (non-breaking change which adds functionality)

## Functional tests

List out the functional tests you've completed to verify your changes work locally.

## Checklist

_Put an `x` in the boxes that apply._

- [x] Lint and unit tests pass locally with my changes
- [x] I have added necessary documentation (if appropriate)

## Screenshots

Please attach any screenshots that illustrate these changes.
