### PR TITLE
Adds processed_samples to Search Response

### DIFF
--- a/api/data_refinery_api/serializers.py
+++ b/api/data_refinery_api/serializers.py
@@ -194,6 +194,7 @@ class ExperimentSerializer(serializers.ModelSerializer):
     organisms = serializers.StringRelatedField(many=True)
     platforms = serializers.ReadOnlyField()
     samples = serializers.StringRelatedField(many=True)
+    processed_samples = serializers.StringRelatedField(many=True)
     pretty_platforms = serializers.ReadOnlyField()
     sample_metadata = serializers.ReadOnlyField(source='get_sample_metadata_fields')
 
@@ -208,6 +209,7 @@ class ExperimentSerializer(serializers.ModelSerializer):
                     'source_url',
                     'platforms',
                     'pretty_platforms',
+                    'processed_samples',
                     'has_publication',
                     'publication_title',
                     'publication_doi',

--- a/api/data_refinery_api/tests.py
+++ b/api/data_refinery_api/tests.py
@@ -365,7 +365,7 @@ class APITestCases(APITestCase):
         # This has to be done manually due to dicts requring distinct keys
         response = self.client.get(reverse('search') + "?search=THISWILLBEINASEARCHRESULT&technology=MICROARRAY&technology=FAKE-TECH")
         self.assertEqual(response.json()['count'], 2)
-        self.assertEqual(response.json()['results']['processed_samples'], ['1123', '3345'])
+        self.assertEqual(response.json()['results'][0]['processed_samples'], ['1123', '3345'])
 
     @patch('data_refinery_common.message_queue.send_job')
     def test_create_update_dataset(self, mock_send_job):

--- a/api/data_refinery_api/tests.py
+++ b/api/data_refinery_api/tests.py
@@ -365,6 +365,7 @@ class APITestCases(APITestCase):
         # This has to be done manually due to dicts requring distinct keys
         response = self.client.get(reverse('search') + "?search=THISWILLBEINASEARCHRESULT&technology=MICROARRAY&technology=FAKE-TECH")
         self.assertEqual(response.json()['count'], 2)
+        self.assertEqual(response.json()['results']['processed_samples'], ['1123', '3345'])
 
     @patch('data_refinery_common.message_queue.send_job')
     def test_create_update_dataset(self, mock_send_job):

--- a/common/data_refinery_common/models/models.py
+++ b/common/data_refinery_common/models/models.py
@@ -333,6 +333,10 @@ class Experiment(models.Model):
     def get_processed_samples(self):
         return self.samples.filter(is_processed=True)
 
+    @property
+    def processed_samples(self):
+        return self.samples.filter(is_processed=True)
+
 class ExperimentAnnotation(models.Model):
     """ Semi-standard information associated with an Experiment """
 


### PR DESCRIPTION
## Issue Number
n/a

## Purpose/Implementation Notes

Adds a field so that 'Add to Dataset' can only add the processed responses.

## Types of changes

- New feature (non-breaking change which adds functionality)

## Functional tests

New assertion