### PR TITLE
Update No-Op Dockerfile to Use Latest Identifier Refinery Archive'

### DIFF
--- a/workers/dockerfiles/Dockerfile.no_op
+++ b/workers/dockerfiles/Dockerfile.no_op
@@ -40,7 +40,7 @@ WORKDIR /home/user
 ENV R_LIBS "/usr/local/lib/R/site-library"
 RUN mkdir -p gene_indexes
 WORKDIR /home/user/gene_indexes
-RUN curl -O https://zenodo.org/record/1322711/files/all_1532646318.zip
+RUN curl -O https://zenodo.org/record/1327563/files/all_1533307773.zip
 RUN unzip *.zip
 RUN rm *.zip
 WORKDIR /home/user


### PR DESCRIPTION
## Issue Number

Found in Jackiecrunch.

## Purpose/Implementation Notes

The previous identifier refinery archive was missing two platforms, including `hthgu133pluspm`, which we needed. The upstream bug is fixed and the result published, this just uses the latest version.

## Types of changes

- Bugfix (non-breaking change which fixes an issue)
