### PR TITLE
Allow multiple filters in same category

### DIFF
--- a/api/data_refinery_api/tests.py
+++ b/api/data_refinery_api/tests.py
@@ -348,9 +348,9 @@ class APITestCases(APITestCase):
         self.assertEqual(len(response.json()['results'][0]['platforms']), 2)
         self.assertEqual(sorted(response.json()['results'][0]['platforms']), sorted(ex.platforms))
         self.assertEqual(sorted(response.json()['results'][0]['platforms']), sorted(['AFFY', 'ILLUMINA']))
-        self.assertEqual(response.json()['filters']['technology'], {'MICROARRAY': 2})
+        self.assertEqual(response.json()['filters']['technology'], {'FAKE-TECH': 1, 'MICROARRAY': 2, 'RNA-SEQ': 1})
         self.assertEqual(response.json()['filters']['publication'], {})
-        self.assertEqual(response.json()['filters']['organism'], {'HOMO_SAPIENS': 2})
+        self.assertEqual(response.json()['filters']['organism'], {'Extra-Terrestrial-1982': 1, 'HOMO_SAPIENS': 3})
 
         response = self.client.get(reverse('search'),
                                    {'search': 'THISWILLBEINASEARCHRESULT',
@@ -360,6 +360,11 @@ class APITestCases(APITestCase):
         response = self.client.get(reverse('search'), {'search': 'Clark Kent'})
         self.assertEqual(response.json()['count'], 1)
         self.assertEqual(response.json()['results'][0]['accession_code'], "FINDME_TEMPURA")
+
+        # Test multiple filters
+        # This has to be done manually due to dicts requring distinct keys
+        response = self.client.get(reverse('search') + "?search=THISWILLBEINASEARCHRESULT&technology=MICROARRAY&technology=FAKE-TECH")
+        self.assertEqual(response.json()['count'], 2)
 
     @patch('data_refinery_common.message_queue.send_job')
     def test_create_update_dataset(self, mock_send_job):

--- a/api/data_refinery_api/views.py
+++ b/api/data_refinery_api/views.py
@@ -159,13 +159,6 @@ class SearchAndFilter(generics.ListAPIView):
                         '@submitter_institution',
                         'experimentannotation__data'
                     )
-    filter_fields = (   'has_publication', 
-                        'submitter_institution', 
-                        'technology',
-                        'source_first_published', 
-                        'organisms__name',
-                        'samples__platform_accession_code'
-                    )
 
     def list(self, request, *args, **kwargs):
         """ Adds counts on certain filter fields to result JSON."""


### PR DESCRIPTION
## Issue Number

Fixes #441

## Purpose/Implementation Notes

Since our desired filter behavior wasn't covered by the default filter, I had to implement a custom FilterSet using `ModelMultipleChoiceFilter`s where conceivably we would want to apply more than one filter.

## Types of changes

What types of changes does your code introduce?

<!-- Remove any which your PR isn't -->
- New feature (non-breaking change which adds functionality)

## Functional tests

I ran the API locally to make sure that the output was correct.

## Checklist

_Put an `x` in the boxes that apply._

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

