### PR TITLE
Prettier handling of null organisms

### DIFF
--- a/api/data_refinery_api/views.py
+++ b/api/data_refinery_api/views.py
@@ -142,6 +142,12 @@ class SearchAndFilter(generics.ListAPIView):
 
         organisms = qs.values('organisms__name').annotate(Count('organisms__name', unique=True))
         for organism in organisms:
+
+            # This experiment has no ExperimentOrganism-association, which is bad.
+            # This information may still live on the samples though.
+            if not organism['organisms__name']:
+                continue
+
             response.data['filters']['organism'][organism['organisms__name']] = organism['organisms__name__count']
 
         return response

--- a/common/data_refinery_common/models/models.py
+++ b/common/data_refinery_common/models/models.py
@@ -263,6 +263,7 @@ class Experiment(models.Model):
         metadata = {}
         metadata['title'] = self.title
         metadata['accession_code'] = self.accession_code
+        metadata['organisms'] = self.organisms
         metadata['description'] = self.description
         metadata['protocol_description'] = self.protocol_description
         metadata['technology'] = self.technology


### PR DESCRIPTION
## Issue Number

https://github.com/AlexsLemonade/refinebio-frontend/issues/108

## Purpose/Implementation Notes

Doesn't return `null` organisms, however the fact that these were being returned at all suggests that there is an underlying data problem that this PR doesn't address (in particular, a missing `ExperimentOrganismAssociation`, which if I remember was added so that we could have this feature in the first place).

## Types of changes
- Bugfix (non-breaking change which fixes an issue)

## Functional tests

New assertions added.

## Checklist

_Put an `x` in the boxes that apply._

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules
