### PR TITLE
Improve the way we check the git branch while deploying.

### DIFF
--- a/.circleci/update_docker_img.sh
+++ b/.circleci/update_docker_img.sh
@@ -11,9 +11,8 @@ source ~/refinebio/common.sh
 # However it cannot be on both master and dev because merges create new commits.
 # Therefore check to see if either master or dev show up in the list
 # of branches containing that tag.
-master_check=$(git branch --contains tags/$CIRCLE_TAG | grep '^  master$' || true)
-dev_check=$(git branch --contains tags/$CIRCLE_TAG | grep '^  dev$' || true)
-
+master_check=$(git log --decorate=full | head -1 | grep origin/master || true)
+dev_check=$(git log --decorate=full | head -1 | grep origin/dev || true)
 
 if [[ ! -z $master_check ]]; then
     DOCKERHUB_REPO=ccdl


### PR DESCRIPTION
## Issue Number

N/A: https://circleci.com/gh/AlexsLemonade/refinebio/7559 deployed staging instead of prod because it thought it was a dev branch.

## Purpose/Implementation Notes

This method of checking is less finicky.

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

Ran these commands on a circle server to make sure they did what we wanted.
