### PR TITLE
Fix part of deploy script dedicated to starting the API.

### DIFF
--- a/infrastructure/deploy.sh
+++ b/infrastructure/deploy.sh
@@ -249,6 +249,10 @@ chmod 600 data-refinery-key.pem
 API_IP_ADDRESS=$(terraform output -json api_server_1_ip | jq -c '.value' | tr -d '"')
 echo "Restarting API with latest image."
 
+# To check to see if the docker container needs to be stopped before
+# it can be started, grep for the name of the container. However if
+# it's not found then grep will return a non-zero exit code so in that
+# case return an empty string.
 container_running=$(ssh -o StrictHostKeyChecking=no \
                         -i data-refinery-key.pem \
                         ubuntu@$API_IP_ADDRESS  "docker ps" | grep dr_api || echo "")

--- a/infrastructure/deploy.sh
+++ b/infrastructure/deploy.sh
@@ -249,12 +249,9 @@ chmod 600 data-refinery-key.pem
 API_IP_ADDRESS=$(terraform output -json api_server_1_ip | jq -c '.value' | tr -d '"')
 echo "Restarting API with latest image."
 
-container_running=$(ssh -q -o StrictHostKeyChecking=no \
+container_running=$(ssh -o StrictHostKeyChecking=no \
                         -i data-refinery-key.pem \
-                        ubuntu@$API_IP_ADDRESS exit && \
-                        ssh -o StrictHostKeyChecking=no \
-                        -i data-refinery-key.pem \
-                        ubuntu@$API_IP_ADDRESS  "docker ps" | grep dr_api)
+                        ubuntu@$API_IP_ADDRESS  "docker ps" | grep dr_api || echo "")
 
 ssh -o StrictHostKeyChecking=no \
     -i data-refinery-key.pem \


### PR DESCRIPTION
## Issue Number

N/A came up because the API didn't get deployed correctly.

## Purpose/Implementation Notes

We recently changed the API container to only be started by the deploy script via ssh, rather than only being restarted that way. However there was a command which was tripping that part of the script up by returning a non-zero exit code. This fixes that.

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

Ran a deploy after tainting the API server. It recreated it and then was able to start the container.

## Checklist

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules
