### PR TITLE
Adds RDS Parameter Groups and Instance Type Variable

### DIFF
--- a/format_nomad_with_env.sh
+++ b/format_nomad_with_env.sh
@@ -93,16 +93,6 @@ else
     export AWS_CREDS="
         AWS_ACCESS_KEY_ID = \"$AWS_ACCESS_KEY_ID_WORKER\"
         AWS_SECRET_ACCESS_KEY = \"$AWS_SECRET_ACCESS_KEY_WORKER\""
-    export LOGGING_CONFIG="
-        logging {
-          type = \"awslogs\"
-          config {
-            awslogs-region = \"$REGION\",
-            awslogs-group = \"data-refinery-log-group-$USER-$STAGE\",
-            awslogs-stream = \"log-stream-nomad-docker-downloader-$USER-$STAGE\"
-          }
-        }
-"
 fi
 
 # Read all environment variables from the file for the appropriate
@@ -131,9 +121,9 @@ export_log_conf (){
         logging {
           type = \"awslogs\"
           config {
-            awslogs-region = \"$region\",
-            awslogs-group = \"data-refinery-log-group-$user-$stage\",
-            awslogs-stream = \"log-stream-$1-docker-$user-$stage\"
+            awslogs-region = \"$REGION\",
+            awslogs-group = \"data-refinery-log-group-$USER-$STAGE\",
+            awslogs-stream = \"log-stream-$1-docker-$USER-$STAGE\"
           }
         }"
     else

--- a/infrastructure/instances.tf
+++ b/infrastructure/instances.tf
@@ -348,12 +348,12 @@ resource "aws_db_parameter_group" "postgres_parameters" {
 
   parameter {
     name = "deadlock_timeout"
-    value = "60000" # 60000ms = 60m
+    value = "60000" # 60000ms = 60s
   }
 
   parameter {
     name = "statement_timeout"
-    value = "60000" # 60000ms = 60m
+    value = "60000" # 60000ms = 60s
   }
 }
 

--- a/infrastructure/instances.tf
+++ b/infrastructure/instances.tf
@@ -341,23 +341,43 @@ resource "aws_autoscaling_policy" "clients_scale_down" {
 # Database
 ##
 
+resource "aws_db_parameter_group" "postgres_parameters" {
+  name = "postgres-parameters-${var.user}-${var.stage}"
+  description = "Postgres Parameters ${var.user} ${var.stage}"
+  family = "postgres9.6"
+
+  parameter {
+    name = "deadlock_timeout"
+    value = "60000" # 60000ms = 60m
+  }
+
+  parameter {
+    name = "statement_timeout"
+    value = "60000" # 60000ms = 60m
+  }
+}
+
 resource "aws_db_instance" "postgres_db" {
   identifier = "data-refinery-${var.user}-${var.stage}"
   allocated_storage = 100
   storage_type = "gp2"
   engine = "postgres"
   engine_version = "9.6.6"
-  instance_class = "db.t2.micro"
+  instance_class = "db.${var.database_instance_type}"
   name = "data_refinery"
   username = "${var.database_user}"
   password = "${var.database_password}"
+
   db_subnet_group_name = "${aws_db_subnet_group.data_refinery.name}"
+  parameter_group_name = "${aws_db_parameter_group.postgres_parameters.name}"
+
   # We probably actually want to keep this, but TF is broken here.
   # Related: https://github.com/hashicorp/terraform/issues/5417
   skip_final_snapshot = true
   vpc_security_group_ids = ["${aws_security_group.data_refinery_db.id}"]
   multi_az = true
   publicly_accessible = true
+  
 }
 
 ##

--- a/infrastructure/variables.tf
+++ b/infrastructure/variables.tf
@@ -47,16 +47,20 @@ variable "database_timeout" {
   default = "30"
 }
 
+variable "database_instance_type" {
+  default = "t2.micro"
+}
+
 variable "running_in_cloud" {
   default = "True"
 }
 
 # This is a placeholder until there is a production image ready.
 variable "workers_docker_image" {
-  default = "wkurt/dr_worker:6"
+  default = "miserlou/data_refinery_workers"
 }
 variable "foreman_docker_image" {
-  default = "wkurt/dr_foreman:6"
+  default = "miserlou/data_refinery_foreman"
 }
 variable "use_s3" {
   default = "True"


### PR DESCRIPTION
## Issue Number

n/a

## Purpose/Implementation Notes

Connecting to the API during heavy scrape can cause `django.db.utils.OperationalError: FATAL:  remaining connection slots are reserved for non-replication superuser connections`.

This adds a) an RDS Parameter Group so we can configure the timeout and b) variablizes a hard-coded RDS instance type string so that we can beef it up to something better that a t2.micro in production.

This actually doesn't solve the underlying problem, but it does make it rarer. The correct solution in the future will be to have separate database users for API and Foreman/Worker instances, and then to reserve a minimum number of connections just for the API user (which should also have PgBouncer installed).

## Types of changes

- New feature (non-breaking change which adds functionality)

## Functional tests

Tested, and got this result:

Before:
![screen shot 2018-05-17 at 3 58 22 pm](https://user-images.githubusercontent.com/139987/40201703-d91875a8-59ed-11e8-86cb-504eb2627c5d.png)


After:
![screen shot 2018-05-17 at 4 01 11 pm](https://user-images.githubusercontent.com/139987/40201705-dcd3c9ae-59ed-11e8-8087-46c129a05143.png)

## Checklist

_Put an `x` in the boxes that apply._

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules