### PR TITLE
Increase RAM Amount Upon Retrying Salmon Jobs

### DIFF
--- a/api/data_refinery_api/urls.py
+++ b/api/data_refinery_api/urls.py
@@ -91,7 +91,7 @@ urlpatterns = [
 
     # Endpoints / Self-documentation
     url(r'^experiments/$', ExperimentList.as_view(), name="experiments"),
-    url(r'^experiments/(?P<pk>[0-9]+)/$', ExperimentDetail.as_view(), name="experiments_detail"),
+    url(r'^experiments/(?P<pk>.+)/$', ExperimentDetail.as_view(), name="experiments_detail"),
     url(r'^samples/$', SampleList.as_view(), name="samples"),
     url(r'^samples/(?P<pk>[0-9]+)/$', SampleDetail.as_view(), name="samples_detail"),
     url(r'^organisms/$', OrganismList.as_view(), name="organisms"),

--- a/api/data_refinery_api/views.py
+++ b/api/data_refinery_api/views.py
@@ -2,7 +2,7 @@ from django.conf import settings
 from django.db.models import Count
 from django.db.models.aggregates import Avg
 from django.db.models.expressions import F
-from django.http import Http400, Http404, HttpResponse, HttpResponseRedirect
+from django.http import Http404, HttpResponse, HttpResponseRedirect, HttpResponseBadRequest
 from django.shortcuts import get_object_or_404
 
 from django_filters.rest_framework import DjangoFilterBackend
@@ -413,7 +413,7 @@ class ExperimentDetail(APIView):
                 return Experiment.public_objects.get(accession_code=pk)
             except Experiment.DoesNotExist:
                 raise Http404
-            raise Http400
+            return HttpResponseBadRequest("Bad PK or Accession") 
 
     def get(self, request, pk, format=None):
         experiment = self.get_object(pk)

--- a/api/data_refinery_api/views.py
+++ b/api/data_refinery_api/views.py
@@ -2,7 +2,7 @@ from django.conf import settings
 from django.db.models import Count
 from django.db.models.aggregates import Avg
 from django.db.models.expressions import F
-from django.http import Http404, HttpResponse, HttpResponseRedirect
+from django.http import Http400, Http404, HttpResponse, HttpResponseRedirect
 from django.shortcuts import get_object_or_404
 
 from django_filters.rest_framework import DjangoFilterBackend
@@ -413,7 +413,7 @@ class ExperimentDetail(APIView):
                 return Experiment.public_objects.get(accession_code=pk)
             except Experiment.DoesNotExist:
                 raise Http404
-            raise Http404
+            raise Http400
 
     def get(self, request, pk, format=None):
         experiment = self.get_object(pk)

--- a/api/data_refinery_api/views.py
+++ b/api/data_refinery_api/views.py
@@ -407,8 +407,10 @@ class ExperimentDetail(APIView):
         try:
             return Experiment.public_objects.get(pk=pk)
         except Experiment.DoesNotExist:
+            raise Http404
+        except Exception:
             try:
-                return Experiment.public_objects.get(accession_code=accession_code)
+                return Experiment.public_objects.get(accession_code=pk)
             except Experiment.DoesNotExist:
                 raise Http404
             raise Http404

--- a/api/data_refinery_api/views.py
+++ b/api/data_refinery_api/views.py
@@ -407,6 +407,10 @@ class ExperimentDetail(APIView):
         try:
             return Experiment.public_objects.get(pk=pk)
         except Experiment.DoesNotExist:
+            try:
+                return Experiment.public_objects.get(accession_code=accession_code)
+            except Experiment.DoesNotExist:
+                raise Http404
             raise Http404
 
     def get(self, request, pk, format=None):

--- a/foreman/data_refinery_foreman/foreman/main.py
+++ b/foreman/data_refinery_foreman/foreman/main.py
@@ -232,9 +232,20 @@ def requeue_processor_job(last_job: ProcessorJob) -> None:
     """
     num_retries = last_job.num_retries + 1
 
+    # The Salmon pipeline is quite RAM-sensitive.
+    # Try it again with an increased RAM amount, if possible.
+    new_ram_amount = last_job.ram_amount
+    if last_job.pipeline_applied == "SALMON":
+        if new_ram_amount == 4096:
+            new_ram_amount = 8192
+        elif new_ram_amount == 8192:
+            new_ram_amount = 12288
+        elif new_ram_amount == 12288:
+            new_ram_amount = 16384
+
     new_job = ProcessorJob(num_retries=num_retries,
                            pipeline_applied=last_job.pipeline_applied,
-                           ram_amount=last_job.ram_amount,
+                           ram_amount=new_ram_amount,
                            volume_index=last_job.volume_index)
     new_job.save()
 

--- a/foreman/data_refinery_foreman/foreman/test_main.py
+++ b/foreman/data_refinery_foreman/foreman/test_main.py
@@ -319,12 +319,10 @@ class SurveyTestCase(TestCase):
         self.assertTrue(original_job.retried)
         self.assertEqual(original_job.num_retries, 0)
         self.assertFalse(original_job.success)
-
-        # import pdb
-        # pdb.set_trace()
-
         retried_job = jobs[1]
         self.assertEqual(retried_job.num_retries, 1)
+        self.assertEqual(original_job.ram_amount, 8192)
+        self.assertEqual(retried_job.ram_amount, 12288)
 
     @patch('data_refinery_foreman.foreman.main.send_job')
     def test_repeated_processor_failures(self, mock_send_job):

--- a/foreman/data_refinery_foreman/foreman/test_main.py
+++ b/foreman/data_refinery_foreman/foreman/test_main.py
@@ -260,7 +260,7 @@ class SurveyTestCase(TestCase):
         self.assertEqual(jobs.count(), 1)
 
     def create_processor_job(self, pipeline="AFFY_TO_PCL", ram_amount=2048):
-        job = ProcessorJob(pipeline_applied=pipline,
+        job = ProcessorJob(pipeline_applied=pipeline,
                            nomad_job_id="PROCESSOR/dispatch-1528945054-e8eaf540",
                            ram_amount=ram_amount,
                            num_retries=0,

--- a/foreman/data_refinery_foreman/foreman/test_main.py
+++ b/foreman/data_refinery_foreman/foreman/test_main.py
@@ -259,9 +259,10 @@ class SurveyTestCase(TestCase):
         # Make sure no additional job was created.
         self.assertEqual(jobs.count(), 1)
 
-    def create_processor_job(self):
-        job = ProcessorJob(pipeline_applied="AFFY_TO_PCL",
+    def create_processor_job(self, pipline="AFFY_TO_PCL", ram_amount=2048):
+        job = ProcessorJob(pipeline_applied=pipline,
                            nomad_job_id="PROCESSOR/dispatch-1528945054-e8eaf540",
+                           ram_amount=ram_amount,
                            num_retries=0,
                            success=None)
         job.save()
@@ -305,6 +306,29 @@ class SurveyTestCase(TestCase):
 
         retried_job = jobs[1]
         self.assertEqual(retried_job.num_retries, 1)
+
+        ProcessorJob.objects.all().delete()
+
+    @patch('data_refinery_foreman.foreman.main.send_job')
+    def test_requeuing_processor_job_w_more_ram(self, mock_send_job):
+        job = self.create_processor_job(pipeline="SALMON", ram_amount=8192)
+
+        main.requeue_processor_job(job)
+        self.assertEqual(len(mock_send_job.mock_calls), 1)
+
+        jobs = ProcessorJob.objects.order_by('id')
+        original_job = jobs[0]
+        self.assertTrue(original_job.retried)
+        self.assertEqual(original_job.num_retries, 0)
+        self.assertFalse(original_job.success)
+
+        # import pdb
+        # pdb.set_trace()
+
+        retried_job = jobs[1]
+        self.assertEqual(retried_job.num_retries, 1)
+
+        ProcessorJob.objects.all().delete()
 
     @patch('data_refinery_foreman.foreman.main.send_job')
     def test_repeated_processor_failures(self, mock_send_job):

--- a/foreman/data_refinery_foreman/foreman/test_main.py
+++ b/foreman/data_refinery_foreman/foreman/test_main.py
@@ -259,7 +259,7 @@ class SurveyTestCase(TestCase):
         # Make sure no additional job was created.
         self.assertEqual(jobs.count(), 1)
 
-    def create_processor_job(self, pipline="AFFY_TO_PCL", ram_amount=2048):
+    def create_processor_job(self, pipeline="AFFY_TO_PCL", ram_amount=2048):
         job = ProcessorJob(pipeline_applied=pipline,
                            nomad_job_id="PROCESSOR/dispatch-1528945054-e8eaf540",
                            ram_amount=ram_amount,
@@ -307,8 +307,6 @@ class SurveyTestCase(TestCase):
         retried_job = jobs[1]
         self.assertEqual(retried_job.num_retries, 1)
 
-        ProcessorJob.objects.all().delete()
-
     @patch('data_refinery_foreman.foreman.main.send_job')
     def test_requeuing_processor_job_w_more_ram(self, mock_send_job):
         job = self.create_processor_job(pipeline="SALMON", ram_amount=8192)
@@ -327,8 +325,6 @@ class SurveyTestCase(TestCase):
 
         retried_job = jobs[1]
         self.assertEqual(retried_job.num_retries, 1)
-
-        ProcessorJob.objects.all().delete()
 
     @patch('data_refinery_foreman.foreman.main.send_job')
     def test_repeated_processor_failures(self, mock_send_job):

--- a/format_nomad_with_env.sh
+++ b/format_nomad_with_env.sh
@@ -227,7 +227,7 @@ if [[ $project == "workers" ]]; then
         else
             export_log_conf "processor"
             # rams=(1024 2048 3072 4096 5120 6144 7168 8192 9216 10240 11264 12288 13312)
-            rams=(2048 3072 4096 8192 12288)
+            rams=(2048 3072 4096 8192 12288 16384)
             for r in "${rams[@]}"
             do
                 for ((j=0; j<MAX_CLIENTS; j++));


### PR DESCRIPTION
## Issue Number

https://github.com/AlexsLemonade/refinebio/issues/680
https://github.com/AlexsLemonade/refinebio/issues/681 (Hopefully)
https://github.com/AlexsLemonade/refinebio/issues/683 (Hopefully)

## Purpose/Implementation Notes

If a SALMON job gets retried, increase the amount of RAM if possible.

This PR also includes an API change necessary for https://github.com/AlexsLemonade/refinebio-frontend/issues/346

## Types of changes
- New feature (non-breaking change which adds functionality)

## Functional tests

New test case.
