### PR TITLE
Reorganized the No-Op Dockerfile For Improved Cachebility'

### DIFF
--- a/workers/dockerfiles/Dockerfile.no_op
+++ b/workers/dockerfiles/Dockerfile.no_op
@@ -38,14 +38,14 @@ WORKDIR /home/user
 
 # Noop-specific requirements
 ENV R_LIBS "/usr/local/lib/R/site-library"
+COPY workers/install_gene_convert.R .
+RUN Rscript install_gene_convert.R
 RUN mkdir -p gene_indexes
 WORKDIR /home/user/gene_indexes
 RUN curl -O https://zenodo.org/record/1327563/files/all_1533307773.zip
 RUN unzip *.zip
 RUN rm *.zip
 WORKDIR /home/user
-COPY workers/install_gene_convert.R .
-RUN Rscript install_gene_convert.R
 # End Noop-specific
 
 COPY workers/data_refinery_workers/processors/requirements.txt .


### PR DESCRIPTION
## Issue Number

n/a

## Purpose/Implementation Notes

Since the `curl` line in the NO_OP dockerfile can't be cached, having the R installer below it causes it to re-run every time. This small reorganization allows it be cached more often.

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Checklist

_Put an `x` in the boxes that apply._

- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules
