### PR TITLE
Allow API to nomad API communication

### DIFF
--- a/infrastructure/networking.tf
+++ b/infrastructure/networking.tf
@@ -61,7 +61,6 @@ resource "aws_route_table" "data_refinery" {
   }
 }
 
-
 resource "aws_route_table_association" "data_refinery_1a" {
   subnet_id      = "${aws_subnet.data_refinery_1a.id}"
   route_table_id = "${aws_route_table.data_refinery.id}"
@@ -178,7 +177,6 @@ resource "aws_acm_certificate" "ssl-cert" {
     Environment = "data-refinery-circleci-staging"
   }
 }
-
 
 resource "aws_cloudfront_distribution" "static-distribution" {
   aliases = ["${var.static_bucket_prefix == "dev" ? var.user : var.static_bucket_prefix}${var.static_bucket_root}"]

--- a/infrastructure/security.tf
+++ b/infrastructure/security.tf
@@ -57,7 +57,8 @@ resource "aws_security_group_rule" "data_refinery_worker_nomad" {
 }
 
 # Allow the Nomad HTTP API to be accessible by the API security group. See:
-resource "aws_security_group_rule" "data_refinery_worker_nomad" {
+# https://www.nomadproject.io/guides/cluster/requirements.html#ports-used
+resource "aws_security_group_rule" "data_refinery_api_nomad" {
   type = "ingress"
   from_port = 4646
   to_port = 4646

--- a/infrastructure/security.tf
+++ b/infrastructure/security.tf
@@ -56,6 +56,16 @@ resource "aws_security_group_rule" "data_refinery_worker_nomad" {
   security_group_id = "${aws_security_group.data_refinery_worker.id}"
 }
 
+# Allow the Nomad HTTP API to be accessible by the API security group. See:
+resource "aws_security_group_rule" "data_refinery_worker_nomad" {
+  type = "ingress"
+  from_port = 4646
+  to_port = 4646
+  protocol = "tcp"
+  self = true
+  security_group_id = "${aws_security_group.data_refinery_api.id}"
+}
+
 # Allow Nomad RPC calls to go through to each other. See:
 # https://www.nomadproject.io/guides/cluster/requirements.html#ports-used
 resource "aws_security_group_rule" "data_refinery_worker_nomad_rpc" {


### PR DESCRIPTION
## Issue Number

https://github.com/AlexsLemonade/refinebio-frontend/issues/155

## Purpose/Implementation Notes

Allows the API security group to talk to the nomad server group on port 4646 so we can dispatch Nomad jobs.

## Types of changes
- Bugfix (non-breaking change which fixes an issue)

## Functional tests
I haven't tried this yet. My gut says this is the problem.

## Checklist

- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules
