### PR TITLE
Add "organisms__name" filter in SearchResult API

### DIFF
--- a/api/data_refinery_api/tests.py
+++ b/api/data_refinery_api/tests.py
@@ -253,8 +253,8 @@ class APITestCases(APITestCase):
         ex3.accession_code = "FINDME3"
         ex3.title = "THISWILLBEINASEARCHRESULT"
         ex3.description = "SOWILLTHIS"
-        ex2.technology = "FAKE-TECH"
-        ex2.submitter_institution = "Utopia"
+        ex3.technology = "FAKE-TECH"
+        ex3.submitter_institution = "Utopia"
         experiments.append(ex3)
 
         sample1 = Sample()

--- a/api/data_refinery_api/views.py
+++ b/api/data_refinery_api/views.py
@@ -107,15 +107,16 @@ class SearchAndFilter(generics.ListAPIView):
     pagination_class = LimitOffsetPagination
 
     filter_backends = (DjangoFilterBackend, filters.SearchFilter,)
-    search_fields = (   'title', 
-                        '@description', 
-                        '@accession_code', 
-                        '@protocol_description', 
+    search_fields = (   'title',
+                        '@description',
+                        '@accession_code',
+                        '@protocol_description',
                         '@publication_title',
                         'publication_doi',
                         'pubmed_id'
                     )
-    filter_fields = ('has_publication', 'submitter_institution', 'technology', 'source_first_published')
+    filter_fields = ('has_publication', 'submitter_institution', 'technology',
+                     'source_first_published', 'organisms__name')
 
 
     def list(self, request, *args, **kwargs):
@@ -131,6 +132,8 @@ class SearchAndFilter(generics.ListAPIView):
 
         techs = qs.values('technology').annotate(Count('technology', unique=True))
         for tech in techs:
+            if not tech['technology'] or not tech['technology'].strip():
+                continue
             response.data['filters']['technology'][tech['technology']] = tech['technology__count']
 
         pubs = qs.values('has_publication').annotate(Count('has_publication', unique=True))


### PR DESCRIPTION
## Issue Number
This is the backend fix for:
https://github.com/AlexsLemonade/refinebio-frontend/issues/108

## Purpose/Implementation Notes

(1) Add `organisms__name` filter
(2) Skip `technology` counter if it is None or a string of white space characters only.

## Types of changes

What types of changes does your code introduce?

<!-- Remove any which your PR isn't -->
- Bugfix (non-breaking change which fixes an issue)

## Checklist

_Put an `x` in the boxes that apply._

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

