### PR TITLE
Kurtwheeler/fix no op iamge

### DIFF
--- a/workers/affymetrix_dependencies.R
+++ b/workers/affymetrix_dependencies.R
@@ -226,3 +226,7 @@ pd_annotation_pkgs <- c(
   'pd.zebrafish_3.12.0.tar.gz'
 )
 install_with_url(annotation_url, pd_annotation_pkgs)
+
+# Load this libraries because apparently just installing it isn't
+# enough to verify that the correct versions of dependencies are installed.
+library('foreach')

--- a/workers/illumina_dependencies.R
+++ b/workers/illumina_dependencies.R
@@ -39,3 +39,15 @@ illumina_pkgs <- c(
   'illuminaRatv1.db_1.26.0.tar.gz'
 )
 install_with_url(release_url, illumina_pkgs)
+
+# Load these libraries because apparently just installing them isn't
+# enough to verify that they have complementary versions.
+library("optparse")
+library(data.table)
+library("dplyr")
+library("rlang")
+library(AnnotationDbi)
+library(lazyeval)
+library(limma)
+library(oligo)
+library(doParallel)

--- a/workers/illumina_dependencies.R
+++ b/workers/illumina_dependencies.R
@@ -9,6 +9,8 @@ devtools::install_version('doParallel', version='1.0.11')
 devtools::install_version('data.table', version='1.11.0')
 devtools::install_version('optparse', version='1.4.4')
 devtools::install_version('lazyeval', version='0.2.1')
+devtools::install_version('tidyverse', version='1.2.1')
+devtools::install_version('rlang', version='0.2.2')
 
 # devtools::install_url() requires biocLite.R
 source('https://bioconductor.org/biocLite.R')

--- a/workers/install_affy_only.R
+++ b/workers/install_affy_only.R
@@ -34,10 +34,3 @@ bioc_pkgs <- c(
   'limma_3.34.9.tar.gz'
 )
 install_with_url(bioc_url, bioc_pkgs)
-
-# Load these libraries because apparently just installing them isn't
-# enough to verify that they have complementary versions.
-library("optparse")
-library(data.table)
-library(lazyeval)
-library(AnnotationDbi)

--- a/workers/install_affy_only.R
+++ b/workers/install_affy_only.R
@@ -34,3 +34,10 @@ bioc_pkgs <- c(
   'limma_3.34.9.tar.gz'
 )
 install_with_url(bioc_url, bioc_pkgs)
+
+# Load these libraries because apparently just installing them isn't
+# enough to verify that they have complementary versions.
+library("optparse")
+library(data.table)
+library(lazyeval)
+library(AnnotationDbi)

--- a/workers/install_gene_convert.R
+++ b/workers/install_gene_convert.R
@@ -7,7 +7,7 @@ devtools::install_version('data.table', version='1.11.0')
 devtools::install_version('optparse', version='1.4.4')
 
 devtools::install_version('tidyverse', version='1.2.1')
-devtools::install_version('rlang', version='0.2.1')
+devtools::install_version('rlang', version='0.2.2')
 
 # devtools::install_url() requires biocLite.R
 source('https://bioconductor.org/biocLite.R')

--- a/workers/install_gene_convert.R
+++ b/workers/install_gene_convert.R
@@ -36,3 +36,12 @@ illumina_pkgs <- c(
   'illuminaRatv1.db_1.26.0.tar.gz'
 )
 install_with_url(release_url, illumina_pkgs)
+
+# Load these libraries because apparently just installing them isn't
+# enough to verify that they have complementary versions.
+library("optparse")
+library(data.table)
+library("dplyr")
+library("rlang")
+library(lazyeval)
+library(AnnotationDbi)

--- a/workers/qn_dependencies.R
+++ b/workers/qn_dependencies.R
@@ -24,3 +24,9 @@ bioc_pkgs <- c(
    'preprocessCore_1.42.0.tar.gz'
 )
 install_with_url(bioc_url, bioc_pkgs)
+
+# Load these libraries because apparently just installing them isn't
+# enough to verify that they have complementary versions.
+library("optparse")
+library(data.table)
+library("preprocessCore")


### PR DESCRIPTION
## Issue Number

N/A the no_op image decided to break on us due to R dependencies changing.... somehow.

## Purpose/Implementation Notes

https://circleci.com/gh/AlexsLemonade/refinebio/8438 failed because:
```
2018-10-15 20:20:27,109 local data_refinery_workers.processors.utils ERROR [processor_job: 4] [pipeline_applied: NO_OP] [failure_reason: Status code 1 from gene_convert.R: b"Error in loadNamespace(i, c(lib.loc, .libPaths()), versionCheck = vI[[i]]) : \n  namespace 'rlang' 0.2.1 is already loaded, but >= 0.2.2 is required\nCalls: :: ... tryCatch -> tryCatchList -> tryCatchOne -> <Anonymous>\nExecution halted\n"] [no_retry: True]: Processor job failed!
```

Not the most useful error output, but running the image locally I was able to reproduce and get the full error output:
```
Error: package or namespace load failed for 'dplyr' in loadNamespace(i, c(lib.loc, .libPaths()), versionCheck = vI[[i]]):
 namespace 'rlang' 0.2.1 is already loaded, but >= 0.2.2 is required
```

I've bumped up rlang from 0.2.1 to 0.2.2 to hopefully fix the current version conflict we're seeing with dplyr. I have also tried to make it so that R will break at build time rather than run time.

I had thought we already protected ourselves against those kinds of issues, but it turns out that just installing a package doesn't mean you can actually use it...

@jaclyn-taroni when you get back we should discuss an audit of our R code for other issues where dependencies are not actually verified to be working before run time.

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

Circle is running the unit tests right now which is sufficient for this change.

## Checklist

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules
