### PR TITLE
Prevent the downloaders tests from timing out in CCI.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,7 +37,9 @@ jobs:
       # Running these in the same job as the common tests is good
       # because their dockerfiles are very similar so a lot of the
       # build time is saved by only building those layers once.
-      - run: .circleci/filter_tests.sh -t downloaders
+      - run:
+          command: .circleci/filter_tests.sh -t downloaders
+          no_output_timeout: 36000
 
       # Push the no_op and downloader images to the local docker repo so Nomad
       # can pull from there when running end-to-end tests.


### PR DESCRIPTION
## Issue Number

NA

## Purpose/Implementation Notes

The downloader tests have been failing because of a timeout. This has been fixed in a couple branches already, so this works, this just makes it so others don't need to repeat that change.

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

This is a change to CI and it already works here: https://circleci.com/gh/AlexsLemonade/refinebio/2683?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link

## Checklist

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works