### PR TITLE
Always have a wwww.refine.bio alternate CNAME on the CF distribution

### DIFF
--- a/infrastructure/networking.tf
+++ b/infrastructure/networking.tf
@@ -187,7 +187,7 @@ resource "aws_acm_certificate_validation" "ssl-cert" {
 }
 
 resource "aws_cloudfront_distribution" "static-distribution" {
-  aliases = ["${var.static_bucket_prefix == "dev" ? var.user : var.static_bucket_prefix}${var.static_bucket_root}"]
+  aliases = ["${var.static_bucket_prefix == "dev" ? var.user : var.static_bucket_prefix}${var.static_bucket_root}", "www.refine.bio"]
 
   origin {
     domain_name = "${aws_s3_bucket.data-refinery-static.website_endpoint}"


### PR DESCRIPTION
## Issue Number

HOTFIX

## Purpose/Implementation Notes

We got hit with some downtime because of this. All CF distributions will now have the `www.` alternate CNAME, but since only one will be connected in the DNS this will only impact prod, but will potentially allow us to do blue/green deployments in the future if we want to go that route.

This has been set manually for now so now immediate change is required, but this will prevent breakage in the future.
