### PR TITLE
Add a Simple DatasetStats Endpoint

### DIFF
--- a/api/data_refinery_api/urls.py
+++ b/api/data_refinery_api/urls.py
@@ -24,6 +24,7 @@ from data_refinery_api.views import (
     Stats,
     CreateDatasetView,
     DatasetView,
+    DatasetStatsView,
     APITokenView,
     TranscriptomeIndexDetail
 )
@@ -102,6 +103,7 @@ urlpatterns = [
     # Deliverables
     url(r'^dataset/$', DatasetRoot.as_view(), name="dataset_root"),
     url(r'^dataset/create/$', CreateDatasetView.as_view(), name="create_dataset"),
+    url(r'^dataset/stats/(?P<id>[0-9a-f-]+)/$', DatasetStatsView.as_view(), name="dataset_stats"),
     url(r'^dataset/(?P<id>[0-9a-f-]+)/$', DatasetView.as_view(), name="dataset"),
     url(r'^token/$', APITokenView.as_view(), name="token"),
     url(r'^token/(?P<id>[0-9a-f-]+)/$', APITokenView.as_view(), name="token_id"),

--- a/api/data_refinery_api/views.py
+++ b/api/data_refinery_api/views.py
@@ -224,11 +224,11 @@ class DatasetStatsView(APIView):
 
     {
         "HOMO_SAPIENS": {
-            "experiments": 5,
-            "samples": 55 },
+            "num_experiments": 5,
+            "num_samples": 55 },
         "GALLUS_GALLUS": {
-            "experiments": 5,
-            "samples": 55 },
+            "num_experiments": 5,
+            "num_samples": 55 },
     }
 
     """
@@ -250,15 +250,15 @@ class DatasetStatsView(APIView):
 
         # Count the samples
         all_sample_accessions = [value[0] for value in dataset.data.values()]
-        delete_me = []
+        empty_species = []
         for species in stats.keys():
             samples = Sample.objects.filter(accession_code__in=all_sample_accessions, organism__name=species)
-            stats[species]['num_samples'] = stats[species]['num_samples'] + len(samples)
+            stats[species]['num_samples'] = len(samples)
             if stats[species]['num_samples'] == 0:
-                delete_me.append(species)
+                empty_species.append(species)
 
         # Delete empty associations
-        for species in delete_me:
+        for species in empty_species:
             del stats[species]
 
         return Response(stats)

--- a/api/data_refinery_api/views.py
+++ b/api/data_refinery_api/views.py
@@ -188,7 +188,7 @@ class DatasetView(generics.RetrieveUpdateAPIView):
             token_id = self.request.data.get('token_id')
             try:
                 token = APIToken.objects.get(id=token_id, is_activated=True)
-            except Exception: # Generall APIToken.DoesNotExist or django.core.exceptions.ValidationError
+            except Exception: # General APIToken.DoesNotExist or django.core.exceptions.ValidationError
                 raise APIException("You must provide an active API token ID")
 
             if not already_processing:
@@ -218,6 +218,50 @@ class DatasetView(generics.RetrieveUpdateAPIView):
             serializer.validated_data['data'] = old_data
             serializer.validated_data['aggregate_by'] = old_aggregate
         serializer.save()
+
+class DatasetStatsView(APIView):
+    """ Get stats for a given dataset. Ex:
+
+    {
+        "HOMO_SAPIENS": {
+            "experiments": 5,
+            "samples": 55 },
+        "GALLUS_GALLUS": {
+            "experiments": 5,
+            "samples": 55 },
+    }
+
+    """
+
+    def get(self, request, id):
+        
+        dataset = get_object_or_404(Dataset, id=id)
+        stats = {}
+
+        experiments = Experiment.objects.filter(accession_code__in=dataset.data.keys())
+        
+        # Find all the species for these experiments
+        for experiment in experiments:
+            species_names = experiment.organisms.values_list('name')
+            for species_name in species_names:
+                species = stats.get(species_name[0], {"num_experiments": 0, "num_samples": 0})
+                species['num_experiments'] = species['num_experiments'] + 1
+                stats[species_name[0]] = species
+
+        # Count the samples
+        all_sample_accessions = [value[0] for value in dataset.data.values()]
+        delete_me = []
+        for species in stats.keys():
+            samples = Sample.objects.filter(accession_code__in=all_sample_accessions, organism__name=species)
+            stats[species]['num_samples'] = stats[species]['num_samples'] + len(samples)
+            if stats[species]['num_samples'] == 0:
+                delete_me.append(species)
+
+        # Delete empty associations
+        for species in delete_me:
+            del stats[species]
+
+        return Response(stats)
 
 class APITokenView(APIView):
     """

--- a/workers/run_tests.sh
+++ b/workers/run_tests.sh
@@ -195,6 +195,13 @@ if [[ -z $tag || $tag == "no_op" ]]; then
         wget -q -O "$no_test_raw_dir/$no_file3" \
              "$test_data_repo/$no_file3"
     fi
+    no_file4="GSM269747-tbl-1.txt"
+    if [ ! -e "$no_test_raw_dir/$no_file4" ]; then
+        mkdir -p $no_test_raw_dir
+        echo "Downloading NOOP file4."
+        wget -q -O "$no_test_raw_dir/$no_file4" \
+             "$test_data_repo/$no_file4"
+    fi
 fi
 
 if [[ -z $tag || $tag == "smasher" ]]; then


### PR DESCRIPTION
## Issue Number

https://github.com/AlexsLemonade/refinebio-frontend/issues/192

## Purpose/Implementation Notes

The Download page currently has a very costly stats table which requires fetching and tabulating statistics about a dataset. This adds an endpoint so those stats can be done on the server without fetching the whole set at once.

## Types of changes
- New feature (non-breaking change which adds functionality)

## Functional tests
New test case added.

## Checklist

_Put an `x` in the boxes that apply._

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules