### PR TITLE
Fix deploys when API instance needs to be cycled.

### DIFF
--- a/infrastructure/api-configuration/api-server-instance-user-data.tpl.sh
+++ b/infrastructure/api-configuration/api-server-instance-user-data.tpl.sh
@@ -89,11 +89,36 @@ echo "
     maxage 3
 }" >> /etc/logrotate.conf
 
+# Install our environment variables
+cat <<"EOF" > environment
+${api_environment}
+EOF
+
 chown -R ubuntu /home/ubuntu
 
 STATIC_VOLUMES=/tmp/volumes_static
 mkdir -p /tmp/volumes_static
 chmod a+rwx /tmp/volumes_static
+
+# These database values are created after TF
+# is run, so we have to pass them in programatically
+docker run \
+       --env-file environment \
+       -e DATABASE_HOST=${database_host} \
+       -e DATABASE_NAME=${database_name} \
+       -e DATABASE_USER=${database_user} \
+       -e DATABASE_PASSWORD=${database_password} \
+       -v "$STATIC_VOLUMES":/tmp/www/static \
+       --log-driver=awslogs \
+       --log-opt awslogs-region=${region} \
+       --log-opt awslogs-group=${log_group} \
+       --log-opt awslogs-stream=${log_stream} \
+       -p 8081:8081 \
+       --name=dr_api \
+       -it -d ${dockerhub_repo}/${api_docker_image} /bin/sh -c "/home/user/collect_and_run_uwsgi.sh"
+
+# Don't leave secrets lying around.
+rm -f environment
 
 # Delete the cloudinit and syslog in production.
 export STAGE=${stage}

--- a/infrastructure/deploy.sh
+++ b/infrastructure/deploy.sh
@@ -258,23 +258,26 @@ container_running=$(ssh -o StrictHostKeyChecking=no \
                         -i data-refinery-key.pem \
                         ubuntu@$API_IP_ADDRESS  "docker ps" | grep dr_api || echo "")
 
-ssh -o StrictHostKeyChecking=no \
-    -i data-refinery-key.pem \
-    ubuntu@$API_IP_ADDRESS  "docker pull $DOCKERHUB_REPO/$API_DOCKER_IMAGE"
+# If the container isn't running, then it's because the instance is spinning up.
+# The container will be started by the API's init script, so no need to do anything more.
+if [[ -z $container_running ]]; then
 
-if [[ ! -z $container_running ]]; then
+
+    ssh -o StrictHostKeyChecking=no \
+        -i data-refinery-key.pem \
+        ubuntu@$API_IP_ADDRESS  "docker pull $DOCKERHUB_REPO/$API_DOCKER_IMAGE"
+
     ssh -o StrictHostKeyChecking=no \
         -i data-refinery-key.pem \
         ubuntu@$API_IP_ADDRESS "docker rm -f dr_api"
-fi
 
-scp -o StrictHostKeyChecking=no \
-    -i data-refinery-key.pem \
-    api-configuration/environment ubuntu@$API_IP_ADDRESS:/home/ubuntu/environment
+    scp -o StrictHostKeyChecking=no \
+        -i data-refinery-key.pem \
+        api-configuration/environment ubuntu@$API_IP_ADDRESS:/home/ubuntu/environment
 
-ssh -o StrictHostKeyChecking=no \
-    -i data-refinery-key.pem \
-    ubuntu@$API_IP_ADDRESS "docker run \
+    ssh -o StrictHostKeyChecking=no \
+        -i data-refinery-key.pem \
+        ubuntu@$API_IP_ADDRESS "docker run \
        --env-file environment \
        -e DATABASE_HOST=$DATABASE_HOST \
        -e DATABASE_NAME=$DATABASE_NAME \
@@ -289,5 +292,10 @@ ssh -o StrictHostKeyChecking=no \
        --name=dr_api \
        -it -d $DOCKERHUB_REPO/$API_DOCKER_IMAGE /bin/sh -c /home/user/collect_and_run_uwsgi.sh"
 
+    # Don't leave secrets lying around.
+    ssh -o StrictHostKeyChecking=no \
+        -i data-refinery-key.pem \
+        ubuntu@$API_IP_ADDRESS "rm -f environment"
+fi
 
 echo "Deploy completed successfully."

--- a/infrastructure/instances.tf
+++ b/infrastructure/instances.tf
@@ -475,9 +475,6 @@ resource "aws_instance" "api_server_1" {
   user_data = "${data.template_file.api_server_script_smusher.rendered}"
   key_name = "${aws_key_pair.data_refinery.key_name}"
 
-  # Don't delete production servers by mistake!
-  disable_api_termination = "${var.stage == "prod" ? true : false}"
-
   tags = {
     Name = "API Server 1 ${var.user}-${var.stage}"
   }

--- a/infrastructure/instances.tf
+++ b/infrastructure/instances.tf
@@ -440,6 +440,10 @@ data "local_file" "api_nginx_config" {
   filename = "api-configuration/nginx_config.conf"
 }
 
+data "local_file" "api_environment" {
+  filename = "api-configuration/environment"
+}
+
 # This script smusher serves a similar purpose to
 # ${data.template_file.nomad_lead_server_script_smusher} but for the Nginx/API.
 data "template_file" "api_server_script_smusher" {

--- a/infrastructure/instances.tf
+++ b/infrastructure/instances.tf
@@ -447,6 +447,9 @@ data "template_file" "api_server_script_smusher" {
 
   vars {
     nginx_config = "${data.local_file.api_nginx_config.content}"
+    api_environment = "${data.local_file.api_environment.content}"
+    dockerhub_repo = "${var.dockerhub_repo}"
+    api_docker_image = "${var.api_docker_image}"
     user = "${var.user}"
     stage = "${var.stage}"
     region = "${var.region}"


### PR DESCRIPTION
## Issue Number

https://github.com/AlexsLemonade/refinebio/issues/746

## Purpose/Implementation Notes

The API instance takes long enough to spin up that the deploy.sh script would try to launch the container on it before it was ready. This makes the initial container launch be handled by the instance startup script and subsequent updates to the API are managed remotely via deploy.sh.

This also removes the instance protection for the API instance because sometimes it needs to be cycled and not being able to delete it breaks the deploy.

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

No functional tests yet, going to test in staging deploy.

## Checklist

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules
