### PR TITLE
Kurtwheeler/unsurveyor

### DIFF
--- a/common/data_refinery_common/models/models.py
+++ b/common/data_refinery_common/models/models.py
@@ -796,6 +796,8 @@ class ComputedFile(models.Model):
             pass
 
     def delete_s3_file(self, force=False):
+        # If we're not running in the cloud then we shouldn't try to
+        # delete something from S3 unless force is set.
         if not settings.RUNNING_IN_CLOUD and not force:
             return False
 

--- a/common/data_refinery_common/models/models.py
+++ b/common/data_refinery_common/models/models.py
@@ -804,8 +804,8 @@ class ComputedFile(models.Model):
             return True
         except:
             logger.exception("Failed to delete S3 object for Computed File.",
-                             "computed_file"=self.id,
-                             "s3_object"=self.s3_key)
+                             computed_file=self.id,
+                             s3_object=self.s3_key)
             return False
 
     def get_synced_file_path(self, force=False):

--- a/foreman/data_refinery_foreman/surveyor/management/commands/test_unsurvey.py
+++ b/foreman/data_refinery_foreman/surveyor/management/commands/test_unsurvey.py
@@ -1,0 +1,77 @@
+import json
+import datetime
+from unittest.mock import Mock, patch, call
+from django.test import TransactionTestCase
+from data_refinery_common.models import (
+    DownloaderJob,
+    SurveyJob,
+    SurveyJobKeyValue,
+    Organism,
+    Experiment,
+    ExperimentSampleAssociation,
+    Sample,
+    OriginalFile,
+    OriginalFileSampleAssociation
+)
+from data_refinery_foreman.surveyor.management.commands.unsurvey import purge_experiment
+from data_refinery_foreman.surveyor.geo import GeoSurveyor
+
+class SurveyTestCase(TransactionTestCase):
+    @patch('data_refinery_foreman.surveyor.external_source.message_queue.send_job')
+    def test_geo_survey_microarray(self, mock_send_task):
+        """Test that the unsurveyor works correctly.
+
+        This includes not deleting samples which also belong to other
+        experiments. Therefore we survey a superseries and one of its
+        sub-experiments, then delete the superseries to make sure the
+        sub-experiment wasn't touched.
+
+        We mock out the send_job function so that we don't actually
+        process these. The unsurveyor code related to ComputedFile,
+        ComputationalResult, and ProcessorJobs won't be tested by
+        this, but it's been functionally tested.
+        """
+        superseries_accession = "GSE59795"
+        sub_experiment_accession = "GSE46580"
+
+        # Survey the superseries.
+        survey_job = SurveyJob(source_type="GEO")
+        survey_job.save()
+
+        key_value_pair = SurveyJobKeyValue(survey_job=survey_job,
+                                           key="experiment_accession_code",
+                                           value=superseries_accession)
+        key_value_pair.save()
+
+        geo_surveyor = GeoSurveyor(survey_job)
+        geo_surveyor.survey()
+
+        # Survey the sub-experiment
+        survey_job = SurveyJob(source_type="GEO")
+        survey_job.save()
+
+        key_value_pair = SurveyJobKeyValue(survey_job=survey_job,
+                                           key="experiment_accession_code",
+                                           value=sub_experiment_accession)
+        key_value_pair.save()
+
+        geo_surveyor = GeoSurveyor(survey_job)
+        geo_surveyor.survey()
+
+        # Purge the superseries
+        purge_experiment(superseries_accession)
+
+        # Make sure the subexperiment samples weren't affected.
+        experiment = Experiment.objects.filter(accession_code=sub_experiment_accession)[0]
+        experiment_sample_assocs = ExperimentSampleAssociation.objects.filter(experiment=experiment)
+        samples = Sample.objects.filter(id__in=experiment_sample_assocs.values('sample_id'))
+        self.assertEqual(samples.count(), 4)
+
+        # Make sure sub-experiment original files weren't affected.
+        og_file_sample_assocs = OriginalFileSampleAssociation.objects.filter(sample_id__in=samples.values('id'))
+        original_files = OriginalFile.objects.filter(id__in=og_file_sample_assocs.values('original_file_id'))
+        self.assertEqual(original_files.count(), 6)
+
+        # Make sure the superseries samples are gone.
+        self.assertEqual(Sample.objects.count(), 4)
+        self.assertEqual(OriginalFile.objects.count(), 6)

--- a/foreman/data_refinery_foreman/surveyor/management/commands/unsurvey.py
+++ b/foreman/data_refinery_foreman/surveyor/management/commands/unsurvey.py
@@ -77,8 +77,10 @@ def purge_experiment(accession: str) -> None:
 
     for downloader_job in downloader_jobs:
         extra_assocs = DownloaderJobOriginalFileAssociation.objects.filter(
-            downloader_job=downloader_job,
-            original_file_id__not_in=uniquely_assoced_og_file_ids)
+            downloader_job=downloader_job
+        ).exclude(
+            original_file_id__in=uniquely_assoced_og_file_ids
+        )
         if extra_assocs.count() == 0:
             DownloaderJobOriginalFileAssociation.objects.filter(downloader_job=downloader_job).delete()
             downloader_job.delete()
@@ -88,8 +90,10 @@ def purge_experiment(accession: str) -> None:
 
     for processor_job in processor_jobs:
         extra_assocs = ProcessorJobOriginalFileAssociation.objects.filter(
-            processor_job=processor_job,
-            original_file_id__not_in=uniquely_assoced_og_file_ids)
+            processor_job=processor_job
+        ).exclude(
+            original_file_id__in=uniquely_assoced_og_file_ids
+        )
         if extra_assocs.count() == 0:
             ProcessorJobOriginalFileAssociation.objects.filter(processor_job=processor_job).delete()
             processor_job.delete()

--- a/foreman/data_refinery_foreman/surveyor/management/commands/unsurvey.py
+++ b/foreman/data_refinery_foreman/surveyor/management/commands/unsurvey.py
@@ -1,0 +1,148 @@
+"""
+This command will remove experiments and all data that is uniquely associated with them.
+(i.e. it's only associated with these experiment and not others.)
+This can be used so that a surveyor job that went wrong can be rerun.
+"""
+
+from django.core.management.base import BaseCommand
+from data_refinery_common.models import *
+from data_refinery_common.logging import get_and_configure_logger
+
+logger = get_and_configure_logger(__name__)
+
+def purge_experiment(accession: str) -> None:
+    experiment = Experiment.objects.filter(accession_code=accession)[0]
+    ExperimentAnnotation.objects.filter(experiment=experiment).delete()
+    experiment_sample_assocs = ExperimentSampleAssociation.objects.filter(experiment=experiment)
+    samples = Sample.objects.filter(id__in=experiment_sample_assocs.values('sample_id'))
+
+    uniquely_assoced_sample_ids = []
+    deletable_experiment_sample_assocs = []
+    for sample in samples:
+        assoc_query = ExperimentSampleAssociation.objects.filter(sample=sample)
+        if assoc_query.count() == 1:
+            uniquely_assoced_sample_ids.append(sample.id)
+            SampleAnnotation.objects.filter(sample=sample).delete()
+            deletable_experiment_sample_assocs.append(assoc_query[0].id)
+
+    comp_result_sample_assocs = SampleResultAssociation.objects.filter(sample_id__in=uniquely_assoced_sample_ids)
+    comp_results = ComputationalResult.objects.filter(id__in=comp_result_sample_assocs.values('computational_result_id'))
+
+    uniquely_assoced_comp_result_ids = []
+    deletable_sample_result_assocs = []
+    for comp_result in comp_results:
+        extra_assocs = SampleResultAssociation.objects.filter(
+            computational_result=comp_result,
+            sample_id__not_in=uniquely_assoced_sample_ids)
+        if extra_assocs.count == 0:
+            uniquely_assoced_comp_result_ids.append(comp_result.id)
+
+            unique_associations = SampleResultAssociation.objects.filter(result=comp_result)
+            for assoc in unique_associations:
+                deletable_sample_result_assocs.append(assoc)
+
+            ComputationalResultAnnotation.objects.filter(result=comp_result).delete()
+            computed_files = ComputedFile.objects.filter(result=comp_result)
+            for computed_file in computed_files:
+                computed_file.delete_local_file()
+                computed_file.delete()
+
+    og_file_sample_assocs = OriginalFileSampleAssociation.objects.filter(sample_id__in=uniquely_assoced_sample_ids)
+    original_files = OriginalFile.objects.filter(id__in=og_file_sample_assocs.values('original_file_id'))
+
+    uniquely_assoced_og_file_ids = []
+    deletable_og_file_assocs = []
+    for original_file in original_files:
+        extra_assocs = OriginalFileSampleAssociation.objects.filter(
+            original_file=original_file,
+            sample_id__not_in=uniquely_assoced_sample_ids)
+        if extra_assocs.count == 0:
+            uniquely_assoced_og_file_ids.append(original_file.id)
+
+            unique_associations = OriginalFilesampleAssociation.objects.filter(original_file=original_file)
+            for assoc in unique_associations:
+                deletable_og_file_assocs.append(assoc)
+
+    og_file_dj_assocs = DownloaderJobOriginalFileAssociation.objects.filter(original_file_id__in=uniquely_assoced_og_file_ids)
+    downloader_jobs = DownloaderJob.objects.filter(id__in=og_file_dj_assocs.values('downloader_job_id'))
+
+    for downloader_job in downloader_jobs:
+        extra_assocs = DownloaderJobOriginalFileAssociation.objects.filter(
+            downloader_job=downloader_job,
+            original_file_id__not_in=uniquely_assoced_og_file_ids)
+        if extra_assocs.count == 0:
+            DownloaderJobOriginalFileAssociation.objects.filter(downloader_job=downloader_job).delete()
+            downloader_job.delete()
+
+    for processor_job in processor_jobs:
+        extra_assocs = ProcessorJobOriginalFileAssociation.objects.filter(
+            processor_job=processor_job,
+            original_file_id__not_in=uniquely_assoced_og_file_ids)
+        if extra_assocs.count == 0:
+            ProcessorJobOriginalFileAssociation.objects.filter(processor_job=processor_job).delete()
+            processor_job.delete()
+
+    for og_file_assoc in deletable_og_file_assocs:
+        og_file_assoc.delete()
+
+    for comp_result_assoc in deletable_sample_result_assocs:
+        comp_result_assoc.delete()
+
+    for sample_assoc in deletable_experiment_sample_assocs:
+        sample_assoc.delete()
+
+    OriginalFiles.objects.filter(id__in=uniquely_assoced_og_file_ids).delete()
+    ComputationalResult.objects.filter(id__in=uniquely_assoced_comp_result_ids).delete()
+    Samples.objects.filter(id__in=uniquely_assoced_sample_ids).delete()
+    experiment.delete()
+
+
+
+
+class Command(BaseCommand):
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--accession",
+            help=("An experiment accession code to survey, download, and process."))
+        parser.add_argument(
+            "--file",
+            type=str,
+            help=("An optional file listing accession codes. s3:// URLs are also accepted.")
+        )
+
+    def handle(self, *args, **options):
+        if options["accession"] is None and options['file'] is None:
+            logger.error("You must specify an experiment accession or file.")
+            sys.exit(1)
+
+        accessions = []
+        if options["file"]:
+            if 's3://' in options["file"]:
+                bucket, key = parse_s3_url(options["file"])
+                s3 = boto3.resource('s3')
+                try:
+                    filepath = "/tmp/input_" + str(uuid.uuid4()) + ".txt"
+                    s3.Bucket(bucket).download_file(key, filepath)
+                except botocore.exceptions.ClientError as e:
+                    if e.response['Error']['Code'] == "404":
+                        logger.error("The remote file does not exist.")
+                        raise
+                    else:
+                        raise
+            else:
+                filepath = options["file"]
+
+            with open(filepath) as file:
+                for accession in file:
+                    accessions.append(accession)
+        else:
+            accessions.append(options['accession'])
+
+        for accession in accessions:
+            logger.info("Purging Experiment with accession: %s", accession)
+            try:
+                purge_experiment(accession)
+            except Exception as e:
+                logger.exception("Exception caught while purging experiment with accession: %s", accession)
+
+        logger.info("Purged %s experiments.", str(len(accessions)))

--- a/foreman/data_refinery_foreman/surveyor/management/commands/unsurvey.py
+++ b/foreman/data_refinery_foreman/surveyor/management/commands/unsurvey.py
@@ -3,6 +3,7 @@ This command will remove experiments and all data that is uniquely associated wi
 (i.e. it's only associated with these experiment and not others.)
 This can be used so that a surveyor job that went wrong can be rerun.
 """
+import sys
 
 from django.core.management.base import BaseCommand
 from data_refinery_common.models import *
@@ -155,11 +156,23 @@ class Command(BaseCommand):
             type=str,
             help=("An optional file listing accession codes. s3:// URLs are also accepted.")
         )
+        parser.add_argument('--force',
+                            help='Do not ask for confirmation.',
+                            action='store_true')
 
     def handle(self, *args, **options):
         if options["accession"] is None and options['file'] is None:
             logger.error("You must specify an experiment accession or file.")
             sys.exit(1)
+
+        if not options["force"]:
+            print('-------------------------------------------------------------------------------')
+            print('This will delete all objects in the database. Are you sure you want to do this?')
+            answer = input('You must type "yes", all other input will be ignored: ')
+
+            if answer != "yes":
+                print('Not unsurveying because confirmation was denied.')
+                sys.exit(1)
 
         accessions = []
         if options["file"]:

--- a/foreman/data_refinery_foreman/surveyor/test_end_to_end.py
+++ b/foreman/data_refinery_foreman/surveyor/test_end_to_end.py
@@ -8,11 +8,25 @@ from data_refinery_common.models import (
     Organism,
     SurveyJob,
     SurveyJobKeyValue,
+    Experiment,
+    ExperimentAnnotation,
+    ExperimentSampleAssociation,
+    Sample,
+    SampleAnnotation,
+    OriginalFile,
+    OriginalFileSampleAssociation,
+    SampleResultAssociation,
+    ComputationalResult,
+    ComputationalResultAnnotation,
+    SampleComputedFileAssociation,
+    ComputedFile,
     DownloaderJob,
+    DownloaderJobOriginalFileAssociation,
     ProcessorJob,
-    Sample
+    ProcessorJobOriginalFileAssociation
 )
 from data_refinery_foreman.surveyor import surveyor
+from data_refinery_foreman.surveyor.management.commands.unsurvey import purge_experiment
 
 # Import and set logger
 import logging
@@ -87,7 +101,8 @@ class NoOpEndToEndTestCase(TransactionTestCase):
         organism = Organism(name="HOMO_SAPIENS", taxonomy_id=9606, is_scientific_name=True)
         organism.save()
 
-        survey_job = surveyor.survey_ae_experiment("E-GEOD-45547")
+        accession_code = "E-GEOD-45547"
+        survey_job = surveyor.survey_ae_experiment(accession_code)
 
         self.assertTrue(survey_job.success)
 
@@ -104,3 +119,23 @@ class NoOpEndToEndTestCase(TransactionTestCase):
         for processor_job in processor_jobs:
             processor_job = wait_for_job(processor_job, ProcessorJob, start_time)
             self.assertTrue(processor_job.success)
+
+        # Test that the unsurveyor deletes all objects related to the experiment
+        purge_experiment(accession_code)
+
+        self.assertEqual(Experiment.objects.all().count(), 0)
+        self.assertEqual(ExperimentAnnotation.objects.all().count(), 0)
+        self.assertEqual(ExperimentSampleAssociation.objects.all().count(), 0)
+        self.assertEqual(Sample.objects.all().count(), 0)
+        self.assertEqual(SampleAnnotation.objects.all().count(), 0)
+        self.assertEqual(OriginalFile.objects.all().count(), 0)
+        self.assertEqual(OriginalFileSampleAssociation.objects.all().count(), 0)
+        self.assertEqual(SampleResultAssociation.objects.all().count(), 0)
+        self.assertEqual(ComputationalResult.objects.all().count(), 0)
+        self.assertEqual(ComputationalResultAnnotation.objects.all().count(), 0)
+        self.assertEqual(SampleComputedFileAssociation.objects.all().count(), 0)
+        self.assertEqual(ComputedFile.objects.all().count(), 0)
+        self.assertEqual(DownloaderJob.objects.all().count(), 0)
+        self.assertEqual(DownloaderJobOriginalFileAssociation.objects.all().count(), 0)
+        self.assertEqual(ProcessorJob.objects.all().count(), 0)
+        self.assertEqual(ProcessorJobOriginalFileAssociation.objects.all().count(), 0)


### PR DESCRIPTION
## Issue Number

#451 (although only the half related to being able to resurvey an experiment)

## Purpose/Implementation Notes

When we have a surveyor bug that we fix and so we want to rerun the affected experiments, we don't have a good way of doing so. This adds the ability to "unsurvey" an experiment, so that a new survey job can be run.

## Types of changes

- New feature (non-breaking change which adds functionality)

## Functional tests

I surveyed, downloaded, and processed an experiment locally. I then ran the unsurveyor and verified that all the tables were emptied.

## Checklist

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules
