### PR TITLE
Fixes SRA surveyor's read run generation range logic.

### DIFF
--- a/foreman/data_refinery_foreman/surveyor/sra.py
+++ b/foreman/data_refinery_foreman/surveyor/sra.py
@@ -317,13 +317,18 @@ class SraSurveyor(ExternalSourceSurveyor):
 
         return download_url
 
-    def _generate_experiment_and_samples(self, run_accession: str) -> (Experiment, List[Sample]):
+    def _generate_experiment_and_samples(self, run_accession: str, study_accession: str=None) -> (Experiment, List[Sample]):
         """Generates Experiments and Samples for the provided run_accession."""
         metadata = SraSurveyor.gather_all_metadata(run_accession)
 
         if metadata == {}:
-            logger.error("Could not discover any metadata for run.",
-                         accession=run_accession)
+            if study_accession:
+                logger.error("Could not discover any metadata for run.",
+                             accession=run_accession,
+                study_accession=study_accession)
+            else:
+                logger.error("Could not discover any metadata for run.",
+                             accession=run_accession)
             return (None, None)  # This will cascade properly
 
         if DOWNLOAD_SOURCE == "ENA":
@@ -538,7 +543,8 @@ class SraSurveyor(ExternalSourceSurveyor):
                         end_id = end[3::]
 
                         for run_id in range(int(start_id), int(end_id) + 1):
-                            accessions_to_run.append(accession[0] + "RR" + str(run_id))
+                            run_id = str(run_id).zfill(len(start_id))
+                            accessions_to_run.append(accession[0] + "RR" + run_id)
                     break
 
             experiment = None
@@ -549,7 +555,7 @@ class SraSurveyor(ExternalSourceSurveyor):
                              accession,
                              survey_job=self.survey_job.id)
 
-                returned_experiment, samples = self._generate_experiment_and_samples(run_id)
+                returned_experiment, samples = self._generate_experiment_and_samples(run_id, accession)
 
                 # Some runs may return (None, None). If this happens
                 # we don't want to set experiment to None.

--- a/foreman/data_refinery_foreman/surveyor/test_sra.py
+++ b/foreman/data_refinery_foreman/surveyor/test_sra.py
@@ -117,6 +117,19 @@ class SraSurveyorTestCase(TestCase):
         self.assertEqual(experiment.accession_code, "SRP111553")
         self.assertEqual(len(samples), 16) # 8 samples with 2 runs each
 
+        survey_job = SurveyJob(source_type="SRA")
+        survey_job.save()
+        key_value_pair = SurveyJobKeyValue(survey_job=survey_job,
+                                           key="experiment_accession_code",
+                                           value="DRP003977")
+        key_value_pair.save()
+
+        sra_surveyor = SraSurveyor(survey_job)
+        experiment, samples = sra_surveyor.discover_experiment_and_samples()
+
+        self.assertEqual(experiment.accession_code, "DRP003977")
+        self.assertEqual(len(samples), 9)
+
     @patch('data_refinery_foreman.surveyor.sra.requests.get')
     def test_metadata_is_gathered_correctly(self, mock_get):
         mock_get.side_effect = mocked_requests_get
@@ -180,4 +193,3 @@ class SraSurveyorTestCase(TestCase):
 
         ncbi_url = SraSurveyor._build_ncbi_file_url(metadata["run_accession"])
         self.assertEqual(ncbi_url, 'anonftp@ftp.ncbi.nlm.nih.gov:/sra/sra-instant/reads/ByRun/sra/DRR/DRR002/DRR002116/DRR002116.sra')
-


### PR DESCRIPTION
## Issue Number

N/A Came up during crunch

## Purpose/Implementation Notes

Crunch had a bunch of:

```
2018-09-18 17:31:37,488 local data_refinery_foreman.surveyor.sra ERROR [accession: DRR51062]: Could not discover any metadata for run.
```

Turns out we were missing some zeroes. This fixes that.

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

Tested by running previously broken accession: DRP003977

## Checklist

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules
