### PR TITLE
Ensure get_ip_address returns a single IP

### DIFF
--- a/common.sh
+++ b/common.sh
@@ -4,7 +4,7 @@ get_ip_address () {
     if [ `uname` == "Linux" ]; then
         echo $(ip route get 8.8.8.8 | grep -oE 'src ([0-9]{1,3}\.){3}[0-9]{1,3}' | awk '{print $2; exit}')
     elif [ `uname` == 'Darwin' ]; then # MacOS
-        echo $(ifconfig | grep "inet " | grep -v 127.0.0.1 | cut -d\  -f2)
+        echo $(ifconfig | grep "inet " | grep -v 127.0.0.1 | cut -d\  -f2 | tail -1)
     fi
 }
 


### PR DESCRIPTION
## Issue Number

N/A

## Purpose/Implementation Notes

The function `get_ip_address` in `common.sh` was returning two IP addresses in my computer. This PR ensures only one get's returned. Before it was:

```sh
$ source common.sh
$ HOST_IP=$(get_ip_address)
$ DB_HOST_IP=$(get_docker_db_ip_address)
$ echo $HOST_IP
192.168.150.86 169.254.111.170
```

And that was giving the following error when running `./api/serve.sh`

```sh
Unable to find image '169.254.111.170:latest' locally
docker: Error response from daemon: pull access denied for 169.254.111.170, repository does not exist or may require 'docker login'.
```

Thanks to @kurtwheeler for helping diagnose the error.

## Types of changes

What types of changes does your code introduce?

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

I ran `'./api/serve.sh` successfully.

## Checklist

- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules
