### PR TITLE
Disables docker layer caching for deploys.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -189,7 +189,6 @@ jobs:
 
   deploy:
     machine:
-      docker_layer_caching: true
       pre:
         - sudo rm -rf /usr/local/android-sdk-linux
         - sudo rm -rf /usr/local/go


### PR DESCRIPTION
## Issue Number

N/A

## Purpose/Implementation Notes

DLC runs out of disk space when deploying, so don't use DLC.

## Types of changes

- Bugfix (non-breaking change which fixes an issue)
