### PR TITLE
Make sure certbot has HTTP access to the server it's running on

### DIFF
--- a/infrastructure/api-configuration/api-server-instance-user-data.tpl.sh
+++ b/infrastructure/api-configuration/api-server-instance-user-data.tpl.sh
@@ -39,8 +39,12 @@ if [[ ${stage} == "staging" || ${stage} == "prod" ]]; then
     # will circumvent certbot's limit because the 5-a-week limit only applies to the
     # "same set of domains", so by changing that set we get to use the 20-a-week limit.
     if [[ ${stage} == "staging" ]]; then
+        # The certbot challenge cannot be completed until the aws_lb_target_group_attachment resources are created.
+        sleep 180
         certbot --nginx -d api.staging.refine.bio -n --agree-tos --redirect -m g3w4k4t5n3s7p7v8@alexslemonade.slack.com
     elif [[ ${stage} == "prod" ]]; then
+        # The certbot challenge cannot be completed until the aws_lb_target_group_attachment resources are created.
+        sleep 180
         certbot --nginx -d api.refine.bio -n --agree-tos --redirect -m g3w4k4t5n3s7p7v8@alexslemonade.slack.com
     fi
 fi


### PR DESCRIPTION
## Issue Number

N/A, deploys have consistently broken the https://api.staging.refine.bio link

## Purpose/Implementation Notes

My theory is that because the load balancer attachments cannot happen until after the API server comes back up, that it's running certbot before they exist so the certbot challenge cannot make a HTTP request to the server it is running on. I'm not sure, but it seems plausible.

I thought about trying to curl in a loop while waiting for the attachments come up, but I'm not sure what that would look like and the only way I can figure that out would be to break the attachments again. For now, waiting 3 minutes on our API seems like an acceptable stopgap.

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

N/A cause I can't test outside of staging.
