### PR TITLE
Allow deploys to continue if image tages already exist.

### DIFF
--- a/.circleci/update_docker_img.sh
+++ b/.circleci/update_docker_img.sh
@@ -27,26 +27,6 @@ fi
 # Docker images that we want to protect from accidental overwriting in "ccdl" account.
 CCDL_WORKER_IMGS="smasher illumina affymetrix salmon transcriptome no_op downloaders"
 
-# If any of the three images could be overwritten by the building process,
-# print out a message and terminate immediately.
-for IMG in $CCDL_WORKER_IMGS; do
-    image_name="$DOCKERHUB_REPO/dr_$IMG"
-    if docker_img_exists $image_name $CIRCLE_TAG; then
-        echo "Docker image exists, building process terminated: $image_name:$CIRCLE_TAG"
-        exit 1
-    fi
-done
-
-CCDL_OTHER_IMGS="$DOCKERHUB_REPO/dr_foreman $DOCKERHUB_REPO/dr_api"
-
-# Handle the foreman and API separately.
-for IMG in $CCDL_OTHER_IMGS; do
-    if docker_img_exists $IMG $CIRCLE_TAG; then
-        echo "Docker image exists, building process terminated: $IMG:$CIRCLE_TAG"
-        exit 1
-    fi
-done
-
 # Create ~/refinebio/common/dist/data-refinery-common-*.tar.gz, which is
 # required by the workers and data_refinery_foreman images.
 cd ~/refinebio/common && python setup.py sdist
@@ -56,30 +36,42 @@ docker login -u $DOCKER_ID -p $DOCKER_PASSWD
 
 cd ~/refinebio
 for IMG in $CCDL_WORKER_IMGS; do
-    image_name="$DOCKERHUB_REPO/dr_$IMG"
-    # Build and push image
-    docker build -t $image_name:$CIRCLE_TAG -f workers/dockerfiles/Dockerfile.$IMG .
-    docker push $image_name:$CIRCLE_TAG
-    # Update latest version
-    docker tag $image_name:$CIRCLE_TAG $image_name:latest
-    docker push $image_name:latest
+    if docker_img_exists $image_name $CIRCLE_TAG; then
+        echo "Docker image exists, skipping: $image_name:$CIRCLE_TAG"
+    else
+        image_name="$DOCKERHUB_REPO/dr_$IMG"
+        # Build and push image
+        docker build -t $image_name:$CIRCLE_TAG -f workers/dockerfiles/Dockerfile.$IMG .
+        docker push $image_name:$CIRCLE_TAG
+        # Update latest version
+        docker tag $image_name:$CIRCLE_TAG $image_name:latest
+        docker push $image_name:latest
 
-    # Save some space when we're through
-    docker rmi $image_name:$CIRCLE_TAG 
+        # Save some space when we're through
+        docker rmi $image_name:$CIRCLE_TAG
+    fi
 done
 
 # Build and push foreman image
 FOREMAN_DOCKER_IMAGE="$DOCKERHUB_REPO/dr_foreman"
-docker build -t "$FOREMAN_DOCKER_IMAGE:$CIRCLE_TAG" -f foreman/dockerfiles/Dockerfile.foreman .
-docker push "$FOREMAN_DOCKER_IMAGE:$CIRCLE_TAG"
-# Update latest version
-docker tag "$FOREMAN_DOCKER_IMAGE:$CIRCLE_TAG" "$FOREMAN_DOCKER_IMAGE:latest"
-docker push "$FOREMAN_DOCKER_IMAGE:latest"
+if docker_img_exists $FOREMAN_DOCKER_IMAGE $CIRCLE_TAG; then
+    echo "Docker image exists, skipping: $:$CIRCLE_TAG"
+else
+    docker build -t "$FOREMAN_DOCKER_IMAGE:$CIRCLE_TAG" -f foreman/dockerfiles/Dockerfile.foreman .
+    docker push "$FOREMAN_DOCKER_IMAGE:$CIRCLE_TAG"
+    # Update latest version
+    docker tag "$FOREMAN_DOCKER_IMAGE:$CIRCLE_TAG" "$FOREMAN_DOCKER_IMAGE:latest"
+    docker push "$FOREMAN_DOCKER_IMAGE:latest"
+fi
 
 # Build and push API image
 API_DOCKER_IMAGE="$DOCKERHUB_REPO/dr_api"
-docker build -t "$API_DOCKER_IMAGE:$CIRCLE_TAG" -f api/dockerfiles/Dockerfile.api_production .
-docker push "$API_DOCKER_IMAGE:$CIRCLE_TAG"
-# Update latest version
-docker tag "$API_DOCKER_IMAGE:$CIRCLE_TAG" "$API_DOCKER_IMAGE:latest"
-docker push "$API_DOCKER_IMAGE:latest"
+if docker_img_exists $FOREMAN_DOCKER_IMAGE $CIRCLE_TAG; then
+    echo "Docker image exists, skipping: $:$CIRCLE_TAG"
+else
+    docker build -t "$API_DOCKER_IMAGE:$CIRCLE_TAG" -f api/dockerfiles/Dockerfile.api_production .
+    docker push "$API_DOCKER_IMAGE:$CIRCLE_TAG"
+    # Update latest version
+    docker tag "$API_DOCKER_IMAGE:$CIRCLE_TAG" "$API_DOCKER_IMAGE:latest"
+    docker push "$API_DOCKER_IMAGE:latest"
+fi


### PR DESCRIPTION
## Issue Number

N/A came up because https://circleci.com/gh/AlexsLemonade/refinebio/5850 failed

## Purpose/Implementation Notes

We don't want to overwrite existing docker images so we bail out of deploys if the images already exist. However building the docker images takes a long time and sometimes the step after that fails. Rather than waiting for another build time we could iterate on the same deploy quicker by just continuing with the deploy if the images exist.

We still won't overwrite the images, but this way our deploy times aren't as crippling.

## Types of changes

- New feature (non-breaking change which adds functionality)

## Functional tests

I have not tested this yet because it is deploy code so I wanna test it in CI.

## Checklist

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules
