### PR TITLE
Add sample_metadata to experiments endpoint

### DIFF
--- a/api/data_refinery_api/serializers.py
+++ b/api/data_refinery_api/serializers.py
@@ -194,6 +194,7 @@ class ExperimentSerializer(serializers.ModelSerializer):
     platforms = serializers.ReadOnlyField()
     samples = serializers.StringRelatedField(many=True)
     pretty_platforms = serializers.ReadOnlyField()
+    sample_metadata = serializers.ReadOnlyField(source='get_sample_metadata_fields')
 
     class Meta:
         model = Experiment
@@ -215,7 +216,8 @@ class ExperimentSerializer(serializers.ModelSerializer):
                     'organisms',
                     'submitter_institution',
                     'created_at',
-                    'last_modified'
+                    'last_modified',
+                    'sample_metadata',
                 )
 
 class ExperimentAnnotationSerializer(serializers.ModelSerializer):
@@ -233,6 +235,7 @@ class DetailedExperimentSerializer(serializers.ModelSerializer):
     annotations = ExperimentAnnotationSerializer(many=True, source='experimentannotation_set')
     samples = SampleSerializer(many=True)
     organisms = OrganismSerializer(many=True)
+    sample_metadata = serializers.ReadOnlyField(source='get_sample_metadata_fields')
 
     class Meta:
         model = Experiment
@@ -257,6 +260,7 @@ class DetailedExperimentSerializer(serializers.ModelSerializer):
                     'last_modified',
                     'created_at',
                     'organisms',
+                    'sample_metadata',
                 )
 
 class PlatformSerializer(serializers.ModelSerializer):

--- a/common/data_refinery_common/models/models.py
+++ b/common/data_refinery_common/models/models.py
@@ -310,9 +310,15 @@ class Experiment(models.Model):
         See https://github.com/AlexsLemonade/refinebio-frontend/issues/211 for why this is needed.
         """
         fields = []
-        for sample in self.samples.all():
-            metadata = sample.to_metadata_dict()
-            fields += [k for k, v in metadata.items() if v and k not in fields]
+
+        possible_fields = ['title', 'accession_code', 'sex', 'age', 'specimen_part', 'genotype',
+                           'disease', 'disease_stage', 'cell_line', 'treatment', 'race', 'subject',
+                           'compound', 'time']
+
+        for field in possible_fields:
+            filter = {"age__isnull": True} if field == 'age' else {'%s__exact' % field: ''}
+            if len(self.samples.exclude(**filter)) > 0:
+                fields.append(field)
         return fields
 
     @property

--- a/common/data_refinery_common/models/models.py
+++ b/common/data_refinery_common/models/models.py
@@ -127,7 +127,7 @@ class Sample(models.Model):
         metadata = {}
         metadata['title'] = self.title
         metadata['accession_code'] = self.accession_code
-        metadata['organism'] = self.organism.name
+        metadata['organism'] = self.organism.name if self.organism else None
         metadata['source_archive_url'] = self.source_archive_url
         metadata['sex'] = self.sex
         metadata['age'] = self.age or ''

--- a/common/data_refinery_common/models/models.py
+++ b/common/data_refinery_common/models/models.py
@@ -311,9 +311,8 @@ class Experiment(models.Model):
         """
         fields = []
 
-        possible_fields = ['title', 'accession_code', 'sex', 'age', 'specimen_part', 'genotype',
-                           'disease', 'disease_stage', 'cell_line', 'treatment', 'race', 'subject',
-                           'compound', 'time']
+        possible_fields = ['sex', 'age', 'specimen_part', 'genotype', 'disease', 'disease_stage',
+                           'cell_line', 'treatment', 'race', 'subject', 'compound', 'time']
 
         for field in possible_fields:
             filter = {"age__isnull": True} if field == 'age' else {'%s__exact' % field: ''}

--- a/common/data_refinery_common/models/models.py
+++ b/common/data_refinery_common/models/models.py
@@ -305,6 +305,16 @@ class Experiment(models.Model):
 
         return metadata
 
+    def get_sample_metadata_fields(self):
+        """ Get all metadata fields that are non-empty for at least one sample in the experiment.
+        See https://github.com/AlexsLemonade/refinebio-frontend/issues/211 for why this is needed.
+        """
+        fields = []
+        for sample in self.samples.all():
+            metadata = sample.to_metadata_dict()
+            fields += [k for k, v in metadata.items() if v and k not in fields]
+        return fields
+
     @property
     def platforms(self):
         """ Returns a list of related pipelines """

--- a/common/data_refinery_common/models/test_models.py
+++ b/common/data_refinery_common/models/test_models.py
@@ -1,0 +1,64 @@
+from unittest.mock import Mock, patch, call
+from django.test import TestCase
+from data_refinery_common.models import (
+    Experiment, Sample, ExperimentSampleAssociation
+)
+
+class ExperimentModelTestCase(TestCase):
+    def tearDown(self):
+        Experiment.objects.all().delete()
+        Sample.objects.all().delete()
+
+    # Test for `get_sample_metadata_fields`
+    def test_get_sample_metadata_fields(self):
+        experiment = Experiment()
+        experiment.save()
+
+        sample = Sample()
+        sample.title = "123"
+        sample.accession_code = "123"
+        sample.specimen_part = "Lung"
+        sample.sex = "Male"
+        sample.save()
+
+        experiment_sample_association = ExperimentSampleAssociation()
+        experiment_sample_association.sample = sample
+        experiment_sample_association.experiment = experiment
+        experiment_sample_association.save()
+
+        self.assertEqual(set(experiment.get_sample_metadata_fields()), set(['specimen_part', 'sex']))
+
+    # Test for when no metadata fields are present
+    def test_get_sample_metadata_fields_none(self):
+        experiment = Experiment()
+        experiment.save()
+
+        sample = Sample()
+        sample.title = "123"
+        sample.accession_code = "123"
+        sample.save()
+
+        experiment_sample_association = ExperimentSampleAssociation()
+        experiment_sample_association.sample = sample
+        experiment_sample_association.experiment = experiment
+        experiment_sample_association.save()
+
+        self.assertEqual(experiment.get_sample_metadata_fields(), [])
+
+    # Since 'age' is stored as a number, it can lead to errors where other fields wouldn't
+    def test_get_sample_metadata_fields_age(self):
+        experiment = Experiment()
+        experiment.save()
+
+        sample = Sample()
+        sample.title = "123"
+        sample.accession_code = "123"
+        sample.age = 23
+        sample.save()
+
+        experiment_sample_association = ExperimentSampleAssociation()
+        experiment_sample_association.sample = sample
+        experiment_sample_association.experiment = experiment
+        experiment_sample_association.save()
+
+        self.assertEqual(set(experiment.get_sample_metadata_fields()), set(['age']))


### PR DESCRIPTION
## Issue Number

https://github.com/AlexsLemonade/refinebio-frontend/issues/211

## Purpose/Implementation Notes

This PR adds a field to the ExperimentSerializer that gives all of the metadata fields that at least one associated Sample has. This is so that this can be displayed on the frontend.

## Types of changes

What types of changes does your code introduce?

<!-- Remove any which your PR isn't -->
- New feature (non-breaking change which adds functionality)

## Functional tests

I ran the API locally to make sure that the output was correct.

## Checklist

_Put an `x` in the boxes that apply._

- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

