### PR TITLE
Make Foreman support existing surveyor jobs

### DIFF
--- a/foreman/data_refinery_foreman/foreman/main.py
+++ b/foreman/data_refinery_foreman/foreman/main.py
@@ -549,25 +549,23 @@ def retry_lost_survey_jobs() -> None:
     lost_jobs = []
     for job in potentially_lost_jobs:
         try:
+            # Surveyor jobs didn't always have nomad_job_ids. If they
+            # don't have one then by this point they've definitely died.
             if job.nomad_job_id:
                 job_status = nomad_client.job.get_job(job.nomad_job_id)["Status"]
-                # If the job is still pending, then it makes sense that it
-                # hasn't started and if it's running then it may not have
-                # been able to mark the job record as started yet.
-                if job_status != "pending" and job_status != "running":
-                    logger.info(("Determined that a survey job needs to be requeued because its"
-                                 " Nomad Job's status is: %s."),
-                                job_status,
-                                job_id=job.id
-                    )
-                    lost_jobs.append(job)
             else:
-                # If there is no nomad_job_id field set, we could be
-                # in the small window where the job was created but
-                # hasn't yet gotten a chance to be queued.
-                # If this job really should be restarted we'll get it in the next loop.
-                if timezone.now() - job.created_at > MIN_LOOP_TIME:
-                    lost_jobs.append(job)
+                job_status = "dead"
+
+            # If the job is still pending, then it makes sense that it
+            # hasn't started and if it's running then it may not have
+            # been able to mark the job record as started yet.
+            if job_status != "pending" and job_status != "running":
+                logger.info(("Determined that a survey job needs to be requeued because its"
+                             " Nomad Job's status is: %s."),
+                            job_status,
+                            job_id=job.id
+                )
+                lost_jobs.append(job)
         except URLNotFoundNomadException:
             logger.exception(("Determined that a survey job needs to be requeued because "
                               "querying for its Nomad job failed: "),

--- a/foreman/data_refinery_foreman/foreman/main.py
+++ b/foreman/data_refinery_foreman/foreman/main.py
@@ -507,7 +507,13 @@ def retry_hung_survey_jobs() -> None:
     hung_jobs = []
     for job in potentially_hung_jobs:
         try:
-            job_status = nomad_client.job.get_job(job.nomad_job_id)["Status"]
+            # Surveyor jobs didn't always have nomad_job_ids. If they
+            # don't have one then by this point they've definitely died.
+            if job.nomad_job_id:
+                job_status = nomad_client.job.get_job(job.nomad_job_id)["Status"]
+            else:
+                job_status = "dead"
+
             if job_status != "running":
                 # Make sure it didn't finish since our original query.
                 job.refresh_from_db()


### PR DESCRIPTION
## Issue Number

N/A came up during staging test.

## Purpose/Implementation Notes

In https://github.com/AlexsLemonade/refinebio/pull/773 I added nomad_job_id to SurveyJobs, which means all existing SurveyJobs can't even make a request to nomad because there's no ID to format into the URL. This means that the Foreman would spin forever on them because it would never mark them as retried and instead just throw an exception on every job like that every time it loops. Very chatty.

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

I had some jobs sitting in my local database from #773 so I'm testing this on them.

## Checklist

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules
