### PR TITLE
Changes psycopg2 to psycopg2-binary to remove the warning about it. A…

### DIFF
--- a/api/dockerfiles/Dockerfile.api
+++ b/api/dockerfiles/Dockerfile.api
@@ -3,6 +3,8 @@ FROM python:3.6.1-slim
 RUN groupadd user && useradd --create-home --home-dir /home/user -g user user
 WORKDIR /home/user
 
+RUN pip install --upgrade pip
+
 COPY api/requirements.txt .
 
 RUN pip install -r requirements.txt
@@ -20,4 +22,3 @@ USER user
 EXPOSE 8000
 
 ENTRYPOINT []
-

--- a/api/requirements.in
+++ b/api/requirements.in
@@ -1,6 +1,6 @@
 coverage
 django
-psycopg2
+psycopg2-binary
 boto3
 requests
 python-nomad

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -22,7 +22,8 @@ itypes==1.1.0             # via coreapi
 jinja2==2.10              # via coreschema
 jmespath==0.9.3           # via boto3, botocore
 markupsafe==1.0           # via jinja2
-psycopg2==2.7.4
+psycopg2-binary==2.7.4
+psycopg2==2.7.4           # via djangorestframework-hstore
 python-dateutil==2.6.1    # via botocore
 python-nomad==0.6.1
 pytz==2018.3              # via django

--- a/common/Dockerfile
+++ b/common/Dockerfile
@@ -3,6 +3,8 @@ FROM python:3.6.1-slim
 RUN groupadd user && useradd --create-home --home-dir /home/user -g user user
 WORKDIR /home/user
 
+RUN pip install --upgrade pip
+
 COPY common/requirements.txt .
 
 RUN pip install -r requirements.txt
@@ -11,4 +13,4 @@ COPY common/ .
 
 USER user
 
-ENTRYPOINT [""] 
+ENTRYPOINT [""]

--- a/common/setup.py
+++ b/common/setup.py
@@ -30,7 +30,7 @@ setup(
                       "billiard>=3.5.0.3",
                       "requests>=2.18.4",
                       "retrying>=1.3.3",
-                      "psycopg2>=2.7.4",
+                      "psycopg2-binary>=2.7.4",
                       "python-nomad>=0.6.1"
     ],
     license="BSD License",

--- a/foreman/dockerfiles/Dockerfile.foreman
+++ b/foreman/dockerfiles/Dockerfile.foreman
@@ -3,6 +3,8 @@ FROM python:3.6.1-slim
 RUN groupadd user && useradd --create-home --home-dir /home/user -g user user
 WORKDIR /home/user
 
+RUN pip install --upgrade pip
+
 COPY foreman/requirements.txt .
 
 # The base image does not have Python 2.X on it at all, so all calls

--- a/workers/data_refinery_workers/downloaders/requirements.in
+++ b/workers/data_refinery_workers/downloaders/requirements.in
@@ -1,6 +1,6 @@
 django
 requests
-psycopg2
+psycopg2-binary
 retrying
 python-nomad
 coveralls

--- a/workers/data_refinery_workers/downloaders/requirements.txt
+++ b/workers/data_refinery_workers/downloaders/requirements.txt
@@ -11,7 +11,7 @@ coveralls==1.3.0
 django==2.0
 docopt==0.6.2             # via coveralls
 idna==2.6                 # via requests
-psycopg2==2.7.3.2
+psycopg2-binary==2.7.4
 python-nomad==0.5.0
 pytz==2017.3              # via django
 requests==2.18.4

--- a/workers/data_refinery_workers/processors/requirements.in
+++ b/workers/data_refinery_workers/processors/requirements.in
@@ -1,6 +1,6 @@
 django
 requests
-psycopg2
+psycopg2-binary
 boto3
 retrying
 python-nomad

--- a/workers/data_refinery_workers/processors/requirements.txt
+++ b/workers/data_refinery_workers/processors/requirements.txt
@@ -28,7 +28,7 @@ matplotlib==2.1.0         # via multiqc
 multiqc==1.5
 networkx==2.1             # via colormath
 numpy==1.14.3             # via colormath, matplotlib, multiqc
-psycopg2==2.7.4
+psycopg2-binary==2.7.4
 pyparsing==2.2.0          # via matplotlib
 python-dateutil==2.7.3    # via botocore, matplotlib
 python-nomad==0.8.0


### PR DESCRIPTION
…lso kills a couple pip version warnings.

## Purpose/Implementation Notes

Every time we start a container the message:

```
/usr/local/lib/python3.5/dist-packages/psycopg2/__init__.py:144: UserWarning: The psycopg2 wheel package will be renamed from release 2.8; in order to keep installing from binary please use "pip install psycopg2-binary" instead. For details see: <http://initd.org/psycopg/docs/install.html#binary-install-from-pypi>.
```

Is the first thing out of the container. Some of our processors don't have many logs, so this message can for sections of our log files be about 25% of the log messages. This is really annoying so I'm finally fixing this the right way.

Also I got really sick of seeing
```
You are using pip version 9.0.1, however version 10.0.1 is available.
You should consider upgrading via the 'pip install --upgrade pip' command.
```
when building Docker images so I have also fixed this in `api` and `foreman.

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

I've build the `api` and `foreman` images and ran their tests locally. The workers' tests take a while longer so I'm going to rely on CI to do those for me. However I have rebuilt and pushed the `ccdl/dr_affymetrix:remove-psycopg2-warnings` image so that the CI tests will use the new image.

## Checklist

- [x] Lint and unit tests pass locally with my changes
