### PR TITLE
Fix to id refinery file extension

### DIFF
--- a/workers/data_refinery_workers/processors/no_op.py
+++ b/workers/data_refinery_workers/processors/no_op.py
@@ -161,7 +161,7 @@ def _convert_genes(job_context: Dict) -> Dict:
 def _convert_affy_genes(job_context: Dict) -> Dict:
     """ Convert to Ensembl genes if we can"""
 
-    gene_index_path = "/home/user/gene_indexes/" + job_context["internal_accession"] + ".tar.gz"
+    gene_index_path = "/home/user/gene_indexes/" + job_context["internal_accession"] + ".tsv.gz"
     if not os.path.exists(gene_index_path):
         logger.error("Missing gene index file for platform!",
             platform=job_context["internal_accession"],


### PR DESCRIPTION
## Issue Number

AlexsLemonade/identifier-refinery#4

## Purpose/Implementation Notes

Trivial fix to id refinery file extension (`tar.gz` -> `tsv.gz`)
