### PR TITLE
Fixes issue with queue_downloader_jobs and adds an unit test for it.

### DIFF
--- a/foreman/data_refinery_foreman/surveyor/external_source.py
+++ b/foreman/data_refinery_foreman/surveyor/external_source.py
@@ -57,7 +57,7 @@ class ExternalSourceSurveyor:
         # Get all of the undownloaded original files related to this Experiment.
         relations = ExperimentSampleAssociation.objects.filter(experiment=experiment)
         samples = Sample.objects.filter(id__in=relations.values('sample_id'))
-        files_to_download = OriginalFile.objects.filter(originalfilesampleassociation__in=samples.values('pk'), is_downloaded=False)
+        files_to_download = OriginalFile.objects.filter(samples__in=samples.values('pk'), is_downloaded=False)
 
         downloaded_urls = []
         for original_file in files_to_download:

--- a/foreman/data_refinery_foreman/surveyor/test_external_source.py
+++ b/foreman/data_refinery_foreman/surveyor/test_external_source.py
@@ -1,0 +1,96 @@
+from unittest.mock import Mock, patch, call
+from django.test import TestCase
+from data_refinery_foreman.surveyor.sra import SraSurveyor
+from data_refinery_common.models import (
+    SurveyJob,
+    Experiment,
+    ExperimentSampleAssociation,
+    Sample,
+    OriginalFile,
+    OriginalFileSampleAssociation,
+    DownloaderJob
+
+)
+
+class SraSurveyorTestCase(TestCase):
+    @patch('data_refinery_foreman.surveyor.external_source.send_job')
+    def test_queue_downloader_jobs(self, mock_send_task):
+        """Make sure that queue_downloader_jobs queues all expected Downloader
+        jobs for a given experiment.
+        """
+        # First, create an experiment with two samples associated with it
+        # and create two original files for each of those samples.
+        experiment_object = Experiment()
+        experiment_object.save()
+
+        sample_object_1 = Sample()
+        sample_object_1.accession_code = "Sample1"
+        sample_object_1.save()
+        sample_object_2 = Sample()
+        sample_object_2.accession_code = "Sample2"
+        sample_object_2.save()
+
+        association = ExperimentSampleAssociation()
+        association.experiment = experiment_object
+        association.sample = sample_object_1
+        association.save()
+
+        association = ExperimentSampleAssociation()
+        association.experiment = experiment_object
+        association.sample = sample_object_2
+        association.save()
+
+        original_file = OriginalFile()
+        original_file.source_url = "first_url"
+        original_file.source_filename = "first_filename"
+        original_file.is_downloaded = False
+        original_file.has_raw = True
+        original_file.save()
+
+        original_file_sample_association = OriginalFileSampleAssociation()
+        original_file_sample_association.original_file = original_file
+        original_file_sample_association.sample = sample_object_1
+        original_file_sample_association.save()
+
+        original_file = OriginalFile()
+        original_file.source_url = "second_url"
+        original_file.source_filename = "second_filename"
+        original_file.is_downloaded = False
+        original_file.has_raw = True
+        original_file.save()
+
+        original_file_sample_association = OriginalFileSampleAssociation()
+        original_file_sample_association.original_file = original_file
+        original_file_sample_association.sample = sample_object_1
+        original_file_sample_association.save()
+
+        original_file = OriginalFile()
+        original_file.source_url = "third_url"
+        original_file.source_filename = "third_filename"
+        original_file.is_downloaded = False
+        original_file.has_raw = True
+        original_file.save()
+
+        original_file_sample_association = OriginalFileSampleAssociation()
+        original_file_sample_association.original_file = original_file
+        original_file_sample_association.sample = sample_object_2
+        original_file_sample_association.save()
+
+        original_file = OriginalFile()
+        original_file.source_url = "fourth_url"
+        original_file.source_filename = "fourth_filename"
+        original_file.is_downloaded = False
+        original_file.has_raw = True
+        original_file.save()
+
+        original_file_sample_association = OriginalFileSampleAssociation()
+        original_file_sample_association.original_file = original_file
+        original_file_sample_association.sample = sample_object_2
+        original_file_sample_association.save()
+
+        survey_job = SurveyJob(source_type="SRA")
+        survey_job.save()
+        surveyor = SraSurveyor(survey_job)
+        surveyor.queue_downloader_jobs(experiment_object)
+
+        self.assertEqual(DownloaderJob.objects.all().count(), 4)

--- a/foreman/data_refinery_foreman/surveyor/test_geo.py
+++ b/foreman/data_refinery_foreman/surveyor/test_geo.py
@@ -46,4 +46,6 @@ class SurveyTestCase(TestCase):
 
         self.assertEqual(124, Sample.objects.all().count())
         downloader_jobs = DownloaderJob.objects.all()
-        self.assertEqual(124, downloader_jobs.count())
+        
+        # 124 samples + 2 metadata files that get picked up
+        self.assertEqual(126, downloader_jobs.count())


### PR DESCRIPTION
## Purpose/Implementation Notes

I found a bug where we would only queue a single downloader job for paired RNASeq reads, when really we need to queue two: one for each member of the pair.

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

I ran:
```
./foreman/run_surveyor.sh survey_sra --accession ERR1562482
```

and made sure that the processor job was able to complete successfully. Before I made this change, the surveyor would queue only a single downloader job which would complete, but because the other half of the pair hadn't been downloaded yet it wouldn't queue a processor job.

## Checklist

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules
