### PR TITLE
Move all Custom Exceptions to Exception from BaseException

### DIFF
--- a/common/data_refinery_common/models/organism.py
+++ b/common/data_refinery_common/models/organism.py
@@ -19,11 +19,11 @@ EFETCH_URL = NCBI_ROOT_URL + "efetch.fcgi"
 TAXONOMY_DATABASE = "taxonomy"
 
 
-class UnscientificNameError(BaseException):
+class UnscientificNameError(Exception):
     pass
 
 
-class InvalidNCBITaxonomyId(BaseException):
+class InvalidNCBITaxonomyId(Exception):
     pass
 
 

--- a/foreman/data_refinery_foreman/surveyor/array_express.py
+++ b/foreman/data_refinery_foreman/surveyor/array_express.py
@@ -28,7 +28,7 @@ EXPERIMENTS_URL = "https://www.ebi.ac.uk/arrayexpress/json/v3/experiments/"
 SAMPLES_URL = EXPERIMENTS_URL + "{}/samples"
 UNKNOWN="UNKNOWN"
 
-class UnsupportedPlatformException(BaseException):
+class UnsupportedPlatformException(Exception):
     pass
 
 class ArrayExpressSurveyor(ExternalSourceSurveyor):

--- a/foreman/data_refinery_foreman/surveyor/external_source.py
+++ b/foreman/data_refinery_foreman/surveyor/external_source.py
@@ -22,7 +22,7 @@ from data_refinery_common.logging import get_and_configure_logger
 logger = get_and_configure_logger(__name__)
 
 
-class InvalidProcessedFormatError(BaseException):
+class InvalidProcessedFormatError(Exception):
     pass
 
 

--- a/foreman/data_refinery_foreman/surveyor/geo.py
+++ b/foreman/data_refinery_foreman/surveyor/geo.py
@@ -23,7 +23,7 @@ from data_refinery_common.logging import get_and_configure_logger
 
 logger = get_and_configure_logger(__name__)
 
-class GeoUnsupportedPlatformException(BaseException):
+class GeoUnsupportedPlatformException(Exception):
     pass
 
 class GeoSurveyor(ExternalSourceSurveyor):

--- a/foreman/data_refinery_foreman/surveyor/sra.py
+++ b/foreman/data_refinery_foreman/surveyor/sra.py
@@ -31,7 +31,7 @@ ENA_DOWNLOAD_URL_TEMPLATE = ("ftp://ftp.sra.ebi.ac.uk/vol1/fastq/{short_accessio
 ENA_SUB_DIR_PREFIX = "/00"
 
 
-class UnsupportedDataTypeError(BaseException):
+class UnsupportedDataTypeError(Exception):
     pass
 
 

--- a/foreman/data_refinery_foreman/surveyor/surveyor.py
+++ b/foreman/data_refinery_foreman/surveyor/surveyor.py
@@ -10,7 +10,7 @@ from data_refinery_common.logging import get_and_configure_logger
 logger = get_and_configure_logger(__name__)
 
 
-class SourceNotSupportedError(BaseException):
+class SourceNotSupportedError(Exception):
     pass
 
 

--- a/format_nomad_with_env.sh
+++ b/format_nomad_with_env.sh
@@ -93,16 +93,6 @@ else
     export AWS_CREDS="
         AWS_ACCESS_KEY_ID = \"$AWS_ACCESS_KEY_ID_WORKER\"
         AWS_SECRET_ACCESS_KEY = \"$AWS_SECRET_ACCESS_KEY_WORKER\""
-    export LOGGING_CONFIG="
-        logging {
-          type = \"awslogs\"
-          config {
-            awslogs-region = \"$REGION\",
-            awslogs-group = \"data-refinery-log-group-$USER-$STAGE\",
-            awslogs-stream = \"log-stream-nomad-docker-downloader-$USER-$STAGE\"
-          }
-        }
-"
 fi
 
 # Read all environment variables from the file for the appropriate
@@ -131,9 +121,9 @@ export_log_conf (){
         logging {
           type = \"awslogs\"
           config {
-            awslogs-region = \"$region\",
-            awslogs-group = \"data-refinery-log-group-$user-$stage\",
-            awslogs-stream = \"log-stream-$1-docker-$user-$stage\"
+            awslogs-region = \"$REGION\",
+            awslogs-group = \"data-refinery-log-group-$USER-$STAGE\",
+            awslogs-stream = \"log-stream-$1-docker-$USER-$STAGE\"
           }
         }"
     else


### PR DESCRIPTION
## Issue Number

n/a

## Purpose/Implementation Notes

From the [docs](https://docs.python.org/3/library/exceptions.html#base-classes):

> The base class for all built-in exceptions. It is not meant to be directly inherited by user-defined classes (for that, use Exception).

We have lots of cases where our custom exceptions aren't being caught by our catch-alls because we've been inheriting from the wrong type.

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

Essentially a trivial change. Fixes places where failing in experiments.

## Checklist

_Put an `x` in the boxes that apply._

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules
