### PR TITLE
Replace Management Command Return Codes with Sys Exits

### DIFF
--- a/foreman/data_refinery_foreman/surveyor/management/commands/survey_array_express.py
+++ b/foreman/data_refinery_foreman/surveyor/management/commands/survey_array_express.py
@@ -7,6 +7,7 @@ experiment accession code per line.
 import boto3
 import botocore
 import uuid
+import sys
 
 from django.core.management.base import BaseCommand
 from data_refinery_foreman.surveyor import surveyor
@@ -31,7 +32,7 @@ class Command(BaseCommand):
     def handle(self, *args, **options):
         if options["accession"] is None and options['file'] is None:
             logger.error("You must specify an experiment accession or file.")
-            return 1
+            sys.exit(1) 
         if options["file"]:
 
             if 's3://' in options["file"]:
@@ -57,7 +58,7 @@ class Command(BaseCommand):
                         print(e)        
         else:
             surveyor.survey_ae_experiment(self.get_ae_accession(options['accession']))
-            return 0
+            sys.exit(0) 
 
     def get_ae_accession(self, accession):
         """This allows us to support ascession codes in both

--- a/foreman/data_refinery_foreman/surveyor/management/commands/survey_geo.py
+++ b/foreman/data_refinery_foreman/surveyor/management/commands/survey_geo.py
@@ -6,7 +6,7 @@ or for each accession in a file containing one experiment accession code per lin
 import boto3
 import botocore
 import uuid
-
+import sys
 
 from django.core.management.base import BaseCommand
 from data_refinery_foreman.surveyor import surveyor
@@ -29,7 +29,7 @@ class Command(BaseCommand):
     def handle(self, *args, **options):
         if options["accession"] is None and options['file'] is None:
             logger.error("You must specify an experiment accession or file.")
-            return 1
+            sys.exit(1) 
         if options["file"]:
             if 's3://' in options["file"]:
                 bucket, key = parse_s3_url(options["file"])
@@ -54,4 +54,4 @@ class Command(BaseCommand):
                         logger.exception(e)
         else:
             surveyor.survey_geo_experiment(options['accession'])
-            return 0
+            sys.exit(0) 

--- a/foreman/data_refinery_foreman/surveyor/management/commands/survey_sra.py
+++ b/foreman/data_refinery_foreman/surveyor/management/commands/survey_sra.py
@@ -30,7 +30,7 @@ class Command(BaseCommand):
     def handle(self, *args, **options):
         if options["accession"] is None and options["file"] is None:
             logger.error("You must specify accession or input file.")
-            return 1
+            sys.exit(1) 
         if options["file"]:
             if 's3://' in options["file"]:
                 bucket, key = parse_s3_url(options["file"])
@@ -53,4 +53,4 @@ class Command(BaseCommand):
                         print(e)
         else:
             surveyor.survey_sra_experiment(options["accession"])
-            return 0
+            sys.exit(0) 

--- a/foreman/data_refinery_foreman/surveyor/management/commands/survey_transcriptome.py
+++ b/foreman/data_refinery_foreman/surveyor/management/commands/survey_transcriptome.py
@@ -1,6 +1,7 @@
 """
 This command will create and run survey jobs for the specified ensembl division.
 """
+import sys
 
 from django.core.management.base import BaseCommand
 from data_refinery_foreman.surveyor import surveyor
@@ -33,11 +34,11 @@ class Command(BaseCommand):
     def handle(self, *args, **options):
         if options["ensembl_division"] is None:
             logger.error("You must specify an ensembl_division.")
-            return 1
+            sys.exit(1) 
         else:
             surveyor.survey_transcriptome_index(
                 organism_name=options['organism_name'],
                 ensembl_division=options['ensembl_division'],
                 number_of_organisms=options['number_of_organisms'],
             )
-            return 0
+            sys.exit(0) 

--- a/workers/data_refinery_workers/downloaders/management/commands/run_downloader_job.py
+++ b/workers/data_refinery_workers/downloaders/management/commands/run_downloader_job.py
@@ -1,3 +1,5 @@
+import sys
+
 from django.core.management.base import BaseCommand
 from data_refinery_common.job_lookup import Downloaders
 from data_refinery_common.logging import get_and_configure_logger
@@ -24,13 +26,13 @@ class Command(BaseCommand):
     def handle(self, *args, **options):
         if options["job_id"] is None:
             logger.error("You must specify a job ID.")
-            return 1
+            sys.exit(1) 
 
         try:
             job_type = Downloaders[options["job_name"]]
         except KeyError:
             logger.error("You must specify a valid job name.")
-            return 1
+            sys.exit(1) 
 
         if job_type is Downloaders.ARRAY_EXPRESS:
             download_array_express(options["job_id"])
@@ -45,6 +47,6 @@ class Command(BaseCommand):
                           "no downloader function is known to run it."),
                          options["job_name"],
                          options["job_id"])
-            return 1
+            sys.exit(1) 
 
-        return 0
+        sys.exit(0) 

--- a/workers/data_refinery_workers/processors/management/commands/run_processor_job.py
+++ b/workers/data_refinery_workers/processors/management/commands/run_processor_job.py
@@ -1,3 +1,5 @@
+import sys
+
 from django.core.management.base import BaseCommand
 from data_refinery_common.job_lookup import ProcessorPipeline
 from data_refinery_common.logging import get_and_configure_logger
@@ -20,13 +22,13 @@ class Command(BaseCommand):
     def handle(self, *args, **options):
         if options["job_id"] is None:
             logger.error("You must specify a job ID.")
-            return 1
+            sys.exit(1) 
 
         try:
             job_type = ProcessorPipeline[options["job_name"]]
         except KeyError:
             logger.error("You must specify a valid job name.")
-            return 1
+            sys.exit(1) 
 
         if job_type is ProcessorPipeline.AFFY_TO_PCL:
             from data_refinery_workers.processors.array_express import affy_to_pcl
@@ -57,6 +59,6 @@ class Command(BaseCommand):
                           "no processor function is known to run it."),
                          options["job_name"],
                          options["job_id"])
-            return 1
+            sys.exit(1) 
 
-        return 0
+        sys.exit(0) 


### PR DESCRIPTION
## Issue Number
n/a

## Purpose/Implementation Notes

Fixes lots of:

```
data-refinery-log-group-circleci-staging log-stream-processor-docker-circleci-staging Traceback (most recent call last):
data-refinery-log-group-circleci-staging log-stream-processor-docker-circleci-staging   File "manage.py", line 23, in <module>
data-refinery-log-group-circleci-staging log-stream-processor-docker-circleci-staging     execute_from_command_line(sys.argv)
data-refinery-log-group-circleci-staging log-stream-processor-docker-circleci-staging   File "/usr/local/lib/python3.5/dist-packages/django/core/management/__init__.py", line 371, in execute_from_command_line
data-refinery-log-group-circleci-staging log-stream-processor-docker-circleci-staging     utility.execute()
data-refinery-log-group-circleci-staging log-stream-processor-docker-circleci-staging   File "/usr/local/lib/python3.5/dist-packages/django/core/management/__init__.py", line 365, in execute
data-refinery-log-group-circleci-staging log-stream-processor-docker-circleci-staging     self.fetch_command(subcommand).run_from_argv(self.argv)
data-refinery-log-group-circleci-staging log-stream-processor-docker-circleci-staging   File "/usr/local/lib/python3.5/dist-packages/django/core/management/base.py", line 288, in run_from_argv
data-refinery-log-group-circleci-staging log-stream-processor-docker-circleci-staging     self.execute(*args, **cmd_options)
data-refinery-log-group-circleci-staging log-stream-processor-docker-circleci-staging   File "/usr/local/lib/python3.5/dist-packages/django/core/management/base.py", line 344, in execute
data-refinery-log-group-circleci-staging log-stream-processor-docker-circleci-staging     self.stdout.write(output)
data-refinery-log-group-circleci-staging log-stream-processor-docker-circleci-staging   File "/usr/local/lib/python3.5/dist-packages/django/core/management/base.py", line 103, in write
data-refinery-log-group-circleci-staging log-stream-processor-docker-circleci-staging     if ending and not msg.endswith(ending):
data-refinery-log-group-circleci-staging log-stream-processor-docker-circleci-staging AttributeError: 'int' object has no attribute 'endswith'
```
