### PR TITLE
Adds hgu133a.tsv.gz

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,9 +50,6 @@ jobs:
           command: .circleci/filter_tests.sh -t downloaders
           no_output_timeout: 36000
 
-      # Run NO_OP tests
-      - run: .circleci/filter_tests.sh -t no_op
-
       # Push the no_op and downloader images to the local docker repo so Nomad
       # can pull from there when running end-to-end tests.
       - run: docker push localhost:5000/dr_downloaders
@@ -69,7 +66,10 @@ jobs:
           command: .circleci/filter_tests.sh -t smasher
           # Smashing can apparently take a long time on CI
           no_output_timeout: 36000
-
+      
+      # Run NO_OP tests
+      - run: sudo chown -R circleci:circleci workers/test_volume/
+      - run: .circleci/filter_tests.sh -t no_op
 
   # This tests workers tests tagged as 'affymetrix' or 'agilient' since they share the same image
   affymetrix_common_agilent_tests:


### PR DESCRIPTION
## Issue Number

https://sentry.io/greenelab/staging-refinebio/issues/612563649/

## Purpose/Implementation Notes

This is a short-term fix for `STAGING-REFINEBIO-17`, adding the `hgu133a` gene conversion matrix.

All of these files should be replaced with a dynamic loading from Zenodo, but this will make the `no_op` work for those thousand samples in the meantime.

## Methods

Related: https://github.com/AlexsLemonade/identifier-refinery#methods

## Types of changes
- Bugfix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
