### PR TITLE
Dualsmash Part 2: Transform and Smash

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,7 +58,10 @@ jobs:
       - run: sudo chown -R circleci:circleci workers/test_volume/
       - run: .circleci/filter_tests.sh -t illumina
 
-        # Run Smasher tests.
+      # Run Smasher tests.
+      - run: sudo apt-get update && sudo apt-get install -qq -y python-pip libpython-dev
+      - run: curl -O https://bootstrap.pypa.io/get-pip.py && sudo python get-pip.py
+      - run: sudo pip install -q awscli --upgrade
       - run: sudo chown -R circleci:circleci workers/test_volume/
       - run:
           command: .circleci/filter_tests.sh -t smasher

--- a/workers/data_refinery_workers/processors/requirements.txt
+++ b/workers/data_refinery_workers/processors/requirements.txt
@@ -29,7 +29,7 @@ mpmath==1.0.0             # via sympy
 multiqc==1.5
 networkx==2.1             # via colormath
 numpy==1.14.4
-pandas==0.23.0
+pandas>=0.23.1
 psycopg2-binary==2.7.4
 pyparsing==2.2.0          # via matplotlib
 python-dateutil==2.7.3    # via botocore, matplotlib, pandas

--- a/workers/data_refinery_workers/processors/salmon.py
+++ b/workers/data_refinery_workers/processors/salmon.py
@@ -245,6 +245,17 @@ def _tximport(job_context: Dict, experiment_dir: str) -> Dict:
         s_r = SampleResultAssociation(sample=sample, result=result)
         s_r.save()
 
+    rds_file = ComputedFile()
+    rds_file.absolute_file_path = experiment_dir + '/txi_out.RDS'
+    rds_file.filename = 'txi_out.RDS'
+    rds_file.result = result
+    rds_file.is_smashable = False
+    rds_file.is_qc = False
+    rds_file.is_public = True
+    rds_file.calculate_sha1()
+    rds_file.calculate_size()
+    rds_file.save()
+
     # Split the tximport result into smashable subfiles
     big_tsv = experiment_dir + '/gene_lengthScaledTPM.tsv'
     data = pd.read_csv(big_tsv, sep='\t', header=0, index_col=0)

--- a/workers/data_refinery_workers/processors/salmon.py
+++ b/workers/data_refinery_workers/processors/salmon.py
@@ -251,7 +251,7 @@ def _tximport(job_context: Dict, experiment_dir: str) -> Dict:
     individual_files = []
     frames = np.split(data, len(data.columns), axis=1)
     for frame in frames:
-        frame_path = os.path.join(experiment_dir, frame.columns.values[0]) + '.tsv'
+        frame_path = os.path.join(experiment_dir, frame.columns.values[0]) + '_gene_lengthScaledTPM.tsv'
         frame.to_csv(frame_path, sep='\t', encoding='utf-8')
 
         sample = Sample.objects.get(accession_code=frame.columns.values[0])

--- a/workers/data_refinery_workers/processors/smasher.py
+++ b/workers/data_refinery_workers/processors/smasher.py
@@ -14,6 +14,7 @@ from django.utils import timezone
 from typing import Dict
 
 import pandas as pd
+import numpy as np
 from sklearn import preprocessing
 
 from data_refinery_common.logging import get_and_configure_logger
@@ -74,9 +75,26 @@ def _smash(job_context: Dict) -> Dict:
             # Merge all the frames into one
             all_frames = []
             for computed_file in input_files:
-                data = pd.DataFrame.from_csv(str(computed_file.absolute_file_path), sep='\t', header=0)
+                computed_file_path = str(computed_file.absolute_file_path)
+                data = pd.DataFrame.from_csv(computed_file_path, sep='\t', header=0)
+
+                # via https://github.com/AlexsLemonade/refinebio/issues/330:
+                #   aggregating by experiment -> return untransformed output from tximport
+                #   aggregating by species -> log2(x + 1) tximport output               
+                if job_context['dataset'].aggregate_by == 'SPECIES':
+                    if 'lengthScaledTPM' in computed_file_path:
+                        data = data + 1
+                        data = np.log2(data)
+
+                # Ensure that we don't have any dangling Brainarray-generated probe symbols.
+                # BA likes to leave '_at', signifying probe identifiers,
+                # on their converted, non-probe identifiers. It makes no sense.
+                # So, we chop them off and don't worry about it.
+                data.index = data.index.str.replace('_at', '')
+
                 all_frames.append(data)
                 num_samples = num_samples + 1
+
             job_context['all_frames'] = all_frames
 
             merged = all_frames[0]
@@ -165,6 +183,7 @@ def _smash(job_context: Dict) -> Dict:
         job_context['failure_reason'] = str(e)
         return job_context
 
+    job_context['metadata'] = metadata
     job_context['dataset'].success = True
     job_context['dataset'].save()
 

--- a/workers/data_refinery_workers/processors/test_smasher.py
+++ b/workers/data_refinery_workers/processors/test_smasher.py
@@ -109,7 +109,7 @@ def prepare_job():
     pjda = ProcessorJobDatasetAssociation()
     pjda.processor_job = pj
     pjda.dataset = ds
-    pjda.save()
+    pjda.save() 
 
     return pj
 
@@ -462,6 +462,11 @@ class SmasherTestCase(TestCase):
         computed_file.is_smashable = True
         computed_file.save()
 
+        assoc = SampleComputedFileAssociation()
+        assoc.sample = sample
+        assoc.computed_file = computed_file
+        assoc.save()
+
         # RNASEQ TECH
         experiment = Experiment()
         experiment.accession_code = "SRS332914"
@@ -474,7 +479,7 @@ class SmasherTestCase(TestCase):
         sample.accession_code = 'SRS332914'
         sample.title = 'SRS332914'
         sample.organism = gallus_gallus
-        sample.technology="RNA-SEQ"
+        sample.technology = "RNA-SEQ"
         sample.save()
 
         sra = SampleResultAssociation()
@@ -495,6 +500,11 @@ class SmasherTestCase(TestCase):
         computed_file.is_smashable = True
         computed_file.save()
 
+        assoc = SampleComputedFileAssociation()
+        assoc.sample = sample
+        assoc.computed_file = computed_file
+        assoc.save()
+
         # CROSS-SMASH BY SPECIES
         ds = Dataset()
         ds.data = {'GSM1487313': ['GSM1487313'], 'SRS332914': ['SRS332914']}
@@ -509,8 +519,9 @@ class SmasherTestCase(TestCase):
         pjda.save()
 
         self.assertTrue(ds.is_cross_technology())
-
         final_context = smasher.smash(pj.pk, upload=False)
+        self.assertTrue(os.path.exists(final_context['output_file']))
+        self.assertEqual(len(final_context['final_frame'].columns), 2)
 
         # THEN BY EXPERIMENT
         ds.aggregate_by = 'EXPERIMENT'
@@ -520,6 +531,19 @@ class SmasherTestCase(TestCase):
         ds = Dataset.objects.get(id=dsid)
 
         final_context = smasher.smash(pj.pk, upload=False)
+        self.assertTrue(os.path.exists(final_context['output_file']))
+        self.assertEqual(len(final_context['final_frame'].columns), 1)
+
+        # THEN BY ALL
+        ds.aggregate_by = 'ALL'
+        ds.save()
+
+        dsid = ds.id
+        ds = Dataset.objects.get(id=dsid)
+
+        final_context = smasher.smash(pj.pk, upload=False)
+        self.assertTrue(os.path.exists(final_context['output_file']))
+        self.assertEqual(len(final_context['final_frame'].columns), 2)
 
     @tag("smasher")
     def test_sanity_imports(self):


### PR DESCRIPTION
## Issue Number

https://github.com/AlexsLemonade/refinebio/issues/330
Depends on: https://github.com/AlexsLemonade/refinebio/pull/355
Conflicts with: https://github.com/AlexsLemonade/refinebio/pull/307

## Purpose/Implementation Notes

Adds ability to smash RNASeq/Microarray data together. 

## Methods
Jackie recommended: 

```
aggregating by experiment -> return untransformed output from tximport
aggregating by species -> log2(x + 1) tximport output
```

For `SPECIES`, this is accomplished by: 

```
data = data + 1
data = np.log2(data)
```

I don't understand the inclusion of `aggregating by experiment`, since there are no experiments (as far as I am aware) which use both technologies at once. Still, if it does occur, the transformation above won't.


## Types of changes

What types of changes does your code introduce?
- New feature (non-breaking change which adds functionality)

## Functional tests

New tests and new test data is provided.

## Checklist

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules