### PR TITLE
Add Support for Smashing `SRP051449`

### DIFF
--- a/workers/data_refinery_workers/processors/smasher.py
+++ b/workers/data_refinery_workers/processors/smasher.py
@@ -497,10 +497,11 @@ def _smash(job_context: Dict) -> Dict:
                         ks_test = rlang("ks.test")
 
                         set_seed(123)
-                        n = ncol(reso)
+
+                        n = ncol(reso)[0]
                         m = 2
                         if n < m:
-                            raise Exception("Found fewer columns that required for QN combinatorial - bad smash?")
+                            raise Exception("Found fewer columns than required for QN combinatorial - bad smash?")
                         combos = combn(ncol(reso), 2)
 
                         # Convert to NP, Shuffle, Return to R
@@ -710,8 +711,8 @@ def _notify(job_context: Dict) -> Dict:
 
             if job_context['job'].failure_reason not in ['', None]:
                 SUBJECT = "There was a problem processing your refine.bio dataset :("
-                BODY_TEXT = "We tried but were unable to process your requested dataset. Error was: \n\n" + str(job_context['job'].failure_reason) + "\nDataset ID: " + str(dataset.id) + "\n We have been notified and are looking into the problem. \n\nSorry!"
-                FORMATTED_HTML = "We tried but were unable to process your requested dataset. Error was: <br /><br />" + job_context['job'].failure_reason + "<br />Dataset: " + str(dataset.id) + "<br /> We have been notified and are looking into the problem. <br /><br />Sorry!"
+                BODY_TEXT = "We tried but were unable to process your requested dataset. Error was: \n\n" + str(job_context['job'].failure_reason) + "\nDataset ID: " + str(job_context['dataset'].id) + "\n We have been notified and are looking into the problem. \n\nSorry!"
+                FORMATTED_HTML = "We tried but were unable to process your requested dataset. Error was: <br /><br />" + job_context['job'].failure_reason + "<br />Dataset: " + str(job_context['dataset'].id) + "<br /> We have been notified and are looking into the problem. <br /><br />Sorry!"
                 job_context['success'] = False
             else:
                 SUBJECT = "Your refine.bio Dataset is Ready!"

--- a/workers/data_refinery_workers/processors/smasher.py
+++ b/workers/data_refinery_workers/processors/smasher.py
@@ -394,13 +394,16 @@ def _smash(job_context: Dict) -> Dict:
                     # Explicitly title this dataframe
                     try:
                         # Unfortuantely, we can't use this as `title` can cause a collision
-                        #data.columns = [computed_file.samples.all()[0].title]
+                        # data.columns = [computed_file.samples.all()[0].title]
                         # So we use this, which also helps us support the case of missing SampleComputedFileAssociation
-                        data.columns = [computed_file.filename]
+                        data.columns = [computed_file.samples.all()[0].accession_code]
                     except ValueError:
                         # This sample might have multiple channels, or something else.
                         # Don't mess with it.
                         pass
+                    except Exception as e:
+                        # Okay, somebody probably forgot to create a SampleComputedFileAssociation
+                        data.columns = [computed_file.filename]
 
                     all_frames.append(data)
                     num_samples = num_samples + 1

--- a/workers/data_refinery_workers/processors/smasher.py
+++ b/workers/data_refinery_workers/processors/smasher.py
@@ -145,11 +145,11 @@ def _get_tsv_columns(samples_metadata):
                     else:
                         _add_annotation_column(annotation_columns, annotation_key)
 
-    # Return sorted columns, in which "refinebio_title" is always the first,
+    # Return sorted columns, in which "refinebio_accession_code" is always the first,
     # followed by the other refinebio columns (in alphabetic order), and
     # annotation columns (in alphabetic order) at the end.
-    refinebio_columns.discard('refinebio_title')
-    return ['refinebio_title'] + sorted(refinebio_columns) + sorted(annotation_columns)
+    refinebio_columns.discard('refinebio_accession_code')
+    return ['refinebio_accession_code'] + sorted(refinebio_columns) + sorted(annotation_columns)
 
 def _add_annotation_value(row_data, col_name, col_value, sample_accession_code):
     """Adds a new `col_name` key whose value is `col_value` to row_data.

--- a/workers/data_refinery_workers/processors/test_qn_reference.py
+++ b/workers/data_refinery_workers/processors/test_qn_reference.py
@@ -118,8 +118,8 @@ class QNRefTestCase(TestCase):
         final_context = smasher.smash(pj.pk, upload=False)
         self.assertTrue(final_context['success'])
 
-        self.assertEqual(final_context['merged_qn']['1.tsv'][0], -0.437948852881293)
-        self.assertEqual(final_context['original_merged']['1.tsv'][0], -0.576210936113982)
+        self.assertEqual(final_context['merged_qn']['1'][0], -0.437948852881293)
+        self.assertEqual(final_context['original_merged']['1'][0], -0.576210936113982)
 
         ## 
         # Test via management command

--- a/workers/data_refinery_workers/processors/test_qn_reference.py
+++ b/workers/data_refinery_workers/processors/test_qn_reference.py
@@ -118,8 +118,8 @@ class QNRefTestCase(TestCase):
         final_context = smasher.smash(pj.pk, upload=False)
         self.assertTrue(final_context['success'])
 
-        self.assertEqual(final_context['merged_qn']['1'][0], -0.437948852881293)
-        self.assertEqual(final_context['original_merged']['1'][0], -0.576210936113982)
+        self.assertEqual(final_context['merged_qn']['1.tsv'][0], -0.437948852881293)
+        self.assertEqual(final_context['original_merged']['1.tsv'][0], -0.576210936113982)
 
         ## 
         # Test via management command

--- a/workers/data_refinery_workers/processors/test_smasher.py
+++ b/workers/data_refinery_workers/processors/test_smasher.py
@@ -629,7 +629,7 @@ class SmasherTestCase(TestCase):
 
         sample = Sample()
         sample.accession_code = 'SRR1731761'
-        sample.title = 'SRR1731761_output_gene_lengthScaledTPM.tsv'
+        sample.title = 'Danio rerio'
         sample.organism = danio_rerio
         sample.save()
 
@@ -661,7 +661,7 @@ class SmasherTestCase(TestCase):
 
         sample = Sample()
         sample.accession_code = 'SRR1731762'
-        sample.title = 'SRR1731762_output_gene_lengthScaledTPM.tsv'
+        sample.title = 'Danio rerio'
         sample.organism = danio_rerio
         sample.save()
 

--- a/workers/data_refinery_workers/processors/test_smasher.py
+++ b/workers/data_refinery_workers/processors/test_smasher.py
@@ -613,7 +613,7 @@ class SmasherTestCase(TestCase):
 
     @tag("smasher")
     def test_no_smash_dupe_two(self):
-        """ """
+        """ Tests the SRP051449 case, where the titles collide. Also uses a real QN target file."""
 
         job = ProcessorJob()
         job.pipeline_applied = "SMASHER"

--- a/workers/data_refinery_workers/processors/test_smasher.py
+++ b/workers/data_refinery_workers/processors/test_smasher.py
@@ -611,6 +611,103 @@ class SmasherTestCase(TestCase):
             self.assertTrue('_x' not in column)
 
     @tag("smasher")
+    def test_no_smash_dupe_two(self):
+        """ """
+
+        job = ProcessorJob()
+        job.pipeline_applied = "SMASHER"
+        job.save()
+
+        experiment = Experiment()
+        experiment.accession_code = "SRP051449"
+        experiment.save()
+
+        result = ComputationalResult()
+        result.save()
+
+        danio_rerio = Organism.get_object_for_name("DANIO_RERIO")
+
+        sample = Sample()
+        sample.accession_code = 'SRR1731761'
+        sample.title = 'SRR1731761_output_gene_lengthScaledTPM.tsv'
+        sample.organism = danio_rerio
+        sample.save()
+
+        sra = SampleResultAssociation()
+        sra.sample = sample
+        sra.result = result
+        sra.save()
+
+        esa = ExperimentSampleAssociation()
+        esa.experiment = experiment
+        esa.sample = sample
+        esa.save()
+
+        computed_file = ComputedFile()
+        computed_file.filename = "SRR1731761_output_gene_lengthScaledTPM.tsv"
+        computed_file.absolute_file_path = "/home/user/data_store/PCL/" + computed_file.filename
+        computed_file.result = result
+        computed_file.size_in_bytes = 123
+        computed_file.is_smashable = True
+        computed_file.save()
+
+        result = ComputationalResult()
+        result.save()
+
+        assoc = SampleComputedFileAssociation()
+        assoc.sample = sample
+        assoc.computed_file = computed_file
+        assoc.save()
+
+        sample = Sample()
+        sample.accession_code = 'SRR1731762'
+        sample.title = 'SRR1731762_output_gene_lengthScaledTPM.tsv'
+        sample.organism = danio_rerio
+        sample.save()
+
+        sra = SampleResultAssociation()
+        sra.sample = sample
+        sra.result = result
+        sra.save()
+
+        esa = ExperimentSampleAssociation()
+        esa.experiment = experiment
+        esa.sample = sample
+        esa.save()
+
+        computed_file = ComputedFile()
+        computed_file.filename = "SRR1731762_output_gene_lengthScaledTPM.tsv"
+        computed_file.absolute_file_path = "/home/user/data_store/PCL/" + computed_file.filename
+        computed_file.result = result
+        computed_file.size_in_bytes = 123
+        computed_file.is_smashable = True
+        computed_file.save()
+
+        result = ComputationalResult()
+        result.save()
+
+        assoc = SampleComputedFileAssociation()
+        assoc.sample = sample
+        assoc.computed_file = computed_file
+        assoc.save()
+
+        ds = Dataset()
+        ds.data = {'SRP051449': ['SRR1731761', 'SRR1731762']}
+        ds.aggregate_by = 'SPECIES'
+        ds.scale_by = 'NONE'
+        ds.email_address = "null@derp.com"
+        ds.quantile_normalize = False
+        ds.save()
+
+        pjda = ProcessorJobDatasetAssociation()
+        pjda.processor_job = job
+        pjda.dataset = ds
+        pjda.save()
+
+        final_context = smasher.smash(job.pk, upload=False)
+        self.assertTrue(final_context['success'])
+
+    @tag("smasher")
     def test_log2(self):
         pj = ProcessorJob()
         pj.pipeline_applied = "SMASHER"

--- a/workers/data_refinery_workers/processors/test_smasher.py
+++ b/workers/data_refinery_workers/processors/test_smasher.py
@@ -1144,7 +1144,7 @@ class TsvTestCase(TestCase):
     def test_columns(self):
         columns = smasher._get_tsv_columns(self.metadata['samples'])
         self.assertEqual(len(columns), 21)
-        self.assertEqual(columns[0], 'refinebio_title')
+        self.assertEqual(columns[0], 'refinebio_accession_code')
         self.assertTrue('refinebio_accession_code' in columns)
         self.assertTrue('cell population' in columns)
         self.assertTrue('dose' in columns)

--- a/workers/data_refinery_workers/processors/test_smasher.py
+++ b/workers/data_refinery_workers/processors/test_smasher.py
@@ -22,7 +22,8 @@ from data_refinery_common.models import (
     ExperimentSampleAssociation,
     Dataset,
     ProcessorJobDatasetAssociation,
-    SampleComputedFileAssociation
+    SampleComputedFileAssociation,
+    ComputationalResultAnnotation
 )
 from data_refinery_workers.processors import smasher
 
@@ -696,13 +697,29 @@ class SmasherTestCase(TestCase):
         ds.aggregate_by = 'SPECIES'
         ds.scale_by = 'NONE'
         ds.email_address = "null@derp.com"
-        ds.quantile_normalize = False
+        ds.quantile_normalize = True
         ds.save()
 
         pjda = ProcessorJobDatasetAssociation()
         pjda.processor_job = job
         pjda.dataset = ds
         pjda.save()
+
+        cr = ComputationalResult()
+        cr.save()
+
+        computed_file = ComputedFile()
+        computed_file.filename = "danio_target.tsv"
+        computed_file.absolute_file_path = "/home/user/data_store/PCL/" + computed_file.filename
+        computed_file.result = cr
+        computed_file.size_in_bytes = 123
+        computed_file.is_smashable = False
+        computed_file.save()
+
+        cra = ComputationalResultAnnotation()
+        cra.data = {'organism_id': danio_rerio.id, 'is_qn': True}
+        cra.result = cr
+        cra.save()
 
         final_context = smasher.smash(job.pk, upload=False)
         self.assertTrue(final_context['success'])

--- a/workers/data_refinery_workers/processors/utils.py
+++ b/workers/data_refinery_workers/processors/utils.py
@@ -152,7 +152,7 @@ def end_job(job_context: Dict, abort=False):
         # S3-sync Computed Files
         for computed_file in job_context.get('computed_files', []):
             # Ensure even distribution across S3 servers
-            nonce = ''.join(random.choice(string.ascii_lowercase + string.digits) for _ in range(8))
+            nonce = ''.join(random.choice(string.ascii_lowercase + string.digits) for _ in range(24))
             result = computed_file.sync_to_s3(S3_BUCKET_NAME, nonce + "_" + computed_file.filename)
             if result:
                 computed_file.delete_local_file()

--- a/workers/run_tests.sh
+++ b/workers/run_tests.sh
@@ -239,6 +239,8 @@ if [[ -z $tag || $tag == "smasher" ]]; then
     pcl_name7="GSM1084807-tbl-1.txt"
     pcl_name_gs1="GSM1084806-tbl-1.txt"
     pcl_name_gs2="GSM1084807-tbl-1.txt"
+    pcl_name_ts1="SRR1731761_output_gene_lengthScaledTPM.tsv"
+    pcl_name_ts2="SRR1731762_output_gene_lengthScaledTPM.tsv"
     pcl_test_raw_dir="$volume_directory/PCL"
     pcl_test_data_1="$pcl_test_raw_dir/$pcl_name"
     pcl_test_data_2="$pcl_test_raw_dir/$pcl_name2"
@@ -249,6 +251,8 @@ if [[ -z $tag || $tag == "smasher" ]]; then
     pcl_test_data_7="$pcl_test_raw_dir/$pcl_name7"
     pcl_test_data_gs1="$pcl_test_raw_dir/$pcl_name_gs1"
     pcl_test_data_gs2="$pcl_test_raw_dir/$pcl_name_gs2"
+    pcl_test_data_ts1="$pcl_test_raw_dir/$pcl_name_ts1"
+    pcl_test_data_ts2="$pcl_test_raw_dir/$pcl_name_ts2"
     if [ ! -e "$pcl_test_data_1" ]; then
         mkdir -p $pcl_test_raw_dir
         echo "Downloading PCL for tests."
@@ -295,7 +299,16 @@ if [[ -z $tag || $tag == "smasher" ]]; then
         wget -q -O $pcl_test_data_gs2 \
              "$test_data_repo/$pcl_name_gs2"
     fi
-
+    if [ ! -e "$pcl_test_data_ts1" ]; then
+        echo "Downloading PCLTS1 for tests."
+        wget -q -O $pcl_test_data_ts1 \
+             "$test_data_repo/$pcl_name_ts1"
+    fi
+    if [ ! -e "$pcl_test_data_ts2" ]; then
+        echo "Downloading PCLTS2 for tests."
+        wget -q -O $pcl_test_data_ts2 \
+             "$test_data_repo/$pcl_name_ts2"
+    fi
     if [[ -z $AWS_ACCESS_KEY_ID ]]; then
         export AWS_ACCESS_KEY_ID=`~/bin/aws configure get default.aws_access_key_id`
         export AWS_SECRET_ACCESS_KEY=`~/bin/aws configure get default.aws_secret_access_key`

--- a/workers/run_tests.sh
+++ b/workers/run_tests.sh
@@ -241,6 +241,7 @@ if [[ -z $tag || $tag == "smasher" ]]; then
     pcl_name_gs2="GSM1084807-tbl-1.txt"
     pcl_name_ts1="SRR1731761_output_gene_lengthScaledTPM.tsv"
     pcl_name_ts2="SRR1731762_output_gene_lengthScaledTPM.tsv"
+    pcl_name_ta1="danio_target.tsv"
     pcl_test_raw_dir="$volume_directory/PCL"
     pcl_test_data_1="$pcl_test_raw_dir/$pcl_name"
     pcl_test_data_2="$pcl_test_raw_dir/$pcl_name2"
@@ -253,6 +254,7 @@ if [[ -z $tag || $tag == "smasher" ]]; then
     pcl_test_data_gs2="$pcl_test_raw_dir/$pcl_name_gs2"
     pcl_test_data_ts1="$pcl_test_raw_dir/$pcl_name_ts1"
     pcl_test_data_ts2="$pcl_test_raw_dir/$pcl_name_ts2"
+    pcl_test_data_ta1="$pcl_test_raw_dir/$pcl_name_ta1"
     if [ ! -e "$pcl_test_data_1" ]; then
         mkdir -p $pcl_test_raw_dir
         echo "Downloading PCL for tests."
@@ -308,6 +310,11 @@ if [[ -z $tag || $tag == "smasher" ]]; then
         echo "Downloading PCLTS2 for tests."
         wget -q -O $pcl_test_data_ts2 \
              "$test_data_repo/$pcl_name_ts2"
+    fi
+    if [ ! -e "$pcl_test_data_ta1" ]; then
+        echo "Downloading PCLTA1 for tests."
+        wget -q -O $pcl_test_data_ta1 \
+             "$test_data_repo/$pcl_name_ta1"
     fi
     if [[ -z $AWS_ACCESS_KEY_ID ]]; then
         export AWS_ACCESS_KEY_ID=`~/bin/aws configure get default.aws_access_key_id`


### PR DESCRIPTION
## Issue Number

n/a

## Purpose/Implementation Notes
We can't rely on externally supplied `title` fields for smash column titles as they aren't guaranteed to be unique. Switches to use `accession_code`, which is. Also fixes an email bug case.

## Types of changes
- Bugfix (non-breaking change which fixes an issue)

## Functional tests

New test files and assertions added.

## Checklist

_Put an `x` in the boxes that apply._

- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules