### PR TITLE
Remove stack-aware terraform config.

### DIFF
--- a/infrastructure/init_terraform.sh
+++ b/infrastructure/init_terraform.sh
@@ -11,6 +11,11 @@ else
     STAGE=$TF_VAR_stage
 fi
 
+# Terraform leaves some stack-specific config lying around.
+# This config messes up initialization of an arbitrary stage, since it is stack-specific.
+# Therefore in order to be able to switch between different stacks, just remove that config.
+rm -rf .terraform
+
 # Force copy will allow us to get past the prompt asking if we want to
 # switch to the remote backend.
 terraform init \


### PR DESCRIPTION
## Issue Number

N/A came up while running staging deploy using latest deploy box code

## Purpose/Implementation Notes

The `.terraform` directory contains a terraform.tfstate file containing backend configuration information like:
```
{
    "version": 3,
    "serial": 2,
    "lineage": "c7e9df1f-5f53-6da7-57d1-331032e3a0b0",
    "backend": {
        "type": "s3",
        "config": {
            "bucket": "refinebio-tfstate-deploy-staging",
            "key": "terraform-circleci.tfstate",
            "region": "us-east-1"
        },
        "hash": 17430002091488791519
    },
    "modules": [
        {
            "path": [
                "root"
            ],
            "outputs": {},
            "resources": {},
            "depends_on": []
        }
    ]
}
```
This means that after having run `terraform init` on a box, that subsequent inits will try to use the same lineage-id, fail to do so, and then decide to start over. Or something like that. I'm not 100% sure what terraform does under the hood, but the end result is that it blows away existing remote state files and starts over. This is the opposite of what we want.

What we really want to happen is that when we tell terraform "here is an S3 bucket with a statefile" we want terraform to use that statefile as a starting point. This has been working for a while in circleci, because every time we ran a deploy we started with a fresh instance that didn't have a populated `.terraform` directory. Therefore the fix this PR introduces is to just blow away the `.terraform` directory so that we just init based off the existing statefile like we want.

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

I tested this by sshing onto the deploy box and destroying the resources created by terraform when it thought it had to start over, reverting the statefile in the S3 bucket using the S3 versioning we have enabled, blowing away .terraform, running `TF_VAR_user=circleci TF_VAR_stage=staging ./init_terraform.sh`, and then checking `terraform output` and seeing all the resources that have been existing in the staging stack.

## Checklist

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules
