### PR TITLE
Kurtwheeler fix rebuilding docker imgs

### DIFF
--- a/.circleci/run_terraform.sh
+++ b/.circleci/run_terraform.sh
@@ -62,8 +62,8 @@ cd ~/refinebio/infrastructure
 # However it cannot be on both master and dev because merges create new commits.
 # Therefore check to see if either master or dev show up in the list
 # of branches containing that tag.
-master_check=$(git branch --contains tags/$CIRCLE_TAG | grep '^  master$')
-dev_check=$(git branch --contains tags/$CIRCLE_TAG | grep '^  dev$')
+master_check=$(git branch --contains tags/$CIRCLE_TAG | grep '^  master$' || true)
+dev_check=$(git branch --contains tags/$CIRCLE_TAG | grep '^  dev$' || true)
 
 
 if [[ ! -z $master_check ]]; then

--- a/.circleci/slackpost.sh
+++ b/.circleci/slackpost.sh
@@ -23,8 +23,8 @@ then
 fi
 
 # ------------
-master_check=$(git branch --contains tags/$CIRCLE_TAG | grep '^  master$')
-dev_check=$(git branch --contains tags/$CIRCLE_TAG | grep '^  dev$')
+master_check=$(git branch --contains tags/$CIRCLE_TAG | grep '^  master$' || true)
+dev_check=$(git branch --contains tags/$CIRCLE_TAG | grep '^  dev$' || true)
 
 if [[ ! -z $master_check ]]; then
     CIRCLE_BRANCH=master

--- a/.circleci/update_docker_img.sh
+++ b/.circleci/update_docker_img.sh
@@ -11,8 +11,8 @@ source ~/refinebio/common.sh
 # However it cannot be on both master and dev because merges create new commits.
 # Therefore check to see if either master or dev show up in the list
 # of branches containing that tag.
-master_check=$(git branch --contains tags/$CIRCLE_TAG | grep '^  master$')
-dev_check=$(git branch --contains tags/$CIRCLE_TAG | grep '^  dev$')
+master_check=$(git branch --contains tags/$CIRCLE_TAG | grep '^  master$' || true)
+dev_check=$(git branch --contains tags/$CIRCLE_TAG | grep '^  dev$' || true)
 
 
 if [[ ! -z $master_check ]]; then


### PR DESCRIPTION
## Issue Number

N/A

## Purpose/Implementation Notes

This came up while trying to redeploy the staging server: https://circleci.com/gh/AlexsLemonade/refinebio/4696

I didn't realize that if grep fails to match, then it exits with error code 1. This uses a fix from https://unix.stackexchange.com/questions/330660/prevent-grep-from-exiting-in-case-of-nomatch to make this not crash the script.

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

I've tested this by running the new lines on a circleci box that I ssh'd onto, but I can't test it further than that really.

## Checklist

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules

## Screenshots

Please attach any screenshots that illustrate these changes.
