### PR TITLE
Ensembl adds organisms sometimes, so let's not check hard numbers.

### DIFF
--- a/foreman/data_refinery_foreman/surveyor/test_transcriptome_index.py
+++ b/foreman/data_refinery_foreman/surveyor/test_transcriptome_index.py
@@ -31,7 +31,7 @@ class SurveyTestCase(TestCase):
         surveyor.survey(source_type="TRANSCRIPTOME_INDEX")
 
         downloader_jobs = DownloaderJob.objects.order_by("id").all()
-        self.assertEqual(downloader_jobs.count(), 53)
+        self.assertGreater(downloader_jobs.count(), 50)
         send_job_calls = []
         for downloader_job in downloader_jobs:
             send_job_calls.append(


### PR DESCRIPTION
## Issue Number

N/A

## Purpose/Implementation Notes

This test broke because Ensembl added some more organisms to their Plant division. This will happen over time, so we should just not check hard numbers and instead make sure we're generating a lot of jobs for them.

Broken build: https://circleci.com/gh/AlexsLemonade/refinebio/3723

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

This is a unit test fix.

## Checklist

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules
