### PR TITLE
De-duplicate Rows from NO_OP Processor

### DIFF
--- a/workers/data_refinery_workers/processors/gene_convert.R
+++ b/workers/data_refinery_workers/processors/gene_convert.R
@@ -82,7 +82,8 @@ message("Merging..")
 colnames(data)[1] <- detected_id
 
 converted_exprs <- index_data %>%  
-  dplyr::select(c("ENSEMBL", detected_id)) %>%  # sub "ENSEMBL" for "GENEID"
+  dplyr::select(c("ENSEMBL", detected_id)) %>%
+  dplyr::distinct() %>% 
   dplyr::inner_join(data, by = detected_id)
 
 converted_exprs <- converted_exprs %>%
@@ -92,9 +93,6 @@ message(head(converted_exprs))
 
 # Data here can have duplicate rows that need to be squished together (via mean/max/etc),
 # but this should be done at smash-time so that we can provide options on the squish method.
-
-# Except if the values themselves are the same
-converted_exprs <- converted_exprs[!duplicated(converted_exprs), ]
 
 # Save to output file
 write.table(converted_exprs, outFilePath, row.names=FALSE, col.names=TRUE, quote=FALSE, sep="\t")

--- a/workers/data_refinery_workers/processors/gene_convert.R
+++ b/workers/data_refinery_workers/processors/gene_convert.R
@@ -37,9 +37,6 @@ outFilePath <- opt$outputFile
 message("Loading...")
 source("http://bioconductor.org/biocLite.R")
 
-# library(Biobase)
-# library("AnnotationDbi")
-
 # Read the data file
 message("Reading data file...")
 suppressWarnings(data <- fread(filePath, 
@@ -83,14 +80,6 @@ if (any(overlap >= 0.5)) {
 
 message("Merging..")
 colnames(data)[1] <- detected_id
-#merged <- merge(data, index_data, by=detected_id, all.x=TRUE)
-
-# Old version - R has 'choose the first' behavior
-#out<-join(df1, df2, type="full")
-
-# Take 2
-# merged <- dplyr::inner_join(data, index_data, by=detected_id)
-# message(head(merged))
 
 converted_exprs <- index_data %>%  
   dplyr::select(c("ENSEMBL", detected_id)) %>%  # sub "ENSEMBL" for "GENEID"
@@ -100,21 +89,6 @@ converted_exprs <- converted_exprs %>%
   dplyr::select(-rlang::UQ(rlang::sym(detected_id)))
 
 message(head(converted_exprs))
-
-# data <- merged[, c(3,2)]
-
-# message("Replacing..")
-# # Replace the probe IDs with Ensembles
-# i <- 0
-# c <- which( colnames(index_data) == detected_id )
-# ec <- which( colnames(index_data) == "ENSEMBL" )
-# for(m in data[, 1]){
-# 	data[i, 1] = index_data[i, ec]
-# 	i <- i + 1;
-# }
-
-# Remove all of the unmapped (NA) values (likely control probes?)
-# data <- data[complete.cases(data), ]
 
 # Data here can have duplicate rows that need to be squished together (via mean/max/etc),
 # but this should be done at smash-time so that we can provide options on the squish method.

--- a/workers/data_refinery_workers/processors/gene_convert.R
+++ b/workers/data_refinery_workers/processors/gene_convert.R
@@ -119,5 +119,8 @@ message(head(converted_exprs))
 # Data here can have duplicate rows that need to be squished together (via mean/max/etc),
 # but this should be done at smash-time so that we can provide options on the squish method.
 
+# Except if the values themselves are the same
+converted_exprs <- converted_exprs[!duplicated(converted_exprs), ]
+
 # Save to output file
 write.table(converted_exprs, outFilePath, row.names=FALSE, col.names=TRUE, quote=FALSE, sep="\t")

--- a/workers/data_refinery_workers/processors/test_no_op.py
+++ b/workers/data_refinery_workers/processors/test_no_op.py
@@ -104,7 +104,7 @@ class NOOPTestCase(TestCase):
         final_context = no_op.no_op_processor(job.pk)
         self.assertTrue(final_context['success'])
         self.assertTrue(os.path.exists(final_context['output_file_path']))
-        self.assertEqual(os.path.getsize(final_context['output_file_path']), 346325)
+        self.assertEqual(os.path.getsize(final_context['output_file_path']), 346535)
 
     @tag('no_op')
     def test_convert_processed_illumina(self):

--- a/workers/data_refinery_workers/processors/test_no_op.py
+++ b/workers/data_refinery_workers/processors/test_no_op.py
@@ -103,6 +103,8 @@ class NOOPTestCase(TestCase):
 
         final_context = no_op.no_op_processor(job.pk)
         self.assertTrue(final_context['success'])
+        self.assertTrue(os.path.exists(final_context['output_file_path']))
+        self.assertEqual(os.path.getsize(final_context['output_file_path']), 346325)
 
     @tag('no_op')
     def test_convert_processed_illumina(self):


### PR DESCRIPTION
## Issue Number

Jackiecrunch.

## Purpose/Implementation Notes

Some of the files output by the NO_OP processor were significantly larger than they should have been. This deduplicates those lines (although it doesn't adequately explain _why_ those were duplicated in the first place.)

## Types of changes
- Bugfix (non-breaking change which fixes an issue)


## Functional tests

Tested locally, and a new assertion is added to make sure that the file is the correct size.

## Checklist

_Put an `x` in the boxes that apply._

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules