### PR TITLE
Fix the transcriptome index path again... basically the opposite as b…

### DIFF
--- a/workers/data_refinery_workers/downloaders/sra.py
+++ b/workers/data_refinery_workers/downloaders/sra.py
@@ -115,8 +115,7 @@ def _download_file_aspera(download_url: str,
             if attempt > 5:
                 logger.info("Final shell call of `%s` to ascp failed with error message: %s",
                          formatted_command,
-                         stderr,
-                         stdout,
+                         stderr + "\nSTDOUT: " + stdout,
                          downloader_job=downloader_job.id)
                 downloader_job.failure_reason = "stderr:\n " + stderr + "\nstdout:\n " + stdout
                 return False

--- a/workers/data_refinery_workers/processors/test_salmon.py
+++ b/workers/data_refinery_workers/processors/test_salmon.py
@@ -342,12 +342,10 @@ class SalmonTestCase(TestCase):
         # Test `salmon quant` on sample1 (SRR1206053)
         sample1_dir = os.path.join(experiment_dir, sample1_accession)
 
-        genes_to_transcripts_path = os.path.join(experiment_dir, 'index', 'genes_to_transcripts.txt')
         job1_context = salmon._prepare_files({"job_dir_prefix": "TEST",
                                               "job_id": "TEST",
                                               'pipeline': Pipeline(name="Salmon"),
                                               'computed_files': [],
-                                              "genes_to_transcripts_path": genes_to_transcripts_path,
                                               "original_files": [og_file_1]})
 
         # Check quant.sf in `salmon quant` output dir of sample1
@@ -365,7 +363,6 @@ class SalmonTestCase(TestCase):
                                               "job_id": "TEST2",
                                               'pipeline': Pipeline(name="Salmon"),
                                               'computed_files': [],
-                                              "genes_to_transcripts_path": genes_to_transcripts_path,
                                               "original_files": [og_file_2]})
 
         # Clean up tximport output:

--- a/workers/run_tests.sh
+++ b/workers/run_tests.sh
@@ -66,9 +66,9 @@ if [[ -z $tag || $tag == "salmon" ]]; then
     # TODO: rename the test_data_new to test_data and remove check for
     # the new file. These are here temporarily so other branches'
     # tests don't break.
-    if [[ ! -e $volume_directory/salmon_tests || ! -e $volume_directory/salmon_tests/new ]]; then
+    if [[ ! -e $volume_directory/salmon_tests || ! -e $volume_directory/salmon_tests/newer ]]; then
         echo "Downloading 'salmon quant' test data..."
-        wget -q -O $volume_directory/salmon_tests.tar.gz $test_data_repo/salmon_tests_new.tar.gz
+        wget -q -O $volume_directory/salmon_tests.tar.gz $test_data_repo/salmon_tests_newer.tar.gz
         tar xzf $volume_directory/salmon_tests.tar.gz -C $volume_directory
         rm $volume_directory/salmon_tests.tar.gz
     fi


### PR DESCRIPTION
…efore. Fix a log statement in sra downloader.

## Issue Number

N/A came up during crunch

## Purpose/Implementation Notes

https://github.com/AlexsLemonade/refinebio/pull/620 corrected a path that didn't need to be corrected. I think it may have been because our old tx indices had a nested index directory in them. After running the crunch today it turns out its not necessary.

This also fixes a bad log statement that was causing errors like:
```
TypeError: not all arguments converted during string formatting
```

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

These are being tested in the crunch.

## Checklist

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules
