### PR TITLE
Increase IPv4 address space of Docker bridge network - I Think

### DIFF
--- a/infrastructure/nomad-configuration/client-instance-user-data.tpl.sh
+++ b/infrastructure/nomad-configuration/client-instance-user-data.tpl.sh
@@ -84,6 +84,13 @@ echo "
     maxage 3
 }" >> /etc/logrotate.conf
 
+# Docker runs out of IPv4
+cat <<"EOF" > /etc/docker/daemon.json
+{
+  "bip": "172.17.77.1/22"
+}
+EOF
+
 # Output the files we need to start up Nomad and register jobs:
 # (Note that the lines starting with "$" are where
 #  Terraform will template in the contents of those files.)


### PR DESCRIPTION
## Issue Number

n/a

## Purpose/Implementation Notes
Docker ran out of internal IPv4 addresses. I think this fixes it but I haven't tested it yet. Submitting here for consideration.