### PR TITLE
Makes the Foreman reliably dispatch Janitor jobs every half hour.

### DIFF
--- a/foreman/data_refinery_foreman/foreman/main.py
+++ b/foreman/data_refinery_foreman/foreman/main.py
@@ -396,7 +396,7 @@ def retry_lost_processor_jobs() -> None:
 
 @do_forever(JANITOR_DISPATCH_TIME)
 def send_janitor_jobs():
-    """ If we're in the send_minutes window, dispatch some janitors """
+    """Dispatch a Janitor job for each instance in the cluster"""
 
     # This is a fairly hacky way of finding all of our volume indexes
     indexes = ProcessorJob.objects.all().values_list('volume_index').distinct()

--- a/foreman/data_refinery_foreman/foreman/main.py
+++ b/foreman/data_refinery_foreman/foreman/main.py
@@ -38,6 +38,9 @@ MIN_LOOP_TIME = timedelta(minutes=2)
 # threads are still alive and then heart beating.
 THREAD_WAIT_TIME = timedelta(minutes=10)
 
+# How frequently we dispatch Janitor jobs.
+JANITOR_DISPATCH_TIME = timedelta(minutes=30)
+
 
 @retry(stop_max_attempt_number=3)
 @transaction.atomic
@@ -391,36 +394,30 @@ def retry_lost_processor_jobs() -> None:
         handle_processor_jobs(lost_jobs)
 
 
-def send_janitor_jobs(send_minutes=[0, 30]):
+@do_forever(JANITOR_DISPATCH_TIME)
+def send_janitor_jobs():
     """ If we're in the send_minutes window, dispatch some janitors """
 
-    start_time = timezone.now()
-    if (start_time.minute in send_minutes) or (RUNNING_IN_CLOUD == "False"):
-        # This is a fairly hacky way of finding all of our volume indexes
-        indexes = ProcessorJob.objects.all().values_list('volume_index').distinct()
+    # This is a fairly hacky way of finding all of our volume indexes
+    indexes = ProcessorJob.objects.all().values_list('volume_index').distinct()
 
-        for index in indexes:
-            actual_index = index[0]
-            new_job = ProcessorJob(num_retries=0,
-                                   pipeline_applied="JANITOR",
-                                   ram_amount=2048,
-                                   volume_index=actual_index)
-            new_job.save()
-            logger.info("Sending Janitor with index: ",
-                job_id=new_job.id,
-                index=actual_index
-            )
-            try:
-                send_job(ProcessorPipeline["JANITOR"], new_job)
-            except Exception as e:
-                # If we can't dispatch this job, something else has gone wrong.
-                continue
+    for index in indexes:
+        actual_index = index[0]
+        new_job = ProcessorJob(num_retries=0,
+                               pipeline_applied="JANITOR",
+                               ram_amount=2048,
+                               volume_index=actual_index)
+        new_job.save()
+        logger.info("Sending Janitor with index: ",
+            job_id=new_job.id,
+            index=actual_index
+        )
+        try:
+            send_job(ProcessorPipeline["JANITOR"], new_job)
+        except Exception as e:
+            # If we can't dispatch this job, something else has gone wrong.
+            continue
 
-        # Wait for the next minute if we've dispatched
-        loop_time = timezone.now() - start_time
-        if loop_time < timedelta(minutes=1):
-            remaining_time = THREAD_WAIT_TIME - loop_time
-            time.sleep(remaining_time.seconds)
 
 def monitor_jobs():
     """Runs a thread for each job monitoring loop."""
@@ -429,6 +426,14 @@ def monitor_jobs():
                             retry_lost_processor_jobs]
 
     threads = []
+
+    # Start the thread to dispatch Janitor jobs.
+    thread = Thread(target=send_janitor_jobs, name="send_janitor_jobs")
+    thread.start()
+    threads.append(thread)
+    logger.info("Thread started for monitoring function: send_janitor_jobs")
+
+
     for f in processor_functions:
         thread = Thread(target=f, name=f.__name__)
         thread.start()

--- a/foreman/data_refinery_foreman/foreman/main.py
+++ b/foreman/data_refinery_foreman/foreman/main.py
@@ -463,8 +463,6 @@ def monitor_jobs():
     while(True):
         start_time = timezone.now()
 
-        send_janitor_jobs()
-
         for thread in threads:
             if not thread.is_alive():
                 logger.error("Foreman Thread for the function %s has died!!!!", thread.name)

--- a/foreman/data_refinery_foreman/foreman/test_main.py
+++ b/foreman/data_refinery_foreman/foreman/test_main.py
@@ -513,14 +513,17 @@ class SurveyTestCase(TestCase):
         retried_job = jobs[1]
         self.assertEqual(retried_job.num_retries, 1)
 
-    def test_janitor(self):
+    @patch('data_refinery_foreman.foreman.main.send_job')
+    def test_janitor(self, mock_send_job):
 
         for p in ["1", "2", "3"]:
             pj = ProcessorJob()
             pj.volume_index = p
             pj.save()
 
-        main.send_janitor_jobs(range(0,60))
+        # Just run it once, not forever so get the function that is
+        # decorated with @do_forever
+        main.send_janitor_jobs.__wrapped__()
 
         self.assertEqual(ProcessorJob.objects.all().count(), 6)
         self.assertEqual(ProcessorJob.objects.filter(pipeline_applied="JANITOR").count(), 3)


### PR DESCRIPTION
## Issue Number

https://github.com/AlexsLemonade/refinebio/pull/738 wasn't a good enough fix

## Purpose/Implementation Notes

When I tested https://github.com/AlexsLemonade/refinebio/pull/738 I didn't want to wait a half hour so I changed the minutes to be every minute. Well that happened to be the only way this works since the loop send_janitor_jobs only runs every 10 minutes and send_janitor_jobs doesn't have a loop of its own.

Anyway I ended up going with the `do_forever` implementation because it was super easy, we know it works, and if that thread ever dies we'll know because there's a loop monitoring its health.

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

I pushed a foreman image up with these changes, pulled it onto the staging foreman instance, restarted the foreman, made sure it started all the threads, made sure it dispatched janitor jobs, made sure those janitor jobs cleaned up the directories they were supposed to, and then made sure no more janitor jobs were dispatched for a half hour.

## Checklist

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules
