### PR TITLE
Adds converted GPLs and A-GEODs to supported microarray list.

### DIFF
--- a/common/data_refinery_common/test_utils.py
+++ b/common/data_refinery_common/test_utils.py
@@ -51,6 +51,7 @@ class UtilsTestCase(TestCase):
         has_equgene11st = False
         has_A_AFFY_59 = False
         has_GPL23026 = False
+        has_AGEOD23026 = False
         for platform in supported_microarray_platforms:
             if platform["platform_accession"] == "equgene11st" and platform["is_brainarray"]:
                 has_equgene11st = True
@@ -61,9 +62,13 @@ class UtilsTestCase(TestCase):
             if platform["external_accession"] == "GPL23026" and not platform["is_brainarray"]:
                 has_GPL23026 = True
 
+            if platform["external_accession"] == "A-GEOD-23026" and not platform["is_brainarray"]:
+                has_AGEOD23026 = True
+
         self.assertTrue(has_equgene11st)
         self.assertTrue(has_A_AFFY_59)
         self.assertTrue(has_GPL23026)
+        self.assertTrue(has_AGEOD23026)
 
     def test_get_internal_microarray_accession(self):
         """Test that supported microarray platforms setting is set correctly."""

--- a/common/data_refinery_common/utils.py
+++ b/common/data_refinery_common/utils.py
@@ -83,9 +83,29 @@ def get_supported_microarray_platforms(platforms_csv: str="config/supported_micr
             if reader.line_num is 1:
                 continue
 
+            external_accession = line[1]
+            is_brainarray = True if line[2] == 'y' else False
             SUPPORTED_MICROARRAY_PLATFORMS.append({"platform_accession": line[0],
-                                                   "external_accession": line[1],
-                                                   "is_brainarray": True if line[2] == 'y' else False})
+                                                   "external_accession": external_accession,
+                                                   "is_brainarray": is_brainarray})
+
+            # A-GEOD-13158 is the same platform as GPL13158 and this
+            # pattern is generalizable. Since we don't want to have to
+            # list a lot of platforms twice just with different prefixes,
+            # we just convert them and add them to the list.
+            if external_accession[:6] == "A-GEOD":
+                converted_accession = external_accession.replace("A-GEOD-", "GPL")
+                SUPPORTED_MICROARRAY_PLATFORMS.append({"platform_accession": line[0],
+                                                       "external_accession": converted_accession,
+                                                       "is_brainarray": is_brainarray})
+
+            # Our list of supported platforms contains both A-GEOD-*
+            # and GPL*, so convert both ways.
+            if external_accession[:3] == "GPL":
+                converted_accession = external_accession.replace("GPL", "A-GEOD-")
+                SUPPORTED_MICROARRAY_PLATFORMS.append({"platform_accession": line[0],
+                                                       "external_accession": converted_accession,
+                                                       "is_brainarray": is_brainarray})
 
     return SUPPORTED_MICROARRAY_PLATFORMS
 

--- a/foreman/data_refinery_foreman/surveyor/array_express.py
+++ b/foreman/data_refinery_foreman/surveyor/array_express.py
@@ -89,10 +89,10 @@ class ArrayExpressSurveyor(ExternalSourceSurveyor):
             experiment["platform_accession_name"] = UNKNOWN
             experiment["manufacturer"] = UNKNOWN
         else:
-            external_accession = get_normalized_platform(parsed_json["arraydesign"][0]["accession"])
+            external_accession = parsed_json["arraydesign"][0]["accession"]
             for platform in get_supported_microarray_platforms():
                 if platform["external_accession"] == external_accession:
-                    experiment["platform_accession_code"] = platform["platform_accession"]
+                    experiment["platform_accession_code"] = get_normalized_platform(platform["platform_accession"])
 
                     # Illumina appears in the accession codes for
                     # platforms manufactured by Illumina


### PR DESCRIPTION
## Issue Number

N/A, came up in Jackie Crunch

## Purpose/Implementation Notes

When I implemented the supported platforms lists, I missed the fact that A-GEOD-XXX and GPLXXX are the same platform and therefore are only specified once in the list. This addresses that by performing a conversion and including them in the list.

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

I added a unit test and I made sure that running the surveyor for E-GEOD-77094 populated the platform fields for the samples successfully.

## Checklist

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules
