### PR TITLE
Make prepare_image.sh fail if it cannot prepare the image.

### DIFF
--- a/prepare_image.sh
+++ b/prepare_image.sh
@@ -89,4 +89,9 @@ else
         finished=$?
         attempts=$[$attempts+1]
     done
+
+    if (( attempts >= 3 )); then
+        echo "Could not build $image_name after three attempts."
+        exit 1
+    fi
 fi


### PR DESCRIPTION
## Issue Number

N/A came up because zenodo went down but it didn't make our tests fail when we couldn't build no_op

## Purpose/Implementation Notes

If we couldn't build an image prepare_image.sh would still exit with a status code of 0. This meant our tests continued with an old image causing problems. This exits with a status code of 1 if we cannot build an image after three attempts.

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

Tried to build a no_op image while zenodo was down, exit code was 1.

## Checklist

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules
