### PR TITLE
Make it so that a nomad job being collected mid nomad purge doesn't b…

### DIFF
--- a/infrastructure/deploy.sh
+++ b/infrastructure/deploy.sh
@@ -141,7 +141,7 @@ echo "Killing base jobs.."
 if [[ $(nomad status) != "No running jobs" ]]; then
     for job in $(nomad status | grep running | awk {'print $1'} || grep --invert-match /)
     do
-        nomad stop -purge -detach $job > /dev/null
+        nomad stop -purge -detach $job > /dev/null || true
     done
 fi
 
@@ -153,7 +153,7 @@ if [[ $(nomad status) != "No running jobs" ]]; then
     do
         # Skip the header row for jobs.
         if [ $job != "ID" ]; then
-            nomad stop -purge -detach $job > /dev/null
+            nomad stop -purge -detach $job > /dev/null || true
         fi
     done
 fi

--- a/infrastructure/deploy.sh
+++ b/infrastructure/deploy.sh
@@ -141,6 +141,8 @@ echo "Killing base jobs.."
 if [[ $(nomad status) != "No running jobs" ]]; then
     for job in $(nomad status | grep running | awk {'print $1'} || grep --invert-match /)
     do
+        # '|| true' so that if a job is garbage collected before we can remove it the error
+        # doesn't interrupt our deploy.
         nomad stop -purge -detach $job > /dev/null || true
     done
 fi
@@ -153,6 +155,8 @@ if [[ $(nomad status) != "No running jobs" ]]; then
     do
         # Skip the header row for jobs.
         if [ $job != "ID" ]; then
+            # '|| true' so that if a job is garbage collected before we can remove it the error
+            # doesn't interrupt our deploy.
             nomad stop -purge -detach $job > /dev/null || true
         fi
     done


### PR DESCRIPTION
…reak deploys.

## Issue Number

N/A

## Purpose/Implementation Notes

I did a manual deploy so it'd be faster but it died because it couldn't find one of the jobs. I suspect this is because nomad garbage collected that job in between when we discovered it and when our loop got to it. This just makes it so that a job being missing won't trigger an error and therefore won't interrupt our deploy.

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

None because this can only get tested via deploy, but it's basic bash so I'm confidant.

## Checklist

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules
