### PR TITLE
Sends exception info into sentry from the API.

### DIFF
--- a/api/data_refinery_api/middleware.py
+++ b/api/data_refinery_api/middleware.py
@@ -30,3 +30,17 @@ class SentryCatchBadRequestMiddleware(MiddlewareMixin):
         result = client.captureMessage(message=message, data=data)
 
         return response
+
+    def process_exception(self, request, exception):
+        from raven.contrib.django.models import client
+
+        if not client.is_enabled():
+            return
+
+        data = client.get_data_from_request(request)
+        data.update({
+            "level": logging.WARN,
+            "logger": "BadRequestMiddleware",
+        })
+
+        client.captureMessage(message=str(exception), data=data)


### PR DESCRIPTION
## Issue Number

N/A

## Purpose/Implementation Notes

While trying to debug an issue with requesting a dataset, I found that I could not see the stack trace for the exception triggered by the `Submit` button. Therefore I've added some additional middleware code to capture the exception information for bad requests.

Here is an example I triggered on my local server (configured to use the staging API Sentry project for testing): https://sentry.io/greenelab/staging-refinebio-api/issues/607845320

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

I wasn't able to get a unit test to trigger my process_exception function. My suspicion is that there's different Django magic at play during tests, but I don't really know. I've typed up a description of what I've tried into this [stackoverflow post]() and if someone comes along and answers it I'll use that information to add a unit test.

As mentioned above I have actually tested this while running the server locally though.

## Checklist

- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules
