### PR TITLE
Hopefully better Linux IP address detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,17 @@ Instructions for installing Docker and Nomad can be found by
 following the link for each service. git-crypt and jq can be installed via
 `sudo apt-get install git-crypt jq`.
 
+When installing pip packages later in the install, you might get an error saying you need sudo permissions.
+In order to fix this you have to edit your `~/.config/pip/pip.conf` to add this:
+
+```
+[install]
+user = yes
+no-binary = :all:
+```
+
+This sets pip to install all packages in your user directory so sudo is not required for pip intalls.
+
 #### Mac
 
 The following services will need to be installed:
@@ -170,6 +181,10 @@ Finally, to make the migrations to the database, use:
 ```bash
 ./common/make_migrations.sh
 ```
+
+Note: there is a small chance this might fail with a `can't stat`, error. If this happens, you have
+to manually change permissions on the volumes directory with `sudo chmod -R 740 volumes_postgres`
+then re-run the migrations.
 
 If you need to access a `psql` shell for inspecting the database, you can use:
 

--- a/README.md
+++ b/README.md
@@ -82,10 +82,11 @@ so Docker does not need sudo permissions.
 - [Nomad](https://www.nomadproject.io/docs/install/index.html#precompiled-binaries) can be installed on Linux clients with `sudo ./install_nomad.sh`.
 - git-crypt
 - jq
+- iproute2
 
 Instructions for installing Docker and Nomad can be found by
-following the link for each service. git-crypt and jq can be installed via
-`sudo apt-get install git-crypt jq`.
+following the link for each service. git-crypt, jq, and iproute2 can be installed via
+`sudo apt-get install git-crypt jq iproute2`.
 
 When installing pip packages later in the install, you might get an error saying you need sudo permissions.
 In order to fix this you have to edit your `~/.config/pip/pip.conf` to add this:

--- a/common.sh
+++ b/common.sh
@@ -2,7 +2,7 @@
 
 get_ip_address () {
     if [ `uname` == "Linux" ]; then
-        echo $(ip route get 8.8.8.8 | awk '{print $NF; exit}')
+        echo $(ip route get 8.8.8.8 | grep -oE 'src ([0-9]{1,3}\.){3}[0-9]{1,3}' | awk '{print $2; exit}')
     elif [ `uname` == 'Darwin' ]; then # MacOS
         echo $(ifconfig | grep "inet " | grep -v 127.0.0.1 | cut -d\  -f2)
     fi


### PR DESCRIPTION
The old command to detect IP addresses on Linux was `ip route get 8.8.8.8 | awk '{print $NF; exit}'`,
but that did not work on my machine or the default Ubuntu docker image I tested. It turns out that `ip route` does not
appear to have standardized output across different versions and distros. I found this alternate option that is hopefully
standardized and installed by any sane Linux distro to give us the internal ip address for the setup scripts.

## Issue Number

N/A

## Purpose/Implementation Notes

Make the install scripts work on more people's hardware.

## Methods

N/A

## Types of changes
- Bugfix

## Functional tests

Running the get_ip_address function on my laptop gave the correct internal ip address, and it made the install scripts start working properly.

## Checklist

_Put an `x` in the boxes that apply._

- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots

N/A
