### PR TITLE
Add an acm_certificate_validation resource to prevent deploys from be…

### DIFF
--- a/infrastructure/networking.tf
+++ b/infrastructure/networking.tf
@@ -176,6 +176,10 @@ resource "aws_acm_certificate" "ssl-cert" {
   }
 }
 
+resource "aws_acm_certificate_validation" "ssl-cert" {
+  certificate_arn = "${aws_acm_certificate.ssl-cert.arn}"
+}
+
 resource "aws_cloudfront_distribution" "static-distribution" {
   aliases = ["${var.static_bucket_prefix == "dev" ? var.user : var.static_bucket_prefix}${var.static_bucket_root}"]
 
@@ -250,7 +254,7 @@ resource "aws_cloudfront_distribution" "static-distribution" {
 
   viewer_certificate {
     cloudfront_default_certificate = true
-    acm_certificate_arn = "${aws_acm_certificate.ssl-cert.arn}"
+    acm_certificate_arn = "${aws_acm_certificate_validation.ssl-cert.certificate_arn}"
     ssl_support_method = "sni-only"
   }
 }


### PR DESCRIPTION
…ing interrupted.

## Issue Number

https://github.com/AlexsLemonade/refinebio/issues/486

## Purpose/Implementation Notes

Our issue was that we were creating an ACM cert and then immediately tried to use it to launch a CloudFront distribution, but it hadn't been validated yet so it couldn't be used for CloudFront. Enough people ran into this issue in the past that Terraform created another resource just to wait.

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

I ran

```
terraform taint aws_acm_certificate.ssl-cert
terraform taint aws_cloudfront_distribution.static-distribution
```

And ran another deploy and the resources got recreated without raising an error like it used to.

## Checklist

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules
