### PR TITLE
Prevent us from queuing additional jobs for a sample that has already…

### DIFF
--- a/foreman/data_refinery_foreman/surveyor/array_express.py
+++ b/foreman/data_refinery_foreman/surveyor/array_express.py
@@ -420,12 +420,15 @@ class ArrayExpressSurveyor(ExternalSourceSurveyor):
 
             # Create the sample object
             try:
+                # Associate it with the experiment, but since it
+                # already exists it already has original files
+                # associated with it and it's already been downloaded,
+                # so don't add it to created_samples.
                 sample_object = Sample.objects.get(accession_code=sample_accession_code)
                 logger.debug("Sample %s already exists, skipping object creation.",
                              sample_accession_code,
                              experiment_accession_code=experiment.accession_code,
                              survey_job=self.survey_job.id)
-                continue
             except Sample.DoesNotExist:
                 sample_object = Sample()
 
@@ -466,19 +469,19 @@ class ArrayExpressSurveyor(ExternalSourceSurveyor):
                 original_file_sample_association.sample = sample_object
                 original_file_sample_association.save()
 
+                created_samples.append(sample_object)
+
+                logger.debug("Created " + str(sample_object),
+                             experiment_accession_code=experiment.accession_code,
+                             survey_job=self.survey_job.id,
+                             sample=sample_object.id)
+
             # Create associations if they don't already exist
             ExperimentSampleAssociation.objects.get_or_create(
                 experiment=experiment, sample=sample_object)
 
             ExperimentOrganismAssociation.objects.get_or_create(
                 experiment=experiment, organism=organism)
-
-            logger.debug("Created " + str(sample_object),
-                         experiment_accession_code=experiment.accession_code,
-                         survey_job=self.survey_job.id,
-                         sample=sample_object.id)
-
-            created_samples.append(sample_object)
 
         return created_samples
 

--- a/workers/data_refinery_workers/processors/agilent_twocolor.py
+++ b/workers/data_refinery_workers/processors/agilent_twocolor.py
@@ -33,7 +33,7 @@ def _prepare_files(job_context: Dict) -> Dict:
     job_context so everything is prepared for processing.
     """
     original_file = job_context["original_files"][0]
-    job_context["input_file_path"] = original_file.get_synced_file_path()
+    job_context["input_file_path"] = original_file.absolute_file_path
     # Turns /home/user/data_store/E-GEOD-8607/raw/foo.txt into /home/user/data_store/E-GEOD-8607/processed/foo.cel
     pre_part = original_file.absolute_file_path.split('/')[:-2]
     end_part = original_file.absolute_file_path.split('/')[-1]

--- a/workers/data_refinery_workers/processors/array_express.py
+++ b/workers/data_refinery_workers/processors/array_express.py
@@ -49,7 +49,8 @@ def _prepare_files(job_context: Dict) -> Dict:
         job_context["success"] = False
         return job_context
 
-    new_filename = original_file.filename.upper().replace(".CEL", ".PCL")
+    file_extension_start = original_file.filename.upper().find(".CEL")
+    new_filename= original_file.filename[:file_extension_start] + ".PCL"
     job_context["output_file_path"] = job_context["work_dir"] + "/" + new_filename
 
     return job_context

--- a/workers/data_refinery_workers/processors/salmon.py
+++ b/workers/data_refinery_workers/processors/salmon.py
@@ -219,7 +219,7 @@ def _run_fastqc(job_context: Dict) -> Dict:
 
     # We could use --noextract here, but MultiQC wants extracted files.
     command_str = ("./FastQC/fastqc --outdir={qc_directory} {files}")
-    files = ' '.join(file.get_synced_file_path() for file in job_context['original_files'])
+    files = ' '.join(file.absolute_file_path for file in job_context['original_files'])
     formatted_command = command_str.format(qc_directory=job_context["qc_directory"],
                 files=files)
 


### PR DESCRIPTION
… been discovered.

## Issue Number

https://github.com/AlexsLemonade/refinebio/issues/596

## Purpose/Implementation Notes

@arielsvn noticed that we're returning duplicate processor information about samples. This was happening because we were processing samples once for every experiment they are part of. This branch prevents that by not doing anything to previously-discovered samples other than associating them with the currently-being-surveyed experiment.

This means we'll save some compute costs because we'll run fewer jobs!

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

The unit tests should cover this change well.

## Checklist

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules
