### PR TITLE
Start Nomad Servers with Monit

### DIFF
--- a/infrastructure/nomad-configuration/lead-server-instance-user-data.tpl.sh
+++ b/infrastructure/nomad-configuration/lead-server-instance-user-data.tpl.sh
@@ -89,8 +89,33 @@ chmod +x install_nomad.sh
 #  -p 8126:8126\
 #  graphiteapp/graphite-statsd
 
-# Start the Nomad agent in server mode.
-nohup nomad agent -config server.hcl > /var/log/nomad_server.log &
+# Start the Nomad agent in server mode via Monit
+apt-get -y install monit
+
+echo "
+#!/bin/sh
+nomad status
+exit \$?
+" >> /home/ubuntu/nomad_status.sh
+chmod +x /home/ubuntu/nomad_status.sh
+
+echo "
+#!/bin/sh
+killall nomad
+nomad agent -config /home/ubuntu/server.hcl > /var/log/nomad_server.log &
+" >> /home/ubuntu/kill_restart_nomad.sh
+chmod +x /home/ubuntu/kill_restart_nomad.sh
+/home/ubuntu/kill_restart_nomad.sh
+
+echo '
+check program nomad with path "/bin/bash /home/ubuntu/nomad_status.sh" as uid 0 and with gid 0
+    start program = "/home/ubuntu/kill_restart_nomad.sh" as uid 0 and with gid 0
+    if status != 0
+        then restart
+set daemon 300
+' >> /etc/monit/monitrc
+
+service monit restart
 
 # Create the CW metric job in a crontab
 # write out current crontab

--- a/infrastructure/nomad-configuration/lead-server-instance-user-data.tpl.sh
+++ b/infrastructure/nomad-configuration/lead-server-instance-user-data.tpl.sh
@@ -90,7 +90,7 @@ chmod +x install_nomad.sh
 #  graphiteapp/graphite-statsd
 
 # Start the Nomad agent in server mode via Monit
-apt-get -y install monit
+apt-get -y install monit htop
 
 echo "
 #!/bin/sh

--- a/infrastructure/nomad-configuration/lead-server-instance-user-data.tpl.sh
+++ b/infrastructure/nomad-configuration/lead-server-instance-user-data.tpl.sh
@@ -102,6 +102,7 @@ chmod +x /home/ubuntu/nomad_status.sh
 echo "
 #!/bin/sh
 killall nomad
+sleep 120
 nomad agent -config /home/ubuntu/server.hcl > /var/log/nomad_server.log &
 " >> /home/ubuntu/kill_restart_nomad.sh
 chmod +x /home/ubuntu/kill_restart_nomad.sh

--- a/infrastructure/nomad-configuration/server-instance-user-data.tpl.sh
+++ b/infrastructure/nomad-configuration/server-instance-user-data.tpl.sh
@@ -55,8 +55,33 @@ EOF
 chmod +x install_nomad.sh
 ./install_nomad.sh
 
-# Start the Nomad agent in server mode.
-nohup nomad agent -config server.hcl > /var/log/nomad_server.log &
+# Start the Nomad agent in server mode via Monit
+apt-get -y install monit
+
+echo "
+#!/bin/sh
+nomad status
+exit \$?
+" >> /home/ubuntu/nomad_status.sh
+chmod +x /home/ubuntu/nomad_status.sh
+
+echo "
+#!/bin/sh
+killall nomad
+nomad agent -config /home/ubuntu/server.hcl > /var/log/nomad_server.log &
+" >> /home/ubuntu/kill_restart_nomad.sh
+chmod +x /home/ubuntu/kill_restart_nomad.sh
+/home/ubuntu/kill_restart_nomad.sh
+
+echo '
+check program nomad with path "/bin/bash /home/ubuntu/nomad_status.sh" as uid 0 and with gid 0
+    start program = "/home/ubuntu/kill_restart_nomad.sh" as uid 0 and with gid 0
+    if status != 0
+        then restart
+set daemon 300
+' >> /etc/monit/monitrc
+
+service monit restart
 
 # Give the Nomad server time to start up.
 sleep 30

--- a/infrastructure/nomad-configuration/server-instance-user-data.tpl.sh
+++ b/infrastructure/nomad-configuration/server-instance-user-data.tpl.sh
@@ -68,6 +68,7 @@ chmod +x /home/ubuntu/nomad_status.sh
 echo "
 #!/bin/sh
 killall nomad
+sleep 120
 nomad agent -config /home/ubuntu/server.hcl > /var/log/nomad_server.log &
 " >> /home/ubuntu/kill_restart_nomad.sh
 chmod +x /home/ubuntu/kill_restart_nomad.sh

--- a/infrastructure/nomad-configuration/server-instance-user-data.tpl.sh
+++ b/infrastructure/nomad-configuration/server-instance-user-data.tpl.sh
@@ -56,7 +56,7 @@ chmod +x install_nomad.sh
 ./install_nomad.sh
 
 # Start the Nomad agent in server mode via Monit
-apt-get -y install monit
+apt-get -y install monit htop
 
 echo "
 #!/bin/sh


### PR DESCRIPTION
## Issue Number

https://github.com/hashicorp/nomad/issues/4864

## Purpose/Implementation Notes

Part 1 of hacks to get around Nomad being a pile of hot garbage.

## Methods
Nomad will die some times. This makes sure that if it goes down, we make it come back up.

This isn't really a solution since the underlying problem is still there, but at least it'll come back up if it can - which it probably can't.

From the `monit` log, you can see it working:

```
[UTC Nov 13 20:40:10] info     : 'ip-10-0-122-116.ec2.internal' Monit 5.16 started
[UTC Nov 13 20:45:10] error    : 'nomad' '/bin/bash' failed with exit status (1) -- Error querying jobs: Get http://127.0.0.1:4646/v1/jobs: dial tcp 127.0.0.1:4646: getsockopt: connection refused
[UTC Nov 13 20:45:10] info     : 'nomad' trying to restart
[UTC Nov 13 20:45:10] info     : 'nomad' start: /home/ubuntu/kill_restart_nomad.sh
```

It's now passed the 5 minute health window, and the health check passed so it hasn't restarted the service. `nomad status` works again. If I manually kill nomad, monit will start it again.

## Types of changes

- New feature (non-breaking change which adds functionality)
