### PR TITLE
survey_sra.py: add support of s3 path

### DIFF
--- a/foreman/data_refinery_foreman/surveyor/management/commands/survey_sra.py
+++ b/foreman/data_refinery_foreman/surveyor/management/commands/survey_sra.py
@@ -3,10 +3,14 @@ This command will create and run survey jobs for each SRA run accession
 in the range from start_accession to end_accession.
 """
 
+import boto3
+import botocore
+import uuid
+
 from django.core.management.base import BaseCommand
 from data_refinery_foreman.surveyor import surveyor
 from data_refinery_common.logging import get_and_configure_logger
-
+from data_refinery_common.utils import parse_s3_url
 
 logger = get_and_configure_logger(__name__)
 
@@ -20,7 +24,7 @@ class Command(BaseCommand):
         parser.add_argument(
             "--file",
             type=str,
-            help=("An optional file listing accession codes.")
+            help=("An optional file listing accession codes. s3:// URLs are also accepted.")
         )
 
     def handle(self, *args, **options):
@@ -28,8 +32,21 @@ class Command(BaseCommand):
             logger.error("You must specify accession or input file.")
             return 1
         if options["file"]:
-            with open(options["file"]) as file:
-                for acession in file:
+            if 's3://' in options["file"]:
+                bucket, key = parse_s3_url(options["file"])
+                s3 = boto3.resource('s3')
+                try:
+                    filepath = "/tmp/input_" + str(uuid.uuid4()) + ".txt"
+                    s3.Bucket(bucket).download_file(key, filepath)
+                except botocore.exceptions.ClientError as e:
+                    if e.response['Error']['Code'] == "404":
+                        logger.error("The remote file does not exist.")
+                    raise
+            else:
+                filepath = options["file"]
+
+            with open(filepath) as file:
+                for accession in file:
                     try:
                         surveyor.survey_sra_experiment(accession.strip())
                     except Exception as e:


### PR DESCRIPTION
## Purpose/Implementation Notes

Allow this management command to specify both a regular file path and AWS s3 path.

## Types of changes

- Bugfix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)

## Functional tests

I manually ran this management command a few times with regular file, s3 path and "--accession" option.

## Checklist

_Put an `x` in the boxes that apply._

- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots

