### PR TITLE
Switch from Ubuntu to High Availablity Keyserver

### DIFF
--- a/common/Dockerfile.tests
+++ b/common/Dockerfile.tests
@@ -5,7 +5,7 @@ RUN \
   apt-get install -y lsb-release && \
   echo "deb http://archive.linux.duke.edu/cran/bin/linux/ubuntu $(lsb_release -sc)/" \
       >> /etc/apt/sources.list.d/added_repos.list && \
-  apt-key adv --keyserver keyserver.ubuntu.com --recv-keys E084DAB9 && \
+  apt-key adv --keyserver ha.pool.sks-keyservers.net --recv-keys E084DAB9 && \
   apt-get update -qq && \
   apt-get install -y \
   ed \

--- a/workers/dockerfiles/Dockerfile.affymetrix
+++ b/workers/dockerfiles/Dockerfile.affymetrix
@@ -8,7 +8,7 @@ RUN \
   apt-get install -y lsb-release && \
   echo "deb http://archive.linux.duke.edu/cran/bin/linux/ubuntu $(lsb_release -sc)/" \
       >> /etc/apt/sources.list.d/added_repos.list && \
-  apt-key adv --keyserver keyserver.ubuntu.com --recv-keys E084DAB9 && \
+  apt-key adv --keyserver ha.pool.sks-keyservers.net --recv-keys E084DAB9 && \
   apt-get update -qq && \
   apt-get install -y \
   ed \

--- a/workers/dockerfiles/Dockerfile.downloaders
+++ b/workers/dockerfiles/Dockerfile.downloaders
@@ -5,7 +5,7 @@ RUN \
   apt-get install -y lsb-release && \
   echo "deb http://archive.linux.duke.edu/cran/bin/linux/ubuntu $(lsb_release -sc)/" \
       >> /etc/apt/sources.list.d/added_repos.list && \
-  apt-key adv --keyserver keyserver.ubuntu.com --recv-keys E084DAB9 && \
+  apt-key adv --keyserver ha.pool.sks-keyservers.net --recv-keys E084DAB9 && \
   apt-get update -qq && \
   apt-get install -y \
   ed \

--- a/workers/dockerfiles/Dockerfile.illumina
+++ b/workers/dockerfiles/Dockerfile.illumina
@@ -5,7 +5,7 @@ RUN \
   apt-get install -y lsb-release && \
   echo "deb http://archive.linux.duke.edu/cran/bin/linux/ubuntu $(lsb_release -sc)/" \
       >> /etc/apt/sources.list.d/added_repos.list && \
-  apt-key adv --keyserver keyserver.ubuntu.com --recv-keys E084DAB9 && \
+  apt-key adv --keyserver ha.pool.sks-keyservers.net --recv-keys E084DAB9 && \
   apt-get update -qq && \
   apt-get install -y \
   ed \

--- a/workers/dockerfiles/Dockerfile.salmon
+++ b/workers/dockerfiles/Dockerfile.salmon
@@ -5,7 +5,7 @@ RUN \
   apt-get install -y apt-utils lsb-release && \
   echo "deb http://archive.linux.duke.edu/cran/bin/linux/ubuntu $(lsb_release -sc)/" \
       >> /etc/apt/sources.list.d/added_repos.list && \
-  apt-key adv --keyserver keyserver.ubuntu.com --recv-keys E084DAB9 && \
+  apt-key adv --keyserver ha.pool.sks-keyservers.net --recv-keys E084DAB9 && \
   apt-get update -qq && \
   apt-get install -y \
   ed \


### PR DESCRIPTION
## Issue Number

n/a

## Purpose/Implementation Notes

The Ubuntu keyserver is constantly down and it's causing our tests to fail all the time for no fault of our own. 

This switches to a high availability public keyserver that should fix some of our problems.

## Types of changes

- Bugfix (non-breaking change which fixes an issue)


