### PR TITLE
Sync Original and Result Files to S3_IA

### DIFF
--- a/common/data_refinery_common/models/models.py
+++ b/common/data_refinery_common/models/models.py
@@ -689,8 +689,6 @@ class ComputedFile(models.Model):
             os.remove(self.absolute_file_path)
         except OSError:
             pass
-        self.is_downloaded = False
-        self.save()
 
     def get_synced_file_path(self):
         """ Fetches the absolute file path to this ComputedFile, fetching from S3 if it

--- a/common/data_refinery_common/models/models.py
+++ b/common/data_refinery_common/models/models.py
@@ -570,6 +570,29 @@ class OriginalFile(models.Model):
         else:
             return self.filename
 
+    def sync_from_s3(self):
+        """ Downloads a file from S3 to the local file system.
+        Returns the absolute file path.
+        """
+        try:
+            S3.download_file(
+                        self.s3_bucket, 
+                        self.s3_key,
+                        self.absolute_file_path
+                    )
+            return self.absolute_file_path
+        except Exception as e:
+            logger.exception(e)
+            return None
+
+    def get_synced_file_path(self):
+        """ Fetches the absolute file path to this ComputedFile, fetching from S3 if it
+        isn't already available locally. """
+        if os.path.exists(self.absolute_file_path):
+            return self.absolute_file_path
+        else:
+            return self.sync_from_s3()
+
     def delete_local_file(self):
         """ Deletes a file from the path and actually removes it from the file system,
         resetting the is_downloaded flag to false. Can be refetched from source if needed. """

--- a/common/data_refinery_common/models/models.py
+++ b/common/data_refinery_common/models/models.py
@@ -16,12 +16,17 @@ from django.db import transaction
 from django.db import models
 from django.utils import timezone
 
+from data_refinery_common.logging import get_and_configure_logger
 from data_refinery_common.models.organism import Organism
-from data_refinery_common.utils import get_s3_url
+from data_refinery_common.utils import get_env_variable, get_s3_url
 
 # We have to set the signature_version to v4 since us-east-1 buckets require
 # v4 authentication.
 S3 = boto3.client('s3', config=Config(signature_version='s3v4'))
+
+logger = get_and_configure_logger(__name__)
+LOCAL_ROOT_DIR = get_env_variable("LOCAL_ROOT_DIR", "/home/user/data_store")
+CHUNK_SIZE = 1024 * 256 # chunk_size is in bytes
 
 """
 # First Order Classes
@@ -480,10 +485,15 @@ class OriginalFile(models.Model):
     objects = models.Manager()
     public_objects = PublicObjectsManager()
 
+    # File Properties
     filename = models.CharField(max_length=255)
     absolute_file_path = models.CharField(max_length=255, blank=True, null=True)
     size_in_bytes = models.BigIntegerField(blank=True, null=True)
     sha1 = models.CharField(max_length=64)
+
+    # AWS
+    s3_bucket = models.CharField(max_length=255, blank=True, null=True)
+    s3_key = models.CharField(max_length=255, blank=True, null=True)
 
     # Relations
     samples = models.ManyToManyField('Sample', through='OriginalFileSampleAssociation')
@@ -512,6 +522,29 @@ class OriginalFile(models.Model):
         self.last_modified = current_time
         return super(OriginalFile, self).save(*args, **kwargs)
 
+    def sync_to_s3(self, s3_bucket=None, s3_key=None) -> bool:
+        """ Syncs this OriginalFile to AWS S3.
+        """
+        self.s3_bucket = s3_bucket
+        self.s3_key = s3_key
+
+        try:
+            S3.upload_file(
+                        self.absolute_file_path, 
+                        s3_bucket, 
+                        s3_key,
+                        ExtraArgs={
+                            'ACL': 'public-read',
+                            'StorageClass': 'STANDARD_IA'
+                        }
+                    )
+            self.save()
+        except Exception as e:
+            logger.exception(e)
+            return False
+
+        return True
+
     def calculate_sha1(self) -> None:
         """ Calculate the SHA1 value of a given file.
         """
@@ -536,6 +569,17 @@ class OriginalFile(models.Model):
             return self.source_filename
         else:
             return self.filename
+
+    def delete_local_file(self):
+        """ Deletes a file from the path and actually removes it from the file system,
+        resetting the is_downloaded flag to false. Can be refetched from source if needed. """
+
+        try:
+            os.remove(self.absolute_file_path)
+        except OSError:
+            pass
+        self.is_downloaded = False
+        self.save()
 
 
 class ComputedFile(models.Model):
@@ -566,8 +610,8 @@ class ComputedFile(models.Model):
     is_qc = models.BooleanField(default=False)
 
     # AWS
-    s3_bucket = models.CharField(max_length=255)
-    s3_key = models.CharField(max_length=255)
+    s3_bucket = models.CharField(max_length=255, blank=True, null=True)
+    s3_key = models.CharField(max_length=255, blank=True, null=True)
 
     # Common Properties
     is_public = models.BooleanField(default=True)
@@ -584,12 +628,41 @@ class ComputedFile(models.Model):
 
     def sync_to_s3(self, s3_bucket=None, s3_key=None) -> bool:
         """ Syncs a file to AWS S3.
