### PR TITLE
Fixes ps sometimes not outputting enough output to show up in grep.

### DIFF
--- a/foreman/run_tests.sh
+++ b/foreman/run_tests.sh
@@ -21,7 +21,8 @@ fi
 cd ..
 
 # Ensure that Nomad is running first
-if ! ps aux | grep test_nomad | grep -v grep > /dev/null; then
+# Double w in `ps` will cause the columns to never be truncated regardless of environment.
+if ! ps auxww | grep test_nomad | grep -v grep > /dev/null; then
     echo "You must start the nomad test environment first with" >&2
     echo "'sudo -E ./run_nomad.sh -e test'" >&2
     exit 1

--- a/run_all_tests.sh
+++ b/run_all_tests.sh
@@ -7,7 +7,8 @@
 # This should mirror what happens in the CircleCI config (.circleci/config).
 
 # Ensure that Nomad is running first
-if ! ps aux | grep test_nomad | grep -v grep > /dev/null; then
+# Double w in `ps` will cause the columns to never be truncated regardless of environment.
+if ! ps auxww | grep test_nomad | grep -v grep > /dev/null; then
     echo "You must start the nomad test environment first with" >&2
     echo "'sudo -E ./run_nomad.sh -e test'" >&2
     exit 1


### PR DESCRIPTION
## Issue Number

N/A

## Purpose/Implementation Notes

When I was running tests through emacs it was repeatedly telling me that I had to run nomad. After a lot of confusion I realized that it was because when emacs ran `ps aux` in its shell, the output was truncated:
```
root      6238  1.4  0.2 865196 37800 pts/0    Sl   15:37   0:45 nomad agent -bind 192.168.150.16 -data-dir /home/k
```
This is a feature of `ps`, I guess to make it more usable on terminals with limited width. However it made it so `test_nomad` didn't appear in the command, so it was caught by `grep test_nomad`.

`ps` has the option:
```
w      Wide output.  Use this option twice for unlimited width.
```
which prevents this behavior. Since we're just grepping this output, there's no benefit to ever having it truncated so I think this is a fix which will be generally useful.

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

I've run tests with this. It doesn't affect any general test behavior, except that it fixes running tests in emacs for me.

## Checklist

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules
