### PR TITLE
Makes downloader and processor jobs complain when they don't have fai…

### DIFF
--- a/common/data_refinery_common/logging.py
+++ b/common/data_refinery_common/logging.py
@@ -17,20 +17,22 @@ FORMAT_STRING = (
 
 
 def unconfigure_root_logger():
-    root_logger = logging.getLogger(None)
+    """Prevents the root logger from duplicating our messages.
 
+    The root handler comes preconfigured with a handler. This causes
+    all our logs to be logged twice, once with our cool handler and
+    one that lacks all context. This function removes that stupid
+    extra handler.
+    """
+    root_logger = logging.getLogger(None)
     # Remove all handlers
     for handler in list(root_logger.handlers):
         root_logger.removeHandler(handler)
 
 
-# We want this function to be run once. Having it top level like this
-# will cause it to be run when the module is first imported, then not
-# again.
-unconfigure_root_logger()
-
-
 def get_and_configure_logger(name: str) -> logging.Logger:
+    unconfigure_root_logger()
+
     # Set level to a environment variable; I think at least
     logger = daiquiri.getLogger(name)
     logger.setLevel(logging.INFO)

--- a/workers/data_refinery_workers/downloaders/utils.py
+++ b/workers/data_refinery_workers/downloaders/utils.py
@@ -52,6 +52,14 @@ def end_downloader_job(job: DownloaderJob, success: bool):
     if success:
         logger.info("Downloader Job completed successfully.",
                     downloader_job=job.id)
+    else:
+        logger.info("Downloader job failed!",
+                    downloader_job=job.id,
+                    downloader_task=downloader_task)
+        if not job.failure_reason:
+            logger.error("Downloader job failed without having failure_reason set. FIX ME!!!!!!!!",
+                         downloader_job=job.id,
+                         downloader_task=downloader_task)
 
     job.success = success
     job.end_time = timezone.now()

--- a/workers/data_refinery_workers/downloaders/utils.py
+++ b/workers/data_refinery_workers/downloaders/utils.py
@@ -53,13 +53,15 @@ def end_downloader_job(job: DownloaderJob, success: bool):
         logger.info("Downloader Job completed successfully.",
                     downloader_job=job.id)
     else:
-        logger.info("Downloader job failed!",
-                    downloader_job=job.id,
-                    downloader_task=job.downloader_task)
         if not job.failure_reason:
             logger.error("Downloader job failed without having failure_reason set. FIX ME!!!!!!!!",
                          downloader_job=job.id,
                          downloader_task=job.downloader_task)
+        else:
+            logger.info("Downloader job failed!",
+                        downloader_job=job.id,
+                        downloader_task=job.downloader_task,
+                        failure_reason=job.failure_reason)
 
     job.success = success
     job.end_time = timezone.now()

--- a/workers/data_refinery_workers/downloaders/utils.py
+++ b/workers/data_refinery_workers/downloaders/utils.py
@@ -55,11 +55,11 @@ def end_downloader_job(job: DownloaderJob, success: bool):
     else:
         logger.info("Downloader job failed!",
                     downloader_job=job.id,
-                    downloader_task=downloader_task)
+                    downloader_task=job.downloader_task)
         if not job.failure_reason:
             logger.error("Downloader job failed without having failure_reason set. FIX ME!!!!!!!!",
                          downloader_job=job.id,
-                         downloader_task=downloader_task)
+                         downloader_task=job.downloader_task)
 
     job.success = success
     job.end_time = timezone.now()

--- a/workers/data_refinery_workers/processors/utils.py
+++ b/workers/data_refinery_workers/processors/utils.py
@@ -135,13 +135,15 @@ def end_job(job_context: Dict, abort=False):
                     processor_job=job.id,
                     pipeline_applied=job.pipeline_applied)
     else:
-        logger.info("Processor job failed!",
-                    processor_job=job.id,
-                    pipeline_applied=job.pipeline_applied)
         if not job.failure_reason:
             logger.error("Processor job failed without having failure_reason set. FIX ME!!!!!!!!",
                          processor_job=job.id,
                          pipeline_applied=job.pipeline_applied)
+        else:
+            logger.info("Processor job failed!",
+                        processor_job=job.id,
+                        pipeline_applied=job.pipeline_applied,
+                        failure_reason=job.failure_reason)
 
     # Return Final Job context so testers can check it
     return job_context

--- a/workers/data_refinery_workers/processors/utils.py
+++ b/workers/data_refinery_workers/processors/utils.py
@@ -128,9 +128,17 @@ def end_job(job_context: Dict, abort=False):
     job.save()
 
     if success:
-        logger.info("Processor job completed successfully.", processor_job=job.id)
+        logger.info("Processor job completed successfully.",
+                    processor_job=job.id,
+                    pipeline_applied=job.pipeline_applied)
     else:
-        logger.info("Processor job failed!", processor_job=job.id)
+        logger.info("Processor job failed!",
+                    processor_job=job.id,
+                    pipeline_applied=job.pipeline_applied)
+        if not job.failure_reason:
+            logger.error("Processor job failed without having failure_reason set. FIX ME!!!!!!!!",
+                         processor_job=job.id,
+                         pipeline_applied=job.pipeline_applied)
 
     # Return Final Job context so testers can check it
     return job_context

--- a/workers/data_refinery_workers/processors/utils.py
+++ b/workers/data_refinery_workers/processors/utils.py
@@ -107,21 +107,24 @@ def end_job(job_context: Dict, abort=False):
                 sample.save()
 
     # S3-sync Original Files
-    for original_files in job_context['original_files']:
-        original_files.delete_local_file()
+    if 'original_files' in job_context:
+        for original_files in job_context['original_files']:
+            original_files.delete_local_file()
 
     # S3-sync Computed Files
-    for computed_file in job_context['computed_files']:
-        # Ensure even distribution across S3 servers
-        nonce = ''.join(random.choice(string.ascii_lowercase + string.digits) for _ in range(8))
-        result = computed_file.sync_to_s3(S3_BUCKET_NAME, nonce + "_" + computed_file.filename)
-        if result:
-            computed_file.delete_local_file()
+    if 'computed_files' in job_context:
+        for computed_file in job_context['computed_files']:
+            # Ensure even distribution across S3 servers
+            nonce = ''.join(random.choice(string.ascii_lowercase + string.digits) for _ in range(8))
+            result = computed_file.sync_to_s3(S3_BUCKET_NAME, nonce + "_" + computed_file.filename)
+            if result:
+                computed_file.delete_local_file()
 
     # If the pipeline includes any steps, save it.
-    pipeline = job_context['pipeline']
-    if len(pipeline.steps):
-        pipeline.save()
+    if 'pipeline' in job_context:
+        pipeline = job_context['pipeline']
+        if len(pipeline.steps):
+            pipeline.save()
 
     job.success = success
     job.end_time = timezone.now()


### PR DESCRIPTION
…lure_reason set.

## Issue Number

N/A came up during Jackie Crunch

## Purpose/Implementation Notes

I keep seeing jobs that have `end_time` but no `failure_reason`. This shouldn't happen. If we know a job is failing we should say why. This will hopefully make cases where we don't easier to find and track down and alert us if we accidentally introduce any new ones.

While I tested this I once again noticed that all of our log messages appear twice, once with our nice context and one with nothing. I fixed this while I was there.

While testing I also noticed that if `end_job` is ever called with an incomplete `job_context` we would throw an error. If this ever were to happen it would probably be because the job didn't make it very far and so this new error would be hiding whatever caused the job to fail so early.

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

```
>>> from data_refinery_workers.processors.utils import end_job
>>> from data_refinery_common.models import ProcessorJob
>>> pj = ProcessorJob(success=False, pipeline_applied="AFFY_TO_PCL") 
>>> pj.save()
>>> job_context = {"job": pj, "success": False}
>>> end_job(job_context)
2018-08-14 15:48:06,324 local/MainProcess data_refinery_workers.processors.utils INFO [pipeline_applied: AFFY_TO_PCL] [processor_job: 6]: Processor job failed!
2018-08-14 15:48:06,326 local/MainProcess data_refinery_workers.processors.utils ERROR [pipeline_applied: AFFY_TO_PCL] [processor_job: 6]: Processor job failed without having failure_reason set. FIX ME!!!!!!!!
{'success': False, 'job': <ProcessorJob: ProcessorJob 6: AFFY_TO_PCL>}
```

I ran a similar functional test for downloaders.

## Checklist

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules
