### PR TITLE
Add force-copy argument to terraform init so it will switch backends.

### DIFF
--- a/infrastructure/init_terraform.sh
+++ b/infrastructure/init_terraform.sh
@@ -11,6 +11,9 @@ else
     STAGE=$TF_VAR_stage
 fi
 
+# Force copy will allow us to get past the prompt asking if we want to
+# switch to the remote backend.
 terraform init \
+    -force-copy \
     -backend-config="bucket=refinebio-tfstate-deploy-$STAGE" \
     -backend-config="key=terraform-${TF_VAR_user}.tfstate"


### PR DESCRIPTION
## Issue Number

N/A

## Purpose/Implementation Notes

I realized our first deploy where we cutover from local to remote backends will fail because terraform will try to prompt us for input. This uses a flag to avoid that.

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

I haven't, this will work or I will manually have to get the cutover to work.

## Checklist

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- x] Any dependent changes have been merged and published in downstream modules
