### PR TITLE
Remove the manual implementation of the remote terraform backend.

### DIFF
--- a/.circleci/cleanup_instance.sh
+++ b/.circleci/cleanup_instance.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+rm -rf /usr/local/android-sdk-linux
+rm -rf /usr/local/go
+rm -rf /usr/local/android-ndk
+rm -rf /home/ubuntu/nvm
+rm -rf /home/ubuntu/.android
+rm -rf /home/ubuntu/.phpenv
+rm -rf /home/ubuntu/.rvm

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,18 +4,12 @@ jobs:
   # These are grouped together because in total they take less time than our other tests individually.
   main_tests:
     working_directory: ~/refinebio
-    machine:
-      docker_layer_caching: true
-      pre:
-        - sudo rm -rf /usr/local/android-sdk-linux
-        - sudo rm -rf /usr/local/go
-        - sudo rm -rf /usr/local/android-ndk
-        - sudo rm -rf /home/ubuntu/nvm
-        - sudo rm -rf /home/ubuntu/.android
-        - sudo rm -rf /home/ubuntu/.phpenv
-        - sudo rm -rf /home/ubuntu/.rvm
+    machine: true
     steps:
       - checkout
+
+      # Clean up stuff circle provides that we don't need.
+      - run: sudo bash .circleci/cleanup_instance.sh
 
       # Setup Postgres in a Container
       - run: ./run_postgres.sh
@@ -70,17 +64,12 @@ jobs:
 
   common_tests:
     working_directory: ~/refinebio
-    machine:
-      pre:
-        - sudo rm -rf /usr/local/android-sdk-linux
-        - sudo rm -rf /usr/local/go
-        - sudo rm -rf /usr/local/android-ndk
-        - sudo rm -rf /home/ubuntu/nvm
-        - sudo rm -rf /home/ubuntu/.android
-        - sudo rm -rf /home/ubuntu/.phpenv
-        - sudo rm -rf /home/ubuntu/.rvm
+    machine: true
     steps:
       - checkout
+
+      # Clean up stuff circle provides that we don't need.
+      - run: sudo bash .circleci/cleanup_instance.sh
 
       # Setup Postgres in a Container
       - run: ./run_postgres.sh
@@ -99,18 +88,12 @@ jobs:
   # This tests workers tests tagged as 'salmon'
   salmon_and_api_tests:
     working_directory: ~/refinebio
-    machine:
-      docker_layer_caching: true
-      pre:
-        - sudo rm -rf /usr/local/android-sdk-linux
-        - sudo rm -rf /usr/local/go
-        - sudo rm -rf /usr/local/android-ndk
-        - sudo rm -rf /home/ubuntu/nvm
-        - sudo rm -rf /home/ubuntu/.android
-        - sudo rm -rf /home/ubuntu/.phpenv
-        - sudo rm -rf /home/ubuntu/.rvm
+    machine: true
     steps:
       - checkout
+
+      # Clean up stuff circle provides that we don't need.
+      - run: sudo bash .circleci/cleanup_instance.sh
 
       # Setup Postgres in a Container
       - run: ./run_postgres.sh
@@ -132,18 +115,12 @@ jobs:
 
   tx_illumina_affy_agilent_tests:
     working_directory: ~/refinebio
-    machine:
-      docker_layer_caching: true
-      pre:
-        - sudo rm -rf /usr/local/android-sdk-linux
-        - sudo rm -rf /usr/local/go
-        - sudo rm -rf /usr/local/android-ndk
-        - sudo rm -rf /home/ubuntu/nvm
-        - sudo rm -rf /home/ubuntu/.android
-        - sudo rm -rf /home/ubuntu/.phpenv
-        - sudo rm -rf /home/ubuntu/.rvm
+    machine: true
     steps:
       - checkout
+
+      # Clean up stuff circle provides that we don't need.
+      - run: sudo bash .circleci/cleanup_instance.sh
 
       # Setup Postgres in a Container
       - run: ./run_postgres.sh
@@ -184,18 +161,14 @@ jobs:
 
 
   deploy:
-    machine:
-      pre:
-        - sudo rm -rf /usr/local/android-sdk-linux
-        - sudo rm -rf /usr/local/go
-        - sudo rm -rf /usr/local/android-ndk
-        - sudo rm -rf /home/ubuntu/nvm
-        - sudo rm -rf /home/ubuntu/.android
-        - sudo rm -rf /home/ubuntu/.phpenv
-        - sudo rm -rf /home/ubuntu/.rvm
+    machine: true
     working_directory: ~/refinebio
     steps:
       - checkout
+
+      # Clean up stuff circle provides that we don't need.
+      - run: sudo bash .circleci/cleanup_instance.sh
+
       - run: bash .circleci/verify_tag.sh
       - run: bash .circleci/git_decrypt.sh
       - run: bash .circleci/update_docker_img.sh


### PR DESCRIPTION
## Issue Number

N/A I've been meaning to clean this up for a while, finally saw some error output about it and did it!

## Purpose/Implementation Notes

In https://github.com/AlexsLemonade/refinebio/pull/462 I switched us to using Terraform's built in remote-backend feature. However I wanted to migrate our old stacks into it so I left our manual state file management code around so it would pull down existing state to use as a starting point. Well I never went back and cleared it out once there was no infrastructure that was only tracked via our manual state files.

This finally addresses that.

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

N/A but this stuff hasn't affected anything for a while. It will be tested via a staging deploy.

## Checklist

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules
