### PR TITLE
Kurtwheeler match internal accessions

### DIFF
--- a/common/data_refinery_common/test_utils.py
+++ b/common/data_refinery_common/test_utils.py
@@ -65,6 +65,13 @@ class UtilsTestCase(TestCase):
         self.assertTrue(has_A_AFFY_59)
         self.assertTrue(has_GPL23026)
 
+    def test_get_internal_microarray_accession(self):
+        """Test that supported microarray platforms setting is set correctly."""
+
+        self.assertEqual(utils.get_internal_microarray_accession("hgu133a"), "hgu133a")
+        self.assertEqual(utils.get_internal_microarray_accession("A-AFFY-59"), "soybean")
+        self.assertEqual(utils.get_internal_microarray_accession("GPL23026"), "Illumina_HumanHT-12_V4.0")
+
     def test_supported_rnaseq_platforms(self):
         """Test that supported RNASeq platforms setting is set correctly."""
         self.assertTrue("Illumina HiSeq 1000" in utils.get_supported_rnaseq_platforms())

--- a/common/data_refinery_common/utils.py
+++ b/common/data_refinery_common/utils.py
@@ -135,9 +135,10 @@ def get_readable_affymetrix_names(mapping_csv: str="config/readable_affymetrix_n
 def get_internal_microarray_accession(accession_code):
     platforms = get_supported_microarray_platforms()
 
-    all_c = []
     for platform in platforms:
         if platform['external_accession'] == accession_code:
+            return platform['platform_accession']
+        elif platform['platform_accession'] == accession_code:
             return platform['platform_accession']
 
     return None


### PR DESCRIPTION
## Issue Number

https://sentry.io/greenelab/staging-refinebio/issues/612490086/?query=is:unresolved

## Purpose/Implementation Notes

We try to translate external platform accession codes to a common representation we call internal accession codes. However if we end up with an accession code which is already internal, we fail to match it. This makes us able to match those.

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

New test case.

## Checklist

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules
