### PR TITLE
Kurtwheeler/work dir smasher

### DIFF
--- a/workers/data_refinery_workers/processors/smasher.py
+++ b/workers/data_refinery_workers/processors/smasher.py
@@ -368,8 +368,6 @@ def _smash(job_context: Dict) -> Dict:
         final_zip_base = "/home/user/data_store/smashed/" + str(job_context["dataset"].pk)
         shutil.make_archive(final_zip_base, 'zip', smash_path)
         job_context["output_file"] = final_zip_base + ".zip"
-        # and clean up the unzipped directory.
-        shutil.rmtree(smash_path)
     except Exception as e:
         logger.exception("Could not smash dataset.",
                         dataset_id=job_context['dataset'].id,

--- a/workers/data_refinery_workers/processors/utils.py
+++ b/workers/data_refinery_workers/processors/utils.py
@@ -226,8 +226,7 @@ def run_pipeline(start_value: Dict, pipeline: List[Callable]):
                               " function {} in pipeline: ").format(processor.__name__)
             logger.exception(failure_reason,
                              no_retry=job.no_retry,
-                             processor_job=job_id,
-                             job_context=last_result)
+                             processor_job=job_id)
             last_result["success"] = False
             last_result["job"].failure_reason = failure_reason + str(e)
             return end_job(last_result)

--- a/workers/data_refinery_workers/processors/utils.py
+++ b/workers/data_refinery_workers/processors/utils.py
@@ -160,7 +160,7 @@ def end_job(job_context: Dict, abort=False):
             pipeline.save()
 
     if "work_dir" in job_context and RUNNING_IN_CLOUD == "True":
-        shutil.rmtree(job_context["work_dir"])
+        shutil.rmtree(job_context["work_dir"], ignore_errors=True)
 
     job.success = success
     job.end_time = timezone.now()


### PR DESCRIPTION
…self.

## Issue Number

N/A, came up while trying to get smasher jobs working in staging again

## Purpose/Implementation Notes

It looks like the smasher jobs failed because they had already cleaned up after themselves. This both prevents them from cleaning up after themselves and makes it so that doesn't break `end_job`.

Additional it is unsafe to log the smasher's job context so `end_job` no longer will do so.

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

N/A

## Checklist

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules
