### PR TITLE
Fixes Two Issues Which Caused Extra Jobs of the Wrong Type

### DIFF
--- a/common/data_refinery_common/job_lookup.py
+++ b/common/data_refinery_common/job_lookup.py
@@ -124,9 +124,9 @@ def determine_processor_pipeline(sample_object: Sample, original_file=None) -> P
 
     # Optional explicit filetype checks
     if original_file:
-        if original_file.filename[-3].upper() == "CEL":
+        if original_file.filename[-3:].upper() == "CEL":
             return ProcessorPipeline.AFFY_TO_PCL 
-        if original_file.filename[-3].upper() == "TXT":
+        if original_file.filename[-3:].upper() == "TXT":
             return ProcessorPipeline.NO_OP 
 
     if sample_object.technology == "MICROARRAY":

--- a/common/data_refinery_common/job_lookup.py
+++ b/common/data_refinery_common/job_lookup.py
@@ -122,13 +122,6 @@ def determine_processor_pipeline(sample_object: Sample, original_file=None) -> P
     if not _is_platform_supported(sample_object.platform_accession_code):
         return ProcessorPipeline.NONE
 
-    # Optional explicit filetype checks
-    if original_file:
-        if original_file.filename[-3:].upper() == "CEL":
-            return ProcessorPipeline.AFFY_TO_PCL 
-        if original_file.filename[-3:].upper() == "TXT":
-            return ProcessorPipeline.NO_OP 
-
     if sample_object.technology == "MICROARRAY":
         if not sample_object.has_raw:
             return ProcessorPipeline.NO_OP
@@ -136,6 +129,12 @@ def determine_processor_pipeline(sample_object: Sample, original_file=None) -> P
             if sample_object.manufacturer == "ILLUMINA":
                 return ProcessorPipeline.ILLUMINA_TO_PCL
             elif sample_object.manufacturer == "AFFYMETRIX":
+                # Optional explicit filetype checks
+                if original_file:
+                    if original_file.filename[-3:].upper() == "CEL":
+                        return ProcessorPipeline.AFFY_TO_PCL 
+                    if original_file.filename[-3:].upper() == "TXT":
+                        return ProcessorPipeline.NO_OP
                 return ProcessorPipeline.AFFY_TO_PCL
             elif sample_object.manufacturer == "AGILENT":
                 # We currently aren't prepared to process Agilent because we don't have

--- a/common/data_refinery_common/message_queue.py
+++ b/common/data_refinery_common/message_queue.py
@@ -73,4 +73,9 @@ def send_job(job_type: Enum, job) -> None:
     except URLNotFoundNomadException:
         logger.error("Dispatching Nomad job of type %s for job spec %s to host %s and port %s failed.",
                      job_type, nomad_job, nomad_host, nomad_port, job=str(job.id))
-        raise
+    except Exception as e:
+        logger.exception('Unable to Dispatch Nomad Job.', 
+            job_name=job_type.value, 
+            job_id=str(job.id),
+            reason=str(e)
+        )

--- a/foreman/data_refinery_foreman/surveyor/geo.py
+++ b/foreman/data_refinery_foreman/surveyor/geo.py
@@ -364,6 +364,11 @@ class GeoSurveyor(ExternalSourceSurveyor):
                 )[0]
 
             for sample_object in all_samples:
+
+                # We don't need a .txt if we have a .CEL
+                if sample_object.has_raw:
+                    continue
+
                 OriginalFileSampleAssociation.objects.get_or_create(
                     sample=sample_object, original_file=original_file)
 

--- a/foreman/data_refinery_foreman/surveyor/geo.py
+++ b/foreman/data_refinery_foreman/surveyor/geo.py
@@ -354,9 +354,10 @@ class GeoSurveyor(ExternalSourceSurveyor):
 
         # These are the Miniml/Soft/Matrix URLs that are always(?) provided.
         # GEO describes different types of data formatting as "families"
+        assocs = []
         for family_url in [self.get_miniml_url(experiment_accession_code)]:
 
-            original_file = OriginalFile.objects.get_or_create(
+            miniml_original_file = OriginalFile.objects.get_or_create(
                     source_url = family_url,
                     source_filename = family_url.split('/')[-1],
                     has_raw = sample_object.has_raw,
@@ -369,8 +370,10 @@ class GeoSurveyor(ExternalSourceSurveyor):
                 if sample_object.has_raw:
                     continue
 
-                OriginalFileSampleAssociation.objects.get_or_create(
-                    sample=sample_object, original_file=original_file)
+                assocs.append(OriginalFileSampleAssociation.objects.get_or_create(
+                    sample=sample_object, original_file=miniml_original_file)[0])
+        if len(assocs) == 0:
+            miniml_original_file.delete()
 
         return experiment_object, all_samples
 

--- a/foreman/data_refinery_foreman/surveyor/geo.py
+++ b/foreman/data_refinery_foreman/surveyor/geo.py
@@ -354,25 +354,22 @@ class GeoSurveyor(ExternalSourceSurveyor):
 
         # These are the Miniml/Soft/Matrix URLs that are always(?) provided.
         # GEO describes different types of data formatting as "families"
-        assocs = []
-        for family_url in [self.get_miniml_url(experiment_accession_code)]:
+        family_url = self.get_miniml_url(experiment_accession_code):
+        miniml_original_file = OriginalFile.objects.get_or_create(
+                source_url = family_url,
+                source_filename = family_url.split('/')[-1],
+                has_raw = sample_object.has_raw,
+                is_archive = True
+            )[0]
+        for sample_object in all_samples:
+            # We don't need a .txt if we have a .CEL
+            if sample_object.has_raw:
+                continue
+            OriginalFileSampleAssociation.objects.get_or_create(
+                sample=sample_object, original_file=miniml_original_file)
 
-            miniml_original_file = OriginalFile.objects.get_or_create(
-                    source_url = family_url,
-                    source_filename = family_url.split('/')[-1],
-                    has_raw = sample_object.has_raw,
-                    is_archive = True
-                )[0]
-
-            for sample_object in all_samples:
-
-                # We don't need a .txt if we have a .CEL
-                if sample_object.has_raw:
-                    continue
-
-                assocs.append(OriginalFileSampleAssociation.objects.get_or_create(
-                    sample=sample_object, original_file=miniml_original_file)[0])
-        if len(assocs) == 0:
+        # Delete this Original file if it isn't being used.
+        if OriginalFileSampleAssociation.objects.filter(original_file=miniml_original_file).count() == 0:
             miniml_original_file.delete()
 
         return experiment_object, all_samples

--- a/workers/data_refinery_workers/downloaders/geo.py
+++ b/workers/data_refinery_workers/downloaders/geo.py
@@ -351,7 +351,6 @@ def download_geo(job_id: int) -> None:
                 actual_file.filename = og_file['filename']
                 actual_file.calculate_size()
                 actual_file.calculate_sha1()
-
                 actual_file.has_raw = has_raw
                 actual_file.save()
 

--- a/workers/data_refinery_workers/downloaders/utils.py
+++ b/workers/data_refinery_workers/downloaders/utils.py
@@ -112,6 +112,7 @@ def create_processor_job_for_original_files(original_files: List[OriginalFile],
     Create a processor job and queue a processor task for sample related to an experiment.
 
     """
+
     # For anything that has raw data there should only be one Sample per OriginalFile
     sample_object = original_files[0].samples.first()
     pipeline_to_apply = determine_processor_pipeline(sample_object, original_files[0])


### PR DESCRIPTION
## Issue Number

Discovered during: https://github.com/AlexsLemonade/refinebio/issues/466

## Purpose/Implementation Notes

Two issues were combining here to create superfluous `AFFY_TO_PCL` jobs being created for files that should have been `NO_OP`'d if they were to be processed at all, but shouldn't have been.

One fix is a really stupid one, the file type dispatcher wasn't using slices properly so it just wasn't working at all.

The second fix is a behavior change: we don't create OriginalFile:Sample associations if the sample is comes from a `_family` (processed) file if that Sample _also_ has raw data. Is that the correct behavior? I'm not sure, but it stops us from creating additional `NO_OP` jobs in the situation where we're already going to have an `AFFY_TO_PCL` anyway. 

We might end up with an extra file lying around though.

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

Tried locally with `GSE12021`

## Checklist

_Put an `x` in the boxes that apply._

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules
