### PR TITLE
Add `has_publication` to `filter_fields`

### DIFF
--- a/api/data_refinery_api/tests.py
+++ b/api/data_refinery_api/tests.py
@@ -261,6 +261,7 @@ class APITestCases(APITestCase):
         ex2.description = "SOWILLTHIS"
         ex2.technology = "RNA-SEQ"
         ex2.submitter_institution = "Funkytown"
+        ex2.has_publication = True
         experiments.append(ex2)
 
         ex3 = Experiment()
@@ -334,8 +335,13 @@ class APITestCases(APITestCase):
         response = self.client.get(reverse('search'), {'search': 'THISWILLBEINASEARCHRESULT'})
         self.assertEqual(response.json()['count'], 3)
 
-        response = self.client.get(reverse('search'), {'search': 'TEMPURA'})
-        self.assertEqual(response.json()['count'], 1)
+        # Test filter
+        response = self.client.get(reverse('search'), {'search': 'FINDME', 'has_publication': True})
+        for result in response.json()['results']:
+            self.assertTrue(result['has_publication'])
+        response = self.client.get(reverse('search'), {'search': 'FINDME', 'has_publication': False})
+        for result in response.json()['results']:
+            self.assertFalse(result['has_publication'])
 
         # Test search and filter
         response = self.client.get(reverse('search'),
@@ -347,7 +353,7 @@ class APITestCases(APITestCase):
         self.assertEqual(sorted(response.json()['results'][0]['platforms']), sorted(ex.platforms))
         self.assertEqual(sorted(response.json()['results'][0]['platforms']), sorted(['AFFY', 'ILLUMINA']))
         self.assertEqual(response.json()['filters']['technology'], {'FAKE-TECH': 1, 'MICROARRAY': 2, 'RNA-SEQ': 1})
-        self.assertEqual(response.json()['filters']['publication'], {})
+        self.assertEqual(response.json()['filters']['publication'], {'has_publication': 1})
         self.assertEqual(response.json()['filters']['organism'], {'Extra-Terrestrial-1982': 1, 'HOMO_SAPIENS': 3})
 
         response = self.client.get(reverse('search'),

--- a/api/data_refinery_api/views.py
+++ b/api/data_refinery_api/views.py
@@ -160,6 +160,7 @@ class SearchAndFilter(generics.ListAPIView):
                         '@submitter_institution',
                         'experimentannotation__data'
                     )
+    filter_fields = ('has_publication')
 
     def list(self, request, *args, **kwargs):
         """ Adds counts on certain filter fields to result JSON."""


### PR DESCRIPTION
## Issue Number

https://github.com/AlexsLemonade/refinebio-frontend/issues/339

## Purpose/Implementation Notes
Uses the `filter_fields` to add support for `has_publication` filtering. However, I'm not entirely convinced that this will be consequence-free in other places, so we may want to reassess and add the filtering in manually, as we do for some other fields. Waiting for Ariel to check first.

## Types of changes
- Bugfix (non-breaking change which fixes an issue)

## Functional tests
New assertions.
