### PR TITLE
Improve foreman lost job logic so that jobs without their nomad_job_i…

### DIFF
--- a/common/data_refinery_common/message_queue.py
+++ b/common/data_refinery_common/message_queue.py
@@ -74,8 +74,9 @@ def send_job(job_type: Enum, job) -> None:
         logger.error("Dispatching Nomad job of type %s for job spec %s to host %s and port %s failed.",
                      job_type, nomad_job, nomad_host, nomad_port, job=str(job.id))
     except Exception as e:
-        logger.exception('Unable to Dispatch Nomad Job.', 
-            job_name=job_type.value, 
+        logger.exception('Unable to Dispatch Nomad Job.',
+            job_name=job_type.value,
             job_id=str(job.id),
             reason=str(e)
         )
+        raise

--- a/foreman/data_refinery_foreman/foreman/main.py
+++ b/foreman/data_refinery_foreman/foreman/main.py
@@ -58,12 +58,19 @@ def requeue_downloader_job(last_job: DownloaderJob) -> None:
     logger.info("Requeuing Downloader Job which had ID %d with a new Downloader Job with ID %d.",
                 last_job.id,
                 new_job.id)
-    send_job(Downloaders[last_job.downloader_task], new_job)
+    try:
+        send_job(Downloaders[last_job.downloader_task], new_job)
 
-    last_job.retried = True
-    last_job.success = False
-    last_job.retried_job = new_job
-    last_job.save()
+        last_job.retried = True
+        last_job.success = False
+        last_job.retried_job = new_job
+        last_job.save()
+    except:
+        logger.error("Failed to requeue Downloader Job which had ID %d with a new Downloader Job with ID %d.",
+                     last_job.id,
+                     new_job.id)
+        # Can't communicate with nomad just now, leave the job for a later loop.
+        new_job.delete()
 
 
 def handle_repeated_failure(job) -> None:
@@ -235,15 +242,22 @@ def requeue_processor_job(last_job: ProcessorJob) -> None:
         ProcessorJobDatasetAssociation.objects.get_or_create(processor_job=new_job,
                                                      data_set=data_set)
 
-    logger.info("Requeuing Processor Job which had ID %d with a new Processor Job with ID %d.",
-                last_job.id,
-                new_job.id)
-    send_job(ProcessorPipeline[last_job.pipeline_applied], new_job)
+    try:
+        logger.info("Requeuing Processor Job which had ID %d with a new Processor Job with ID %d.",
+                    last_job.id,
+                    new_job.id)
+        send_job(ProcessorPipeline[last_job.pipeline_applied], new_job)
 
-    last_job.retried = True
-    last_job.success = False
-    last_job.retried_job = new_job
-    last_job.save()
+        last_job.retried = True
+        last_job.success = False
+        last_job.retried_job = new_job
+        last_job.save()
+    except:
+        logger.error("Failed to requeue Processor Job which had ID %d with a new Processor Job with ID %d.",
+                     last_job.id,
+                     new_job.id)
+        # Can't communicate with nomad just now, leave the job for a later loop.
+        new_job.delete()
 
 
 def handle_processor_jobs(jobs: List[ProcessorJob]) -> None:

--- a/run_shell.sh
+++ b/run_shell.sh
@@ -38,5 +38,4 @@ docker run -it \
        --env-file foreman/environments/local \
        --volume /tmp:/tmp \
        --volume $volume_directory:/home/user/data_store \
-       --entrypoint ./manage.py \
-       --interactive dr_shell shell
+       --interactive dr_shell python3 manage.py shell


### PR DESCRIPTION
…d field populated can be retried.

## Issue Number

N/A Came up during Jackie Crunch

## Purpose/Implementation Notes

I found some jobs from the jackie crunch which needed retrying:
```
 id | downloader_task | accession_code | start_time | end_time | success | nomad_job_id | num_retries | retried | worker_id | worker_version | failure_reason |          created_at           |         last_modified         | retried_job_id 
----+-----------------+----------------+------------+----------+---------+--------------+-------------+---------+-----------+----------------+----------------+-------------------------------+-------------------------------+----------------
 59 | GEO             | GSE56409       |            |          |         |              |           0 | f       |           |                |                | 2018-08-10 20:45:48.262597+00 | 2018-08-10 20:45:48.262597+00 |               
 60 | GEO             | GSE44719       |            |          |         |              |           0 | f       |           |                |                | 2018-08-10 20:46:10.465899+00 | 2018-08-10 20:46:10.465899+00 |               
 61 | GEO             | GSE44719       |            |          |         |              |           0 | f       |           |                |                | 2018-08-10 20:46:10.573443+00 | 2018-08-10 20:46:10.573443+00 |               
 62 | GEO             | GSE77094       |            |          |         |              |           0 | f       |           |                |                | 2018-08-10 20:46:14.869286+00 | 2018-08-10 20:46:14.869286+00 |               
 63 | GEO             | GSE77094       |            |          |         |              |           0 | f       |           |                |                | 2018-08-10 20:46:14.88296+00  | 2018-08-10 20:46:14.88296+00  |               
 64 | GEO             | GSE77094       |            |          |         |              |           0 | f       |           |                |                | 2018-08-10 20:46:14.897512+00 | 2018-08-10 20:46:14.897512+00 |               
 65 | GEO             | GSE77094       |            |          |         |              |           0 | f       |           |                |                | 2018-08-10 20:46:14.911753+00 | 2018-08-10 20:46:14.911753+00 |               
 66 | GEO             | GSE77094       |            |          |         |              |           0 | f       |           |                |                | 2018-08-10 20:46:14.926066+00 | 2018-08-10 20:46:14.926066+00 |               
 67 | GEO             | GSE77094       |            |          |         |              |           0 | f       |           |                |                | 2018-08-10 20:46:14.939822+00 | 2018-08-10 20:46:14.939822+00 |               
 68 | GEO             | GSE77094       |            |          |         |              |           0 | f       |           |                |                | 2018-08-10 20:46:14.953526+00 | 2018-08-10 20:46:14.953526+00 |               
 69 | GEO             | GSE77094       |            |          |         |              |           0 | f       |           |                |                | 2018-08-10 20:46:14.967362+00 | 2018-08-10 20:46:14.967362+00 |               
 70 | GEO             | GSE77094       |            |          |         |              |           0 | f       |           |                |                | 2018-08-10 20:46:14.980854+00 | 2018-08-10 20:46:14.980854+00 |               
 71 | GEO             | GSE77094       |            |          |         |              |           0 | f       |           |                |                | 2018-08-10 20:46:14.994147+00 | 2018-08-10 20:46:14.994147+00 |
```

These jobs didn't get requeued because they didn't have a `nomad_job_id` to query nomad with. This  caused the client to throw a `TypeError` because it was expecting that id to be a string but instead it was None. 

The message_queue was also catching all exceptions. This wasn't great because we do have logic in places that call it to mark jobs as failed if they can't be put into the nomad queue (because then the foreman can retry them in the failed job handler instead of the lost job handler). Therefore I've made the catch-all exception handler in the message_queue raise the exception.

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

TODO

## Checklist

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules
