### PR TITLE
Don't let running the migrations try to talk to AWS.

### DIFF
--- a/infrastructure/deploy.sh
+++ b/infrastructure/deploy.sh
@@ -171,11 +171,13 @@ docker pull $DOCKERHUB_REPO/$FOREMAN_DOCKER_IMAGE
 # Migrate auth.
 docker run \
        --env-file prod_env \
+       --env RUNNING_IN_CLOUD=False \
        $DOCKERHUB_REPO/$FOREMAN_DOCKER_IMAGE python3 manage.py migrate auth
 
 # Apply general migrations.
 docker run \
        --env-file prod_env \
+       --env RUNNING_IN_CLOUD=False \
        $DOCKERHUB_REPO/$FOREMAN_DOCKER_IMAGE python3 manage.py migrate
 
 # Template the environment variables for production into the Nomad Job


### PR DESCRIPTION
## Issue Number

N/A

## Purpose/Implementation Notes

I noticed this issue while standing up a dev stack. The migrations were trying to log their AWS instance id, which they don't have because they aren't run from an AWS instance.

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

I've stood up a dev stack with these changes.

## Checklist

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules
