### PR TITLE
Add zcat to gene conversion R script

### DIFF
--- a/workers/data_refinery_workers/processors/gene_convert.R
+++ b/workers/data_refinery_workers/processors/gene_convert.R
@@ -52,7 +52,8 @@ suppressWarnings(data <- fread(filePath,
 
 # Read the data file
 message("Reading master index...")
-suppressWarnings(index_data <- fread(geneIndexPath,
+index_path <- paste('zcat', geneIndexPath)
+suppressWarnings(index_data <- fread(index_path,
 					stringsAsFactors=FALSE,
 					sep="\t",
 					header=TRUE,

--- a/workers/data_refinery_workers/processors/test_no_op.py
+++ b/workers/data_refinery_workers/processors/test_no_op.py
@@ -2,6 +2,7 @@ import os
 import shutil
 from contextlib import closing
 from django.test import TestCase, tag
+from pathlib import Path
 from unittest.mock import MagicMock
 from data_refinery_common.models import (
     SurveyJob,
@@ -15,26 +16,12 @@ from data_refinery_common.models import (
 from data_refinery_workers.processors import no_op, utils
 
 
-def prepare_job():
-    pj = ProcessorJob()
-    pj.pipeline_applied = "NO_OP"
-    pj.save()
-
-    og_file = OriginalFile()
-    og_file.source_filename = "ftp://ftp.ebi.ac.uk/pub/databases/microarray/data/experiment/GEOD/E-GEOD-59071/E-GEOD-59071.raw.3.zip"
-    og_file.filename = "GSM1426071_CD_colon_active_1.CEL"
-    og_file.absolute_file_path = "/home/user/data_store/raw/TEST/CEL/GSM1426071_CD_colon_active_1.CEL"
-    og_file.save()
-
-    assoc1 = ProcessorJobOriginalFileAssociation()
-    assoc1.original_file = og_file
-    assoc1.processor_job = pj
-    assoc1.save()
-
-    return pj
-
-
 class NOOPTestCase(TestCase):
+    def setUp(self):
+        """Cleanup work dirs from previous test runs that may have failed."""
+        job_dirs = list(Path("/home/user/data_store").glob('**/processor_job_*'))
+        for job_dir in job_dirs:
+            shutil.rmtree(str(job_dir), ignore_errors=True)
 
     @tag('no_op')
     def test_convert_simple_pcl(self):


### PR DESCRIPTION
## Issue Number

N/A

## Purpose/Implementation Notes

`data.table::fread` can't read in gzipped files. Appending `zcat` to the path is what we had prior to #593.
