### PR TITLE
Fixes foreman requeuing jobs it shouldn't. Also a couple other minor bugs

### DIFF
--- a/foreman/data_refinery_foreman/foreman/main.py
+++ b/foreman/data_refinery_foreman/foreman/main.py
@@ -178,7 +178,7 @@ def retry_lost_downloader_jobs() -> None:
         try:
             job_status = nomad_client.job.get_job(job.nomad_job_id)["Status"]
             # If the job is still pending, then it makes sense that it hasn't started.
-            if job_status is not "pending":
+            if job_status != "pending":
                 # However if it's not pending, then it may have
                 # started since our original query.
                 job.refresh_from_db()
@@ -297,7 +297,7 @@ def retry_lost_processor_jobs() -> None:
         try:
             job_status = nomad_client.job.get_job(job.nomad_job_id)["Status"]
             # If the job is still pending, then it makes sense that it hasn't started.
-            if job_status is not "pending":
+            if job_status != "pending":
                 # However if it's not pending, then it may have
                 # started since our original query.
                 job.refresh_from_db()

--- a/foreman/data_refinery_foreman/surveyor/management/commands/survey_sra.py
+++ b/foreman/data_refinery_foreman/surveyor/management/commands/survey_sra.py
@@ -6,6 +6,7 @@ in the range from start_accession to end_accession.
 import boto3
 import botocore
 import uuid
+import sys
 
 from django.core.management.base import BaseCommand
 from data_refinery_foreman.surveyor import surveyor
@@ -30,7 +31,7 @@ class Command(BaseCommand):
     def handle(self, *args, **options):
         if options["accession"] is None and options["file"] is None:
             logger.error("You must specify accession or input file.")
-            sys.exit(1) 
+            sys.exit(1)
         if options["file"]:
             if 's3://' in options["file"]:
                 bucket, key = parse_s3_url(options["file"])
@@ -53,4 +54,4 @@ class Command(BaseCommand):
                         print(e)
         else:
             surveyor.survey_sra_experiment(options["accession"])
-            sys.exit(0) 
+            sys.exit(0)

--- a/workers/data_refinery_workers/processors/salmon.py
+++ b/workers/data_refinery_workers/processors/salmon.py
@@ -171,7 +171,7 @@ def _download_index(job_context: Dict) -> Dict:
             organism=job_context['organism'],
             processor_job=job_context["job_id"]
         )
-        job_context["failure_reason"] = "Missing transcriptome index."
+        job_context["job"].failure_reason = "Missing transcriptome index."
         job_context["success"] = False
         return job_context
 


### PR DESCRIPTION
## Issue Number

N/A

## Purpose/Implementation Notes

While running the crunch for Jackie yesterday, Rich and I noticed that a lot of jobs were getting queued multiple times. This addresses that, along with a couple minor things I bumped into along the way.

Additionally I realized that I wasn't mocking out nomad correctly. This was fine, since before all the tests were making sure that things weren't equal to the value returned, but the additional tests I added meant I needed to fix that so I did.

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

I queued up a couple salmon jobs but made it so they required more RAM than my laptop has. This meant that they sat in a pending state. This allowed me to actually keep the Nomad job in the 'pending' state long enough to see it get queued multiple times.

## Checklist

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules
