### PR TITLE
Fixes some bad resource references in terraform networking config

### DIFF
--- a/infrastructure/networking.tf
+++ b/infrastructure/networking.tf
@@ -131,13 +131,13 @@ resource "aws_lb_listener" "api-http" {
   port = 80
 
   default_action {
-    target_group_arn = "${aws_lb_target_group.api.arn}"
+    target_group_arn = "${aws_lb_target_group.api-http.arn}"
     type = "forward"
   }
 }
 
 resource "aws_lb_target_group_attachment" "api-http" {
-  target_group_arn = "${aws_lb_target_group.api.arn}"
+  target_group_arn = "${aws_lb_target_group.api-http.arn}"
   target_id = "${aws_instance.api_server_1.id}"
   port = 80
 }
@@ -156,13 +156,13 @@ resource "aws_lb_listener" "api-https" {
   port = 443
 
   default_action {
-    target_group_arn = "${aws_lb_target_group.api.arn}"
+    target_group_arn = "${aws_lb_target_group.api-https.arn}"
     type = "forward"
   }
 }
 
 resource "aws_lb_target_group_attachment" "api-https" {
-  target_group_arn = "${aws_lb_target_group.api.arn}"
+  target_group_arn = "${aws_lb_target_group.api-https.arn}"
   target_id = "${aws_instance.api_server_1.id}"
   port = 443
 }


### PR DESCRIPTION
## Issue Number

N/A

## Purpose/Implementation Notes

As part of getting the API using HTTPS, I tested some terraform configurations for the staging stack directly from CircleCI. Once I got a working configuration I then made (what I thought were) the same changes in #343. However I didn't properly test them since the HTTPS stuff isn't really testable without a DNS configuration pointing to it. @Willv19 ran into the issues caused by this bug while trying to stand up a dev stack.

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

Will has been able to run terraform successfully with these changes.

## Checklist

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules