### PR TITLE
Add TSV Metadata to Smasher Output

### DIFF
--- a/workers/data_refinery_workers/processors/smasher.py
+++ b/workers/data_refinery_workers/processors/smasher.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import, unicode_literals
 
 import boto3
+import csv
 import json
 import os
 import shutil
@@ -114,7 +115,7 @@ def _smash(job_context: Dict) -> Dict:
 
         # Create metadata file.
         metadata = {}
-        metadata['files'] = os.listdir(smash_path)
+
         metadata['num_samples'] = num_samples
         metadata['num_experiments'] = job_context["experiments"].count()
         metadata['aggregate_by'] = job_context["dataset"].aggregate_by
@@ -130,6 +131,18 @@ def _smash(job_context: Dict) -> Dict:
             experiments[experiment.accession_code] = experiment.to_metadata_dict()
         metadata['experiments'] = experiments
 
+        # Metadata to TSV
+        with open(smash_path + 'metadata.tsv', 'w') as output_file:
+            sample_ids = [k for k in metadata['samples'].keys()]
+            keys = [k for k in metadata['samples'][sample_ids[0]].keys()] + ['sample_id']
+            dw = csv.DictWriter(output_file, keys, delimiter='\t')
+            dw.writeheader()
+            for key, value in metadata['samples'].items():
+                value['sample_id'] = key
+                dw.writerow(value)
+
+        metadata['files'] = os.listdir(smash_path)
+        # Metadata to JSON
         metadata['created_at'] = datetime.utcnow().strftime('%Y-%m-%dT%H:%M:%S')
         with open(smash_path + 'metadata.json', 'w') as metadata_file: 
             json.dump(metadata, metadata_file, indent=4, sort_keys=True)

--- a/workers/data_refinery_workers/processors/smasher.py
+++ b/workers/data_refinery_workers/processors/smasher.py
@@ -57,6 +57,8 @@ def _smash(job_context: Dict) -> Dict:
     try:
         # Prepare the output directory
         smash_path = "/home/user/data_store/smashed/" + str(job_context["dataset"].pk) + "/"
+        # Ensure we have a fresh smash directory
+        shutil.rmtree(smash_path, ignore_errors=True)
         os.makedirs(smash_path, exist_ok=True)
 
         scalers = {
@@ -133,8 +135,8 @@ def _smash(job_context: Dict) -> Dict:
 
         # Metadata to TSV
         with open(smash_path + 'metadata.tsv', 'w') as output_file:
-            sample_ids = [k for k in metadata['samples'].keys()]
-            keys = [k for k in metadata['samples'][sample_ids[0]].keys()] + ['sample_id']
+            sample_ids = list(metadata['samples'].keys())
+            keys = list(metadata['samples'][sample_ids[0]].keys()) + ['sample_id']
             dw = csv.DictWriter(output_file, keys, delimiter='\t')
             dw.writeheader()
             for key, value in metadata['samples'].items():

--- a/workers/data_refinery_workers/processors/test_smasher.py
+++ b/workers/data_refinery_workers/processors/test_smasher.py
@@ -158,13 +158,13 @@ class SmasherTestCase(TestCase):
 
             final_context = smasher.smash(job.pk, upload=False)
             final_frame = final_context['final_frame']
+
+            # Sanity test that these frames can be computed upon
             final_frame.mean(axis=1)
             final_frame.min(axis=1)
             final_frame.max(axis=1)
             final_frame.std(axis=1)
             final_frame.median(axis=1)
-
-            final_context['output_file']
 
             zf = zipfile.ZipFile(final_context['output_file'])
             namelist = zf.namelist()

--- a/workers/data_refinery_workers/processors/test_smasher.py
+++ b/workers/data_refinery_workers/processors/test_smasher.py
@@ -1,4 +1,6 @@
 import os
+import zipfile
+
 from django.test import TestCase, tag
 from data_refinery_common.models import (
     SurveyJob,
@@ -161,6 +163,17 @@ class SmasherTestCase(TestCase):
             final_frame.max(axis=1)
             final_frame.std(axis=1)
             final_frame.median(axis=1)
+
+            final_context['output_file']
+
+            zf = zipfile.ZipFile(final_context['output_file'])
+            namelist = zf.namelist()
+
+            self.assertTrue('metadata.tsv' in namelist)
+            self.assertTrue('metadata.json' in namelist)
+            self.assertTrue('README.md' in namelist)
+            self.assertTrue('LICENSE.TXT' in namelist)
+            self.assertTrue('GSE51081.tsv' in namelist)
 
             os.remove(final_context['output_file'])
 


### PR DESCRIPTION
## Issue Number

https://github.com/AlexsLemonade/refinebio/issues/332

## Purpose/Implementation Notes

For some peculiar reason, some people prefer TSVs over JSON files for metadata. This adds those files to smasher-produced archives.

## Methods

Fields are provided by the Sample object's `to_metadata_dict` class, so any missing fields should be added there in the future.

## Types of changes
- New feature (non-breaking change which adds functionality)

## Functional tests

New test assertions have been added.

## Checklist

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules
