### PR TITLE
 Use prefetch_related on API search calls 

### DIFF
--- a/api/data_refinery_api/serializers.py
+++ b/api/data_refinery_api/serializers.py
@@ -204,7 +204,8 @@ class DetailedSampleSerializer(serializers.ModelSerializer):
 class ExperimentSerializer(serializers.ModelSerializer):
     organisms = serializers.StringRelatedField(many=True)
     # platforms = serializers.ReadOnlyField()
-    samples = serializers.StringRelatedField(many=True)
+    # samples = serializers.StringRelatedField(many=True)
+    samples = SampleSerializer(many=True)
     # processed_samples = serializers.StringRelatedField(many=True)
     # pretty_platforms = serializers.ReadOnlyField()
     # sample_metadata = serializers.ReadOnlyField(source='get_sample_metadata_fields')
@@ -238,23 +239,7 @@ class ExperimentSerializer(serializers.ModelSerializer):
 
     def setup_eager_loading(queryset):
         """ Perform necessary eager loading of data. """
-        queryset = queryset.prefetch_related(
-            Prefetch(
-                'samples',
-                queryset=ExperimentSampleAssociation.objects.select_related(
-                    'experiment',
-                    'sample',
-                ),
-            ),
-        ).prefetch_related(
-            Prefetch(
-                'organisms',
-                queryset=ExperimentOrganismAssociation.objects.select_related(
-                    'experiment',
-                    'organism',
-                ),
-            ),
-        )
+        queryset = queryset.prefetch_related('samples').prefetch_related('organisms')
         return queryset
 
 class ExperimentAnnotationSerializer(serializers.ModelSerializer):

--- a/api/data_refinery_api/serializers.py
+++ b/api/data_refinery_api/serializers.py
@@ -146,6 +146,36 @@ class SampleSerializer(serializers.ModelSerializer):
                     'last_modified',
                 )
 
+class SearchSampleSerializer(serializers.ModelSerializer):
+
+    class Meta:
+        model = Sample
+        fields = (
+                    'id',
+                    'title',
+                    'accession_code',
+                    'source_database',
+                    'platform_accession_code',
+                    'platform_name',
+                    'pretty_platform',
+                    'technology',
+                    'sex',
+                    'age',
+                    'specimen_part',
+                    'genotype',
+                    'disease',
+                    'disease_stage',
+                    'cell_line',
+                    'treatment',
+                    'race',
+                    'subject',
+                    'compound',
+                    'time',
+                    'is_processed',
+                    'created_at',
+                    'last_modified',
+                )
+
 class SampleAnnotationSerializer(serializers.ModelSerializer):
 
     class Meta:
@@ -203,14 +233,7 @@ class DetailedSampleSerializer(serializers.ModelSerializer):
 
 class ExperimentSerializer(serializers.ModelSerializer):
     organisms = serializers.StringRelatedField(many=True)
-    # platforms = serializers.ReadOnlyField()
-    # samples = serializers.StringRelatedField(many=True)
-    samples = SampleSerializer(many=True)
-    # processed_samples = serializers.StringRelatedField(many=True)
-    # pretty_platforms = serializers.ReadOnlyField()
-    # sample_metadata = serializers.ReadOnlyField(source='get_sample_metadata_fields')
-    # technologies = serializers.ReadOnlyField(source='get_sample_technologies')
-
+    samples = SearchSampleSerializer(many=True)
     class Meta:
         model = Experiment
         fields = (
@@ -220,9 +243,6 @@ class ExperimentSerializer(serializers.ModelSerializer):
                     'accession_code',
                     'source_database',
                     'source_url',
-                    # 'platforms',
-                    # 'pretty_platforms',
-                    # 'processed_samples',
                     'has_publication',
                     'publication_title',
                     'publication_doi',
@@ -233,8 +253,6 @@ class ExperimentSerializer(serializers.ModelSerializer):
                     'submitter_institution',
                     'created_at',
                     'last_modified',
-                    # 'sample_metadata',
-                    # 'technologies'
                 )
 
     def setup_eager_loading(queryset):

--- a/api/data_refinery_api/tests.py
+++ b/api/data_refinery_api/tests.py
@@ -354,9 +354,6 @@ class APITestCases(APITestCase):
                                     'technology': 'MICROARRAY'})
         self.assertEqual(response.json()['count'], 1)
         self.assertEqual(response.json()['results'][0]['accession_code'], 'FINDME_TEMPURA')
-        self.assertEqual(len(response.json()['results'][0]['platforms']), 2)
-        self.assertEqual(sorted(response.json()['results'][0]['platforms']), sorted(ex.platforms))
-        self.assertEqual(sorted(response.json()['results'][0]['platforms']), sorted(['AFFY', 'ILLUMINA']))
         self.assertEqual(response.json()['filters']['technology'], {'FAKE-TECH': 1, 'MICROARRAY': 2, 'RNA-SEQ': 1})
         self.assertEqual(response.json()['filters']['publication'], {'has_publication': 1})
         self.assertEqual(response.json()['filters']['organism'], {'Extra-Terrestrial-1982': 1, 'HOMO_SAPIENS': 3})
@@ -374,8 +371,6 @@ class APITestCases(APITestCase):
         # This has to be done manually due to dicts requring distinct keys
         response = self.client.get(reverse('search') + "?search=THISWILLBEINASEARCHRESULT&technology=MICROARRAY&technology=FAKE-TECH")
         self.assertEqual(response.json()['count'], 2)
-        self.assertEqual(response.json()['results'][0]['processed_samples'], ['1123', '3345'])
-        self.assertEqual(response.json()['results'][0]['technologies'], ['RNA-SEQ'])
 
     @patch('data_refinery_common.message_queue.send_job')
     def test_create_update_dataset(self, mock_send_job):

--- a/api/data_refinery_api/views.py
+++ b/api/data_refinery_api/views.py
@@ -151,20 +151,26 @@ class SearchAndFilter(generics.ListAPIView):
     # '@' Full-text search.
     # '$' Regex search.
     search_fields = (   'title',
-                        'description',
-                        'accession_code',
-                        'protocol_description',
-                        'publication_title',
+                        '@description',
+                        '@accession_code',
+                        '@protocol_description',
+                        '@publication_title',
                         'publication_doi',
                         'publication_authors',
                         'pubmed_id',
-                        'submitter_institution',
+                        '@submitter_institution',
                         'experimentannotation__data'
-                    )
+)
     filter_fields = ('has_publication')
 
     def get_queryset(self):
-        queryset = Experiment.objects.all()
+
+        # For Prod:
+        queryset = Experiment.processed_public_objects.all()
+
+        # For Dev:
+        # queryset = Experiment.objects.all()
+
         # Set up eager loading to avoid N+1 selects
         queryset = self.get_serializer_class().setup_eager_loading(queryset)
         return queryset

--- a/infrastructure/api-configuration/nginx_config.conf
+++ b/infrastructure/api-configuration/nginx_config.conf
@@ -37,7 +37,7 @@ http {
     gzip_comp_level  2;
     gzip_min_length  1000;
     gzip_proxied     expired no-cache no-store private auth;
-    gzip_types       text/plain application/x-javascript text/xml text/css application/xml;
+    gzip_types       text/plain application/x-javascript text/xml text/css application/xml application/json text/html;
 
     # Configuration containing list of application servers
     upstream app{


### PR DESCRIPTION
## Issue Number

https://github.com/AlexsLemonade/refinebio/issues/711

## Purpose/Implementation Notes
Changes us from using 700+ SQL calls per search down to 7. Overall API response is 10-100x faster.

## Methods
Requires front end changes!

Turns out the calculations we making to avoid having to send the entire Sample objects were significantly slower than just sending everything. Sending everything is more useful in terms of API utility, but this change that frontend modifications will have to be made. We discussed this in person but Ariel will need to play with and review this PR before it can be merged. Deploys must also be done in conjunction with corresponding front-end changes. 

## Types of changes
- Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Functional tests
Tests updated to remove fields no longer being passed.