### PR TITLE
Kill nomad jobs in groups of 500 during deploys

### DIFF
--- a/infrastructure/deploy.sh
+++ b/infrastructure/deploy.sh
@@ -219,9 +219,9 @@ if [[ $(nomad status) != "No running jobs" ]]; then
             counter=$((counter+1))
         fi
 
-        # Wait for all the jobs to stop every 500 so we don't knock
+        # Wait for all the jobs to stop every 100 so we don't knock
         # over the deploy box if there are 1000's.
-        if [[ "$counter" -gt 500 ]]; then
+        if [[ "$counter" -gt 100 ]]; then
             wait $(jobs -p)
             counter=0
         fi

--- a/infrastructure/deploy.sh
+++ b/infrastructure/deploy.sh
@@ -208,6 +208,7 @@ wait $(jobs -p)
 # apply migrations.
 echo "Killing dispatch jobs.. (this also takes a while..)"
 if [[ $(nomad status) != "No running jobs" ]]; then
+    counter=0
     for job in $(nomad status | awk {'print $1'} || grep /)
     do
         # Skip the header row for jobs.
@@ -215,11 +216,19 @@ if [[ $(nomad status) != "No running jobs" ]]; then
             # '|| true' so that if a job is garbage collected before we can remove it the error
             # doesn't interrupt our deploy.
             nomad stop -purge -detach $job > /dev/null || true &
+            counter=$((counter+1))
+        fi
+
+        # Wait for all the jobs to stop every 500 so we don't knock
+        # over the deploy box if there are 1000's.
+        if [[ "$counter" -gt 500 ]]; then
+            wait $(jobs -p)
+            counter=0
         fi
     done
 fi
 
-# Wait for these jobs to all die.
+# Wait for any remaining jobs to all die.
 wait $(jobs -p)
 
 # Make sure that prod_env is empty since we are only appending to it.


### PR DESCRIPTION
## Issue Number

https://github.com/AlexsLemonade/refinebio/issues/796

## Purpose/Implementation Notes

The old strategy for killing nomad jobs was to loop through them all with bash, kill each job in a background process, and then wait for all the processes to complete. However this ended up blowing out our RAM usage very heavily causing the issue reported in #796. (At least this what I think crashed it.)

This changes it so we only fire off 500 background processes at a time before waiting for them to complete so we won't have so many running at once.

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

Testing this was harder than implementing it, but what I did was:
  * Modified `deploy.sh` so only the nomad killing part ran and that the Nomad address was set to my local instance of Nomad.
  * Modified `run_nomad.sh` so it ran in server mode instead of dev mode. This meant that dispatched jobs wouldn't run so I could build up a reliable amount of them and not blow out my laptop running actual work.
  * Queued up 10k surveyor jobs using `./foreman/run_surveyor.sh surveyor_dispatcher --file s3://data-refinery-test-assets/ONE_PERCENT_CRUNCH.txt`.
  * Ran the modified `deploy.sh` script to kill them.
  * Monitored my RAM usage in `htop`.

I did this with and without my change. The baseline htop stats after I queued all the jobs with my other processes was 11.5GB with a limit of 15.4GB.

Without this change the RAM got completely saturated and had to use 1.5GB of swap.

With this change RAM never exceeded 13.4 GB and swap was unutilized. I also saw a pattern of the RAM going up a GB or two and then back down once the script hit the periodic `wait`.

I call it a win!

## Checklist

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules
