### PR TITLE
Escape the dollar sign so bash doesn't think we're talkin' bout a va…

### DIFF
--- a/format_nomad_with_env.sh
+++ b/format_nomad_with_env.sh
@@ -203,7 +203,7 @@ export_log_conf (){
         # local/test can still run smasher jobs.
         export SMASHER_CONSTRAINT="
         constraint {
-          attribute = \"${meta.is_smasher}\"
+          attribute = \"\${meta.is_smasher}\"
           operator = \"=\"
           value = \"true\"
         }"


### PR DESCRIPTION
…riable.

## Issue Number

N/A: came up in v1.1.11-dev deploy

## Purpose/Implementation Notes

We got a:
```
../format_nomad_with_env.sh: line 209: 
        constraint {
          attribute = "${meta.is_smasher}"
          operator = "="
          value = "true"
        }: bad substitution
```

because I forgot to retest dev/staging/prod in #834 after I made modifications to get dev/staging working.

This fixes it.

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

I was able to reproduce this:
```
$ sudo ./format_nomad_with_env.sh -p workers -e dev
./format_nomad_with_env.sh: line 172: /home/kurt/Development/refinebio/infrastructure/prod_env: No such file or directory
./format_nomad_with_env.sh: line 209: 
        constraint {
          attribute = "${meta.is_smasher}"
          operator = "="
          value = "true"
        }: bad substitution
```

and then after my change it didn't happen and I checked the output file and it looks good. I'm not going to do a dev deploy for the sake of time and getting this running again.

## Checklist

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules
