### PR TITLE
Sorts sample dictionaries before trying to extract the title in harmony.

### DIFF
--- a/foreman/data_refinery_foreman/surveyor/harmony.py
+++ b/foreman/data_refinery_foreman/surveyor/harmony.py
@@ -25,7 +25,7 @@ def extract_title(sample: Dict) -> str:
                     'extract name'
                    ]
     title_fields = add_variants(title_fields)
-    for key, value in sample.items():
+    for key, value in sorted(sample.items(), key=lambda x: x[0].lower()):
         lower_key = key.lower().strip()
 
         if lower_key in title_fields:
@@ -36,23 +36,23 @@ def extract_title(sample: Dict) -> str:
     return None
 
 def harmonize(metadata: List) -> Dict:
-    """ 
+    """
     Given a list of samples and their metadata, extract these common properties:
 
-      `title`, 
-      `sex`, 
-      `age`, 
+      `title`,
+      `sex`,
+      `age`,
       `specimen_part`,
-      `genetic_information`, 
-      `disease`, 
-      `disease_stage`, 
+      `genetic_information`,
+      `disease`,
+      `disease_stage`,
       `cell_line`,
-      `treatment`, 
+      `treatment`,
       `race`,
       `subject`,
       `compound`,
       `time`
-    
+
     Array Express Example:
          {'Array Data File': 'C30061.CEL',
           'Array Design REF': 'A-AFFY-1',
@@ -303,7 +303,7 @@ def harmonize(metadata: List) -> Dict:
     ##
     # Sex!
     ##
-    sex_fields = [    
+    sex_fields = [
                     'sex',
                     'gender',
                     'subject gender',
@@ -325,7 +325,7 @@ def harmonize(metadata: List) -> Dict:
                     break
                 if value.lower() in ['m', 'male', 'man']:
                     harmonized_samples[title]['sex'] = "male"
-                    break                
+                    break
                 else:
                     harmonized_samples[title]['sex'] = value.lower()
                     break
@@ -333,7 +333,7 @@ def harmonize(metadata: List) -> Dict:
     ##
     # Age!
     ##
-    age_fields = [    
+    age_fields = [
                     'age',
                     'patient age',
                     'age of patient',
@@ -367,23 +367,23 @@ def harmonize(metadata: List) -> Dict:
     ##
     part_fields = [
                     # AE
-                    'organism part', 
-                    'cell type', 
-                    'tissue', 
-                    'tissue type', 
-                    'tissue source', 
-                    'tissue origin', 
-                    'source tissue', 
-                    'tissue subtype', 
-                    'tissue/cell type', 
-                    'tissue region', 
-                    'tissue compartment', 
-                    'tissues', 
-                    'tissue of origin', 
-                    'tissue-type', 
-                    'tissue harvested', 
-                    'cell/tissue type', 
-                    'tissue subregion', 
+                    'organism part',
+                    'cell type',
+                    'tissue',
+                    'tissue type',
+                    'tissue source',
+                    'tissue origin',
+                    'source tissue',
+                    'tissue subtype',
+                    'tissue/cell type',
+                    'tissue region',
+                    'tissue compartment',
+                    'tissues',
+                    'tissue of origin',
+                    'tissue-type',
+                    'tissue harvested',
+                    'cell/tissue type',
+                    'tissue subregion',
                     'organ',
                     'characteristic [organism part]',
                     'characteristics [organism part]',
@@ -402,7 +402,7 @@ def harmonize(metadata: List) -> Dict:
     for sample in original_samples:
         title = sample['title']
         for key, value in sample.items():
-            lower_key = key.lower().strip() 
+            lower_key = key.lower().strip()
             if lower_key in part_fields:
                 harmonized_samples[title]['specimen_part'] = value.lower().strip()
                 break
@@ -411,23 +411,23 @@ def harmonize(metadata: List) -> Dict:
     # Genetic information!
     ##
     genetic_information_fields = [
-                    'strain/background', 
-                    'strain', 
-                    'strain or line', 
-                    'background strain', 
-                    'genotype', 
+                    'strain/background',
+                    'strain',
+                    'strain or line',
+                    'background strain',
+                    'genotype',
                     'genetic background',
-                    'genetic information', 
-                    'genotype/variation', 
-                    'ecotype', 
-                    'cultivar', 
+                    'genetic information',
+                    'genotype/variation',
+                    'ecotype',
+                    'cultivar',
                     'strain/genotype',
                 ]
     genetic_information_fields = add_variants(genetic_information_fields)
     for sample in original_samples:
         title = sample['title']
         for key, value in sample.items():
-            lower_key = key.lower().strip() 
+            lower_key = key.lower().strip()
             if lower_key in genetic_information_fields:
                 harmonized_samples[title]['genetic_information'] = value.lower().strip()
 
@@ -435,10 +435,10 @@ def harmonize(metadata: List) -> Dict:
     # Disease!
     ##
     disease_fields = [
-                    'disease', 
-                    'disease state', 
-                    'disease status', 
-                    'diagnosis', 
+                    'disease',
+                    'disease state',
+                    'disease status',
+                    'diagnosis',
                     'disease',
                     'infection with',
                     'sample type',
@@ -447,7 +447,7 @@ def harmonize(metadata: List) -> Dict:
     for sample in original_samples:
         title = sample['title']
         for key, value in sample.items():
-            lower_key = key.lower().strip() 
+            lower_key = key.lower().strip()
             if lower_key in disease_fields:
                 harmonized_samples[title]['disease'] = value.lower().strip()
 
@@ -456,12 +456,12 @@ def harmonize(metadata: List) -> Dict:
     ##
     disease_stage_fields = [
     	              'disease state',
-                    'disease staging', 
-                    'disease stage', 
-                    'grade', 
-                    'tumor grade', 
-                    'who grade', 
-                    'histological grade', 
+                    'disease staging',
+                    'disease stage',
+                    'grade',
+                    'tumor grade',
+                    'who grade',
+                    'histological grade',
                     'tumor grading',
                     'disease outcome',
                     'subject status',
@@ -470,7 +470,7 @@ def harmonize(metadata: List) -> Dict:
     for sample in original_samples:
         title = sample['title']
         for key, value in sample.items():
-            lower_key = key.lower().strip() 
+            lower_key = key.lower().strip()
             if lower_key in disease_stage_fields:
                 harmonized_samples[title]['disease_stage'] = value.lower().strip()
 
@@ -485,7 +485,7 @@ def harmonize(metadata: List) -> Dict:
     for sample in original_samples:
         title = sample['title']
         for key, value in sample.items():
-            lower_key = key.lower().strip() 
+            lower_key = key.lower().strip()
             if lower_key in cell_line_fields:
                 harmonized_samples[title]['cell_line'] = value.lower().strip()
 
@@ -493,32 +493,32 @@ def harmonize(metadata: List) -> Dict:
     # Treatment!
     ##
     treatment_fields = [
-                    'treatment', 
-                    'treatment group', 
-                    'treatment protocol', 
-                    'drug treatment', 
+                    'treatment',
+                    'treatment group',
+                    'treatment protocol',
+                    'drug treatment',
                     'clinical treatment',
                 ]
     treatment_fields = add_variants(treatment_fields)
     for sample in original_samples:
         title = sample['title']
         for key, value in sample.items():
-            lower_key = key.lower().strip() 
+            lower_key = key.lower().strip()
             if lower_key in treatment_fields:
                 harmonized_samples[title]['treatment'] = value.lower().strip()
     ##
     # Race!
     ##
     race_fields = [
-                    'race', 
-                    'ethnicity', 
+                    'race',
+                    'ethnicity',
                     'race/ethnicity',
                 ]
     race_fields = add_variants(race_fields)
     for sample in original_samples:
         title = sample['title']
         for key, value in sample.items():
-            lower_key = key.lower().strip() 
+            lower_key = key.lower().strip()
             if lower_key in race_fields:
                 harmonized_samples[title]['race'] = value.lower().strip()
 
@@ -527,20 +527,20 @@ def harmonize(metadata: List) -> Dict:
     ##
     subject_fields = [
                     # AE
-                    'subject', 
-                    'subject id', 
-                    'subject/sample source id', 
-                    'subject identifier', 
-                    'human subject anonymized id', 
-                    'individual', 
-                    'individual identifier', 
-                    'individual id', 
-                    'patient', 
-                    'patient id', 
-                    'patient identifier', 
-                    'patient number', 
-                    'patient no', 
-                    'donor id', 
+                    'subject',
+                    'subject id',
+                    'subject/sample source id',
+                    'subject identifier',
+                    'human subject anonymized id',
+                    'individual',
+                    'individual identifier',
+                    'individual id',
+                    'patient',
+                    'patient id',
+                    'patient identifier',
+                    'patient number',
+                    'patient no',
+                    'donor id',
                     'donor',
 
                     # SRA
@@ -550,7 +550,7 @@ def harmonize(metadata: List) -> Dict:
     for sample in original_samples:
         title = sample['title']
         for key, value in sample.items():
-            lower_key = key.lower().strip() 
+            lower_key = key.lower().strip()
             if lower_key in subject_fields:
                 harmonized_samples[title]['subject'] = value.lower().strip()
 
@@ -558,15 +558,15 @@ def harmonize(metadata: List) -> Dict:
     # Developement Stage!
     ##
     development_stage_fields = [
-                    'developmental stage', 
-                    'development stage', 
+                    'developmental stage',
+                    'development stage',
                     'development stages'
                 ]
     development_stage_fields = add_variants(development_stage_fields)
     for sample in original_samples:
         title = sample['title']
         for key, value in sample.items():
-            lower_key = key.lower().strip() 
+            lower_key = key.lower().strip()
             if lower_key in development_stage_fields:
                 harmonized_samples[title]['developmental_stage'] = value.lower().strip()
 
@@ -574,11 +574,11 @@ def harmonize(metadata: List) -> Dict:
     # Compound!
     ##
     compound_fields = [
-                    'compound', 
-                    'compound1', 
-                    'compound2', 
-                    'compound name', 
-                    'drug', 
+                    'compound',
+                    'compound1',
+                    'compound2',
+                    'compound name',
+                    'drug',
                     'drugs',
                     'immunosuppressive drugs'
                 ]
@@ -586,7 +586,7 @@ def harmonize(metadata: List) -> Dict:
     for sample in original_samples:
         title = sample['title']
         for key, value in sample.items():
-            lower_key = key.lower().strip() 
+            lower_key = key.lower().strip()
             if lower_key in compound_fields:
                 harmonized_samples[title]['compound'] = value.lower().strip()
 
@@ -594,12 +594,12 @@ def harmonize(metadata: List) -> Dict:
     # Time!
     ##
     time_fields = [
-                    'time', 
-                    'initial time point', 
-                    'start time', 
-                    'stop time', 
-                    'time point', 
-                    'sampling time point', 
+                    'time',
+                    'initial time point',
+                    'start time',
+                    'stop time',
+                    'time point',
+                    'sampling time point',
                     'sampling time',
                     'time post infection'
                 ]
@@ -607,7 +607,7 @@ def harmonize(metadata: List) -> Dict:
     for sample in original_samples:
         title = sample['title']
         for key, value in sample.items():
-            lower_key = key.lower().strip() 
+            lower_key = key.lower().strip()
             if lower_key in time_fields:
                 harmonized_samples[title]['time'] = value.lower().strip()
 
@@ -616,7 +616,7 @@ def harmonize(metadata: List) -> Dict:
 def add_variants(original_list: List):
     """ Given a list of strings, create variations likely to give metadata hits.
 
-    Ex, given 'cell line', add the ability to hit on 'characteristic [cell_line]' as well. 
+    Ex, given 'cell line', add the ability to hit on 'characteristic [cell_line]' as well.
     """
     precopy = original_list.copy()
 

--- a/foreman/data_refinery_foreman/surveyor/test_harmony.py
+++ b/foreman/data_refinery_foreman/surveyor/test_harmony.py
@@ -324,7 +324,6 @@ class HarmonyTestCase(TestCase):
         samples_endpoint = SAMPLES_URL.format(experiment_accession_code)
         r = utils.requests_retry_session().get(samples_endpoint, timeout=60)
         json_samples = r.json()["experiment"]["sample"]
-        # flat_json_sample = utils.flatten(json_samples[0])
         json_titles = [extract_title(utils.flatten(json_sample)) for json_sample in json_samples]
 
         SDRF_URL_TEMPLATE = "https://www.ebi.ac.uk/arrayexpress/files/{code}/{code}.sdrf.txt"

--- a/foreman/data_refinery_foreman/surveyor/test_harmony.py
+++ b/foreman/data_refinery_foreman/surveyor/test_harmony.py
@@ -13,15 +13,23 @@ from data_refinery_common.models import (
     Organism,
     Sample
 )
-from data_refinery_foreman.surveyor.array_express import ArrayExpressSurveyor
+from data_refinery_foreman.surveyor.array_express import ArrayExpressSurveyor, SAMPLES_URL
 from data_refinery_foreman.surveyor.sra import SraSurveyor, UnsupportedDataTypeError
 from data_refinery_foreman.surveyor.geo import GeoSurveyor
-from data_refinery_foreman.surveyor.harmony import harmonize, parse_sdrf, preprocess_geo
+from data_refinery_foreman.surveyor import utils
+from data_refinery_foreman.surveyor.harmony import (
+    harmonize,
+    parse_sdrf,
+    preprocess_geo,
+    extract_title
+)
 
 # Taken from GEOparse source code cause the docs lie.
 GEOparse.logger.setLevel(logging.getLevelName("WARN"))
 
+
 class HarmonyTestCase(TestCase):
+
     def setUp(self):
         self.sample = Sample()
         self.sample.save()
@@ -30,8 +38,9 @@ class HarmonyTestCase(TestCase):
 
     def test_sdrf_harmony(self):
         """ Harmonize SDRF test"""
-        
-        metadata = parse_sdrf("https://www.ebi.ac.uk/arrayexpress/files/E-MTAB-3050/E-MTAB-3050.sdrf.txt")
+
+        metadata = parse_sdrf(
+            "https://www.ebi.ac.uk/arrayexpress/files/E-MTAB-3050/E-MTAB-3050.sdrf.txt")
         harmonized = harmonize(metadata)
 
         title = 'donor A islets RNA'
@@ -191,10 +200,11 @@ class HarmonyTestCase(TestCase):
             'E-GEOD-19617',
             'E-MTAB-1944',
             'E-GEOD-17114',
-    ]
+        ]
 
         for accession in lots:
-            metadata = parse_sdrf("https://www.ebi.ac.uk/arrayexpress/files/" + accession + "/" + accession + ".sdrf.txt")
+            metadata = parse_sdrf("https://www.ebi.ac.uk/arrayexpress/files/"
+                                  + accession + "/" + accession + ".sdrf.txt")
             if not metadata:
                 continue
             # No assertions, just making sure we don't barf.
@@ -204,7 +214,7 @@ class HarmonyTestCase(TestCase):
         """
         Tests a specific harmonization from SRA
         """
-        
+
         metadata = SraSurveyor.gather_all_metadata("SRR1533126")
         harmonized = harmonize([metadata])
 
@@ -227,8 +237,8 @@ class HarmonyTestCase(TestCase):
 
         # These can be built via
         #    https://www.ncbi.nlm.nih.gov/sra
-        # Searching for 
-        #    (human) NOT cluster_dbgap[PROP] 
+        # Searching for
+        #    (human) NOT cluster_dbgap[PROP]
         # And then Sent To -> File -> Accession List
         lots = [
             'ERR188021',
@@ -236,7 +246,7 @@ class HarmonyTestCase(TestCase):
             'ERR205021',
             'ERR205022',
             'ERR205023',
-            'SRR000001', # Soft fail, bad platform
+            'SRR000001',  # Soft fail, bad platform
             'ERR1737666',
             'ERR030891',
             'ERR030892',
@@ -261,7 +271,7 @@ class HarmonyTestCase(TestCase):
         """
         Thoroughly tests a specific GEO harmonization
         """
-        
+
         # Weird ones caused bugs
         gse = GEOparse.get_GEO("GSE94532", destdir='/tmp')
         preprocessed_samples = preprocess_geo(gse.gsms.items())
@@ -280,11 +290,11 @@ class HarmonyTestCase(TestCase):
         self.assertTrue('specimen_part' in harmonized[title].keys())
         self.assertTrue('subject' in harmonized[title].keys())
 
-        # Agilent Two Color 
+        # Agilent Two Color
         gse = GEOparse.get_GEO("GSE93857", destdir='/tmp')
         preprocessed_samples = preprocess_geo(gse.gsms.items())
         harmonized = harmonize(preprocessed_samples)
-    
+
         gse = GEOparse.get_GEO("GSE103060", destdir='/tmp')
         preprocessed_samples = preprocess_geo(gse.gsms.items())
         harmonized = harmonize(preprocessed_samples)
@@ -303,3 +313,26 @@ class HarmonyTestCase(TestCase):
         self.assertTrue('keratinocyte' == harmonized[title]['specimen_part'])
         self.assertTrue('squamous cell carcinoma' == harmonized[title]['disease'])
         self.assertTrue('azathioprine + prednison' == harmonized[title]['compound'])
+
+    def test_ordering_mismatch(self):
+        """Makes sure that the order samples' keys are in does not affect the title chosen.
+
+        Related: https://github.com/AlexsLemonade/refinebio/pull/304
+        """
+        experiment_accession_code = "E-TABM-38"
+
+        samples_endpoint = SAMPLES_URL.format(experiment_accession_code)
+        r = utils.requests_retry_session().get(samples_endpoint, timeout=60)
+        json_samples = r.json()["experiment"]["sample"]
+        # flat_json_sample = utils.flatten(json_samples[0])
+        json_titles = [extract_title(utils.flatten(json_sample)) for json_sample in json_samples]
+
+        SDRF_URL_TEMPLATE = "https://www.ebi.ac.uk/arrayexpress/files/{code}/{code}.sdrf.txt"
+        sdrf_url = SDRF_URL_TEMPLATE.format(code=experiment_accession_code)
+        sdrf_samples = harmonize(parse_sdrf(sdrf_url))
+
+        # The titles won't match up if the order of the sample dicts
+        # isn't corrected for, resulting in a KeyError being raised.
+        # So if this doesn't raise a KeyError, then we're good.
+        for title in json_titles:
+            sdrf_samples[title]


### PR DESCRIPTION
## Purpose/Implementation Notes

While testing my routing refactor branch I ran into an experiment `E-TABM-38` which caused surveyor jobs to crash because of an uncaught KeyError. This is because `extract_title` was returning different titles for the samples which came from the JSON endpoint and samples which came from the SDRF.

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

I ran `./foreman/run_surveyor.sh survey_all --accession=E-TABM-381` and it finished successfully, whereas before my fix it crashed because of a KeyError.

## Checklist

- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
