### PR TITLE
Kurtwheeler/fix tx index race

### DIFF
--- a/infrastructure/nomad-configuration/client-instance-user-data.tpl.sh
+++ b/infrastructure/nomad-configuration/client-instance-user-data.tpl.sh
@@ -46,10 +46,11 @@ while [  $COUNTER -lt 99 ]; do
 done
 
 sleep 15
-ATTACHED_AS=`lsblk -n | grep 500G | cut -d' ' -f1`
+ATTACHED_AS=`lsblk -n | grep 8.8T | cut -d' ' -f1`
 FILE_RESULT=`file -s /dev/$ATTACHED_AS`
 
-if file -s /dev/$ATTACHED_AS | grep data; then
+# grep -v ext4: make sure the disk is not already formatted.
+if file -s /dev/$ATTACHED_AS | grep data | grep -v ext4; then
 	mkfs -t ext4 /dev/$ATTACHED_AS # This is slow
 fi
 mount /dev/$ATTACHED_AS /var/ebs/

--- a/workers/nomad-job-specs/downloader.nomad.tpl
+++ b/workers/nomad-job-specs/downloader.nomad.tpl
@@ -64,7 +64,7 @@ job "DOWNLOADER" {
         # CPU is in AWS's CPU units.
         cpu = 512
         # Memory is in MB of RAM.
-        memory = 4096
+        memory = 12289
       }
 
       logs {


### PR DESCRIPTION
## Issue Number

N/A came up during crunch

## Purpose/Implementation Notes

I thought that having one processor job download and install the transcriptome index would be enough, and that then the rest could use the index that job installed. This is true, but it takes a while so the other jobs were getting to processing before the first one properly installed the index. Therefore this makes all jobs try to install the index until one of them finishes the process and creates symlinks denoting that it's done.

This also bumps up the downloader RAM requirement to 12GB.

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

I have tested this by running some processors in the dev stack.

## Checklist

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules
