### PR TITLE
Remove All AWS Nomad Log Streams

### DIFF
--- a/infrastructure/logging.tf
+++ b/infrastructure/logging.tf
@@ -17,31 +17,6 @@ resource "aws_cloudwatch_log_group" "data_refinery_log_group" {
 # Streams
 ##
 
-# Nomad
-resource "aws_cloudwatch_log_stream" "log_stream_nomad_server_1" {
-  name           = "log-stream-nomad-server-1-${var.user}-${var.stage}"
-  log_group_name = "${aws_cloudwatch_log_group.data_refinery_log_group.name}"
-}
-
-resource "aws_cloudwatch_log_stream" "log_stream_nomad_server_2" {
-  name           = "log-stream-nomad-server-2-${var.user}-${var.stage}"
-  log_group_name = "${aws_cloudwatch_log_group.data_refinery_log_group.name}"
-}
-resource "aws_cloudwatch_log_stream" "log_stream_nomad_server_3" {
-  name           = "log-stream-nomad-server-3-${var.user}-${var.stage}"
-  log_group_name = "${aws_cloudwatch_log_group.data_refinery_log_group.name}"
-}
-
-# XXX: Once we're using spot instnaces we should have them create the
-# streams themselves so that we'll have streams for the dynamically
-# created instances. However, in the meantime explicitly creating the
-# stream via Terraform is better because it will be able to clean them
-# up too.
-resource "aws_cloudwatch_log_stream" "log_stream_nomad_client" {
-  name           = "log-stream-nomad-client-${var.user}-${var.stage}"
-  log_group_name = "${aws_cloudwatch_log_group.data_refinery_log_group.name}"
-}
-
 # Nomad / Docker
 resource "aws_cloudwatch_log_stream" "log_stream_surveyor" {
   name           = "log-stream-surveyor-${var.user}-${var.stage}"

--- a/infrastructure/nomad-configuration/client-instance-user-data.tpl.sh
+++ b/infrastructure/nomad-configuration/client-instance-user-data.tpl.sh
@@ -69,11 +69,6 @@ cd /home/ubuntu
 cat <<EOF >awslogs.conf
 [general]
 state_file = /var/lib/awslogs/agent-state
-
-[/var/log/nomad_client.log]
-file = /var/log/nomad_client.log
-log_group_name = data-refinery-log-group-${user}-${stage}
-log_stream_name = log-stream-nomad-client-${user}-${stage}
 EOF
 
 mkdir /var/lib/awslogs

--- a/infrastructure/nomad-configuration/lead-server-instance-user-data.tpl.sh
+++ b/infrastructure/nomad-configuration/lead-server-instance-user-data.tpl.sh
@@ -29,11 +29,6 @@ cd /home/ubuntu
 cat <<EOF >awslogs.conf
 [general]
 state_file = /var/lib/awslogs/agent-state
-
-[/var/log/nomad_server.log]
-file = /var/log/nomad_server.log
-log_group_name = data-refinery-log-group-${user}-${stage}
-log_stream_name = log-stream-nomad-server-${server_number}-${user}-${stage}
 EOF
 
 mkdir /var/lib/awslogs

--- a/infrastructure/nomad-configuration/server-instance-user-data.tpl.sh
+++ b/infrastructure/nomad-configuration/server-instance-user-data.tpl.sh
@@ -21,11 +21,6 @@ cd /home/ubuntu
 cat <<EOF >awslogs.conf
 [general]
 state_file = /var/lib/awslogs/agent-state
-
-[/var/log/nomad_server.log]
-file = /var/log/nomad_server.log
-log_group_name = data-refinery-log-group-${user}-${stage}
-log_stream_name = log-stream-nomad-server-${server_number}-${user}-${stage}
 EOF
 
 mkdir /var/lib/awslogs


### PR DESCRIPTION
## Issue Number
n/a

## Purpose/Implementation Notes

Nomad is still polluting our logs. It gives us nothing of value. The logs are still available on the log rotator if we really need them, which we don't.

## Types of changes
- Bugfix (non-breaking change which fixes an issue)

## Checklist

_Put an `x` in the boxes that apply._

- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules
