### PR TITLE
Make Transcriptome Index Processing Higher Priority than Other Jobs

### DIFF
--- a/workers/nomad-job-specs/transcriptome.nomad.tpl
+++ b/workers/nomad-job-specs/transcriptome.nomad.tpl
@@ -2,7 +2,7 @@ job "TRANSCRIPTOME_INDEX_${{RAM}}" {
   datacenters = ["dc1"]
 
   type = "batch"
-  priority = 50
+  priority = 65
 
   parameterized {
     payload       = "forbidden"


### PR DESCRIPTION
## Issue Number
n/a

## Purpose/Implementation Notes

Similar to prioritizing Smasher jobs over all, we want to prioritize txindex jobs over Salmon jobs so that the required indexes are always available.

## Types of changes

- Bugfix (non-breaking change which fixes an issue)
