### PR TITLE
Make Nginx Hush Up

### DIFF
--- a/infrastructure/api-configuration/nginx_config.conf
+++ b/infrastructure/api-configuration/nginx_config.conf
@@ -3,9 +3,7 @@
 # Optionally, we can have Nginx sort itself out:
 worker_processes  auto;
 
-error_log  /tmp/error.log;
-error_log  /tmp/error.log  notice;
-error_log  /tmp/error.log  info;
+error_log  /tmp/error.log  error;
 
 events {
     # Set this to ulimit -n

--- a/workers/data_refinery_workers/processors/salmon.py
+++ b/workers/data_refinery_workers/processors/salmon.py
@@ -245,17 +245,6 @@ def _tximport(job_context: Dict, experiment_dir: str) -> Dict:
         s_r = SampleResultAssociation(sample=sample, result=result)
         s_r.save()
 
-    rds_file = ComputedFile()
-    rds_file.absolute_file_path = experiment_dir + '/txi_out.RDS'
-    rds_file.filename = 'txi_out.RDS'
-    rds_file.result = result
-    rds_file.is_smashable = False
-    rds_file.is_qc = False
-    rds_file.is_public = True
-    rds_file.calculate_sha1()
-    rds_file.calculate_size()
-    rds_file.save()
-
     # Split the tximport result into smashable subfiles
     big_tsv = experiment_dir + '/gene_lengthScaledTPM.tsv'
     data = pd.read_csv(big_tsv, sep='\t', header=0, index_col=0)

--- a/workers/data_refinery_workers/processors/salmon.py
+++ b/workers/data_refinery_workers/processors/salmon.py
@@ -245,6 +245,17 @@ def _tximport(job_context: Dict, experiment_dir: str) -> Dict:
         s_r = SampleResultAssociation(sample=sample, result=result)
         s_r.save()
 
+    rds_file = ComputedFile()
+    rds_file.absolute_file_path = experiment_dir + '/txi_out.RDS'
+    rds_file.filename = 'txi_out.RDS'
+    rds_file.result = result
+    rds_file.is_smashable = False
+    rds_file.is_qc = False
+    rds_file.is_public = True
+    rds_file.calculate_sha1()
+    rds_file.calculate_size()
+    rds_file.save()
+
     # Split the tximport result into smashable subfiles
     big_tsv = experiment_dir + '/gene_lengthScaledTPM.tsv'
     data = pd.read_csv(big_tsv, sep='\t', header=0, index_col=0)


### PR DESCRIPTION
## Issue Number
n/a

## Purpose/Implementation Notes

The logs are now full of: 

```
data-refinery-log-group-circleci-staging log-stream-api-nginx-error-circleci-staging 2018/07/02 23:43:45 [info] 6311#6311: *84929 client closed connection while SSL handshaking, client: 10.0.126.33, server: 0.0.0.0:443
data-refinery-log-group-circleci-staging log-stream-api-nginx-error-circleci-staging 2018/07/02 23:43:45 [info] 6311#6311: *84930 client closed connection while waiting for request, client: 10.0.126.33, server: 0.0.0.0:80
data-refinery-log-group-circleci-staging log-stream-api-nginx-error-circleci-staging 2018/07/02 23:43:46 [info] 6311#6311: *84931 client closed connection while SSL handshaking, client: 10.0.126.33, server: 0.0.0.0:443
data-refinery-log-group-circleci-staging log-stream-api-nginx-error-circleci-staging 2018/07/02 23:43:46 [info] 6311#6311: *84932 client closed connection while waiting for request, client: 10.0.126.33, server: 0.0.0.0:80
data-refinery-log-group-circleci-staging log-stream-api-nginx-error-circleci-staging 2018/07/02 23:43:47 [info] 6311#6311: *84933 client closed connection while SSL handshaking, client: 10.0.126.33, server: 0.0.0.0:443
data-refinery-log-group-circleci-staging log-stream-api-nginx-error-circleci-staging 2018/07/02 23:43:48 [info] 6311#6311: *84934 client closed connection while waiting for request, client: 10.0.126.33, server: 0.0.0.0:80
data-refinery-log-group-circleci-staging log-stream-api-nginx-error-circleci-staging 2018/07/02 23:43:48 [info] 6311#6311: *84935 client closed connection while SSL handshaking, client: 10.0.126.33, server: 0.0.0.0:443
data-refinery-log-group-circleci-staging log-stream-api-nginx-error-circleci-staging 2018/07/02 23:43:49 [info] 6311#6311: *84936 client closed connection while SSL handshaking, client: 10.0.126.33, server: 0.0.0.0:443
data-refinery-log-group-circleci-staging log-stream-api-nginx-error-circleci-staging 2018/07/02 23:43:49 [info] 6311#6311: *84937 client closed connection while SSL handshaking, client: 10.0.126.33, server: 0.0.0.0:443
data-refinery-log-group-circleci-staging log-stream-api-nginx-error-circleci-staging 2018/07/02 23:43:49 [info] 6311#6311: *84938 client closed connection while waiting for request, client: 10.0.126.33, server: 0.0.0.0:80
data-refinery-log-group-circleci-staging log-stream-api-nginx-error-circleci-staging 2018/07/02 23:43:49 [info] 6311#6311: *84939 client closed connection while waiting for request, client: 10.0.126.33, server: 0.0.0.0:80
data-refinery-log-group-circleci-staging log-stream-api-nginx-error-circleci-staging 2018/07/02 23:43:50 [info] 6311#6311: *84940 client closed connection while waiting for request, client: 10.0.126.33, server: 0.0.0.0:80
data-refinery-log-group-circleci-staging log-stream-api-nginx-error-circleci-staging 2018/07/02 23:43:50 [info] 6311#6311: *84941 client closed connection while SSL handshaking, client: 10.0.126.33, server: 0.0.0.0:443
data-refinery-log-group-circleci-staging log-stream-api-nginx-error-circleci-staging 2018/07/02 23:43:50 [info] 6311#6311: *84942 client closed connection while SSL handshaking, client: 10.0.126.33, server: 0.0.0.0:443
```

This should hush that up and only report real errors.

## Types of changes
- Bugfix (non-breaking change which fixes an issue)

## Functional tests

Nope

## Checklist

_Put an `x` in the boxes that apply._

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules