### PR TITLE
Tiny PR: Regionify Hardcoded Region Strings

### DIFF
--- a/infrastructure/cluster_connect.sh
+++ b/infrastructure/cluster_connect.sh
@@ -1,0 +1,2 @@
+#! /bin/bash
+csshX --ssh_args "-i /Users/rjones/Projects/data-refinery/infrastructure/data-refinery-key.pem" --login ubuntu --hosts hosts

--- a/infrastructure/disk.tf
+++ b/infrastructure/disk.tf
@@ -31,7 +31,7 @@ resource "aws_efs_mount_target" "data_refinery_efs_1b" {
 resource "aws_ebs_volume" "data_refinery_ebs" {
   count = "${var.max_clients}"
   availability_zone = "${var.region}a"
-  size = 1600 # 1.6TB
+  size = "${var.volume_size_in_gb}" # 1600 = 1.6TB
   type = "st1" # Throughput Optimized HDD
   tags {
     Name        = "data-refinery-ebs-${count.index}-${var.user}-${var.stage}"

--- a/infrastructure/instances.tf
+++ b/infrastructure/instances.tf
@@ -292,6 +292,19 @@ resource "aws_autoscaling_group" "clients" {
         value = "Nomad Client Instance ${var.user}-${var.stage}"
         propagate_at_launch = true
     }
+
+    tag {
+        key = "User"
+        value = "${var.user}"
+        propagate_at_launch = true
+    }
+
+    tag {
+        key = "Stage"
+        value = "${var.stage}"
+        propagate_at_launch = true
+    }
+
 }
 
 resource "aws_autoscaling_policy" "clients_scale_up" {

--- a/infrastructure/list_hosts.sh
+++ b/infrastructure/list_hosts.sh
@@ -3,4 +3,9 @@
 # ./list_hosts rjones > hosts
 # ./connect_cluster.sh
 
-aws ec2 describe-instances --filters "Name=tag:User,Values=$1" | jq '.Reservations[0].Instances' | grep PublicDnsName | tr -d '"' | sed "s/PublicDnsName: //g" | tr -d "," | awk '{$1=$1};1' | uniq
+if [[ $# -eq 0 ]] ; then
+    echo "Hey, you need to supply a user!" 
+    exit 0
+fi
+
+/Users/rjones/Library/Python/2.7/bin/aws ec2 describe-instances --filters "Name=tag:User,Values=$1" | grep PublicDnsName | tr -d '"' | sed "s/PublicDnsName: //g" | tr -d "," | awk '{$1=$1};1' | uniq

--- a/infrastructure/list_hosts.sh
+++ b/infrastructure/list_hosts.sh
@@ -1,0 +1,6 @@
+#! /bin/bash
+# Use like:
+# ./list_hosts rjones > hosts
+# ./connect_cluster.sh
+
+aws ec2 describe-instances --filters "Name=tag:User,Values=$1" | jq '.Reservations[0].Instances' | grep PublicDnsName | tr -d '"' | sed "s/PublicDnsName: //g" | tr -d "," | awk '{$1=$1};1' | uniq

--- a/infrastructure/nomad-configuration/client-instance-user-data.tpl.sh
+++ b/infrastructure/nomad-configuration/client-instance-user-data.tpl.sh
@@ -36,7 +36,7 @@ done
 
 COUNTER=0
 while [  $COUNTER -lt 99 ]; do
-        EBS_VOLUME_INDEX=`aws ec2 describe-volumes --filters "Name=tag:Index,Values=*" "Name=volume-id,Values=$EBS_VOLUME_ID" --query "Volumes[*].{ID:VolumeId,Tag:Tags}" --region us-east-1 | jq ".[0].Tag[$COUNTER].Value" | tr -d '"'`
+        EBS_VOLUME_INDEX=`aws ec2 describe-volumes --filters "Name=tag:Index,Values=*" "Name=volume-id,Values=$EBS_VOLUME_ID" --query "Volumes[*].{ID:VolumeId,Tag:Tags}" --region ${region} | jq ".[0].Tag[$COUNTER].Value" | tr -d '"'`
         if echo "$EBS_VOLUME_INDEX" | egrep -q '^\-?[0-9]+$'; then
             echo "$EBS_VOLUME_INDEX is an integer!"
             break # This is a Volume Index

--- a/infrastructure/nomad-configuration/client-instance-user-data.tpl.sh
+++ b/infrastructure/nomad-configuration/client-instance-user-data.tpl.sh
@@ -26,7 +26,7 @@ mkdir -p /var/ebs/
 
 fetch_and_mount_volume () {
     INSTANCE_ID=$(curl http://169.254.169.254/latest/meta-data/instance-id)
-    EBS_VOLUME_ID=`aws ec2 describe-volumes --filters "Name=tag:User,Values=${user}" "Name=tag:Stage,Values=${stage}" "Name=tag:IsBig,Values=True" "Name=status,Values=available" "Name=availability-zone,Values=${region}" --region ${region} | jq '.Volumes[0].VolumeId' | tr -d '"'`
+    EBS_VOLUME_ID=`aws ec2 describe-volumes --filters "Name=tag:User,Values=${user}" "Name=tag:Stage,Values=${stage}" "Name=tag:IsBig,Values=True" "Name=status,Values=available" "Name=availability-zone,Values=${region}a" --region ${region} | jq '.Volumes[0].VolumeId' | tr -d '"'`
     aws ec2 attach-volume --volume-id $EBS_VOLUME_ID --instance-id $INSTANCE_ID --device "/dev/sdf" --region ${region}
 }
 

--- a/infrastructure/nomad-configuration/client-instance-user-data.tpl.sh
+++ b/infrastructure/nomad-configuration/client-instance-user-data.tpl.sh
@@ -17,7 +17,7 @@
 export DEBIAN_FRONTEND=noninteractive
 apt-get update -y
 apt-get upgrade -y
-apt-get install --yes nfs-common jq iotop dstat
+apt-get install --yes nfs-common jq iotop dstat speedometer
 
 ulimit -n 65536
 
@@ -26,7 +26,7 @@ mkdir -p /var/ebs/
 
 fetch_and_mount_volume () {
     INSTANCE_ID=$(curl http://169.254.169.254/latest/meta-data/instance-id)
-    EBS_VOLUME_ID=`aws ec2 describe-volumes --filters "Name=tag:User,Values=${user}" "Name=tag:Stage,Values=${stage}" "Name=tag:IsBig,Values=True" "Name=status,Values=available" "Name=availability-zone,Values=us-east-1a" --region us-east-1 | jq '.Volumes[0].VolumeId' | tr -d '"'`
+    EBS_VOLUME_ID=`aws ec2 describe-volumes --filters "Name=tag:User,Values=${user}" "Name=tag:Stage,Values=${stage}" "Name=tag:IsBig,Values=True" "Name=status,Values=available" "Name=availability-zone,Values=${region}" --region ${region} | jq '.Volumes[0].VolumeId' | tr -d '"'`
     aws ec2 attach-volume --volume-id $EBS_VOLUME_ID --instance-id $INSTANCE_ID --device "/dev/sdf" --region ${region}
 }
 

--- a/infrastructure/variables.tf
+++ b/infrastructure/variables.tf
@@ -152,6 +152,10 @@ variable "foreman_instance_type" {
   default = "t2.micro"
 }
 
+variable "volume_size_in_gb" {
+  default = "500"
+}
+
 # Output our production environment variables.
 output "environment_variables" {
   value = [


### PR DESCRIPTION
Replaces two hardcoded `us-east-1- strings. Also adds `speedometer` as a client tool.