### PR TITLE
Improve the way we track nomad queue length to account for running jo…

### DIFF
--- a/infrastructure/nomad-configuration/lead-server-instance-user-data.tpl.sh
+++ b/infrastructure/nomad-configuration/lead-server-instance-user-data.tpl.sh
@@ -98,7 +98,7 @@ nohup nomad agent -config server.hcl > /tmp/nomad_server.log &
 # Create the CW metric job in a crontab
 # write out current crontab
 crontab -l > tempcron
-echo -e '#!/bin/bash\naws cloudwatch put-metric-data --metric-name NomadQueueLength --namespace ${user}-${stage} --value `curl -s localhost:4646/v1/evaluations | python -m json.tool | grep "Status\": \"blocked" | wc -l` --region ${region}' >> update_metric.sh
+echo -e '#!/bin/bash\naws cloudwatch put-metric-data --metric-name NomadQueueLength --namespace ${user}-${stage} --value `nomad status | grep dispatch | grep -e pending -e running | wc -l` --region ${region}' >> update_metric.sh
 chmod +x update_metric.sh
 
 # echo new cron into cron file


### PR DESCRIPTION
…bs as well.

## Issue Number

N/A, came up while trying to run a single experiment in the staging stack.

## Purpose/Implementation Notes

Our nomad queue length doesn't take into account jobs that are running. This means that if we pick up all the jobs that are pending, the queue length goes down to zero and we start killing the instances which are running our jobs.

This became an issue when I tried to run a small experiment which needed to be processed with AFFY. The jobs would get queued, become pending until a client instance spun up, go into running, start downloading the affymetrix image (which takes some time the first time), and then before the image was done downloading the instance got killed because there were no pending jobs.

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

I have run the command: `nomad status | grep dispatch | grep -e pending -e running | wc -l` on the lead nomad server to make sure it produces the desired results.

## Checklist

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules
