### PR TITLE
Kurtwheeler fix gene conversion

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,6 +50,9 @@ jobs:
           command: .circleci/filter_tests.sh -t downloaders
           no_output_timeout: 36000
 
+      # Run NO_OP tests
+      -run: .circleci/filter_tests.sh -t no_op
+
       # Push the no_op and downloader images to the local docker repo so Nomad
       # can pull from there when running end-to-end tests.
       - run: docker push localhost:5000/dr_downloaders

--- a/workers/data_refinery_workers/processors/no_op.py
+++ b/workers/data_refinery_workers/processors/no_op.py
@@ -101,7 +101,7 @@ def _convert_genes(job_context: Dict) -> Dict:
 def _convert_affy_genes(job_context: Dict) -> Dict:
     """ Convert to Ensembl genes if we can"""
 
-    gene_index_path = "/home/user/data_store/" + job_context["internal_accession"] + ".tsv.gz"
+    gene_index_path = "/home/user/gene_indexes/" + job_context["internal_accession"] + ".tsv.gz"
     if not os.path.exists(gene_index_path):
         logger.error("Missing gene index file for platform!",
             platform=job_context["internal_accession"],


### PR DESCRIPTION
## Issue Number

N/A

## Purpose/Implementation Notes

I noticed an error log in the staging logs that said it couldn't find a gene conversion file for `hgu133aplus2`, which is definitely a platform we support.

It turns out the directory path for those files was wrong, and worse our `no_op` tests weren't being run in circleCI.

There's another bug in `gene_convert.R` that will prevent these tests from passing, but I believe another PR will address those.

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

It doesn't work yet.

## Checklist

- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules
