### PR TITLE
Reduces size of test_volume on developer machines

### DIFF
--- a/workers/data_refinery_workers/processors/test_transcriptome_index.py
+++ b/workers/data_refinery_workers/processors/test_transcriptome_index.py
@@ -79,6 +79,9 @@ class TXTestCase(TestCase):
     def test_tx(self):
         """ """
         job = prepare_job()
-        transcriptome_index.build_transcriptome_index(job.pk)
+        job_context = transcriptome_index.build_transcriptome_index(job.pk)
         job = ProcessorJob.objects.get(id=job.pk)
         self.assertTrue(job.success)
+
+        # Cleanup after ourselves so we don't leave 1.3G of data lying around.
+        shutil.rmtree(job_context["output_dir"])

--- a/workers/data_refinery_workers/processors/transcriptome_index.py
+++ b/workers/data_refinery_workers/processors/transcriptome_index.py
@@ -215,6 +215,9 @@ def _create_index(job_context: Dict) -> Dict:
                                             stdout=subprocess.PIPE,
                                             stderr=subprocess.PIPE)
 
+    # The extracted fasta file can be large, no need to leave it lying around.
+    os.remove(job_context["fasta_file_path"])
+
     if rsem_completed_command.returncode != 0:
         stderr = str(rsem_completed_command.stderr)
         error_start = stderr.find("Error:")
@@ -333,15 +336,15 @@ def build_transcriptome_index(job_id: int, length="long") -> None:
     The output of salmon index is a directory which is pushed in full
     to Permanent Storage.
     """
-    utils.run_pipeline({"job_id": job_id, "length": length},
-                       [utils.start_job,
-                        _compute_paths,
-                        _prepare_files,
-                        _extract_assembly_version,
-                        _process_gtf,
-                        _create_index,
-                        _zip_index,
-                        _populate_index_object,
-                        #utils.upload_processed_files,
-                        #utils.cleanup_raw_files,
-                        utils.end_job])
+    return utils.run_pipeline({"job_id": job_id, "length": length},
+                              [utils.start_job,
+                               _compute_paths,
+                               _prepare_files,
+                               _extract_assembly_version,
+                               _process_gtf,
+                               _create_index,
+                               _zip_index,
+                               _populate_index_object,
+                               #utils.upload_processed_files,
+                               #utils.cleanup_raw_files,
+                               utils.end_job])

--- a/workers/run_tests.sh
+++ b/workers/run_tests.sh
@@ -66,11 +66,12 @@ test_data_repo="https://s3.amazonaws.com/data-refinery-test-assets"
 
 if [[ -z $tag || $tag == "salmon" ]]; then
     # Download "salmon quant" test data
-    echo "Downloading 'salmon quant' test data..."
-    rm -rf $volume_directory/salmon_tests/
-
-    wget -q -O $volume_directory/salmon_tests.tar.gz $test_data_repo/salmon_tests.tar.gz
-    tar xzf $volume_directory/salmon_tests.tar.gz -C $volume_directory
+    if [ ! -e $volume_directory/salmon_tests ]; then
+        echo "Downloading 'salmon quant' test data..."
+        wget -q -O $volume_directory/salmon_tests.tar.gz $test_data_repo/salmon_tests.tar.gz
+        tar xzf $volume_directory/salmon_tests.tar.gz -C $volume_directory
+        rm $volume_directory/salmon_tests.tar.gz
+    fi
 
     # Download salmontools test data
     rm -rf $volume_directory/salmontools/

--- a/workers/tester.sh
+++ b/workers/tester.sh
@@ -85,8 +85,8 @@ source common.sh
 HOST_IP=$(get_ip_address)
 DB_HOST_IP=$(get_docker_db_ip_address)
 
-export AWS_ACCESS_KEY_ID=`~/bin/aws configure get default.aws_access_key_id`
-export AWS_SECRET_ACCESS_KEY=`~/bin/aws configure get default.aws_secret_access_key`
+# export AWS_ACCESS_KEY_ID=`~/bin/aws configure get default.aws_access_key_id`
+# export AWS_SECRET_ACCESS_KEY=`~/bin/aws configure get default.aws_secret_access_key`
 
 docker run \
 	   -it \

--- a/workers/tester.sh
+++ b/workers/tester.sh
@@ -85,8 +85,8 @@ source common.sh
 HOST_IP=$(get_ip_address)
 DB_HOST_IP=$(get_docker_db_ip_address)
 
-# export AWS_ACCESS_KEY_ID=`~/bin/aws configure get default.aws_access_key_id`
-# export AWS_SECRET_ACCESS_KEY=`~/bin/aws configure get default.aws_secret_access_key`
+export AWS_ACCESS_KEY_ID=`~/bin/aws configure get default.aws_access_key_id`
+export AWS_SECRET_ACCESS_KEY=`~/bin/aws configure get default.aws_secret_access_key`
 
 docker run \
 	   -it \


### PR DESCRIPTION
## Issue Number

N/A

## Purpose/Implementation Notes

Every now and then I run out of space and have to clean some things up. The `workers/test_volume` seemed larger than it needed to be so I found a few quick changes I could make to reduce the size by a little more than 6GB on a permanent basis.

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

Unit tests cover all the functionality I've changed.

## Checklist

- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