-
-        XXX: TODO!
         """
         self.s3_bucket = s3_bucket
         self.s3_key = s3_key
+
+        try:
+            S3.upload_file(
+                        self.absolute_file_path, 
+                        s3_bucket, 
+                        s3_key,
+                        ExtraArgs={
+                            'ACL': 'public-read',
+                            'StorageClass': 'STANDARD_IA'
+                        }
+                    )
+            self.save()
+        except Exception as e:
+            logger.exception(e)
+            return False
+
         return True
+
+    def sync_from_s3(self):
+        """ Downloads a file from S3 to the local file system.
+        Returns the absolute file path.
+        """
+        try:
+            S3.download_file(
+                        self.s3_bucket, 
+                        self.s3_key,
+                        self.absolute_file_path
+                    )
+            return self.absolute_file_path
+        except Exception as e:
+            logger.exception(e)
+            return None
 
     def calculate_sha1(self) -> None:
         """ Calculate the SHA1 value of a given file.
@@ -608,6 +681,24 @@ class ComputedFile(models.Model):
         self.size_in_bytes = os.path.getsize(self.absolute_file_path)
         return self.size_in_bytes
 
+    def delete_local_file(self):
+        """ Deletes a file from the path and actually removes it from the file system,
+        resetting the is_downloaded flag to false. Can be refetched from source if needed. """
+
+        try:
+            os.remove(self.absolute_file_path)
+        except OSError:
+            pass
+        self.is_downloaded = False
+        self.save()
+
+    def get_synced_file_path(self):
+        """ Fetches the absolute file path to this ComputedFile, fetching from S3 if it
+        isn't already available locally. """
+        if os.path.exists(self.absolute_file_path):
+            return self.absolute_file_path
+        else:
+            return self.sync_from_s3()
 
 class Dataset(models.Model):
     """ A Dataset is a desired set of experiments/samples to smash and download """

--- a/workers/data_refinery_workers/processors/agilent_twocolor.py
+++ b/workers/data_refinery_workers/processors/agilent_twocolor.py
@@ -26,7 +26,7 @@ def _prepare_files(job_context: Dict) -> Dict:
     job_context so everything is prepared for processing.
     """
     original_file = job_context["original_files"][0]
-    job_context["input_file_path"] = original_file.absolute_file_path
+    job_context["input_file_path"] = original_file.get_synced_file_path()
     # Turns /home/user/data_store/E-GEOD-8607/raw/foo.txt into /home/user/data_store/E-GEOD-8607/processed/foo.cel
     pre_part = original_file.absolute_file_path.split('/')[:-2]
     end_part = original_file.absolute_file_path.split('/')[-1]

--- a/workers/data_refinery_workers/processors/agilent_twocolor.py
+++ b/workers/data_refinery_workers/processors/agilent_twocolor.py
@@ -118,9 +118,8 @@ def _create_result_objects(job_context: Dict) -> Dict:
         computed_file.result = result
         computed_file.is_smashable = True
         computed_file.is_qc = False
-        # computed_file.sync_to_s3(S3_BUCKET_NAME, computed_file.sha1 + "_" + computed_file.filename)
-        # TODO here: delete local file after S3 sync
         computed_file.save()
+        job_context['computed_files'].append(computed_file)
     except Exception:
         logger.exception("Exception caught while moving file %s to S3",
                          computed_file.filename,

--- a/workers/data_refinery_workers/processors/array_express.py
+++ b/workers/data_refinery_workers/processors/array_express.py
@@ -26,7 +26,7 @@ def _prepare_files(job_context: Dict) -> Dict:
     job_context so everything is prepared for processing.
     """
     original_file = job_context["original_files"][0]
-    job_context["input_file_path"] = original_file.absolute_file_path
+    job_context["input_file_path"] = original_file.get_synced_file_path()
     # This is ugly, I'm sorry.
     # Turns /home/user/data_store/E-GEOD-8607/raw/foo.cel into /home/user/data_store/E-GEOD-8607/processed/foo.cel
     pre_part = original_file.absolute_file_path.split('/')[:-2]

--- a/workers/data_refinery_workers/processors/array_express.py
+++ b/workers/data_refinery_workers/processors/array_express.py
@@ -169,9 +169,8 @@ def _create_result_objects(job_context: Dict) -> Dict:
         computed_file.result = result
         computed_file.is_smashable = True
         computed_file.is_qc = False
-        # computed_file.sync_to_s3(S3_BUCKET_NAME, computed_file.sha1 + "_" + computed_file.filename)
-        # TODO here: delete local file after S3 sync
         computed_file.save()
+        job_context['computed_files'].append(computed_file)
     except Exception:
         logger.exception("Exception caught while saving file %s to S3",
                          computed_file.filename,

--- a/workers/data_refinery_workers/processors/illumina.py
+++ b/workers/data_refinery_workers/processors/illumina.py
@@ -352,6 +352,7 @@ def _create_result_objects(job_context: Dict) -> Dict:
         computed_file.calculate_sha1()
         computed_file.calculate_size()
         computed_file.save()
+        job_context['computed_files'].append(computed_file)
 
         SampleResultAssociation.objects.get_or_create(
             sample=sample,

--- a/workers/data_refinery_workers/processors/illumina.py
+++ b/workers/data_refinery_workers/processors/illumina.py
@@ -43,7 +43,7 @@ def _prepare_files(job_context: Dict) -> Dict:
     job_context so everything is prepared for processing.
     """
     original_file = job_context["original_files"][0]
-    job_context["input_file_path"] = original_file.absolute_file_path
+    job_context["input_file_path"] = original_file.get_synced_file_path()
     # Turns /home/user/data_store/E-GEOD-8607/raw/foo.txt into /home/user/data_store/E-GEOD-8607/processed/foo.cel
     pre_part = original_file.absolute_file_path.split('/')[:-2] # Cut off '/raw'
     end_part = original_file.absolute_file_path.split('/')[-1] # Get the filename

--- a/workers/data_refinery_workers/processors/salmon.py
+++ b/workers/data_refinery_workers/processors/salmon.py
@@ -55,9 +55,9 @@ def _prepare_files(job_context: Dict) -> Dict:
     logger.debug("Preparing files..")
 
     original_files = job_context["original_files"]
-    job_context["input_file_path"] = original_files[0].absolute_file_path
+    job_context["input_file_path"] = original_files[0].get_synced_file_path()
     if len(original_files) == 2:
-        job_context["input_file_path_2"] = original_files[1].absolute_file_path
+        job_context["input_file_path_2"] = original_files[1].get_synced_file_path()
 
     # There should only ever be one per Salmon run
     job_context['sample'] = job_context['original_files'][0].samples.first()
@@ -497,7 +497,7 @@ def _run_fastqc(job_context: Dict) -> Dict:
 
     # We could use --noextract here, but MultiQC wants extracted files.
     command_str = ("./FastQC/fastqc --outdir={qc_directory} {files}")
-    files = ' '.join(file.absolute_file_path for file in job_context['original_files'])
+    files = ' '.join(file.get_synced_file_path() for file in job_context['original_files'])
     formatted_command = command_str.format(qc_directory=job_context["qc_directory"],
                 files=files)
 

--- a/workers/data_refinery_workers/processors/test_salmon.py
+++ b/workers/data_refinery_workers/processors/test_salmon.py
@@ -168,7 +168,8 @@ class SalmonTestCase(TestCase):
             'input_file_path_2': os.path.join(experiment_dir, 'raw/reads_2.fastq'),
             'index_directory': os.path.join(experiment_dir, 'index'),
             'output_directory': os.path.join(sample_dir, 'processed'),
-            'success': True
+            'success': True,
+            'computed_files': []
         }
         # Check quant.sf in `salmon quant` output dir
         self.chk_salmon_quant(job_context, sample_dir)
@@ -235,7 +236,8 @@ class SalmonTestCase(TestCase):
             'genes_to_transcripts_path': os.path.join(experiment_dir, 'index',
                                                       'genes_to_transcripts.txt'),
             'output_directory': os.path.join(sample2_dir, 'processed'),
-            'success': True
+            'success': True,
+            'computed_files': []
         }
 
         # Check quant.sf in `salmon quant` output dir of sample2
@@ -280,7 +282,8 @@ class SalmonTestCase(TestCase):
             'job_id': 'hippityhoppity',
             'qc_directory': "/home/user/data_store/raw/TEST/SALMON/derp",
             'original_files': [],
-            'success': True
+            'success': True,
+            'computed_files': []
         }
         fail = salmon._run_fastqc(fail_context)
         self.assertFalse(fail['success'])
@@ -329,7 +332,8 @@ class SalmonToolsTestCase(TestCase):
         job_context = {
             'job_id': 456,
             'input_file_path': self.test_dir + 'single_input/single_read.fastq',
-            'output_directory': self.test_dir + 'single_output/'
+            'output_directory': self.test_dir + 'single_output/',
+            'computed_files': []
         }
         job_context["job"] = ProcessorJob()
 
@@ -366,7 +370,8 @@ class TximportTestCase(TestCase):
     def test_tximport_experiment(self):
         job_context = {
             'job_id': 456,
-            'genes_to_transcripts_path': '/home/user/data_store/tximport_test/np_gene2txmap.txt'
+            'genes_to_transcripts_path': '/home/user/data_store/tximport_test/np_gene2txmap.txt',
+            'computed_files': []
         }
         job_context["job"] = ProcessorJob()
 

--- a/workers/data_refinery_workers/processors/test_smasher.py
+++ b/workers/data_refinery_workers/processors/test_smasher.py
@@ -629,3 +629,34 @@ class SmasherTestCase(TestCase):
         import sklearn
         import sympy
 
+    @tag("smasher")
+    def test_get_synced_files(self):
+        """ """
+        result = ComputationalResult()
+        result.save()
+
+        computed_file = ComputedFile()
+        computed_file.s3_key = "all_the_things.jpg"
+        computed_file.s3_bucket = "data-refinery-test-assets"
+        computed_file.filename = "all_the_things.jpg"
+        computed_file.absolute_file_path = "/home/user/data_store/PCL/" + computed_file.filename
+        computed_file.result = result
+        computed_file.size_in_bytes = 9000
+        computed_file.is_smashable = False
+        computed_file.save()
+
+        # Make sure it's not there
+        try:
+            os.remove("/home/user/data_store/PCL/" + computed_file.filename)
+        except OSError:
+            pass
+
+        afp = computed_file.get_synced_file_path()
+        self.assertTrue(os.path.exists(afp))
+
+        afp = computed_file.get_synced_file_path()
+        self.assertTrue(os.path.exists(afp))
+
+        computed_file.delete_local_file()
+        self.assertFalse(os.path.exists(afp))
+

--- a/workers/data_refinery_workers/processors/test_transcriptome_index.py
+++ b/workers/data_refinery_workers/processors/test_transcriptome_index.py
@@ -71,7 +71,7 @@ class TXTestCase(TestCase):
         og_file2.source_url = "ftp://ftp.ensemblgenomes.org/pub/release-39/plants/gtf/aegilops_tauschii/Aegilops_tauschii.ASM34733v1.39.gtf.gz"
         og_file2.source_filename = "aegilops_tauschii_short.gtf.gz"
 
-        job_context = {"original_files": [og_file, og_file2]}
+        job_context = {"original_files": [og_file, og_file2], "computed_files": []}
         job_context = transcriptome_index._extract_assembly_version(job_context)
         self.assertEqual("39", job_context["assembly_version"])
 

--- a/workers/data_refinery_workers/processors/transcriptome_index.py
+++ b/workers/data_refinery_workers/processors/transcriptome_index.py
@@ -317,9 +317,8 @@ def _populate_index_object(job_context: Dict) -> Dict:
     computed_file.result = result
     computed_file.is_smashable = False
     computed_file.is_qc = False
-    #computed_file.sync_to_s3(S3_BUCKET_NAME, computed_file.sha1 + "_" + computed_file.filename)
-    # TODO here: delete local file after S3 sync
     computed_file.save()
+    job_context['computed_files'].append(computed_file)
 
     organism_object = Organism.get_object_for_name(job_context['organism_name'])
     index_object = OrganismIndex()

--- a/workers/data_refinery_workers/processors/utils.py
+++ b/workers/data_refinery_workers/processors/utils.py
@@ -12,11 +12,12 @@ from data_refinery_common.models import (
     ProcessorJobDatasetAssociation,
     OriginalFileSampleAssociation
 )
-from data_refinery_common.utils import get_worker_id
 from data_refinery_workers._version import __version__
 from data_refinery_common.logging import get_and_configure_logger
+from data_refinery_common.utils import get_worker_id, get_env_variable
 
 logger = get_and_configure_logger(__name__)
+S3_BUCKET_NAME = get_env_variable("S3_BUCKET_NAME", "data-refinery")
 
 
 def start_job(job_context: Dict):

--- a/workers/data_refinery_workers/processors/utils.py
+++ b/workers/data_refinery_workers/processors/utils.py
@@ -1,3 +1,4 @@
+import random
 import string
 
 from typing import List, Dict, Callable


### PR DESCRIPTION
## Issue Number

n/a

## Purpose/Implementation Notes

Uploads results of scrapes and computations to AWS S3 Infrequent Access. Downloads ComputedFiles as necessary at smashtime.

OriginalFiles in addition to ComputedFiles are both synced. For the 3-million crunch, we'll want to switch this to simply deleting the OriginalFiles on disk once they're not needed anymore, without any S3 syncing, as it's actually cheaper to rescrape than it is to store them on disk. We will need special considerations for Salmon, as `tximport` requires OriginalFiles survive until all the samples in an experiment are available (I think).

This change will save a projected $22,000,000 annually over the previous method.

## Types of changes

- New feature (non-breaking change which adds functionality)

## Functional tests

New test case added.

## Checklist

_Put an `x` in the boxes that apply._

- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules
