### PR TITLE
Don't remove cloud-init-output.log on nomad servers because they have…

### DIFF
--- a/infrastructure/nomad-configuration/lead-server-instance-user-data.tpl.sh
+++ b/infrastructure/nomad-configuration/lead-server-instance-user-data.tpl.sh
@@ -90,7 +90,7 @@ chmod +x install_nomad.sh
 #  graphiteapp/graphite-statsd
 
 # Start the Nomad agent in server mode.
-nohup nomad agent -config server.hcl > /tmp/nomad_server.log &
+nohup nomad agent -config server.hcl > /var/log/nomad_server.log &
 
 # Create the CW metric job in a crontab
 # write out current crontab
@@ -103,11 +103,3 @@ echo -e "SHELL=/bin/bash\nPATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin
 # install new cron file
 crontab tempcron
 rm tempcron
-
-# Delete the cloudinit and syslog in production.
-export STAGE=${stage}
-if [[ $STAGE = *"prod"* ]]; then
-    rm /var/log/cloud-init.log
-    rm /var/log/cloud-init-output.log
-    rm /var/log/syslog
-fi

--- a/infrastructure/nomad-configuration/server-instance-user-data.tpl.sh
+++ b/infrastructure/nomad-configuration/server-instance-user-data.tpl.sh
@@ -71,11 +71,3 @@ for nomad_job_spec in $nomad_job_specs; do
     echo "registering $nomad_job_spec"
     nomad run -address http://$IP_ADDRESS:4646 $nomad_job_spec
 done
-
-# Delete the cloudinit and syslog in production.
-export STAGE=${stage}
-if [[ $STAGE = *"prod"* ]]; then
-    rm /var/log/cloud-init.log
-    rm /var/log/cloud-init-output.log
-    rm /var/log/syslog
-fi


### PR DESCRIPTION
… no secrets.

## Issue Number

N/A came up while trying to redeploy with larger nomad instances

## Purpose/Implementation Notes

We remove the output of our startup scripts on the nomad servers. When we last deployed they failed to start up correctly, and we couldn't tell what happened. This corrects that.

Additionally I noticed that the log rotate config wasn't using the same log file as where we sent the nomad output for the lead server so I fixed that too. The non-lead server startup scripts were fine.
## Types of changes

What types of changes does your code introduce?

- New feature (non-breaking change which adds functionality)

## Functional tests

N/A
