### PR TITLE
Lock down deploys by verifying git tags.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -195,6 +195,7 @@ jobs:
     working_directory: ~/refinebio
     steps:
       - checkout
+      - run: bash .circleci/verify_tag.sh
       - run: bash .circleci/git_decrypt.sh
       - run: bash .circleci/update_docker_img.sh
       - run: bash .circleci/run_terraform.sh

--- a/.circleci/verify_tag.sh
+++ b/.circleci/verify_tag.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+# This script verifies that the tag triggering this deploy was signed
+# by a trusted member of the CCDL.
+
+dongbo_key="138F2211AC85BFB74DB4F59405153C3530E360A7"
+rich_key="65EC6E219A655CA8CAC3096890D90E5F0A053C53"
+casey_key="DFAA02F5552C553B00CC3DCC31D330047976BAA1"
+kurt_key="B539C2CA0D4424660876A9381E1C8D1C2A663250"
+
+trusted_keys="$dongbo_key $rich_key $casey_key $kurt_key"
+
+for key in $trusted_keys; do
+    gpg --keyserver pgp.mit.edu --recv-keys $key
+done
+
+# If it is not a good key then the exit code is 1, which will cause
+# the deploy to fail.
+git tag --verify $CIRCLE_TAG


### PR DESCRIPTION
## Issue Number

N/A came up during a discussion about our deploy process and it's security.

## Purpose/Implementation Notes

Our deploy process is triggered by pushing git tags. However anyone with access to our repo can push tags to it. This PR makes it so that tags must be signed by a trusted individual before they're pushed.

## Types of changes

- New feature (non-breaking change which adds functionality)

## Functional tests

I ran this script on a tag that I didn't sign and it exited with status code 1.

I ran it on a tag I did sign and it exited with status code 0.

## Checklist

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules
