### PR TITLE
Adds `no_retry` Field to Jobs, Sets It At Irrecoverable Failure Points

### DIFF
--- a/common/data_refinery_common/models/jobs.py
+++ b/common/data_refinery_common/models/jobs.py
@@ -15,6 +15,7 @@ class SurveyJob(models.Model):
 
     source_type = models.CharField(max_length=256)
     success = models.NullBooleanField(null=True)
+    no_retry = models.BooleanField(default=False)
 
     # The start time of the query used to replicate
     replication_started_at = models.DateTimeField(null=True)
@@ -77,6 +78,7 @@ class ProcessorJob(models.Model):
 
     original_files = models.ManyToManyField('OriginalFile', through='ProcessorJobOriginalFileAssociation')
     datasets = models.ManyToManyField('DataSet', through='ProcessorJobDataSetAssociation')
+    no_retry = models.BooleanField(default=False)
 
     # Resources
     ram_amount = models.IntegerField(default=2048)
@@ -136,6 +138,7 @@ class DownloaderJob(models.Model):
     # data_refinery_common.job_lookup.Downloaders
     downloader_task = models.CharField(max_length=256)
     accession_code = models.CharField(max_length=256, blank=True, null=True)
+    no_retry = models.BooleanField(default=False)
 
     original_files = models.ManyToManyField('OriginalFile', through='DownloaderJobOriginalFileAssociation')
 

--- a/foreman/data_refinery_foreman/foreman/main.py
+++ b/foreman/data_refinery_foreman/foreman/main.py
@@ -141,7 +141,8 @@ def retry_hung_downloader_jobs() -> None:
         success=None,
         retried=False,
         end_time=None,
-        start_time__isnull=False
+        start_time__isnull=False,
+        no_retry=False
     )
 
     nomad_host = get_env_variable("NOMAD_HOST")
@@ -179,7 +180,8 @@ def retry_lost_downloader_jobs() -> None:
         success=None,
         retried=False,
         start_time=None,
-        end_time=None
+        end_time=None,
+        no_retry=False
     )
 
     nomad_host = get_env_variable("NOMAD_HOST")
@@ -288,7 +290,8 @@ def retry_hung_processor_jobs() -> None:
         success=None,
         retried=False,
         end_time=None,
-        start_time__isnull=False
+        start_time__isnull=False,
+        no_retry=False
     )
 
     nomad_host = get_env_variable("NOMAD_HOST")
@@ -323,7 +326,8 @@ def retry_lost_processor_jobs() -> None:
         success=None,
         retried=False,
         start_time=None,
-        end_time=None
+        end_time=None,
+        no_retry=False
     )
 
     nomad_host = get_env_variable("NOMAD_HOST")

--- a/workers/data_refinery_workers/downloaders/array_express.py
+++ b/workers/data_refinery_workers/downloaders/array_express.py
@@ -165,7 +165,7 @@ def download_array_express(job_id: int) -> None:
                 logger.warn("Unable to determine platform from CEL file: "
                             + original_file.absolute_file_path,
                             downloader_job=job_id)
-
+                job.no_retry = True
             if platform_accession_code == "UNSUPPORTED":
                 logger.error("Found a raw .CEL file with an unsupported platform!",
                              file_name=original_file.absolute_file_path,
@@ -175,6 +175,7 @@ def download_array_express(job_id: int) -> None:
                 job.failure_reason = ("Found a raw .CEL file with an unsupported platform: "
                                       + original_file.absolute_file_path + " ("
                                       + str(cel_file_platform) + ")")
+                job.no_retry = True
                 success = False
             elif platform_accession_code == "UNDETERMINABLE":
                 # If we cannot determine the platform from the

--- a/workers/data_refinery_workers/processors/array_express.py
+++ b/workers/data_refinery_workers/processors/array_express.py
@@ -82,6 +82,7 @@ def _determine_brainarray_package(job_context: Dict) -> Dict:
         logger.error(error_message, processor_job=job_context["job"].id)
         job_context["job"].failure_reason = error_message
         job_context["success"] = False
+        job_context["job"].no_retry = True
         return job_context
 
     # header is a list of vectors. [0][0] contains the package name.
@@ -146,6 +147,7 @@ def _run_scan_upc(job_context: Dict) -> Dict:
         logger.error(error_message, processor_job=job_context["job_id"])
         job_context["job"].failure_reason = error_message
         job_context["success"] = False
+        job_context["job"].no_retry = True
 
     return job_context
 

--- a/workers/data_refinery_workers/processors/illumina.py
+++ b/workers/data_refinery_workers/processors/illumina.py
@@ -139,6 +139,7 @@ def _detect_columns(job_context: Dict) -> Dict:
         else:
             job_context["job"].failure_reason = "Could not detect PValue column!"
             job_context["success"] = False
+            job_context["job"].no_retry = True
             return job_context
 
         # Then, finally, create an absolutely bonkers regular expression
@@ -194,6 +195,7 @@ def _detect_columns(job_context: Dict) -> Dict:
         job_context["job"].failure_reason = str(e)
         job_context["success"] = False
         logger.exception("Failed to extract columns in " + job_context["input_file_path"], exception=str(e))
+        job_context["job"].no_retry = True
         return job_context
 
     return job_context

--- a/workers/data_refinery_workers/processors/no_op.py
+++ b/workers/data_refinery_workers/processors/no_op.py
@@ -78,6 +78,7 @@ def _prepare_files(job_context: Dict) -> Dict:
                     input_file_path=job_context["input_file_path"])
                 job_context['job'].faiure_reason = str(e)
                 job_context['success'] = False
+                job_context["job"].no_retry = True
                 return job_context
         else:
             if job_context["is_illumina"]:
@@ -118,10 +119,12 @@ def _prepare_files(job_context: Dict) -> Dict:
         if not job_context["internal_accession"]:
             logger.error("Failed to find internal accession for code", code=job_context["platform"])
             job_context['success'] = False
+            job_context["job"].no_retry = True
     except Exception as e:
         logger.exception("Failed to prepare for NO_OP job.", job_id=job_context['job'].id)
         job_context["job"].failure_reason = str(e)
         job_context['success'] = False
+        job_context["job"].no_retry = True
 
     return job_context
 
@@ -164,6 +167,7 @@ def _convert_affy_genes(job_context: Dict) -> Dict:
         logger.error(error_message, context=job_context)
         job_context["job"].failure_reason = error_message
         job_context["success"] = False
+        job_context["job"].no_retry = True
         return job_context
     except Exception as e:
         error_template = ("Encountered error in R code while running {0}"
@@ -173,6 +177,7 @@ def _convert_affy_genes(job_context: Dict) -> Dict:
         logger.error(error_message, context=job_context)
         job_context["job"].failure_reason = error_message
         job_context["success"] = False
+        job_context["job"].no_retry = True
         return job_context
 
     job_context["success"] = True
@@ -260,6 +265,7 @@ def _convert_illumina_genes(job_context: Dict) -> Dict:
         logger.error(error_message, context=job_context)
         job_context["job"].failure_reason = error_message
         job_context["success"] = False
+        job_context["job"].no_retry = True
         return job_context
     except Exception as e:
         error_template = ("Encountered error in R code while running {0}"
@@ -269,6 +275,7 @@ def _convert_illumina_genes(job_context: Dict) -> Dict:
         logger.error(error_message, context=job_context)
         job_context["job"].failure_reason = error_message
         job_context["success"] = False
+        job_context["job"].no_retry = True
         return job_context
 
     job_context["success"] = True


### PR DESCRIPTION
## Issue Number

https://github.com/AlexsLemonade/refinebio/issues/431

## Purpose/Implementation Notes

Adds a `no_retry` field to jobs so that they aren't multiply retried by the foreman if they're irrecoverable. Sets this flag at certain critical failure points, although there may be more (we should look at the logs). I think this gets the major ones though.
## Types of changes
- New feature (non-breaking change which adds functionality)

## Functional tests

Not yet..

## Checklist

_Put an `x` in the boxes that apply._

- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules
