### PR TITLE
Bump uWSGI buffer size to 32768

### DIFF
--- a/api/serve_production.sh
+++ b/api/serve_production.sh
@@ -28,4 +28,4 @@ docker run \
        --link drdb:postgres \
        -v "$STATIC_VOLUMES":/tmp/www/static \
        -p 8081:8081 \
-       -it -d ccdlstaging/api_production /bin/sh -c "/home/user/collect_and_run_uwsgi.sh"
+       -it -d ccdlstaging/dr_api_production /bin/sh -c "/home/user/collect_and_run_uwsgi.sh"

--- a/api/uwsgi.ini
+++ b/api/uwsgi.ini
@@ -8,4 +8,5 @@ max-requests=5000
 master = 1
 processes = 2
 threads = 2
+buffer-size = 32768
 


### PR DESCRIPTION
## Issue Number

https://github.com/AlexsLemonade/refinebio-frontend/issues/121

## Purpose/Implementation Notes

uWSGI barfs on large requests by default. This raises that limit.  Also fixes `serve_production.sh` script.

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests
Verified the cause and effect locally.

## Checklist

_Put an `x` in the boxes that apply._

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules
