### PR TITLE
Make the production SSL cert start with www.

### DIFF
--- a/infrastructure/networking.tf
+++ b/infrastructure/networking.tf
@@ -174,7 +174,7 @@ locals {
 # this since we're using cloudfront. The cert for the API is created
 # an installed by certbot.
 resource "aws_acm_certificate" "ssl-cert" {
-  domain_name = "${ var.stage == "prod" ? "" : local.stage_with_dot }refine.bio"
+  domain_name = "${ var.stage == "prod" ? "www." : local.stage_with_dot }refine.bio"
   validation_method = "DNS"
 
   tags {


### PR DESCRIPTION
## Issue Number

#786

## Purpose/Implementation Notes

This makes the SSL cert for prod have the domain `www.refine.bio` instead of `refine.bio`.

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

N/A only applies to prod :(

## Checklist

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules
