### PR TITLE
Delete original files after processing locally.

### DIFF
--- a/common/data_refinery_common/models/models.py
+++ b/common/data_refinery_common/models/models.py
@@ -641,9 +641,6 @@ class OriginalFile(models.Model):
 
     def delete_local_file(self):
         """ Deletes this file from the local file system."""
-        if not settings.RUNNING_IN_CLOUD:
-            return
-
         try:
             os.remove(self.absolute_file_path)
         except OSError:


### PR DESCRIPTION
## Issue Number

N/A but Ariel mentioned his hard drive got filled up while crunching some data locally.

## Purpose/Implementation Notes

I think we added this to `delete_local_file` for computed files because since we don't upload files while running locally, if you remove the computed file then after processing you end up with nothing. However I can't think of a good reason to have it on the original files, so I think we should remove it. However I may have forgotten the reason.

## Types of changes

- New feature (non-breaking change which adds functionality)

## Functional tests

N/A very minor local-only change, unit tests should be sufficient. 

## Checklist

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules
