### PR TITLE
Fix downloader tests by adding floor to MAX_DOWNLOADER_JOBS_PER_NODE

### DIFF
--- a/workers/data_refinery_workers/downloaders/utils.py
+++ b/workers/data_refinery_workers/downloaders/utils.py
@@ -42,7 +42,13 @@ def get_max_jobs_for_current_node():
     # We basically want to hit 2GB/s total across 10 x1.32larges. Each job hits 18MB/s.
     # So it'd take 111 jobs across 10 boxes to hit our limit, so let's set our GB per to 12,
     # which should pack well enough and give us a slight buffer.
-    return (gb/12)
+    max_jobs = (gb/12)
+
+    # However this will make sure we can still run a few jobs in local environments and in CI.
+    if max_jobs < 5:
+        max_jobs = 5
+
+    return max_jobs
 
 MAX_DOWNLOADER_JOBS_PER_NODE = get_max_jobs_for_current_node()
 


### PR DESCRIPTION
## Issue Number

N/A, failing CI: https://circleci.com/gh/AlexsLemonade/refinebio/8975

## Purpose/Implementation Notes

The CI box doesn't have enough RAM for our normal calculation of MAX_DOWNLOADER_JOBS_PER_NODE to work on it. Therefore made it so that value will never go below 5 so we still can run a few jobs at a time on dev and in tests.

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

This is all about CI.

## Checklist

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules
