### PR TITLE
Make the downloads page faster

### DIFF
--- a/api/data_refinery_api/serializers.py
+++ b/api/data_refinery_api/serializers.py
@@ -468,6 +468,65 @@ class DatasetSerializer(serializers.ModelSerializer):
             raise
         return data
 
+class DatasetDetailsSampleSerializer(serializers.ModelSerializer):
+    """ This serializer contains all of the information about a sample needed for the download page
+    """
+    organism = OrganismSerializer(many=False)
+
+    class Meta:
+        model = Sample
+        fields = (
+                    'accession_code',
+                    'organism',
+                )
+
+class DatasetDetailsExperimentSerializer(serializers.ModelSerializer):
+    """ This serializer contains all of the information about an experiment needed for the download
+    page
+    """
+    organisms = serializers.StringRelatedField(many=True)
+    samples = serializers.StringRelatedField(many=True)
+    sample_metadata = serializers.ReadOnlyField(source='get_sample_metadata_fields')
+    pretty_platforms = serializers.ReadOnlyField()
+
+    class Meta:
+        model = Experiment
+        fields = (
+                    'id',
+                    'title',
+                    'accession_code',
+                    'pretty_platforms',
+                    'samples',
+                    'organisms',
+                    'sample_metadata',
+                )
+
+class DatasetDetailsSerializer(serializers.ModelSerializer):
+    """ This serializer contains all of the information about a dataset needed for the download page
+    """
+    samples = DatasetDetailsSampleSerializer(read_only=True, many=True, source='get_samples')
+    experiments = DatasetDetailsExperimentSerializer(read_only=True, many=True, source='get_experiments')
+
+    class Meta:
+        model = Dataset
+        fields = (
+                    'data',
+                    'aggregate_by',
+                    'scale_by',
+                    'is_processing',
+                    'is_processed',
+                    'experiments',
+                    'samples'
+            )
+        extra_kwargs = {
+                        'is_processing': {
+                            'read_only': True,
+                        },
+                        'is_processed': {
+                            'read_only': True,
+                        },
+                    }
+
 class APITokenSerializer(serializers.ModelSerializer):
 
     class Meta:

--- a/api/data_refinery_api/views.py
+++ b/api/data_refinery_api/views.py
@@ -52,6 +52,7 @@ from data_refinery_api.serializers import (
     # Dataset
     CreateDatasetSerializer,
     DatasetSerializer,
+    DatasetDetailsSerializer,
     APITokenSerializer
 )
 
@@ -184,6 +185,11 @@ class DatasetView(generics.RetrieveUpdateAPIView):
     queryset = Dataset.objects.all()
     serializer_class = DatasetSerializer
     lookup_field = 'id'
+
+    def get_serializer_class(self):
+        if 'details' in self.request.query_params:
+            return DatasetDetailsSerializer
+        return self.serializer_class
 
     def perform_update(self, serializer):
         """ If `start` is set, fire off the job. Disables dataset data updates after that. """


### PR DESCRIPTION
## Issue Number

https://github.com/AlexsLemonade/refinebio-frontend/issues/192

## Purpose/Implementation Notes

The downloads page is currently really slow for large datasets, which has a lot to do with the amount of network requests we make and the size of the responses. This PR makes it so that all of the information for the page is returned at once if `?details=true` is added to the end of a dataset link, which cuts down on network latency issues associated with multiple requests. The serializers used when that parameter is added also make sure that only the relevant information is downloaded at that moment, saving on bandwidth and speeding up the download.

## Types of changes

What types of changes does your code introduce?

<!-- Remove any which your PR isn't -->
- New feature (non-breaking change which adds functionality)

## Functional tests

I ran the API and frontend locally.

## Checklist

_Put an `x` in the boxes that apply._

- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

