### PR TITLE
Fix the staging domain names and disable cloudfront for dev.

### DIFF
--- a/.circleci/remote_deploy.sh
+++ b/.circleci/remote_deploy.sh
@@ -99,7 +99,7 @@ echo "Finished building new images, running run_terraform.sh."
 run_on_deploy_box "sudo touch /var/log/deploy_$CIRCLE_TAG.log"
 run_on_deploy_box "sudo chown ubuntu:ubuntu /var/log/deploy_$CIRCLE_TAG.log"
 run_on_deploy_box "source env_vars && echo -e '######\nStarting new deploy for $CIRCLE_TAG\n######' >> /var/log/deploy_$CIRCLE_TAG.log 2>&1"
-run_on_deploy_box "source env_vars && bash .circleci/run_terraform.sh >> /var/log/deploy_$CIRCLE_TAG.log 2>&1"
+run_on_deploy_box "source env_vars && ./.circleci/run_terraform.sh >> /var/log/deploy_$CIRCLE_TAG.log 2>&1"
 run_on_deploy_box "source env_vars && echo -e '######\nDeploying $CIRCLE_TAG finished!\n######' >> /var/log/deploy_$CIRCLE_TAG.log 2>&1"
 
 # Don't leave secrets lying around.

--- a/.circleci/run_terraform.sh
+++ b/.circleci/run_terraform.sh
@@ -1,3 +1,5 @@
+#!/bin/bash -e
+
 # Import Hashicorps' Key.
 curl https://keybase.io/hashicorp/pgp_keys.asc | gpg --import
 
@@ -70,6 +72,3 @@ fi
 
 # New deployment
 ./deploy.sh -e $ENVIRONMENT -v $CIRCLE_TAG -u circleci
-exit_code=$?
-
-exit $exit_code

--- a/infrastructure/networking.tf
+++ b/infrastructure/networking.tf
@@ -174,6 +174,11 @@ locals {
 # this since we're using cloudfront. The cert for the API is created
 # an installed by certbot.
 resource "aws_acm_certificate" "ssl-cert" {
+  # We don't need this resource for dev stacks.
+  # Apparently `count` is the officially recommended way to conditionally enable or disable a resource:
+  # https://github.com/hashicorp/terraform/issues/1604#issuecomment-266070770
+  count = "${var.stage == "dev" ? 0 : 1}"
+
   domain_name = "${ var.stage == "prod" ? "www." : local.stage_with_dot }refine.bio"
   validation_method = "DNS"
 
@@ -183,11 +188,21 @@ resource "aws_acm_certificate" "ssl-cert" {
 }
 
 resource "aws_acm_certificate_validation" "ssl-cert" {
+  # We don't need this resource for dev stacks.
+  # Apparently `count` is the officially recommended way to conditionally enable or disable a resource:
+  # https://github.com/hashicorp/terraform/issues/1604#issuecomment-266070770
+  count = "${var.stage == "dev" ? 0 : 1}"
+
   certificate_arn = "${aws_acm_certificate.ssl-cert.arn}"
 }
 
 resource "aws_cloudfront_distribution" "static-distribution" {
-  aliases = ["${var.static_bucket_prefix == "dev" ? var.user : var.static_bucket_prefix}${var.static_bucket_root}", "www.refine.bio"]
+  # We don't need this resource for dev stacks.
+  # Apparently `count` is the officially recommended way to conditionally enable or disable a resource:
+  # https://github.com/hashicorp/terraform/issues/1604#issuecomment-266070770
+  count = "${var.stage == "dev" ? 0 : 1}"
+
+  aliases = ["${aws_acm_certificate.ssl-cert.domain_name}"]
 
   origin {
     domain_name = "${aws_s3_bucket.data-refinery-static.website_endpoint}"


### PR DESCRIPTION
## Issue Number

#844 

## Purpose/Implementation Notes

The changes to infrastructure should make it so we don't trip up creating the staging cloudfront distribution so we can deploy. It also disables cloudfront for dev deploys since we don't need it.

I haven't been able to figure out why `remote_deploy.sh` doesn't die after `run_terraform.sh` fails, but this cleans up the way it is called a bit.

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

N/A cause this is all deploy related.

## Checklist

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules
