### PR TITLE
R error -> logger

### DIFF
--- a/workers/data_refinery_workers/processors/no_op.py
+++ b/workers/data_refinery_workers/processors/no_op.py
@@ -245,12 +245,19 @@ def _convert_illumina_genes(job_context: Dict) -> Dict:
                 "--platform", high_db,
                 "--inputFile", job_context['input_file_path'],
                 "--outputFile", job_context['output_file_path']
-            ])
+            ], stderr=subprocess.PIPE)
+    except subprocess.CalledProcessError as e:
+        error_template = "Status code {0} from gene_convert_illumina.R: {1}"
+        error_message = error_template.format(e.returncode, e.stderr)
+        logger.error(error_message, context=job_context)
+        job_context["job"].failure_reason = error_message
+        job_context["success"] = False
+        return job_context
     except Exception as e:
         error_template = ("Encountered error in R code while running gene_convert_illumina.R"
                           " pipeline during processing of {0}: {1}")
         error_message = error_template.format(job_context['input_file_path'], str(e))
-        logger.error(error_message, processor_job=job_context["job_id"])
+        logger.error(error_message, context=job_context)
         job_context["job"].failure_reason = error_message
         job_context["success"] = False
         return job_context

--- a/workers/data_refinery_workers/processors/no_op.py
+++ b/workers/data_refinery_workers/processors/no_op.py
@@ -159,16 +159,16 @@ def _convert_affy_genes(job_context: Dict) -> Dict:
                 "--outputFile", job_context['output_file_path']
             ], stderr=subprocess.PIPE)
     except subprocess.CalledProcessError as e:
-        error_template = "Status code {0} from gene_convert.R: {1}"
-        error_message = error_template.format(e.returncode, e.stderr)
+        error_template = "Status code {0} from {1}: {2}"
+        error_message = error_template.format(e.returncode, job_context['script_name'], e.stderr)
         logger.error(error_message, context=job_context)
         job_context["job"].failure_reason = error_message
         job_context["success"] = False
         return job_context
     except Exception as e:
-        error_template = ("Encountered error in R code while running gene_convert.R"
-                          " pipeline during processing of {0}: {1}")
-        error_message = error_template.format(job_context['input_file_path'], str(e))
+        error_template = ("Encountered error in R code while running {0}"
+                          " pipeline during processing of {1}: {2}")
+        error_message = error_template.format(job_context['script_name'], job_context['input_file_path'], str(e))
         logger.error(error_message, context=job_context)
         job_context["job"].failure_reason = error_message
         job_context["success"] = False
@@ -254,16 +254,16 @@ def _convert_illumina_genes(job_context: Dict) -> Dict:
                 "--outputFile", job_context['output_file_path']
             ], stderr=subprocess.PIPE)
     except subprocess.CalledProcessError as e:
-        error_template = "Status code {0} from gene_convert_illumina.R: {1}"
-        error_message = error_template.format(e.returncode, e.stderr)
+        error_template = "Status code {0} from {1}: {2}"
+        error_message = error_template.format(e.returncode, job_context['script_name'], e.stderr)
         logger.error(error_message, context=job_context)
         job_context["job"].failure_reason = error_message
         job_context["success"] = False
         return job_context
     except Exception as e:
-        error_template = ("Encountered error in R code while running gene_convert_illumina.R"
-                          " pipeline during processing of {0}: {1}")
-        error_message = error_template.format(job_context['input_file_path'], str(e))
+        error_template = ("Encountered error in R code while running {0}"
+                          " pipeline during processing of {1}: {2}")
+        error_message = error_template.format(job_context['script_name'], job_context['input_file_path'], str(e))
         logger.error(error_message, context=job_context)
         job_context["job"].failure_reason = error_message
         job_context["success"] = False

--- a/workers/data_refinery_workers/processors/no_op.py
+++ b/workers/data_refinery_workers/processors/no_op.py
@@ -157,12 +157,19 @@ def _convert_affy_genes(job_context: Dict) -> Dict:
                 "--platform", job_context["internal_accession"],
                 "--inputFile", job_context['input_file_path'],
                 "--outputFile", job_context['output_file_path']
-            ])
+            ], stderr=subprocess.PIPE)
+    except subprocess.CalledProcessError as e:
+        error_template = "Status code {0} from gene_convert.R: {1}"
+        error_message = error_template.format(e.returncode, e.stderr)
+        logger.error(error_message, context=job_context)
+        job_context["job"].failure_reason = error_message
+        job_context["success"] = False
+        return job_context
     except Exception as e:
         error_template = ("Encountered error in R code while running gene_convert.R"
                           " pipeline during processing of {0}: {1}")
         error_message = error_template.format(job_context['input_file_path'], str(e))
-        logger.error(error_message, processor_job=job_context["job_id"])
+        logger.error(error_message, context=job_context)
         job_context["job"].failure_reason = error_message
         job_context["success"] = False
         return job_context

--- a/workers/data_refinery_workers/processors/no_op.py
+++ b/workers/data_refinery_workers/processors/no_op.py
@@ -168,7 +168,8 @@ def _convert_affy_genes(job_context: Dict) -> Dict:
     except Exception as e:
         error_template = ("Encountered error in R code while running {0}"
                           " pipeline during processing of {1}: {2}")
-        error_message = error_template.format(job_context['script_name'], job_context['input_file_path'], str(e))
+        error_message = error_template.format(job_context['script_name'],
+            job_context['input_file_path'], str(e))
         logger.error(error_message, context=job_context)
         job_context["job"].failure_reason = error_message
         job_context["success"] = False
@@ -263,7 +264,8 @@ def _convert_illumina_genes(job_context: Dict) -> Dict:
     except Exception as e:
         error_template = ("Encountered error in R code while running {0}"
                           " pipeline during processing of {1}: {2}")
-        error_message = error_template.format(job_context['script_name'], job_context['input_file_path'], str(e))
+        error_message = error_template.format(job_context['script_name'],
+            job_context['input_file_path'], str(e))
         logger.error(error_message, context=job_context)
         job_context["job"].failure_reason = error_message
         job_context["success"] = False


### PR DESCRIPTION
## Issue Number

N/A

## Purpose/Implementation Notes

There are hundreds of R issues in sentry. These get annotated by the R script and the file that failed, but not the error from R. This edit reports the R script and R error in the logger. 

This does change the behavior slightly: The specific file that was processed doesn't get put into the `job_context["job"].failure_reason`. Instead the R stderr does. It looks like the `job_context['input_file_path']` already gives us the file that was processed. This is the only potentially behavior-breaking change that I know of.

## Methods

N/A

## Types of changes

What types of changes does your code introduce?

- Bugfix (non-breaking change which fixes an issue)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Functional tests

I tested running an R script in python via `subprocess.check_output` and `stderr` from R gets captured and put into the error message with this approach. I did not test running this specific script 😨 . Still trying to figure out the best way to do that.

## Checklist

_Put an `x` in the boxes that apply._

- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules

## Screenshots

Please attach any screenshots that illustrate these changes.
