### PR TITLE
Taints the API server during deploys so a new container will start

### DIFF
--- a/.circleci/update_docker_img.sh
+++ b/.circleci/update_docker_img.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -e
 
 # Load docker_img_exists function
 source ~/refinebio/common.sh
@@ -66,7 +67,7 @@ done
 
 # Build and push foreman image
 FOREMAN_DOCKER_IMAGE="$DOCKERHUB_REPO/dr_foreman"
-docker build -t "$FOREMAN_DOCKER_IMAGE:$CIRCLE_TAG" -f foreman/dockerfiles.foreman .
+docker build -t "$FOREMAN_DOCKER_IMAGE:$CIRCLE_TAG" -f foreman/dockerfiles/Dockerfile.foreman .
 docker push "$FOREMAN_DOCKER_IMAGE:$CIRCLE_TAG"
 # Update latest version
 docker tag "$FOREMAN_DOCKER_IMAGE:$CIRCLE_TAG" "$FOREMAN_DOCKER_IMAGE:latest"

--- a/infrastructure/deploy.sh
+++ b/infrastructure/deploy.sh
@@ -198,6 +198,9 @@ for nomad_job_spec in $nomad_job_specs; do
     nomad run $nomad_job_spec
 done
 
+# Ensure the latest image version is being used for the API and the Foreman
+terraform taint aws_instance.api_server_1
+
 # Remove the ingress config so the next `terraform apply` will remove
 # access for Circle.
 echo "Removing ingress.."


### PR DESCRIPTION
## Issue Number

N/A

## Purpose/Implementation Notes

I ran a deployment but my new API code didn't make it out. I realized that it's cause the server never got restarted. This makes the server restart.

This perhaps could be done in a way which results in less downtime if we ssh'd onto the API server and used `docker restart` but that seems like it'd be more brittle and not the right way to avoid downtime anyway.

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

I ssh'd onto a circleci box and ran these commands manually and saw the API server get restarted as a result.

## Checklist

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules
