### PR TITLE
Fixes up some infra issues in dev stacks, restarts API with latest im…

### DIFF
--- a/infrastructure/api-configuration/api-server-instance-user-data.tpl.sh
+++ b/infrastructure/api-configuration/api-server-instance-user-data.tpl.sh
@@ -34,8 +34,12 @@ if [[ ${stage} == "staging" || ${stage} == "prod" ]]; then
     # have configured to forward mail to the #teamcontact channel in
     # slack. Certbot will use it for "important account
     # notifications".
+    # In the future, if we ever hit the 5-deploy-a-week limit, changing one of these lines to:
+    # certbot --nginx -d api.staging.refine.bio -d api2.staging.refine.bio -n --agree-tos --redirect -m g3w4k4t5n3s7p7v8@alexslemonade.slack.com
+    # will circumvent certbot's limit because the 5-a-week limit only applies to the
+    # "same set of domains", so by changing that set we get to use the 20-a-week limit.
     if [[ ${stage} == "staging" ]]; then
-        certbot --nginx -d api.staging.refine.bio -d api2.staging.refine.bio -n --agree-tos --redirect -m g3w4k4t5n3s7p7v8@alexslemonade.slack.com
+        certbot --nginx -d api.staging.refine.bio -n --agree-tos --redirect -m g3w4k4t5n3s7p7v8@alexslemonade.slack.com
     elif [[ ${stage} == "prod" ]]; then
         certbot --nginx -d api.refine.bio -n --agree-tos --redirect -m g3w4k4t5n3s7p7v8@alexslemonade.slack.com
     fi

--- a/infrastructure/api-configuration/api-server-instance-user-data.tpl.sh
+++ b/infrastructure/api-configuration/api-server-instance-user-data.tpl.sh
@@ -104,6 +104,7 @@ docker run \
        --log-opt awslogs-group=${log_group} \
        --log-opt awslogs-stream=${log_stream} \
        -p 8081:8081 \
+       --name=dr_api \
        -it -d ${dockerhub_repo}/${api_docker_image} /bin/sh -c "/home/user/collect_and_run_uwsgi.sh"
 
 

--- a/infrastructure/deploy.sh
+++ b/infrastructure/deploy.sh
@@ -198,13 +198,46 @@ for nomad_job_spec in $nomad_job_specs; do
     nomad run $nomad_job_spec
 done
 
-# Ensure the latest image version is being used for the API and the Foreman
-terraform taint aws_instance.api_server_1
+# Ensure the latest image version is being used for the Foreman
+terraform taint aws_instance.foreman_server_1
 
 # Remove the ingress config so the next `terraform apply` will remove
 # access for Circle.
 echo "Removing ingress.."
 rm ci_ingress.tf
 terraform apply -var-file=environments/$env.tfvars -auto-approve
+
+# We try to avoid rebuilding the API server because we can only run certbot
+# 5 times a week. Therefore we pull the newest image and restart the API
+# this way rather than by tainting the server like we do for foreman.
+chmod 600 data-refinery-key.pem
+API_IP_ADDRESS=$(terraform output -json api_server_1_ip | jq -c '.value' | tr -d '"')
+echo "Restarting API with latest image."
+
+ssh -o StrictHostKeyChecking=no \
+    -i data-refinery-key.pem \
+    ubuntu@$API_IP_ADDRESS  "docker pull $DOCKERHUB_REPO/$API_DOCKER_IMAGE"
+
+ssh -o StrictHostKeyChecking=no \
+    -i data-refinery-key.pem \
+    ubuntu@$API_IP_ADDRESS "docker rm -f dr_api"
+
+ssh -o StrictHostKeyChecking=no \
+    -i data-refinery-key.pem \
+    ubuntu@$API_IP_ADDRESS "docker run \
+       --env-file environment \
+       -e DATABASE_HOST \
+       -e DATABASE_NAME \
+       -e DATABASE_USER \
+       -e DATABASE_PASSWORD \
+       -v /tmp/volumes_static:/tmp/www/static \
+       --log-driver=awslogs \
+       --log-opt awslogs-region=$REGION \
+       --log-opt awslogs-group=data-refinery-log-group-$USER-$STAGE \
+       --log-opt awslogs-stream=log-stream-api-$USER-$STAGE \
+       -p 8081:8081 \
+       --name=dr_api \
+       -it -d $DOCKERHUB_REPO/$API_DOCKER_IMAGE /bin/sh -c /home/user/collect_and_run_uwsgi.sh"
+
 
 echo "Deploy completed successfully."

--- a/infrastructure/disk.tf
+++ b/infrastructure/disk.tf
@@ -94,7 +94,7 @@ resource "aws_s3_bucket" "data_refinery_transcriptome_index_bucket" {
 }
 
 resource "aws_s3_bucket" "data-refinery-static-access-logs" {
-  bucket = "data-refinery-static-access-logs"
+  bucket = "data-refinery-static-access-logs-${var.user}-${var.stage}"
 
   tags {
     Name = "data-refinery-static-access-logs-${var.user}-${var.stage}"

--- a/infrastructure/networking.tf
+++ b/infrastructure/networking.tf
@@ -107,8 +107,6 @@ resource "aws_lb" "data_refinery_api_load_balancer" {
   internal = false
   load_balancer_type = "network"
 
-  enable_deletion_protection = true
-
   # Only one subnet is allowed and the API lives in 1a.
   subnet_mapping {
     subnet_id = "${aws_subnet.data_refinery_1a.id}"
@@ -183,7 +181,7 @@ resource "aws_cloudfront_distribution" "static-distribution" {
 
   origin {
     domain_name = "${aws_s3_bucket.data-refinery-static.website_endpoint}"
-    origin_id = "data-refinery-circleci-staging"
+    origin_id = "data-refinery-${var.user}-${var.stage}"
 
     custom_origin_config {
       origin_protocol_policy = "http-only"

--- a/infrastructure/variables.tf
+++ b/infrastructure/variables.tf
@@ -207,6 +207,8 @@ output "environment_variables" {
       value = "${var.foreman_docker_image}"},
     {name = "SMASHER_DOCKER_IMAGE"
       value = "${var.smasher_docker_image}"},
+    {name = "API_DOCKER_IMAGE"
+      value = "${var.api_docker_image}"},
     {name = "NOMAD_HOST"
       value = "${aws_instance.nomad_server_1.private_ip}"},
     {name = "NOMAD_PUBLIC_HOST"


### PR DESCRIPTION
…age without tainting the server.

## Issue Number

https://github.com/AlexsLemonade/refinebio/issues/414

## Purpose/Implementation Notes

Prevents needing to run certbot so often by avoiding tainting the API server so often. This is because we only can run certbot 5 times a week before they rate limit us. The reason we were tainting the server is to rerun the startup script so we get the latest API image and restart the container.

We now use ssh to pull the latest image, stop and remove the old container, and start a new one.

## Types of changes

- New feature (non-breaking change which adds functionality)

## Functional tests

I ran `deploy.sh -e dev` locally and was able to start up a local stack and restart the API with subsequent runs.

## Checklist

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules
