### PR TITLE
Make the common project specify the dependencies it needs.

### DIFF
--- a/common/setup.py
+++ b/common/setup.py
@@ -27,7 +27,12 @@ setup(
     install_requires=["django>=1.10.6",
                       "boto3>=1.4.4",
                       "daiquiri>=1.3.0",
-                      "billiard>=3.5.0.3"],
+                      "billiard>=3.5.0.3",
+                      "requests>=2.18.4",
+                      "retrying>=1.3.3",
+                      "psycopg2>=2.7.4",
+                      "python-nomad>=0.6.1"
+    ],
     license="BSD License",
     description="Common functionality to be shared between Data Refinery sub-projects.",
     url="https://www.greenelab.com",


### PR DESCRIPTION
## Purpose/Implementation Notes

A couple dependencies weren't specified in `api/requirements.txt` because they were relied upon solely by the `data_refinery_common` sub-project. However these requirements did not get added to `common/setup.py` in the `install_requires` list. This cause the `api/serve.sh` script to error out because it did not have all the python dependencies it needed.

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

I reran `update_models.sh` and then ran `api/serve.sh` and it started the server successfully.
