### PR TITLE
Quick fix of Processor's API

### DIFF
--- a/api/data_refinery_api/serializers.py
+++ b/api/data_refinery_api/serializers.py
@@ -37,6 +37,7 @@ class ProcessorSerializer(serializers.ModelSerializer):
     class Meta:
         model = Processor
         fields = (
+            'id',
             'name',
             'version',
             'docker_image',
@@ -91,6 +92,7 @@ class ComputedFileSerializer(serializers.ModelSerializer):
 class ComputationalResultSerializer(serializers.ModelSerializer):
     annotations = ComputationalResultAnnotationSerializer(many=True, source='computationalresultannotation_set')
     files = ComputedFileSerializer(many=True, source='computedfile_set')
+    processor = ProcessorSerializer(many=False)
 
     class Meta:
         model = ComputationalResult


### PR DESCRIPTION
## Issue Number
This is a quick fix of the API during review of this PR:
https://github.com/AlexsLemonade/refinebio-docs/pull/23

## Purpose/Implementation Notes
Two modifications of the API:
- Add `id` field to ProcessorSerializer
- Add processor's full information (instead of `id` only) to `ComputationalResultSerializer`.
I also added a new test case for the change.

## Types of changes

What types of changes does your code introduce?

<!-- Remove any which your PR isn't -->
- New feature (non-breaking change which adds functionality)

## Functional tests

List out the functional tests you've completed to verify your changes work locally.

## Checklist

_Put an `x` in the boxes that apply._

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules
