### PR TITLE
Lowers ascp Warning Level and Reduce Retry Wait Period

### DIFF
--- a/workers/data_refinery_workers/downloaders/geo.py
+++ b/workers/data_refinery_workers/downloaders/geo.py
@@ -95,7 +95,7 @@ def _download_file_aspera(download_url: str,
         if completed_command.returncode != 0:
 
             stderr = str(completed_command.stderr).strip()
-            logger.warning("Shell call to ascp failed with error message: %s\nCommand was: %s",
+            logger.debug("Shell call to ascp failed with error message: %s\nCommand was: %s",
                          stderr,
                          formatted_command,
                          downloader_job=downloader_job.id)

--- a/workers/data_refinery_workers/downloaders/sra.py
+++ b/workers/data_refinery_workers/downloaders/sra.py
@@ -88,8 +88,10 @@ def _download_file_aspera(download_url: str,
         # Something went wrong! Else, just fall through to returning True.
         if completed_command.returncode != 0:
 
+            # Most likely, this is the "cannot authenticate" message,
+            # which is because we've nuked ENA.
             stderr = str(completed_command.stderr).strip()
-            logger.error("Shell call to ascp failed with error message: %s\nCommand was: %s",
+            logger.debug("Shell call to ascp failed with error message: %s\nCommand was: %s",
                          stderr,
                          formatted_command,
                          downloader_job=downloader_job.id)
@@ -100,7 +102,7 @@ def _download_file_aspera(download_url: str,
                 downloader_job.failure_reason = stderr
                 return False
             else:
-                time.sleep(300)
+                time.sleep(30)
                 return _download_file_aspera(download_url,
                                              downloader_job,
                                              target_file_path,


### PR DESCRIPTION
## Issue Number

https://sentry.io/greenelab/staging-refinebio/issues/609745158/?query=is:unresolved

## Purpose/Implementation Notes

It seems like we're able to kill ENA's ability to Aspera pretty reliably now. Eventually the server comes back online for a little bit. We don't need to error log every time it happens, and we don't need to hang around for 300s every time.