### PR TITLE
Set Nomad reschedule stanza so that Nomad doesn't reschedule our jobs

### DIFF
--- a/foreman/nomad-job-specs/surveyor.nomad.tpl
+++ b/foreman/nomad-job-specs/surveyor.nomad.tpl
@@ -16,6 +16,7 @@ job "SURVEYOR" {
 
     reschedule {
       attempts = 0
+      unlimited = false
     }
 
     ephemeral_disk {

--- a/foreman/nomad-job-specs/surveyor.nomad.tpl
+++ b/foreman/nomad-job-specs/surveyor.nomad.tpl
@@ -12,7 +12,10 @@ job "SURVEYOR" {
     restart {
       attempts = 0
       mode = "fail"
-      # delay    = "30s"
+    }
+
+    reschedule {
+      attempts = 0
     }
 
     ephemeral_disk {

--- a/foreman/nomad-job-specs/surveyor_dispatcher.nomad.tpl
+++ b/foreman/nomad-job-specs/surveyor_dispatcher.nomad.tpl
@@ -12,7 +12,10 @@ job "SURVEYOR_DISPATCHER" {
     restart {
       attempts = 0
       mode = "fail"
-      # delay    = "30s"
+    }
+
+    reschedule {
+      attempts = 0
     }
 
     ephemeral_disk {

--- a/foreman/nomad-job-specs/surveyor_dispatcher.nomad.tpl
+++ b/foreman/nomad-job-specs/surveyor_dispatcher.nomad.tpl
@@ -16,6 +16,7 @@ job "SURVEYOR_DISPATCHER" {
 
     reschedule {
       attempts = 0
+      unlimited = false
     }
 
     ephemeral_disk {

--- a/workers/nomad-job-specs/affymetrix.nomad.tpl
+++ b/workers/nomad-job-specs/affymetrix.nomad.tpl
@@ -13,7 +13,10 @@ job "AFFY_TO_PCL_${{INDEX}}_${{RAM}}" {
     restart {
       attempts = 0
       mode = "fail"
-      # delay    = "30s"
+    }
+
+    reschedule {
+      attempts = 0
     }
 
     ephemeral_disk {

--- a/workers/nomad-job-specs/affymetrix.nomad.tpl
+++ b/workers/nomad-job-specs/affymetrix.nomad.tpl
@@ -17,6 +17,7 @@ job "AFFY_TO_PCL_${{INDEX}}_${{RAM}}" {
 
     reschedule {
       attempts = 0
+      unlimited = false
     }
 
     ephemeral_disk {

--- a/workers/nomad-job-specs/downloader.nomad.tpl
+++ b/workers/nomad-job-specs/downloader.nomad.tpl
@@ -23,6 +23,7 @@ job "DOWNLOADER" {
 
     reschedule {
       attempts = 0
+      unlimited = false
     }
 
     ephemeral_disk {

--- a/workers/nomad-job-specs/downloader.nomad.tpl
+++ b/workers/nomad-job-specs/downloader.nomad.tpl
@@ -19,7 +19,10 @@ job "DOWNLOADER" {
     restart {
       attempts = 0
       mode = "fail"
-      # delay    = "30s"
+    }
+
+    reschedule {
+      attempts = 0
     }
 
     ephemeral_disk {

--- a/workers/nomad-job-specs/illumina.nomad.tpl
+++ b/workers/nomad-job-specs/illumina.nomad.tpl
@@ -17,6 +17,7 @@ job "ILLUMINA_TO_PCL_${{INDEX}}_${{RAM}}" {
 
     reschedule {
       attempts = 0
+      unlimited = false
     }
 
     ephemeral_disk {

--- a/workers/nomad-job-specs/illumina.nomad.tpl
+++ b/workers/nomad-job-specs/illumina.nomad.tpl
@@ -13,7 +13,10 @@ job "ILLUMINA_TO_PCL_${{INDEX}}_${{RAM}}" {
     restart {
       attempts = 0
       mode = "fail"
-      # delay    = "30s"
+    }
+
+    reschedule {
+      attempts = 0
     }
 
     ephemeral_disk {

--- a/workers/nomad-job-specs/no_op.nomad.tpl
+++ b/workers/nomad-job-specs/no_op.nomad.tpl
@@ -13,7 +13,10 @@ job "NO_OP_${{INDEX}}_${{RAM}}" {
     restart {
       attempts = 0
       mode = "fail"
-      # delay    = "30s"
+    }
+
+    reschedule {
+      attempts = 0
     }
 
     ephemeral_disk {

--- a/workers/nomad-job-specs/no_op.nomad.tpl
+++ b/workers/nomad-job-specs/no_op.nomad.tpl
@@ -17,6 +17,7 @@ job "NO_OP_${{INDEX}}_${{RAM}}" {
 
     reschedule {
       attempts = 0
+      unlimited = false
     }
 
     ephemeral_disk {

--- a/workers/nomad-job-specs/salmon.nomad.tpl
+++ b/workers/nomad-job-specs/salmon.nomad.tpl
@@ -17,6 +17,7 @@ job "SALMON_${{INDEX}}_${{RAM}}" {
 
     reschedule {
       attempts = 0
+      unlimited = false
     }
 
     ephemeral_disk {

--- a/workers/nomad-job-specs/salmon.nomad.tpl
+++ b/workers/nomad-job-specs/salmon.nomad.tpl
@@ -13,7 +13,10 @@ job "SALMON_${{INDEX}}_${{RAM}}" {
     restart {
       attempts = 0
       mode = "fail"
-      # delay    = "30s"
+    }
+
+    reschedule {
+      attempts = 0
     }
 
     ephemeral_disk {

--- a/workers/nomad-job-specs/smasher.nomad.tpl
+++ b/workers/nomad-job-specs/smasher.nomad.tpl
@@ -17,6 +17,7 @@ job "SMASHER" {
 
     reschedule {
       attempts = 0
+      unlimited = false
     }
 
     ephemeral_disk {

--- a/workers/nomad-job-specs/smasher.nomad.tpl
+++ b/workers/nomad-job-specs/smasher.nomad.tpl
@@ -13,7 +13,10 @@ job "SMASHER" {
     restart {
       attempts = 0
       mode = "fail"
-      # delay    = "30s"
+    }
+
+    reschedule {
+      attempts = 0
     }
 
     ephemeral_disk {

--- a/workers/nomad-job-specs/transcriptome.nomad.tpl
+++ b/workers/nomad-job-specs/transcriptome.nomad.tpl
@@ -13,7 +13,10 @@ job "TRANSCRIPTOME_INDEX_${{INDEX}}_${{RAM}}" {
     restart {
       attempts = 0
       mode = "fail"
-      # delay    = "30s"
+    }
+
+    reschedule {
+      attempts = 0
     }
 
     ephemeral_disk {

--- a/workers/nomad-job-specs/transcriptome.nomad.tpl
+++ b/workers/nomad-job-specs/transcriptome.nomad.tpl
@@ -17,6 +17,7 @@ job "TRANSCRIPTOME_INDEX_${{INDEX}}_${{RAM}}" {
 
     reschedule {
       attempts = 0
+      unlimited = false
     }
 
     ephemeral_disk {


### PR DESCRIPTION
## Issue Number

https://github.com/hashicorp/nomad/issues/4700

## Purpose/Implementation Notes

Dang 'ol Nomad trying to take our Foreman's jerb!!!

This was triggering this error: https://github.com/AlexsLemonade/refinebio/blob/dev/workers/data_refinery_workers/processors/utils.py#L48 because we didn't think the same job should be started more than once, not realizing Nomad would try to do it for us if the jobs got interrupted for some reason.

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

I've run `sudo -E ./run_nomad.sh` locally and everything gets registered correctly. Actually crashing jobs is pretty difficult to trigger so further tests will probably have to wait until a big crunch.

## Checklist

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules
