### PR TITLE
The creation of the volume for the postgres container got mangled.

### DIFF
--- a/run_postgres.sh
+++ b/run_postgres.sh
@@ -9,8 +9,8 @@ cd $script_directory
 
 # CircleCI Docker won't make this by default for some reason
 VOLUMES=$script_directory/volumes_postgres
-if [ ! -d $script_directory/$VOLUMES ]; then
-  mkdir $script_directory/$VOLUMES
+if [ ! -d $VOLUMES ]; then
+  mkdir $VOLUMES
 fi
 
 


### PR DESCRIPTION
## Purpose/Implementation Notes

I needed to reset my database. The scripts weren't working for them so I fixed the creation of `volumes_postgres`.

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

I ran:

```
docker kill drdb
docker container prune -f
sudo rm -r volumes_postgres
./run_postgres.sh
./common/install_db_docker.sh
./update_models.sh
```

and everything worked and was happy.

## Checklist

- [x] Lint and unit tests pass locally with my changes
