### PR TITLE
Fixes AWS key conflicts in the midst of deploy.sh.

### DIFF
--- a/format_nomad_with_env.sh
+++ b/format_nomad_with_env.sh
@@ -152,8 +152,8 @@ if [[ $env != "prod" && $env != "staging" && $env != "dev" ]]; then
 else
     export EXTRA_HOSTS=""
     export AWS_CREDS="
-    AWS_ACCESS_KEY_ID = \"$AWS_ACCESS_KEY_ID_WORKER\"
-    AWS_SECRET_ACCESS_KEY = \"$AWS_SECRET_ACCESS_KEY_WORKER\""
+    AWS_ACCESS_KEY_ID = \"$AWS_ACCESS_KEY_ID_CLIENT\"
+    AWS_SECRET_ACCESS_KEY = \"$AWS_SECRET_ACCESS_KEY_CLIENT\""
     # When deploying prod we write the output of Terraform to a
     # temporary environment file.
     environment_file="$script_directory/infrastructure/prod_env"

--- a/infrastructure/deploy.sh
+++ b/infrastructure/deploy.sh
@@ -72,7 +72,10 @@ format_environment_variables () {
   json_env_vars=$(terraform output -json environment_variables | jq -c '.value[]')
   for row in $json_env_vars; do
       env_var_assignment=$(echo $row | jq -r ".name")=$(echo $row | jq -r ".value")
-      export $env_var_assignment
+      # Don't export AWS keys, they'll interefere with our ability to deploy.
+      if [[ $env_var_assignment != *ACCESS_KEY* ]]; then
+          export $env_var_assignment
+      fi
       echo $env_var_assignment >> prod_env
   done
 }

--- a/infrastructure/deploy.sh
+++ b/infrastructure/deploy.sh
@@ -72,10 +72,7 @@ format_environment_variables () {
   json_env_vars=$(terraform output -json environment_variables | jq -c '.value[]')
   for row in $json_env_vars; do
       env_var_assignment=$(echo $row | jq -r ".name")=$(echo $row | jq -r ".value")
-      # Don't export AWS keys, they'll interefere with our ability to deploy.
-      if [[ $env_var_assignment != *ACCESS_KEY* ]]; then
-          export $env_var_assignment
-      fi
+      export $env_var_assignment
       echo $env_var_assignment >> prod_env
   done
 }

--- a/infrastructure/variables.tf
+++ b/infrastructure/variables.tf
@@ -165,9 +165,9 @@ output "environment_variables" {
       value = "${var.user}"},
     {name = "STAGE"
       value = "${var.stage}"},
-    {name = "AWS_ACCESS_KEY_ID"
+    {name = "AWS_ACCESS_KEY_ID_CLIENT"
       value = "${aws_iam_access_key.data_refinery_user_client_key.id}"},
-    {name = "AWS_SECRET_ACCESS_KEY"
+    {name = "AWS_SECRET_ACCESS_KEY_CLIENT"
       value = "${aws_iam_access_key.data_refinery_user_client_key.secret}"},
     {name = "DJANGO_DEBUG"
       value = "${var.django_debug}"},

--- a/workers/nomad-job-specs/downloader.nomad.tpl
+++ b/workers/nomad-job-specs/downloader.nomad.tpl
@@ -64,7 +64,7 @@ job "DOWNLOADER" {
         # CPU is in AWS's CPU units.
         cpu = 512
         # Memory is in MB of RAM.
-        memory = 4096 
+        memory = 4096
       }
 
       logs {


### PR DESCRIPTION
## Issue Number

N/A came up while deploying for crunch.

## Purpose/Implementation Notes

The AWS keys for the nomad clients were getting output by terraform and used by deploy.sh to try to run terraform, which it didn't have enough permissions for. This fixes it so the env var output by terraform won't overwrite the keys of the deployer's host.

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

I have run deploys with these changes.

## Checklist

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules
