### PR TITLE
Move to Hard Limited Pagination on Jobs, add Harakiri

### DIFF
--- a/api/data_refinery_api/views.py
+++ b/api/data_refinery_api/views.py
@@ -561,21 +561,17 @@ class SurveyJobList(PaginatedAPIView):
 	  - ?start_time__lte=2018-03-23T15:29:40.848381Z&start_time__gte=2018-03-23T14:29:40.848381Z
 	  - ?success=True
 
+      Works with required 'limit' and 'offset' params.
+
     """
 
     def get(self, request, format=None):
         filter_dict = request.query_params.dict()
-        filter_dict.pop('limit', None)
-        filter_dict.pop('offset', None)
-        jobs = SurveyJob.objects.filter(**filter_dict)
-
-        page = self.paginate_queryset(jobs)
-        if page is not None:
-            serializer = SurveyJobSerializer(page, many=True)
-            return self.get_paginated_response(serializer.data)
-        else:
-            serializer = SurveyJobSerializer(jobs, many=True)
-            return Response(serializer.data)
+        limit = max(int(filter_dict.pop('limit', 100)), 100)
+        offset = int(filter_dict.pop('offset', 0))
+        jobs = SurveyJob.objects.filter(**filter_dict)[offset:(offset + limit)]
+        serializer = SurveyJobSerializer(jobs, many=True)
+        return Response(serializer.data)
 
 class DownloaderJobList(PaginatedAPIView):
     """
@@ -584,17 +580,11 @@ class DownloaderJobList(PaginatedAPIView):
 
     def get(self, request, format=None):
         filter_dict = request.query_params.dict()
-        filter_dict.pop('limit', None)
-        filter_dict.pop('offset', None)
-        jobs = DownloaderJob.objects.filter(**filter_dict)
-
-        page = self.paginate_queryset(jobs)
-        if page is not None:
-            serializer = DownloaderJobSerializer(page, many=True)
-            return self.get_paginated_response(serializer.data)
-        else:
-            serializer = DownloaderJobSerializer(jobs, many=True)
-            return Response(serializer.data)
+        limit = max(int(filter_dict.pop('limit', 100)), 100)
+        offset = int(filter_dict.pop('offset', 0))
+        jobs = DownloaderJob.objects.filter(**filter_dict)[offset: offset + limit]
+        serializer = DownloaderJobSerializer(jobs, many=True)
+        return Response(serializer.data)
 
 class ProcessorJobList(PaginatedAPIView):
     """
@@ -603,17 +593,11 @@ class ProcessorJobList(PaginatedAPIView):
 
     def get(self, request, format=None):
         filter_dict = request.query_params.dict()
-        filter_dict.pop('limit', None)
-        filter_dict.pop('offset', None)
-        jobs = ProcessorJob.objects.filter(**filter_dict)
-
-        page = self.paginate_queryset(jobs)
-        if page is not None:
-            serializer = ProcessorJobSerializer(page, many=True)
-            return self.get_paginated_response(serializer.data)
-        else:
-            serializer = ProcessorJobSerializer(jobs, many=True)
-            return Response(serializer.data)
+        limit = max(int(filter_dict.pop('limit', 100)), 100)
+        offset = int(filter_dict.pop('offset', 0))
+        jobs = ProcessorJob.objects.filter(**filter_dict)[offset: offset + limit]
+        serializer = ProcessorJobSerializer(jobs, many=True)
+        return Response(serializer.data)
 
 ###
 # Statistics

--- a/api/uwsgi.ini
+++ b/api/uwsgi.ini
@@ -4,7 +4,7 @@ chdir=/home/user
 module=data_refinery_api.wsgi:application
 pidfile=/tmp/project-master.pid
 vacuum=True
-max-requests=5000
+max-requests=500
 master = 1
 processes = 2
 threads = 2
@@ -13,4 +13,4 @@ ignore-write-errors=true
 disable-write-exception=true
 socket-timeout=30
 buffer-size = 32768
-
+harakiri = 30

--- a/common/data_refinery_common/job_lookup.py
+++ b/common/data_refinery_common/job_lookup.py
@@ -200,7 +200,7 @@ def determine_ram_amount(sample: Sample, job) -> int:
     elif job.pipeline_applied == ProcessorPipeline.AGILENT_ONECOLOR_TO_PCL.value:
         return 2048
     elif job.pipeline_applied == ProcessorPipeline.SALMON.value:
-        return 8192
+        return 12288
     elif job.pipeline_applied == ProcessorPipeline.NONE.value:
         return 1024
     else:

--- a/common/data_refinery_common/models/models.py
+++ b/common/data_refinery_common/models/models.py
@@ -809,6 +809,13 @@ class ComputedFile(models.Model):
             else:
                 return self.sync_from_s3(force)
 
+    def s3_url(self):
+        """ Render the resulting S3 URL """
+        if (self.s3_key) and (self.s3_bucket):
+            return "https://s3.amazonaws.com/" + self.s3_bucket + "/" + self.s3_key
+        else:
+            return None
+
 class Dataset(models.Model):
     """ A Dataset is a desired set of experiments/samples to smash and download """
 

--- a/foreman/data_refinery_foreman/surveyor/sra.py
+++ b/foreman/data_refinery_foreman/surveyor/sra.py
@@ -1,3 +1,4 @@
+import random
 import requests
 from typing import List, Dict
 
@@ -31,6 +32,8 @@ ENA_METADATA_URL_TEMPLATE = "https://www.ebi.ac.uk/ena/data/view/{}&display=xml"
 ENA_DOWNLOAD_URL_TEMPLATE = ("ftp://ftp.sra.ebi.ac.uk/vol1/fastq/{short_accession}{sub_dir}"
                              "/{long_accession}/{long_accession}{read_suffix}.fastq.gz")
 NCBI_DOWNLOAD_URL_TEMPLATE = ("anonftp@ftp.ncbi.nlm.nih.gov:/sra/sra-instant/reads/ByRun/sra/"
+                             "{first_three}/{first_six}/{accession}/{accession}.sra")
+NCBI_PRIVATE_DOWNLOAD_URL_TEMPLATE = ("anonftp@ftp-private.ncbi.nlm.nih.gov:/sra/sra-instant/reads/ByRun/sra/"
                              "{first_three}/{first_six}/{accession}/{accession}.sra")
 ENA_SUB_DIR_PREFIX = "/00"
 
@@ -309,11 +312,20 @@ class SraSurveyor(ExternalSourceSurveyor):
         accession = run_accession
         first_three = accession[:3]
         first_six = accession[:6]
-        download_url = NCBI_DOWNLOAD_URL_TEMPLATE.format(
-            first_three=first_three,
-            first_six=first_six,
-            accession=accession
-        )
+
+        # Load balancing via coin flip.
+        if random.choice([True, False]):
+            download_url = NCBI_DOWNLOAD_URL_TEMPLATE.format(
+                first_three=first_three,
+                first_six=first_six,
+                accession=accession
+            )
+        else:
+            download_url = NCBI_PRIVATE_DOWNLOAD_URL_TEMPLATE.format(
+                first_three=first_three,
+                first_six=first_six,
+                accession=accession
+            )
 
         return download_url
 

--- a/foreman/data_refinery_foreman/surveyor/test_sra.py
+++ b/foreman/data_refinery_foreman/surveyor/test_sra.py
@@ -192,4 +192,5 @@ class SraSurveyorTestCase(TestCase):
         self.assertEqual(metadata["submission_title"], "Submitted by RIKEN_CDB on 19-JUL-2013")
 
         ncbi_url = SraSurveyor._build_ncbi_file_url(metadata["run_accession"])
-        self.assertEqual(ncbi_url, 'anonftp@ftp.ncbi.nlm.nih.gov:/sra/sra-instant/reads/ByRun/sra/DRR/DRR002/DRR002116/DRR002116.sra')
+        self.assertTrue(ncbi_url in ['anonftp@ftp.ncbi.nlm.nih.gov:/sra/sra-instant/reads/ByRun/sra/DRR/DRR002/DRR002116/DRR002116.sra',
+            'anonftp@ftp-private.ncbi.nlm.nih.gov:/sra/sra-instant/reads/ByRun/sra/DRR/DRR002/DRR002116/DRR002116.sra'])

--- a/workers/data_refinery_workers/processors/illumina.R
+++ b/workers/data_refinery_workers/processors/illumina.R
@@ -372,7 +372,7 @@ probeIDs <- data[,probeIDColumn]
 
 
 if (length(exprColumns) == 0)
-  stop(paste0("No columns match this pattern: ", exprColumnPattern))
+  stop("No expression columns provided")
 
 exprData <- as.matrix(data[,exprColumns,drop=FALSE])
 rownames(exprData) <- probeIDs

--- a/workers/data_refinery_workers/processors/management/commands/create_qn_target.py
+++ b/workers/data_refinery_workers/processors/management/commands/create_qn_target.py
@@ -88,6 +88,8 @@ class Command(BaseCommand):
 
         if final_context['success']:
             print(":D")
+            self.stdout.write("Target file: " + final_context['target_file'])
+            self.stdout.write("Target S3: " + str(final_context['computed_files'][0].s3_url()))
             sys.exit(0)
         else:
             print(":(")

--- a/workers/data_refinery_workers/processors/test_qn_reference.py
+++ b/workers/data_refinery_workers/processors/test_qn_reference.py
@@ -44,8 +44,9 @@ class QNRefTestCase(TestCase):
             sample.accession_code = code
             sample.title = code
             sample.platform_accession_code = 'A-MEXP-1171'
-            sample.manufacturer = "ILLUMINA"
+            sample.manufacturer = "SLIPPERY DICK'S DISCOUNT MICROARRAYS"
             sample.organism = homo_sapiens
+            sample.technology = "MICROARRAY"
             sample.is_processed = True
             sample.save()
 
@@ -119,3 +120,23 @@ class QNRefTestCase(TestCase):
 
         self.assertEqual(final_context['merged_qn']['1'][0], -0.437948852881293)
         self.assertEqual(final_context['original_merged']['1'][0], -0.576210936113982)
+
+        ## 
+        # Test via management command
+        ##
+
+        from django.core.management import call_command
+        from django.test import TestCase
+        from django.utils.six import StringIO
+
+        out = StringIO()
+        try:
+            call_command('create_qn_target', organism='homo_sapiens', stdout=out)
+        except SystemExit as e: # this is okay!
+            pass
+
+        stdout = out.getvalue()
+        self.assertTrue('Target file' in stdout)
+        path = stdout.split('\n')[0].split(':')[1].strip()
+        self.assertTrue(os.path.exists(path))
+        self.assertEqual(path, utils.get_most_recent_qn_target_for_organism(homo_sapiens).absolute_file_path)

--- a/workers/nomad-job-specs/downloader.nomad.tpl
+++ b/workers/nomad-job-specs/downloader.nomad.tpl
@@ -58,9 +58,9 @@ job "DOWNLOADER" {
       # The resources the job will require.
       resources {
         # CPU is in AWS's CPU units.
-        cpu = 256
+        cpu = 512
         # Memory is in MB of RAM.
-        memory = 1024
+        memory = 4096 
       }
 
       logs {


### PR DESCRIPTION
Ariel thinks he can reliably crash the API server by sending it requests for gigantic querysets. This sets a hard limit on the request size with `max`, and makes the `uswgi` settings more likely to end requests which take too long.