### PR TITLE
Make sure that config is on every docker image.

### DIFF
--- a/api/dockerfiles/Dockerfile.api_local
+++ b/api/dockerfiles/Dockerfile.api_local
@@ -5,6 +5,8 @@ WORKDIR /home/user
 
 RUN pip install --upgrade pip
 
+COPY config/ config/
+
 COPY api/requirements.txt .
 
 RUN pip install -r requirements.txt

--- a/api/dockerfiles/Dockerfile.api_production
+++ b/api/dockerfiles/Dockerfile.api_production
@@ -3,6 +3,8 @@ FROM python:3.6.1
 RUN groupadd user && useradd --create-home --home-dir /home/user -g user user
 WORKDIR /home/user
 
+COPY config/ config/
+
 COPY api/requirements.txt .
 
 RUN pip install -r requirements.txt

--- a/workers/dockerfiles/Dockerfile.affymetrix
+++ b/workers/dockerfiles/Dockerfile.affymetrix
@@ -50,6 +50,8 @@ RUN pip3 install pip --upgrade
 RUN pip3 install setuptools --upgrade && \
   rm -rf /root/.cache
 
+COPY config/ config/
+
 COPY common/dist/data-refinery-common-* common/
 
 # Get the latest version from the dist directory.

--- a/workers/dockerfiles/Dockerfile.illumina
+++ b/workers/dockerfiles/Dockerfile.illumina
@@ -43,6 +43,8 @@ RUN Rscript illumina_dependencies.R
 
 RUN pip3 install --upgrade pip
 
+COPY config/ config/
+
 COPY workers/data_refinery_workers/processors/requirements.txt .
 
 RUN  pip3 --no-cache-dir install -r requirements.txt
@@ -61,4 +63,3 @@ COPY workers/data_refinery_workers/processors/detect_database.R .
 COPY workers/ .
 
 ENTRYPOINT []
-

--- a/workers/dockerfiles/Dockerfile.salmon
+++ b/workers/dockerfiles/Dockerfile.salmon
@@ -63,6 +63,8 @@ RUN unzip fastqc_v0.11.7.zip
 RUN chmod +x ./FastQC/fastqc
 RUN rm -f fastqc_v0.11.7.zip
 
+COPY config/ config/
+
 COPY workers/data_refinery_workers/processors/requirements.txt .
 
 RUN pip3 install -r requirements.txt

--- a/workers/dockerfiles/Dockerfile.smasher
+++ b/workers/dockerfiles/Dockerfile.smasher
@@ -28,6 +28,8 @@ RUN pip3 install --upgrade pip
 RUN pip3 install numpy scipy matplotlib pandas==0.23.1 scikit-learn sympy nose
 # End smasher-specific
 
+COPY config/ config/
+
 COPY workers/data_refinery_workers/processors/requirements.txt .
 
 RUN  pip3 --no-cache-dir install -r requirements.txt

--- a/workers/dockerfiles/Dockerfile.transcriptome
+++ b/workers/dockerfiles/Dockerfile.transcriptome
@@ -58,6 +58,8 @@ RUN rm -r Salmon*
 
 RUN pip3 install --upgrade pip
 
+COPY config/ config/
+
 COPY workers/data_refinery_workers/processors/requirements.txt .
 
 RUN  pip3 --no-cache-dir install -r requirements.txt


### PR DESCRIPTION
## Issue Number

https://sentry.io/greenelab/staging-refinebio/issues/612490086/?query=is:unresolved failed because of not being able to lookup an accession code. Turns out this fix isn't actually related because the no_op image actually had the config in it already, but it's what made me realize we should probably make this change.

## Purpose/Implementation Notes

Every image we have has access to code which relies on the config directory. They may not have actually been calling it so it may not have been an issue, but they can and so it will be much better if they all do.

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

None because this only adds the config, it can't break anything.

## Checklist

- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules
