### PR TITLE
Sets Smash Priority to 100 and All Other Priorities to 50

### DIFF
--- a/workers/nomad-job-specs/affymetrix.nomad.tpl
+++ b/workers/nomad-job-specs/affymetrix.nomad.tpl
@@ -2,6 +2,7 @@ job "AFFY_TO_PCL_${{RAM}}" {
   datacenters = ["dc1"]
 
   type = "batch"
+  priority = 50
 
   parameterized {
     payload       = "forbidden"

--- a/workers/nomad-job-specs/downloader.nomad.tpl
+++ b/workers/nomad-job-specs/downloader.nomad.tpl
@@ -2,6 +2,7 @@ job "DOWNLOADER" {
   datacenters = ["dc1"]
 
   type = "batch"
+  priority = 50
 
   parameterized {
     payload       = "forbidden"

--- a/workers/nomad-job-specs/illumina.nomad.tpl
+++ b/workers/nomad-job-specs/illumina.nomad.tpl
@@ -2,6 +2,7 @@ job "ILLUMINA_TO_PCL_${{RAM}}" {
   datacenters = ["dc1"]
 
   type = "batch"
+  priority = 50
 
   parameterized {
     payload       = "forbidden"

--- a/workers/nomad-job-specs/no_op.nomad.tpl
+++ b/workers/nomad-job-specs/no_op.nomad.tpl
@@ -2,6 +2,7 @@ job "NO_OP_${{RAM}}" {
   datacenters = ["dc1"]
 
   type = "batch"
+  priority = 50
 
   parameterized {
     payload       = "forbidden"

--- a/workers/nomad-job-specs/salmon.nomad.tpl
+++ b/workers/nomad-job-specs/salmon.nomad.tpl
@@ -2,6 +2,7 @@ job "SALMON_${{RAM}}" {
   datacenters = ["dc1"]
 
   type = "batch"
+  priority = 50
 
   parameterized {
     payload       = "forbidden"

--- a/workers/nomad-job-specs/smasher.nomad.tpl
+++ b/workers/nomad-job-specs/smasher.nomad.tpl
@@ -2,7 +2,7 @@ job "SMASHER_${{RAM}}" {
   datacenters = ["dc1"]
 
   type = "batch"
-  priority = 100
+  priority = 75 
 
   parameterized {
     payload       = "forbidden"

--- a/workers/nomad-job-specs/smasher.nomad.tpl
+++ b/workers/nomad-job-specs/smasher.nomad.tpl
@@ -2,6 +2,7 @@ job "SMASHER_${{RAM}}" {
   datacenters = ["dc1"]
 
   type = "batch"
+  priority = 100
 
   parameterized {
     payload       = "forbidden"

--- a/workers/nomad-job-specs/transcriptome.nomad.tpl
+++ b/workers/nomad-job-specs/transcriptome.nomad.tpl
@@ -2,6 +2,7 @@ job "TRANSCRIPTOME_INDEX_${{RAM}}" {
   datacenters = ["dc1"]
 
   type = "batch"
+  priority = 50
 
   parameterized {
     payload       = "forbidden"


### PR DESCRIPTION
## Issue Number

n/a

## Purpose/Implementation Notes

Scraping and processing can happen at their own pace, but people who are smashing need the data as soon as possible. This will create a priority for Smash over Crunch.

I have no idea what these values actually mean, and I can't find any documentation about it. I assume assuming that 100 good, 50 less good.

## Types of changes
- Bugfix (non-breaking change which fixes an issue)

## Functional tests
No

## Checklist

_Put an `x` in the boxes that apply._

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules
