### PR TITLE
Turn on docker caching layer in circleci.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,6 +5,7 @@ jobs:
   main_tests:
     working_directory: ~/refinebio
     machine:
+      docker_layer_caching: true
       pre:
         - sudo rm -rf /usr/local/android-sdk-linux
         - sudo rm -rf /usr/local/go
@@ -49,7 +50,7 @@ jobs:
       # Run Foreman Tests
       - run: mkdir -p test_volume && chmod -R a+rw test_volume
       - run: ./foreman/run_tests.sh
-      
+
      # Run NO_OP tests
       - run: sudo chown -R circleci:circleci workers/test_volume/
       - run: .circleci/filter_tests.sh -t no_op
@@ -69,6 +70,7 @@ jobs:
   affymetrix_common_agilent_tests:
     working_directory: ~/refinebio
     machine:
+      docker_layer_caching: true
       pre:
         - sudo rm -rf /usr/local/android-sdk-linux
         - sudo rm -rf /usr/local/go
@@ -110,6 +112,7 @@ jobs:
   salmon_and_api_tests:
     working_directory: ~/refinebio
     machine:
+      docker_layer_caching: true
       pre:
         - sudo rm -rf /usr/local/android-sdk-linux
         - sudo rm -rf /usr/local/go
@@ -144,6 +147,7 @@ jobs:
   transcriptome_and_illumina_tests:
     working_directory: ~/refinebio
     machine:
+      docker_layer_caching: true
       pre:
         - sudo rm -rf /usr/local/android-sdk-linux
         - sudo rm -rf /usr/local/go
@@ -179,6 +183,7 @@ jobs:
 
   deploy:
     machine:
+      docker_layer_caching: true
       pre:
         - sudo rm -rf /usr/local/android-sdk-linux
         - sudo rm -rf /usr/local/go


### PR DESCRIPTION
## Issue Number

https://github.com/AlexsLemonade/refinebio/issues/490

## Purpose/Implementation Notes

We have the Docker Caching Layer feature enabled on our CircleCI account. This actually turns it on for our builds, however it may take a couple runs for the cache to be populated and used.

We have a two week trial with this feature, so we can see how it does when there's lots of builds on different branches and such, and also how it affects deployments (Which we'll probably need a couple of.)

## Types of changes

- New feature (non-breaking change which adds functionality)

## Functional tests

https://circleci.com/gh/AlexsLemonade/refinebio/4893 ran in 24:54, 10 minutes of which were waiting for SSH sessions. This means the run time for that build went from ~1 hour to ~15 minutes.

## Checklist

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules
