### PR TITLE
Fix Syntax Error in run_nomad.sh

### DIFF
--- a/format_nomad_with_env.sh
+++ b/format_nomad_with_env.sh
@@ -93,16 +93,6 @@ else
     export AWS_CREDS="
         AWS_ACCESS_KEY_ID = \"$AWS_ACCESS_KEY_ID_WORKER\"
         AWS_SECRET_ACCESS_KEY = \"$AWS_SECRET_ACCESS_KEY_WORKER\""
-    export LOGGING_CONFIG="
-        logging {
-          type = \"awslogs\"
-          config {
-            awslogs-region = \"$REGION\",
-            awslogs-group = \"data-refinery-log-group-$USER-$STAGE\",
-            awslogs-stream = \"log-stream-nomad-docker-downloader-$USER-$STAGE\"
-          }
-        }
-"
 fi
 
 # Read all environment variables from the file for the appropriate
@@ -131,9 +121,9 @@ export_log_conf (){
         logging {
           type = \"awslogs\"
           config {
-            awslogs-region = \"$region\",
-            awslogs-group = \"data-refinery-log-group-$user-$stage\",
-            awslogs-stream = \"log-stream-$1-docker-$user-$stage\"
+            awslogs-region = \"$REGION\",
+            awslogs-group = \"data-refinery-log-group-$USER-$STAGE\",
+            awslogs-stream = \"log-stream-$1-docker-$USER-$STAGE\"
           }
         }"
     else

--- a/run_nomad.sh
+++ b/run_nomad.sh
@@ -71,7 +71,7 @@ if [ $env == "test" ]; then
 else
     # This is only for running Nomad in non-cloud environments so if
     # its not test then we're in dev (XXX: change this to local.)
-    env = "dev"
+    env="dev"
 fi
 
 


### PR DESCRIPTION
## Issue Number

n/a

## Purpose/Implementation Notes

`run_nomad.sh`  has a formatting error for non-test running. This whole file is still an XXX-riddled mess but at least with this fix it isn't broken-broken. Previously would cause `env: setenv =: Invalid argument`.

## Types of changes
- Bugfix (non-breaking change which fixes an issue)

## Functional tests

Runs now as described by README. This is a trivial change.

## Checklist

_Put an `x` in the boxes that apply._

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules

