### PR TITLE
Don't send 404s to sentry.

### DIFF
--- a/api/data_refinery_api/middleware.py
+++ b/api/data_refinery_api/middleware.py
@@ -3,7 +3,7 @@ from django.utils.deprecation import MiddlewareMixin
 
 class SentryCatchBadRequestMiddleware(MiddlewareMixin):
     def process_response(self, request, response):
-        if response.status_code < 400:
+        if response.status_code < 400 or response.status_code == 404:
             return response
 
         from raven.contrib.django.models import client

--- a/api/data_refinery_api/tests.py
+++ b/api/data_refinery_api/tests.py
@@ -427,13 +427,13 @@ class APITestCases(APITestCase):
         mock_client.is_enabled.side_effect = lambda: True
         response = self.client.get(reverse('experiments_detail', kwargs={'pk': '1000'}))
         self.assertEqual(response.status_code, 404)
-        mock_client.captureMessage.assert_called()
+        mock_client.captureMessage.assert_not_called()
 
         # A 404 with raven enabled will send a message to sentry
         mock_client.is_enabled.side_effect = lambda: True
         response = self.client.get(reverse('experiments_detail', kwargs={'pk': '1000'})[:-1] + "aasdas/")
         self.assertEqual(response.status_code, 404)
-        mock_client.captureMessage.assert_called()
+        mock_client.captureMessage.assert_not_called()
 
     @patch.object(ExperimentList, 'get')
     @patch('raven.contrib.django.models.client')


### PR DESCRIPTION
## Issue Number

N/A

## Purpose/Implementation Notes

We're getting a ton of 404 errors in sentry about people trying to scrape for common vulnerabilities. This is spammy so I'm filtering out the 404s.

## Types of changes

- New feature (non-breaking change which adds functionality)

## Functional tests

I configured raven on my local server and hit some bad routes and nothing went to sentry.
Also unit tests.

## Checklist

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules

