### PR TITLE
Make API persistent and support HTTPS

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,7 +37,9 @@ jobs:
       # Running these in the same job as the common tests is good
       # because their dockerfiles are very similar so a lot of the
       # build time is saved by only building those layers once.
-      - run: .circleci/filter_tests.sh -t downloaders
+      - run:
+          command: .circleci/filter_tests.sh -t downloaders
+          no_output_timeout: 36000
 
       # Push the no_op and downloader images to the local docker repo so Nomad
       # can pull from there when running end-to-end tests.

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -161,7 +161,7 @@ jobs:
     steps:
       - checkout
       - run: bash .circleci/git_decrypt.sh
-      # - run: bash .circleci/update_docker_img.sh
+      - run: bash .circleci/update_docker_img.sh
       - run: bash .circleci/run_terraform.sh
 
 workflows:
@@ -171,44 +171,41 @@ workflows:
       # test jobs will be triggered by:
       # - any branch commit, or:
       # - tag commits whose names start with letter "v".
-      # - main_tests:
-      #     filters:
-      #       # To allow tag commits whose name start with "v" to trigger
-      #       # "test" job, an explicit "tags" filter is required here.
-      #       tags:
-      #         only: /v.*/
-      # - affymetrix_common_agilent_tests:
-      #     filters:
-      #       # To allow tag commits whose name start with "v" to trigger
-      #       # "test" job, an explicit "tags" filter is required here.
-      #       tags:
-      #         only: /v.*/
-      # - salmon_and_api_tests:
-      #     filters:
-      #       # To allow tag commits whose name start with "v" to trigger
-      #       # "test" job, an explicit "tags" filter is required here.
-      #       tags:
-      #         only: /v.*/
-      # - transcriptome_and_illumina_tests:
-      #     filters:
-      #       # To allow tag commits whose name start with "v" to trigger
-      #       # "test" job, an explicit "tags" filter is required here.
-      #       tags:
-      #         only: /v.*/
-
-      - deploy
-
+      - main_tests:
+          filters:
+            # To allow tag commits whose name start with "v" to trigger
+            # "test" job, an explicit "tags" filter is required here.
+            tags:
+              only: /v.*/
+      - affymetrix_common_agilent_tests:
+          filters:
+            # To allow tag commits whose name start with "v" to trigger
+            # "test" job, an explicit "tags" filter is required here.
+            tags:
+              only: /v.*/
+      - salmon_and_api_tests:
+          filters:
+            # To allow tag commits whose name start with "v" to trigger
+            # "test" job, an explicit "tags" filter is required here.
+            tags:
+              only: /v.*/
+      - transcriptome_and_illumina_tests:
+          filters:
+            # To allow tag commits whose name start with "v" to trigger
+            # "test" job, an explicit "tags" filter is required here.
+            tags:
+              only: /v.*/
       # "deploy" job will be triggered ONLY by tag commits whose name
       # start with letter "v".
-      # - deploy:
-      #     requires:
-      #       - main_tests
-      #       - affymetrix_common_agilent_tests
-      #       - salmon_and_api_tests
-      #       - transcriptome_and_illumina_tests
-      #     filters:
-      #       # No branch commit will ever trigger this job.
-      #       branches:
-      #         ignore: /.*/
-      #       tags:
-      #         only: /v.*/
+      - deploy:
+          requires:
+            - main_tests
+            - affymetrix_common_agilent_tests
+            - salmon_and_api_tests
+            - transcriptome_and_illumina_tests
+          filters:
+            # No branch commit will ever trigger this job.
+            branches:
+              ignore: /.*/
+            tags:
+              only: /v.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -161,7 +161,7 @@ jobs:
     steps:
       - checkout
       - run: bash .circleci/git_decrypt.sh
-      - run: bash .circleci/update_docker_img.sh
+      # - run: bash .circleci/update_docker_img.sh
       - run: bash .circleci/run_terraform.sh
 
 workflows:
@@ -171,42 +171,44 @@ workflows:
       # test jobs will be triggered by:
       # - any branch commit, or:
       # - tag commits whose names start with letter "v".
-      - main_tests:
-          filters:
-            # To allow tag commits whose name start with "v" to trigger
-            # "test" job, an explicit "tags" filter is required here.
-            tags:
-              only: /v.*/
-      - affymetrix_common_agilent_tests:
-          filters:
-            # To allow tag commits whose name start with "v" to trigger
-            # "test" job, an explicit "tags" filter is required here.
-            tags:
-              only: /v.*/
-      - salmon_and_api_tests:
-          filters:
-            # To allow tag commits whose name start with "v" to trigger
-            # "test" job, an explicit "tags" filter is required here.
-            tags:
-              only: /v.*/
-      - transcriptome_and_illumina_tests:
-          filters:
-            # To allow tag commits whose name start with "v" to trigger
-            # "test" job, an explicit "tags" filter is required here.
-            tags:
-              only: /v.*/
+      # - main_tests:
+      #     filters:
+      #       # To allow tag commits whose name start with "v" to trigger
+      #       # "test" job, an explicit "tags" filter is required here.
+      #       tags:
+      #         only: /v.*/
+      # - affymetrix_common_agilent_tests:
+      #     filters:
+      #       # To allow tag commits whose name start with "v" to trigger
+      #       # "test" job, an explicit "tags" filter is required here.
+      #       tags:
+      #         only: /v.*/
+      # - salmon_and_api_tests:
+      #     filters:
+      #       # To allow tag commits whose name start with "v" to trigger
+      #       # "test" job, an explicit "tags" filter is required here.
+      #       tags:
+      #         only: /v.*/
+      # - transcriptome_and_illumina_tests:
+      #     filters:
+      #       # To allow tag commits whose name start with "v" to trigger
+      #       # "test" job, an explicit "tags" filter is required here.
+      #       tags:
+      #         only: /v.*/
+
+      - deploy
 
       # "deploy" job will be triggered ONLY by tag commits whose name
       # start with letter "v".
-      - deploy:
-          requires:
-            - main_tests
-            - affymetrix_common_agilent_tests
-            - salmon_and_api_tests
-            - transcriptome_and_illumina_tests
-          filters:
-            # No branch commit will ever trigger this job.
-            branches:
-              ignore: /.*/
-            tags:
-              only: /v.*/
+      # - deploy:
+      #     requires:
+      #       - main_tests
+      #       - affymetrix_common_agilent_tests
+      #       - salmon_and_api_tests
+      #       - transcriptome_and_illumina_tests
+      #     filters:
+      #       # No branch commit will ever trigger this job.
+      #       branches:
+      #         ignore: /.*/
+      #       tags:
+      #         only: /v.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -195,6 +195,7 @@ workflows:
             # "test" job, an explicit "tags" filter is required here.
             tags:
               only: /v.*/
+
       # "deploy" job will be triggered ONLY by tag commits whose name
       # start with letter "v".
       - deploy:

--- a/.circleci/run_terraform.sh
+++ b/.circleci/run_terraform.sh
@@ -56,7 +56,7 @@ sudo mv nomad /usr/local/bin/
 if [ $CIRCLE_BRANCH == "master" ]; then
     ENVIRONMENT=prod
     BUCKET_NAME="refinebio-tfstate-deploy-production"
-elif [[ $CIRCLE_BRANCH == "dev" || $CIRCLE_BRANCH == "kurtwheeler-make-api-persistent" ]]; then
+elif [[ $CIRCLE_BRANCH == "dev" ]]; then
     ENVIRONMENT=staging
     BUCKET_NAME="refinebio-tfstate-deploy-staging"
 else

--- a/.circleci/run_terraform.sh
+++ b/.circleci/run_terraform.sh
@@ -56,7 +56,7 @@ sudo mv nomad /usr/local/bin/
 if [ $CIRCLE_BRANCH == "master" ]; then
     ENVIRONMENT=prod
     BUCKET_NAME="refinebio-tfstate-deploy-production"
-elif [[ $CIRCLE_BRANCH == "dev" ]]; then
+elif [[ $CIRCLE_BRANCH == "dev" || $CIRCLE_BRANCH == "kurtwheeler-make-api-persistent" ]]; then
     ENVIRONMENT=staging
     BUCKET_NAME="refinebio-tfstate-deploy-staging"
 else

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ Docker](https://docs.docker.com/docker-for-mac/#advanced) from the default of
 
 Run `./create_virtualenv.sh` to set up the virtualenv. It will activate the `dr_env`
 for you the first time. This virtualenv is valid for the entire `refinebio`
-repo. Sub-projects each have their own virtualenvs which are managed by their
+repo. Sub-projects each have their own environments managed by their
 containers. When returning to this project you should run
 `source dr_env/bin/activate` to reactivate the virtualenv.
 
@@ -522,7 +522,7 @@ For convenience, a `deploy.sh` script is also provided, which will perform addit
 steps to configure (such as setting up Nomad job specifications and performing database migrations) and prepare the entire system. It can be used simply (from the `infrastructure` directory), like so:
 
 ```
-./deploy.sh
+./deploy.sh -e dev
 ```
 
 ### Autoscaling and Setting Spot Prices

--- a/infrastructure/api-configuration/api-server-instance-user-data.tpl.sh
+++ b/infrastructure/api-configuration/api-server-instance-user-data.tpl.sh
@@ -29,6 +29,10 @@ if [[ ${stage} == "staging" || ${stage} == "prod" ]]; then
     apt-get update
     apt-get install python-certbot-nginx
 
+    # g3w4k4t5n3s7p7v8@alexslemonade.slack.com is the email address we
+    # have configured to forward mail to the #teamcontact channel in
+    # slack. Certbot will use it for "important account
+    # notifications".
     if [[ ${stage} == "staging" ]]; then
         certbot --nginx -d api.staging.refine.bio -n --agree-tos --redirect -m g3w4k4t5n3s7p7v8@alexslemonade.slack.com
     elif [[ ${stage} == "prod" ]]; then

--- a/infrastructure/api-configuration/api-server-instance-user-data.tpl.sh
+++ b/infrastructure/api-configuration/api-server-instance-user-data.tpl.sh
@@ -30,9 +30,9 @@ if [[ ${stage} == "staging" || ${stage} == "prod" ]]; then
     apt-get install python-certbot-nginx
 
     if [[ ${stage} == "staging" ]]; then
-        certbot --nginx -d api.staging.refine.bio -n --agree-tos -m g3w4k4t5n3s7p7v8@alexslemonade.slack.com
+        certbot --nginx -d api.staging.refine.bio -n --agree-tos --redirect -m g3w4k4t5n3s7p7v8@alexslemonade.slack.com
     elif [[ ${stage} == "prod" ]]; then
-        certbot --nginx -d api.refine.bio -n --agree-tos -m g3w4k4t5n3s7p7v8@alexslemonade.slack.com
+        certbot --nginx -d api.refine.bio -n --agree-tos --redirect -m g3w4k4t5n3s7p7v8@alexslemonade.slack.com
     fi
 fi
 

--- a/infrastructure/api-configuration/api-server-instance-user-data.tpl.sh
+++ b/infrastructure/api-configuration/api-server-instance-user-data.tpl.sh
@@ -21,6 +21,26 @@ apt-get install nginx -y
 cp nginx.conf /etc/nginx/nginx.conf
 service nginx restart
 
+# Create and install SSL Certificate
+apt-get install software-properties-common
+add-apt-repository ppa:certbot/certbot
+apt-get update
+apt-get install python-certbot-nginx
+
+certbot --nginx -d api.staging.refine.bio -n --agree-tos -m g3w4k4t5n3s7p7v8@alexslemonade.slack.com
+
+# Let's Encrypt certs are eligible for renewal 30 days before they
+# expire so try to renew every 29 days and we'll be sure to hit the
+# window. (They are valid for 90 days and renewing too early has no
+# consequences other than potentially hitting a rate limit if you do
+# it too often, which this won't.)
+# See https://certbot.eff.org/docs/using.html#renewing-certificates
+# The command to create this crontab was made with help from:
+# https://stackoverflow.com/a/610860/6095378
+# and
+# https://stackoverflow.com/a/550808/6095378
+echo '0 0 */29 * * root certbot renew' | sudo tee --append /etc/cron.d/renew_ssl_cert
+
 # Install, configure and launch our CloudWatch Logs agent
 cat <<EOF >awslogs.conf
 [general]

--- a/infrastructure/api-configuration/api-server-instance-user-data.tpl.sh
+++ b/infrastructure/api-configuration/api-server-instance-user-data.tpl.sh
@@ -21,25 +21,20 @@ apt-get install nginx -y
 cp nginx.conf /etc/nginx/nginx.conf
 service nginx restart
 
-# Create and install SSL Certificate
-apt-get install software-properties-common
-add-apt-repository ppa:certbot/certbot
-apt-get update
-apt-get install python-certbot-nginx
+if [[ ${stage} == "staging" || ${stage} == "prod" ]]; then
+    # Create and install SSL Certificate
+    # Only necessary on staging and prod
+    apt-get install software-properties-common
+    add-apt-repository ppa:certbot/certbot
+    apt-get update
+    apt-get install python-certbot-nginx
 
-certbot --nginx -d api.staging.refine.bio -n --agree-tos -m g3w4k4t5n3s7p7v8@alexslemonade.slack.com
-
-# Let's Encrypt certs are eligible for renewal 30 days before they
-# expire so try to renew every 29 days and we'll be sure to hit the
-# window. (They are valid for 90 days and renewing too early has no
-# consequences other than potentially hitting a rate limit if you do
-# it too often, which this won't.)
-# See https://certbot.eff.org/docs/using.html#renewing-certificates
-# The command to create this crontab was made with help from:
-# https://stackoverflow.com/a/610860/6095378
-# and
-# https://stackoverflow.com/a/550808/6095378
-echo '0 0 */29 * * root certbot renew' | sudo tee --append /etc/cron.d/renew_ssl_cert
+    if [[ ${stage} == "staging" ]]; then
+        certbot --nginx -d api.staging.refine.bio -n --agree-tos -m g3w4k4t5n3s7p7v8@alexslemonade.slack.com
+    elif [[ ${stage} == "prod" ]]; then
+        certbot --nginx -d api.refine.bio -n --agree-tos -m g3w4k4t5n3s7p7v8@alexslemonade.slack.com
+    fi
+fi
 
 # Install, configure and launch our CloudWatch Logs agent
 cat <<EOF >awslogs.conf

--- a/infrastructure/instances.tf
+++ b/infrastructure/instances.tf
@@ -211,7 +211,7 @@ data "template_file" "nomad_client_config" {
   template = "${file("nomad-configuration/client.tpl.hcl")}"
 
   vars {
-    nomad_server_address = "${aws_instance.nomad_server_1.private_ip}"
+    nomad_lead_server_ip = "${aws_instance.nomad_server_1.private_ip}"
   }
 }
 

--- a/infrastructure/networking.tf
+++ b/infrastructure/networking.tf
@@ -100,7 +100,8 @@ resource "aws_eip" "data_refinery_api_ip" {
 # existing application that was built within the EC2-Classic network,
 # then you should use a Classic Load Balancer.
 #
-# it appears an Application Load Balancer would be best for us.
+# it appears an Network Load Balancer would be best for us because we
+# need a static IP address to point DNS to.
 resource "aws_lb" "data_refinery_api_load_balancer" {
   # Extra short because there is a 32 char limit on this name
   name = "DR-api-${var.user}-${var.stage}"

--- a/infrastructure/networking.tf
+++ b/infrastructure/networking.tf
@@ -115,7 +115,6 @@ resource "aws_lb" "data_refinery_api_load_balancer" {
     subnet_id = "${aws_subnet.data_refinery_1a.id}"
     allocation_id = "${aws_eip.data_refinery_api_ip.id}"
   }
-
 }
 
 resource "aws_lb_target_group" "api-http" {

--- a/infrastructure/nomad-configuration/client.tpl.hcl
+++ b/infrastructure/nomad-configuration/client.tpl.hcl
@@ -22,5 +22,5 @@ consul {
 telemetry {
   publish_allocation_metrics = true
   publish_node_metrics       = true
-  statsd_address = "${nomad_lead_server_ip}:8125"
+  statsd_address = "${nomad_server_address}:8125"
 }

--- a/infrastructure/nomad-configuration/client.tpl.hcl
+++ b/infrastructure/nomad-configuration/client.tpl.hcl
@@ -10,7 +10,7 @@ data_dir = "/tmp/nomad_client1"
 client {
     enabled = true
 
-    servers = ["${nomad_server_address}:4647"]
+    servers = ["${nomad_lead_server_ip}:4647"]
 }
 
 consul {
@@ -22,5 +22,5 @@ consul {
 telemetry {
   publish_allocation_metrics = true
   publish_node_metrics       = true
-  statsd_address = "${nomad_server_address}:8125"
+  statsd_address = "${nomad_lead_server_ip}:8125"
 }


### PR DESCRIPTION
## Issue Number

#342 

## Purpose/Implementation Notes

Because AWS doesn't support the top level domain `.bio`, we cannot use Route53 to manage the domain and therefore cannot use the Amazon Certificate Manager like we did in cognoma. This enables HTTPS (and forces redirection from HTTP). Additionally this uses an AWS Network Load Balancer with an Elastic IP to make it so that when the API server goes down and comes back up with a new IP, our DNS settings are still valid for forwarding traffic to it.

## Types of changes

- New feature (non-breaking change which adds functionality)

## Functional tests

I ran the new configuration with the Load Balancer from CCI and made sure that the elastic IP address was properly working especially when forwarded to via DNS. I also ran the `certbot` commands directly on the API instance to verify that they worked.

I am going to use the merge into dev to both verify that `dev` merges properly cause the staging infrastructure to be updated and that the change to the API server's startup script works properly.

## Checklist

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules
