### PR TITLE
Brings back titles of GEO experiments

### DIFF
--- a/foreman/data_refinery_foreman/surveyor/geo.py
+++ b/foreman/data_refinery_foreman/surveyor/geo.py
@@ -79,7 +79,7 @@ class GeoSurveyor(ExternalSourceSurveyor):
             experiment_object.accession_code = experiment_accession_code
             experiment_object.source_url = "https://www.ncbi.nlm.nih.gov/geo/query/acc.cgi?acc=" + experiment_accession_code
             experiment_object.source_database = "GEO"
-            experiment_object.name = gse.metadata.get('title', [''])[0]
+            experiment_object.title = gse.metadata.get('title', [''])[0]
             experiment_object.description = gse.metadata.get('summary', [''])[0]
             
             # Related: https://github.com/AlexsLemonade/refinebio/issues/222


### PR DESCRIPTION

## Purpose/Implementation Notes

We were setting the wrong property of GEO experiments which resulted in none of them having titles.

## Types of changes

What types of changes does your code introduce?

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

I reran a GEO survey job which had previously resulted in an experiment without a title.
