### PR TITLE
Sets the ulimit option for files for nomad clients.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -76,7 +76,6 @@ jobs:
   affymetrix_common_agilent_tests:
     working_directory: ~/refinebio
     machine:
-      docker_layer_caching: true
       pre:
         - sudo rm -rf /usr/local/android-sdk-linux
         - sudo rm -rf /usr/local/go

--- a/infrastructure/nomad-configuration/client-instance-user-data.tpl.sh
+++ b/infrastructure/nomad-configuration/client-instance-user-data.tpl.sh
@@ -19,6 +19,8 @@ apt-get update -y
 apt-get upgrade -y
 apt-get install --yes nfs-common jq iotop dstat
 
+ulimit -n 65536
+
 # Find, configure and mount a free EBS volume
 mkdir -p /var/ebs/
 EBS_VOLUME_ID=`aws ec2 describe-volumes --filters "Name=tag:User,Values=${user}" "Name=tag:Stage,Values=${stage}" "Name=tag:IsBig,Values=True" "Name=status,Values=available" "Name=availability-zone,Values=us-east-1a" --region us-east-1 | jq '.Volumes[0].VolumeId' | tr -d '"'`


### PR DESCRIPTION
## Issue Number

N/A came up during crunch

## Purpose/Implementation Notes

During the zebrafish crunch, many jobs failed due to 

```
Driver Failure  failed to start task "affy_to_pcl" for alloc "8882c9e9-6f1f-6270-dc0b-910de0f527e5": error creating rpc client for executor plugin: pipe2: too many open files
```

[Here,](https://github.com/hashicorp/nomad/issues/3686#issuecomment-372283062) someone describes an essential property we should set. I have done so in this PR.

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

N/A
