### PR TITLE
Make the get_volume_index function return a default value that is valid.

### DIFF
--- a/common/data_refinery_common/message_queue.py
+++ b/common/data_refinery_common/message_queue.py
@@ -72,7 +72,9 @@ def send_job(job_type: Enum, job) -> None:
                 job_type.value,
                 job.id)
 
-    if isinstance(job, ProcessorJob):
+    # Smasher doesn't need to be on a specific instance since it will
+    # download all the data to its instance anyway.
+    if isinstance(job, ProcessorJob) and job_type is not ProcessorPipeline.SMASHER:
         # Make sure this job goes to the correct EBS resource.
         # If this is being dispatched for the first time, make sure that
         # we store the currently attached index.

--- a/common/data_refinery_common/test_utils.py
+++ b/common/data_refinery_common/test_utils.py
@@ -99,7 +99,7 @@ class UtilsTestCase(TestCase):
 
     def test_volume_index(self):
         """Test that supported RNASeq platforms setting is set correctly."""
-        self.assertEqual(utils.get_volume_index(), "0")
+        self.assertEqual(utils.get_volume_index(), "1")
         with open('/tmp/VOLUME_INDEX', 'wb') as f:
             f.write("123".encode())
         self.assertEqual(utils.get_volume_index(path='/tmp/VOLUME_INDEX'), "123")

--- a/common/data_refinery_common/utils.py
+++ b/common/data_refinery_common/utils.py
@@ -61,7 +61,7 @@ def get_worker_id() -> str:
     return get_instance_id() + "/" + current_process().name
 
 
-def get_volume_index(default="0", path='/home/user/data_store/VOLUME_INDEX') -> str:
+def get_volume_index(default="1", path='/home/user/data_store/VOLUME_INDEX') -> str:
     """ Reads the contents of the VOLUME_INDEX file, else returns default """
 
     try:

--- a/format_nomad_with_env.sh
+++ b/format_nomad_with_env.sh
@@ -175,9 +175,15 @@ done < $environment_file
 # getting the templates from.
 if [[ -z $output_dir ]]; then
     output_dir=nomad-job-specs
-elif [[ ! -d "$output_dir" ]]; then
+fi
+
+if [[ ! -d "$output_dir" ]]; then
     mkdir $output_dir
 fi
+
+# Clean up old files
+rm $output_dir/*.nomad
+rm $output_dir/*.nomad_test
 
 export_log_conf (){
     if [[ $env == 'prod' || $env == 'staging' || $env == 'dev' ]]; then
@@ -211,14 +217,21 @@ if [[ $project == "workers" ]]; then
                        > "$output_dir/$output_file$TEST_POSTFIX" \
                        2> /dev/null
             echo "Made $output_dir/$output_file$TEST_POSTFIX"
+        elif [ $output_file == "smasher.nomad" ]; then
+            export_log_conf "processor"
+            cat nomad-job-specs/$template \
+                | perl -p -e 's/\$\{\{([^}]+)\}\}/defined $ENV{$1} ? $ENV{$1} : $&/eg' \
+                       > "$output_dir/$output_file$TEST_POSTFIX" \
+                       2> /dev/null
+            echo "Made $output_dir/$output_file$TEST_POSTFIX"
         else
             export_log_conf "processor"
-            rams=(1024 2048 3072 4096 5120 6144 7168 8192 9216 10240 11264 12288 13312)  
-            for r in "${rams[@]}"  
+            rams=(1024 2048 3072 4096 5120 6144 7168 8192 9216 10240 11264 12288 13312)
+            for r in "${rams[@]}"
             do
                 indexes=(1 2 3 4 5 6 7 8 9 10)
                 for j in "${indexes[@]}"
-                do  
+                do
                     export INDEX_POSTFIX="_$j"
                     export INDEX="$j"
                     export RAM_POSTFIX="_$r.nomad"

--- a/workers/nomad-job-specs/smasher.nomad.tpl
+++ b/workers/nomad-job-specs/smasher.nomad.tpl
@@ -1,8 +1,8 @@
-job "SMASHER_${{INDEX}}_${{RAM}}" {
+job "SMASHER" {
   datacenters = ["dc1"]
 
   type = "batch"
-  priority = 75 
+  priority = 75
 
   parameterized {
     payload       = "forbidden"
@@ -52,13 +52,7 @@ job "SMASHER_${{INDEX}}_${{RAM}}" {
         # CPU is in AWS's CPU units.
         cpu = 1024
         # Memory is in MB of RAM.
-        memory = ${{RAM}}
-      }
-
-      constraint {
-        attribute = "${meta.volume_index}"
-        operator  = "="
-        value     = "${{INDEX}}"
+        memory = 4096
       }
 
       config {


### PR DESCRIPTION
## Issue Number

N/A Ariel was trying to test the new emails and could not trigger a smash job:

https://sentry.io/greenelab/staging-refinebio-api/issues/612495404/?query=is:unresolved

> Dispatching Nomad job of type ProcessorPipeline.SMASHER for job spec SMASHER_0_4096 to host 10.0.167.44 and port 4646 failed.

## Purpose/Implementation Notes

I fixed this in two ways:
  * First I changed the default value of get_volume_index so that it returns an index that is actually used. We were returning 0 by default when the volume indices go from 1-10. The API doesn't have that set up, so it always chooses the default.
  * However this means that if the system is at rest, i.e. no spot instances are spun up, then we have to spin up instances until one of them chooses to use the EBS volume with index 1. This means that for a single smash job we could have to spin up 10 instances. However the smash job is not preceded by a downloader job and it has to download all of its data anyway so there's really no need for it to be tied to a volume index. Therefore I have also made it so that it's not parameterized on a volume index. Also we're just always using 4096 memory for smasher jobs so I took out it's different RAM amounts. If we end up needing them later, we can add a special case to make an unvolume-indexed-yet-RAM-multiplexed set of nomad jobs for the smasher then.


## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

I was able to queue Ariel's smasher job by setting the volume_index of the job to '1' before sending (via the django shell) so I know the default volume was the problem.

I've also ran `run_nomad.sh` to make sure the smasher nomad job gets templated correctly.

## Checklist

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules
