### PR TITLE
Fix API deploys, prevent logging an error from becoming a new and int…

### DIFF
--- a/infrastructure/api-configuration/api-server-instance-user-data.tpl.sh
+++ b/infrastructure/api-configuration/api-server-instance-user-data.tpl.sh
@@ -90,6 +90,8 @@ cat <<"EOF" > environment
 ${api_environment}
 EOF
 
+chown -R ubuntu /home/ubuntu
+
 STATIC_VOLUMES=/tmp/volumes_static
 mkdir -p /tmp/volumes_static
 chmod a+rwx /tmp/volumes_static

--- a/infrastructure/deploy.sh
+++ b/infrastructure/deploy.sh
@@ -226,6 +226,10 @@ ssh -o StrictHostKeyChecking=no \
     -i data-refinery-key.pem \
     ubuntu@$API_IP_ADDRESS "docker rm -f dr_api"
 
+scp -o StrictHostKeyChecking=no \
+    -i data-refinery-key.pem \
+    api-configuration/environment ubuntu@$API_IP_ADDRESS:/home/ubuntu/environment
+
 ssh -o StrictHostKeyChecking=no \
     -i data-refinery-key.pem \
     ubuntu@$API_IP_ADDRESS "docker run \

--- a/workers/data_refinery_workers/downloaders/geo.py
+++ b/workers/data_refinery_workers/downloaders/geo.py
@@ -444,12 +444,14 @@ def download_geo(job_id: int) -> None:
     if len(unpacked_sample_files) > 0:
         success = True
         logger.debug("File downloaded and extracted successfully.",
-                     url,
+                     url=url,
+                     dl_file_path=dl_file_path,
                      downloader_job=job_id)
     else:
         success = False
         logger.info("Unable to extract any files.",
-                    url,
+                    url=url,
+                    dl_file_path=dl_file_path,
                     downloader_job=job_id)
         job.failure_reason = "Failed to extract any downloaded files."
 


### PR DESCRIPTION
…eresting error.

## Issue Number

N/A JackieCrunch related

## Purpose/Implementation Notes

Two issues:
* When the API was redeployed it didn't have all the environment variables. I think this is related to the `environment` file being created by the root user when the server is created, but then being restarted by the ubuntu user who doesn't have access to the `environment` file. Potentially just the `chown` change could be enough, but I realized that this means that subsequent deploys couldn't change the environment for the API.
* A couple of our error logging calls were malformed so they were throwing their own errors, which made debugging hard.

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

I re-deployed the API with the new code and it started working nicely instead of breaking all over  the place.

I tested the other code by running:
```
./foreman/run_surveyor.sh survey_all --accession=GSE44719
```

locally. Interesting thing about this one was, I accidentally ran it with the `ccdlstaging` image and it failed with the exact same issue as we saw in the dev stack. However when I ran it with the image I built with this new code, not only did the logger call not fail, it didn't even get triggered. It looks like we might be back to being able to download from GEO...

## Checklist

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules

