### PR TITLE
Isolate affy image tests and make them not use DLC

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -124,7 +124,7 @@ jobs:
           command: .circleci/filter_tests.sh -t salmon
           no_output_timeout: 1h
 
-  tx_illumina_affy_agilent_tests:
+  tx_illumina_tests:
     working_directory: ~/refinebio
     machine:
       docker_layer_caching: true
@@ -165,6 +165,25 @@ jobs:
       - run: docker image rm ccdlstaging/dr_transcriptome
       - run: docker image rm ccdlstaging/dr_illumina
 
+  affy_agilent_tests:
+    working_directory: ~/refinebio
+    steps:
+      - checkout
+
+      # Clean up stuff circle provides that we don't need.
+      - run: sudo bash .circleci/cleanup_instance.sh
+
+      # Setup Postgres in a Container
+      - run: ./run_postgres.sh
+      # Let Postgres start up.
+      - run: sleep 30
+      # Finish setting up Postgres now that it's running.
+      - run: ./common/install_db_docker.sh
+
+      # Install our application. Provides the data_refinery_common package for the other images.
+      - run: chmod -R a+wr common
+      - run: ./update_models.sh
+
       - run:
           command: .circleci/filter_tests.sh -t affymetrix
           # This takes a while because the affymetrix image is huge
@@ -176,7 +195,6 @@ jobs:
 
       # This doesn't take as long because the image has already been pulled.
       - run: .circleci/filter_tests.sh -t agilent
-
 
   deploy:
     machine: true
@@ -215,7 +233,13 @@ workflows:
             # "test" job, an explicit "tags" filter is required here.
             tags:
               only: /v.*/
-      - tx_illumina_affy_agilent_tests:
+      - tx_illumina_tests:
+          filters:
+            # To allow tag commits whose name start with "v" to trigger
+            # "test" job, an explicit "tags" filter is required here.
+            tags:
+              only: /v.*/
+      - affy_agilent_tests:
           filters:
             # To allow tag commits whose name start with "v" to trigger
             # "test" job, an explicit "tags" filter is required here.
@@ -229,7 +253,8 @@ workflows:
             - main_tests
             - common_tests
             - salmon_and_api_tests
-            - tx_illumina_affy_agilent_tests
+            - tx_illumina_tests
+            - affy_agilent_tests
           filters:
             # No branch commit will ever trigger this job.
             branches:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -166,6 +166,7 @@ jobs:
       - run: docker image rm ccdlstaging/dr_illumina
 
   affy_agilent_tests:
+    machine: true
     working_directory: ~/refinebio
     steps:
       - checkout


### PR DESCRIPTION
## Issue Number

N/A https://circleci.com/gh/AlexsLemonade/refinebio/9082 failed

## Purpose/Implementation Notes

We hit a:
> failed to register layer: Error processing tar file(exit status 1): write /usr/local/lib/R/site-library/pd.genomewidesnp.6/extdata/pd.genomewidesnp.6.sqlite: no space left on device

error in the above-mentioned build. This was something we had been seeing before turning Docker Layer Caching off because if the cache is warmed on the volume that gets used by CircleCI for docker, then there may not be enough space to fit all of our images. This manifests itself by us not having enough room to download the Affy image onto it.

The solution I've come up with is to just not use The docker layer caching feature for the Affy image. However whether to use that feature or not is job-specific setting so I had to break them into their own job. However this is actually pretty sweet because the job they were in before took the longest to run, even with docker layer caching speeding things up.

## Types of changes

- New feature (non-breaking change which adds functionality)

## Functional tests

This is a CI change so the passing CI tests show it's working.

## Checklist

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules
