### PR TITLE
Readds the configuration necessary for circleci to cache our docker i…

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,8 @@ jobs:
   # These are grouped together because in total they take less time than our other tests individually.
   main_tests:
     working_directory: ~/refinebio
-    machine: true
+    machine:
+      docker_layer_caching: true
     steps:
       - checkout
 
@@ -72,7 +73,8 @@ jobs:
 
   common_tests:
     working_directory: ~/refinebio
-    machine: true
+    machine:
+      docker_layer_caching: true
     steps:
       - checkout
 
@@ -96,7 +98,8 @@ jobs:
   # This tests workers tests tagged as 'salmon'
   salmon_and_api_tests:
     working_directory: ~/refinebio
-    machine: true
+    machine:
+      docker_layer_caching: true
     steps:
       - checkout
 
@@ -123,7 +126,8 @@ jobs:
 
   tx_illumina_affy_agilent_tests:
     working_directory: ~/refinebio
-    machine: true
+    machine:
+      docker_layer_caching: true
     steps:
       - checkout
 


### PR DESCRIPTION
…mages.

## Issue Number

N/A but this is related to dev friendliness because it decreases the time it takes to run circleci tests.

## Purpose/Implementation Notes

When we had docker caching layer on the tests ran faster because all the images except for affy were cached, so we're turning it back on. We can't use it for affy since circleci won't give docker any more disk space, but this way we only have to pull that one image and the rest of the images should be quick.

## Types of changes

- New feature (non-breaking change which adds functionality)

## Functional tests

Tests are currently running, once they finish I will rerun them to make sure the test times drop.

## Checklist

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules
