### PR TITLE
Serialize Objects Name, Not Object Manager

### DIFF
--- a/common/data_refinery_common/models/models.py
+++ b/common/data_refinery_common/models/models.py
@@ -265,7 +265,7 @@ class Experiment(models.Model):
         metadata = {}
         metadata['title'] = self.title
         metadata['accession_code'] = self.accession_code
-        metadata['organisms'] = self.organisms
+        metadata['organisms'] = [organism.name for organism in self.organisms.all()]
         metadata['description'] = self.description
         metadata['protocol_description'] = self.protocol_description
         metadata['technology'] = self.technology


### PR DESCRIPTION
## Issue Number

n/a

## Purpose/Implementation Notes

JSON couldn't serialize an object manager. This preserializes it and fixes the test.

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

Yarp
