### PR TITLE
Set Limit To Maximum Concurrent Survey Jobs

### DIFF
--- a/common/data_refinery_common/message_queue.py
+++ b/common/data_refinery_common/message_queue.py
@@ -96,6 +96,8 @@ def send_job(job_type: Enum, job) -> bool:
     elif isinstance(job, SurveyJob):
         nomad_job = nomad_job + "_" + str(job.ram_amount)
 
+    # We only want to dispatch processor jobs directly.
+    # Everything else will be handled by the Foreman, which will increment the retry counter.
     if is_processor:
         try:
             nomad_response = nomad_client.job.dispatch_job(nomad_job, meta={"JOB_NAME": job_type.value,
@@ -114,4 +116,7 @@ def send_job(job_type: Enum, job) -> bool:
                 reason=str(e)
             )
             raise
+    else:
+        job.num_retries = job.num_retries - 1
+        job.save()
     return True

--- a/common/data_refinery_common/message_queue.py
+++ b/common/data_refinery_common/message_queue.py
@@ -19,7 +19,7 @@ NOMAD_DOWNLOADER_JOB = "DOWNLOADER"
 NONE_JOB_ERROR_TEMPLATE = "send_job was called with NONE job_type: {} for {} job {}"
 
 
-def send_job(job_type: Enum, job) -> bool:
+def send_job(job_type: Enum, job=job, is_dispatch=False) -> bool:
     """Queues a worker job by sending a Nomad Job dispatch message.
 
     job_type must be a valid Enum for ProcessorPipelines or
@@ -98,7 +98,7 @@ def send_job(job_type: Enum, job) -> bool:
 
     # We only want to dispatch processor jobs directly.
     # Everything else will be handled by the Foreman, which will increment the retry counter.
-    if is_processor:
+    if is_processor or is_dispatch:
         try:
             nomad_response = nomad_client.job.dispatch_job(nomad_job, meta={"JOB_NAME": job_type.value,
                                                                             "JOB_ID": str(job.id)})

--- a/common/data_refinery_common/message_queue.py
+++ b/common/data_refinery_common/message_queue.py
@@ -19,7 +19,7 @@ NOMAD_DOWNLOADER_JOB = "DOWNLOADER"
 NONE_JOB_ERROR_TEMPLATE = "send_job was called with NONE job_type: {} for {} job {}"
 
 
-def send_job(job_type: Enum, job=job, is_dispatch=False) -> bool:
+def send_job(job_type: Enum, job, is_dispatch=False) -> bool:
     """Queues a worker job by sending a Nomad Job dispatch message.
 
     job_type must be a valid Enum for ProcessorPipelines or

--- a/common/data_refinery_common/message_queue.py
+++ b/common/data_refinery_common/message_queue.py
@@ -4,7 +4,7 @@ from __future__ import absolute_import, unicode_literals
 from enum import Enum
 import nomad
 from nomad.api.exceptions import URLNotFoundNomadException
-from data_refinery_common.utils import get_env_variable, get_volume_index
+from data_refinery_common.utils import get_env_variable, get_env_variable_gracefully, get_volume_index
 from data_refinery_common.models import ProcessorJob, SurveyJob
 from data_refinery_common.job_lookup import ProcessorPipeline, Downloaders, SurveyJobTypes
 from data_refinery_common.logging import get_and_configure_logger
@@ -17,6 +17,7 @@ logger = get_and_configure_logger(__name__)
 NOMAD_TRANSCRIPTOME_JOB = "TRANSCRIPTOME_INDEX"
 NOMAD_DOWNLOADER_JOB = "DOWNLOADER"
 NONE_JOB_ERROR_TEMPLATE = "send_job was called with NONE job_type: {} for {} job {}"
+RUNNING_IN_CLOUD = bool(get_env_variable_gracefully("RUNNING_IN_CLOUD", "False"))
 
 
 def send_job(job_type: Enum, job, is_dispatch=False) -> bool:
@@ -98,7 +99,7 @@ def send_job(job_type: Enum, job, is_dispatch=False) -> bool:
 
     # We only want to dispatch processor jobs directly.
     # Everything else will be handled by the Foreman, which will increment the retry counter.
-    if is_processor or is_dispatch:
+    if is_processor or is_dispatch or not RUNNING_IN_CLOUD:
         try:
             nomad_response = nomad_client.job.dispatch_job(nomad_job, meta={"JOB_NAME": job_type.value,
                                                                             "JOB_ID": str(job.id)})

--- a/common/data_refinery_common/message_queue.py
+++ b/common/data_refinery_common/message_queue.py
@@ -17,7 +17,11 @@ logger = get_and_configure_logger(__name__)
 NOMAD_TRANSCRIPTOME_JOB = "TRANSCRIPTOME_INDEX"
 NOMAD_DOWNLOADER_JOB = "DOWNLOADER"
 NONE_JOB_ERROR_TEMPLATE = "send_job was called with NONE job_type: {} for {} job {}"
-RUNNING_IN_CLOUD = bool(get_env_variable_gracefully("RUNNING_IN_CLOUD", "False"))
+RUNNING_IN_CLOUD = get_env_variable_gracefully("RUNNING_IN_CLOUD", "False")
+if RUNNING_IN_CLOUD == "False":
+    RUNNING_IN_CLOUD = False
+else:
+    RUNNING_IN_CLOUD = True
 
 
 def send_job(job_type: Enum, job, is_dispatch=False) -> bool:
@@ -99,7 +103,7 @@ def send_job(job_type: Enum, job, is_dispatch=False) -> bool:
 
     # We only want to dispatch processor jobs directly.
     # Everything else will be handled by the Foreman, which will increment the retry counter.
-    if is_processor or is_dispatch or not RUNNING_IN_CLOUD:
+    if is_processor or is_dispatch or (not RUNNING_IN_CLOUD):
         try:
             nomad_response = nomad_client.job.dispatch_job(nomad_job, meta={"JOB_NAME": job_type.value,
                                                                             "JOB_ID": str(job.id)})

--- a/foreman/data_refinery_foreman/foreman/main.py
+++ b/foreman/data_refinery_foreman/foreman/main.py
@@ -32,6 +32,9 @@ RUNNING_IN_CLOUD = get_env_variable_gracefully("RUNNING_IN_CLOUD", False)
 # greater than this because of the first attempt
 MAX_NUM_RETRIES = 2
 
+# This can be overritten by the env var "MAX_TOTAL_JOBS"
+DEFAULT_MAX_JOBS = 10000
+
 # The fastest each thread will repeat its checks.
 # Could be slower if the thread takes longer than this to check its jobs.
 MIN_LOOP_TIME = timedelta(minutes=2)
@@ -145,9 +148,9 @@ def handle_downloader_jobs(jobs: List[DownloaderJob]) -> None:
     nomad_client = Nomad(nomad_host, port=int(nomad_port), timeout=30)
     # Maximum number of total jobs running at a time.
     # We do this now rather than import time for testing purposes.
-    MAX_TOTAL_JOBS = int(get_env_variable_gracefully("MAX_TOTAL_JOBS", 1000))
-    all_jobs = nomad_client.jobs.get_jobs()
-    if len(all_jobs) >= MAX_TOTAL_JOBS:
+    MAX_TOTAL_JOBS = int(get_env_variable_gracefully("MAX_TOTAL_JOBS", DEFAULT_MAX_JOBS))
+    len_all_jobs = len(nomad_client.jobs.get_jobs())
+    if len_all_jobs >= MAX_TOTAL_JOBS:
         logger.info("Not requeuing job until we're running fewer jobs.")
         return False
 
@@ -159,7 +162,7 @@ def handle_downloader_jobs(jobs: List[DownloaderJob]) -> None:
         else:
             handle_repeated_failure(job)
 
-        if jobs_dispatched >= MAX_TOTAL_JOBS:
+        if (jobs_dispatched + len_all_jobs) >= MAX_TOTAL_JOBS:
             logger.info("We hit the maximum total jobs ceiling, so we're not handling any more downloader jobs now.")
             return False
 
@@ -331,9 +334,9 @@ def handle_processor_jobs(jobs: List[ProcessorJob]) -> None:
     nomad_client = Nomad(nomad_host, port=int(nomad_port), timeout=30)
     # Maximum number of total jobs running at a time.
     # We do this now rather than import time for testing purposes.
-    MAX_TOTAL_JOBS = int(get_env_variable_gracefully("MAX_TOTAL_JOBS", 1000))
-    all_jobs = nomad_client.jobs.get_jobs()
-    if len(all_jobs) >= MAX_TOTAL_JOBS:
+    MAX_TOTAL_JOBS = int(get_env_variable_gracefully("MAX_TOTAL_JOBS", DEFAULT_MAX_JOBS))
+    len_all_jobs = len(nomad_client.jobs.get_jobs())
+    if llen_all_jobs >= MAX_TOTAL_JOBS:
         logger.info("Not requeuing job until we're running fewer jobs.")
         return False
 
@@ -345,7 +348,7 @@ def handle_processor_jobs(jobs: List[ProcessorJob]) -> None:
         else:
             handle_repeated_failure(job)
 
-        if jobs_dispatched >= MAX_TOTAL_JOBS:
+        if (jobs_dispatched + len_all_jobs) >= MAX_TOTAL_JOBS:
             logger.info("We hit the maximum total jobs ceiling, so we're not handling any more processor jobs now.")
             return False
 
@@ -519,9 +522,9 @@ def handle_survey_jobs(jobs: List[SurveyJob]) -> None:
     nomad_client = Nomad(nomad_host, port=int(nomad_port), timeout=30)
     # Maximum number of total jobs running at a time.
     # We do this now rather than import time for testing purposes.
-    MAX_TOTAL_JOBS = int(get_env_variable_gracefully("MAX_TOTAL_JOBS", 1000))
-    all_jobs = nomad_client.jobs.get_jobs()
-    if len(all_jobs) >= MAX_TOTAL_JOBS:
+    MAX_TOTAL_JOBS = int(get_env_variable_gracefully("MAX_TOTAL_JOBS", DEFAULT_MAX_JOBS))
+    len_all_jobs = len(nomad_client.jobs.get_jobs())
+    if len_all_jobs >= MAX_TOTAL_JOBS:
         logger.info("Not requeuing job until we're running fewer jobs.")
         return False
 
@@ -533,7 +536,7 @@ def handle_survey_jobs(jobs: List[SurveyJob]) -> None:
         else:
             handle_repeated_failure(job)
 
-        if jobs_dispatched >= MAX_TOTAL_JOBS:
+        if (jobs_dispatched + len_all_jobs) >= MAX_TOTAL_JOBS:
             logger.info("We hit the maximum total jobs ceiling, so we're not handling any more survey jobs now.")
             return False
 

--- a/foreman/data_refinery_foreman/foreman/main.py
+++ b/foreman/data_refinery_foreman/foreman/main.py
@@ -124,7 +124,7 @@ def requeue_downloader_job(last_job: DownloaderJob) -> None:
                 last_job.id,
                 new_job.id)
     try:
-        if send_job(Downloaders[last_job.downloader_task], new_job):
+        if send_job(Downloaders[last_job.downloader_task], job=new_job, is_dispatch=True):
             last_job.retried = True
             last_job.success = False
             last_job.retried_job = new_job
@@ -313,7 +313,7 @@ def requeue_processor_job(last_job: ProcessorJob) -> None:
         logger.info("Requeuing Processor Job which had ID %d with a new Processor Job with ID %d.",
                     last_job.id,
                     new_job.id)
-        if send_job(ProcessorPipeline[last_job.pipeline_applied], new_job):
+        if send_job(ProcessorPipeline[last_job.pipeline_applied], job=new_job, is_dispatch=True):
             last_job.retried = True
             last_job.success = False
             last_job.retried_job = new_job
@@ -502,7 +502,7 @@ def requeue_survey_job(last_job: SurveyJob) -> None:
                 new_job.id)
 
     try:
-        if send_job(SurveyJobTypes.SURVEYOR, new_job):
+        if send_job(SurveyJobTypes.SURVEYOR, job=new_job, is_dispatch=True):
             last_job.retried = True
             last_job.success = False
             last_job.retried_job = new_job
@@ -679,7 +679,7 @@ def send_janitor_jobs():
             index=actual_index
         )
         try:
-            send_job(ProcessorPipeline["JANITOR"], new_job)
+            send_job(ProcessorPipeline["JANITOR"], job=new_job, is_dispatch=True)
         except Exception as e:
             # If we can't dispatch this job, something else has gone wrong.
             continue

--- a/foreman/data_refinery_foreman/foreman/main.py
+++ b/foreman/data_refinery_foreman/foreman/main.py
@@ -155,12 +155,15 @@ def handle_downloader_jobs(jobs: List[DownloaderJob]) -> None:
         return False
 
     jobs_dispatched = 0
-    for job in jobs:
+    for count, job in enumerate(jobs):
         if job.num_retries < MAX_NUM_RETRIES:
             requeue_downloader_job(job)
             jobs_dispatched = jobs_dispatched + 1
         else:
             handle_repeated_failure(job)
+
+        if (count % 100) == 0:
+            len_all_jobs = len(nomad_client.jobs.get_jobs())
 
         if (jobs_dispatched + len_all_jobs) >= MAX_TOTAL_JOBS:
             logger.info("We hit the maximum total jobs ceiling, so we're not handling any more downloader jobs now.")
@@ -336,17 +339,20 @@ def handle_processor_jobs(jobs: List[ProcessorJob]) -> None:
     # We do this now rather than import time for testing purposes.
     MAX_TOTAL_JOBS = int(get_env_variable_gracefully("MAX_TOTAL_JOBS", DEFAULT_MAX_JOBS))
     len_all_jobs = len(nomad_client.jobs.get_jobs())
-    if llen_all_jobs >= MAX_TOTAL_JOBS:
+    if len_all_jobs >= MAX_TOTAL_JOBS:
         logger.info("Not requeuing job until we're running fewer jobs.")
         return False
 
     jobs_dispatched = 0
-    for job in jobs:
+    for count, job in enumerate(jobs):
         if job.num_retries < MAX_NUM_RETRIES:
             requeue_processor_job(job)
             jobs_dispatched = jobs_dispatched + 1
         else:
             handle_repeated_failure(job)
+
+        if (count % 100) == 0:
+            len_all_jobs = len(nomad_client.jobs.get_jobs())
 
         if (jobs_dispatched + len_all_jobs) >= MAX_TOTAL_JOBS:
             logger.info("We hit the maximum total jobs ceiling, so we're not handling any more processor jobs now.")
@@ -529,12 +535,15 @@ def handle_survey_jobs(jobs: List[SurveyJob]) -> None:
         return False
 
     jobs_dispatched = 0
-    for job in jobs:
+    for count, job in enumerate(jobs):
         if job.num_retries < MAX_NUM_RETRIES:
             requeue_survey_job(job)
             jobs_dispatched = jobs_dispatched + 1
         else:
             handle_repeated_failure(job)
+
+        if (count % 100) == 0:
+            len_all_jobs = len(nomad_client.jobs.get_jobs())
 
         if (jobs_dispatched + len_all_jobs) >= MAX_TOTAL_JOBS:
             logger.info("We hit the maximum total jobs ceiling, so we're not handling any more survey jobs now.")

--- a/foreman/data_refinery_foreman/foreman/main.py
+++ b/foreman/data_refinery_foreman/foreman/main.py
@@ -166,7 +166,7 @@ def retry_hung_downloader_jobs() -> None:
 
     nomad_host = get_env_variable("NOMAD_HOST")
     nomad_port = get_env_variable("NOMAD_PORT", "4646")
-    nomad_client = Nomad(nomad_host, port=int(nomad_port), timeout=5)
+    nomad_client = Nomad(nomad_host, port=int(nomad_port), timeout=30)
     hung_jobs = []
     for job in potentially_hung_jobs:
         try:
@@ -205,7 +205,7 @@ def retry_lost_downloader_jobs() -> None:
 
     nomad_host = get_env_variable("NOMAD_HOST")
     nomad_port = get_env_variable("NOMAD_PORT", "4646")
-    nomad_client = Nomad(nomad_host, port=int(nomad_port), timeout=5)
+    nomad_client = Nomad(nomad_host, port=int(nomad_port), timeout=30)
     lost_jobs = []
     for job in potentially_lost_jobs:
         try:
@@ -338,7 +338,7 @@ def retry_hung_processor_jobs() -> None:
 
     nomad_host = get_env_variable("NOMAD_HOST")
     nomad_port = get_env_variable("NOMAD_PORT", "4646")
-    nomad_client = Nomad(nomad_host, port=int(nomad_port), timeout=5)
+    nomad_client = Nomad(nomad_host, port=int(nomad_port), timeout=30)
     hung_jobs = []
     for job in potentially_hung_jobs:
         try:
@@ -427,7 +427,7 @@ def requeue_survey_job(last_job: SurveyJob) -> None:
     """
     nomad_host = get_env_variable("NOMAD_HOST")
     nomad_port = get_env_variable("NOMAD_PORT", "4646")
-    nomad_client = Nomad(nomad_host, port=int(nomad_port), timeout=5)
+    nomad_client = Nomad(nomad_host, port=int(nomad_port), timeout=30)
     # Maximum number of total jobs running at a time.
     # We do this now rather than import time for testing purposes.
     MAX_TOTAL_JOBS = int(get_env_variable_gracefully("MAX_TOTAL_JOBS", 1000))
@@ -518,7 +518,7 @@ def retry_hung_survey_jobs() -> None:
 
     nomad_host = get_env_variable("NOMAD_HOST")
     nomad_port = get_env_variable("NOMAD_PORT", "4646")
-    nomad_client = Nomad(nomad_host, port=int(nomad_port), timeout=5)
+    nomad_client = Nomad(nomad_host, port=int(nomad_port), timeout=30)
     hung_jobs = []
     for job in potentially_hung_jobs:
         try:

--- a/foreman/data_refinery_foreman/foreman/test_main.py
+++ b/foreman/data_refinery_foreman/foreman/test_main.py
@@ -605,6 +605,20 @@ class ForemanTestCase(TestCase):
         self.assertEqual(last_job.num_retries, main.MAX_NUM_RETRIES)
         self.assertFalse(last_job.success)
 
+        # MAX TOTAL tests
+        self.env = EnvironmentVarGuard()
+        self.env.set('MAX_TOTAL_JOBS', '0')
+        with self.env:
+            job = self.create_survey_job()
+            result = main.handle_survey_jobs([job])
+            self.assertFalse(result)
+
+        self.env.set('MAX_TOTAL_JOBS', '1000')
+        with self.env:
+            job = self.create_survey_job()
+            result = main.requeue_survey_job(job)
+            self.assertTrue(result)
+
     @patch('data_refinery_foreman.foreman.main.send_job')
     def test_retrying_failed_survey_jobs(self, mock_send_job):
         mock_send_job.return_value = True
@@ -781,19 +795,7 @@ class ForemanTestCase(TestCase):
 
     @patch('data_refinery_foreman.foreman.main.send_job')
     def test_max_jobs(self, mock_send_job):
-        self.env = EnvironmentVarGuard()
-
-        self.env.set('MAX_TOTAL_JOBS', '0')
-        with self.env:
-            job = self.create_survey_job()
-            result = main.requeue_survey_job(job)
-            self.assertFalse(result)
-
-        self.env.set('MAX_TOTAL_JOBS', '1000')
-        with self.env:
-            job = self.create_survey_job()
-            result = main.requeue_survey_job(job)
-            self.assertTrue(result)
+        return
 
     @patch('data_refinery_foreman.foreman.main.send_job')
     def test_janitor(self, mock_send_job):

--- a/foreman/data_refinery_foreman/foreman/test_main.py
+++ b/foreman/data_refinery_foreman/foreman/test_main.py
@@ -794,10 +794,6 @@ class ForemanTestCase(TestCase):
         self.assertEqual(retried_job.num_retries, 1)
 
     @patch('data_refinery_foreman.foreman.main.send_job')
-    def test_max_jobs(self, mock_send_job):
-        return
-
-    @patch('data_refinery_foreman.foreman.main.send_job')
     def test_janitor(self, mock_send_job):
         mock_send_job.return_value = True
 

--- a/foreman/data_refinery_foreman/surveyor/management/commands/surveyor_dispatcher.py
+++ b/foreman/data_refinery_foreman/surveyor/management/commands/surveyor_dispatcher.py
@@ -66,10 +66,6 @@ def queue_surveyor_for_accession(accession: str) -> None:
     """Dispatches a surveyor job for the accession code."""
     # Start at 256MB of RAM for surveyor jobs.
     survey_job = SurveyJob(ram_amount=256)
-    # Survey Jobs will actually be dispatched by the foreman retry logic as capacity allows,
-    # so we set num_retries to -1 for right now.
-    survey_job.num_retries = -1
-
     set_source_type_for_accession(survey_job, accession)
 
     key_value_pair = SurveyJobKeyValue(survey_job=survey_job,

--- a/foreman/data_refinery_foreman/surveyor/management/commands/surveyor_dispatcher.py
+++ b/foreman/data_refinery_foreman/surveyor/management/commands/surveyor_dispatcher.py
@@ -66,6 +66,9 @@ def queue_surveyor_for_accession(accession: str) -> None:
     """Dispatches a surveyor job for the accession code."""
     # Start at 256MB of RAM for surveyor jobs.
     survey_job = SurveyJob(ram_amount=256)
+    # Survey Jobs will actually be dispatched by the foreman retry logic as capacity allows,
+    # so we set num_retries to -1 for right now.
+    survey_job.num_retries = -1
 
     set_source_type_for_accession(survey_job, accession)
 

--- a/foreman/data_refinery_foreman/surveyor/management/commands/surveyor_dispatcher.py
+++ b/foreman/data_refinery_foreman/surveyor/management/commands/surveyor_dispatcher.py
@@ -74,11 +74,8 @@ def queue_surveyor_for_accession(accession: str) -> None:
                                        value=accession)
     key_value_pair.save()
 
-    try:
-        send_job(SurveyJobTypes.SURVEYOR, survey_job)
-    except:
-        # If we can't dispatch this, then let the foreman retry it late.
-        pass
+    # We don't actually send the job here, we just create it.
+    # The foreman will pick it up and dispatch it when the time is appropriate.
 
 class Command(BaseCommand):
     def add_arguments(self, parser):

--- a/foreman/data_refinery_foreman/surveyor/test_end_to_end.py
+++ b/foreman/data_refinery_foreman/surveyor/test_end_to_end.py
@@ -8,6 +8,7 @@ from datetime import timedelta, datetime
 from django.test import TransactionTestCase, tag
 from django.utils import timezone
 from unittest.mock import patch, Mock
+from test.support import EnvironmentVarGuard # Python >=3
 
 from data_refinery_common.models import (
     Organism,
@@ -65,59 +66,63 @@ class NoOpEndToEndTestCase(TransactionTestCase):
     def test_no_op(self):
         """Survey, download, then process an experiment we know is NO_OP."""
         # Clear out pre-existing work dirs so there's no conflicts:
-        for work_dir in glob.glob(LOCAL_ROOT_DIR + "/processor_job_*"):
-            shutil.rmtree(work_dir)
 
-        # Make sure there are no already existing jobs we might poll for unsuccessfully.
-        DownloaderJobOriginalFileAssociation.objects.all().delete()
-        DownloaderJob.objects.all().delete()
-        ProcessorJobOriginalFileAssociation.objects.all().delete()
-        ProcessorJob.objects.all().delete()
+        self.env = EnvironmentVarGuard()
+        self.env.set('RUNING_IN_CLOUD', 'False')
+        with self.env:
+            for work_dir in glob.glob(LOCAL_ROOT_DIR + "/processor_job_*"):
+                shutil.rmtree(work_dir)
 
-        # Prevent a call being made to NCBI's API to determine
-        # organism name/id.
-        organism = Organism(name="HOMO_SAPIENS", taxonomy_id=9606, is_scientific_name=True)
-        organism.save()
+            # Make sure there are no already existing jobs we might poll for unsuccessfully.
+            DownloaderJobOriginalFileAssociation.objects.all().delete()
+            DownloaderJob.objects.all().delete()
+            ProcessorJobOriginalFileAssociation.objects.all().delete()
+            ProcessorJob.objects.all().delete()
 
-        accession_code = "E-GEOD-3303"
-        survey_job = surveyor.survey_experiment(accession_code, "ARRAY_EXPRESS")
+            # Prevent a call being made to NCBI's API to determine
+            # organism name/id.
+            organism = Organism(name="HOMO_SAPIENS", taxonomy_id=9606, is_scientific_name=True)
+            organism.save()
 
-        self.assertTrue(survey_job.success)
+            accession_code = "E-GEOD-3303"
+            survey_job = surveyor.survey_experiment(accession_code, "ARRAY_EXPRESS")
 
-        downloader_jobs = DownloaderJob.objects.all()
-        self.assertGreater(downloader_jobs.count(), 0)
+            self.assertTrue(survey_job.success)
 
-        logger.info("Survey Job finished, waiting for Downloader Jobs to complete.")
-        start_time = timezone.now()
-        for downloader_job in downloader_jobs:
-            downloader_job = wait_for_job(downloader_job, DownloaderJob, start_time)
-            self.assertTrue(downloader_job.success)
+            downloader_jobs = DownloaderJob.objects.all()
+            self.assertGreater(downloader_jobs.count(), 0)
 
-        processor_jobs = ProcessorJob.objects.all()
-        self.assertGreater(processor_jobs.count(), 0)
+            logger.info("Survey Job finished, waiting for Downloader Jobs to complete.")
+            start_time = timezone.now()
+            for downloader_job in downloader_jobs:
+                downloader_job = wait_for_job(downloader_job, DownloaderJob, start_time)
+                self.assertTrue(downloader_job.success)
 
-        logger.info("Downloader Jobs finished, waiting for processor Jobs to complete.")
-        start_time = timezone.now()
-        for processor_job in processor_jobs:
-            processor_job = wait_for_job(processor_job, ProcessorJob, start_time)
-            self.assertTrue(processor_job.success)
+            processor_jobs = ProcessorJob.objects.all()
+            self.assertGreater(processor_jobs.count(), 0)
 
-        # Test that the unsurveyor deletes all objects related to the experiment
-        purge_experiment(accession_code)
+            logger.info("Downloader Jobs finished, waiting for processor Jobs to complete.")
+            start_time = timezone.now()
+            for processor_job in processor_jobs:
+                processor_job = wait_for_job(processor_job, ProcessorJob, start_time)
+                self.assertTrue(processor_job.success)
 
-        self.assertEqual(Experiment.objects.all().count(), 0)
-        self.assertEqual(ExperimentAnnotation.objects.all().count(), 0)
-        self.assertEqual(ExperimentSampleAssociation.objects.all().count(), 0)
-        self.assertEqual(Sample.objects.all().count(), 0)
-        self.assertEqual(SampleAnnotation.objects.all().count(), 0)
-        self.assertEqual(OriginalFile.objects.all().count(), 0)
-        self.assertEqual(OriginalFileSampleAssociation.objects.all().count(), 0)
-        self.assertEqual(SampleResultAssociation.objects.all().count(), 0)
-        self.assertEqual(ComputationalResult.objects.all().count(), 0)
-        self.assertEqual(ComputationalResultAnnotation.objects.all().count(), 0)
-        self.assertEqual(SampleComputedFileAssociation.objects.all().count(), 0)
-        self.assertEqual(ComputedFile.objects.all().count(), 0)
-        self.assertEqual(DownloaderJob.objects.all().count(), 0)
-        self.assertEqual(DownloaderJobOriginalFileAssociation.objects.all().count(), 0)
-        self.assertEqual(ProcessorJob.objects.all().count(), 0)
-        self.assertEqual(ProcessorJobOriginalFileAssociation.objects.all().count(), 0)
+            # Test that the unsurveyor deletes all objects related to the experiment
+            purge_experiment(accession_code)
+
+            self.assertEqual(Experiment.objects.all().count(), 0)
+            self.assertEqual(ExperimentAnnotation.objects.all().count(), 0)
+            self.assertEqual(ExperimentSampleAssociation.objects.all().count(), 0)
+            self.assertEqual(Sample.objects.all().count(), 0)
+            self.assertEqual(SampleAnnotation.objects.all().count(), 0)
+            self.assertEqual(OriginalFile.objects.all().count(), 0)
+            self.assertEqual(OriginalFileSampleAssociation.objects.all().count(), 0)
+            self.assertEqual(SampleResultAssociation.objects.all().count(), 0)
+            self.assertEqual(ComputationalResult.objects.all().count(), 0)
+            self.assertEqual(ComputationalResultAnnotation.objects.all().count(), 0)
+            self.assertEqual(SampleComputedFileAssociation.objects.all().count(), 0)
+            self.assertEqual(ComputedFile.objects.all().count(), 0)
+            self.assertEqual(DownloaderJob.objects.all().count(), 0)
+            self.assertEqual(DownloaderJobOriginalFileAssociation.objects.all().count(), 0)
+            self.assertEqual(ProcessorJob.objects.all().count(), 0)
+            self.assertEqual(ProcessorJobOriginalFileAssociation.objects.all().count(), 0)

--- a/workers/illumina_dependencies.R
+++ b/workers/illumina_dependencies.R
@@ -7,7 +7,7 @@ devtools::install_version('data.table', version='1.11.0')
 devtools::install_version('optparse', version='1.4.4')
 devtools::install_version('lazyeval', version='0.2.1')
 devtools::install_version('tidyverse', version='1.2.1')
-devtools::install_version('rlang', version='0.2.2')
+devtools::install_version('rlang', version='0.3.0')
 
 # devtools::install_url() requires BiocInstaller
 install.packages('https://bioconductor.org/packages/3.6/bioc/src/contrib/BiocInstaller_1.28.0.tar.gz')

--- a/workers/install_gene_convert.R
+++ b/workers/install_gene_convert.R
@@ -4,7 +4,7 @@ devtools::install_version('data.table', version='1.11.0')
 devtools::install_version('optparse', version='1.4.4')
 
 devtools::install_version('tidyverse', version='1.2.1')
-devtools::install_version('rlang', version='0.2.2')
+devtools::install_version('rlang', version='0.3.0')
 
 # devtools::install_url() requires BiocInstaller
 install.packages('https://bioconductor.org/packages/3.6/bioc/src/contrib/BiocInstaller_1.28.0.tar.gz')


### PR DESCRIPTION
## Issue Number

https://github.com/hashicorp/nomad/issues/4864

## Purpose/Implementation Notes

Nomad is garbage, part two.

We keep all of the job needs in the database, so we don't need to have all of the stuff dispatched to a queue anyway. This sets an arbitrary limit on the number of dispatched survey jobs at a time. It looks like our problems mostly started at >100,000 jobs, so the new limit of 1000 should be safer without limiting our throughput.

## Types of changes
- New feature (non-breaking change which adds functionality)

## Functional tests

New test added. Currently running, might fail due to some unrelated R garbage.