### PR TITLE
Add assembly_name to OrganismIndex API

### DIFF
--- a/api/data_refinery_api/serializers.py
+++ b/api/data_refinery_api/serializers.py
@@ -55,6 +55,7 @@ class OrganismIndexSerializer(serializers.ModelSerializer):
         fields = (
                     's3_url',
                     'source_version',
+                    'assembly_name',
                     'salmon_version',
                     'last_modified',
                 )


### PR DESCRIPTION
## Issue Number

This is a quick fix based on:
https://github.com/AlexsLemonade/refinebio-frontend/issues/99#issuecomment-417074733

## Purpose/Implementation Notes

Add `assembly_name` to transcriptome index API.

## Checklist

_Put an `x` in the boxes that apply._

- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

