### PR TITLE
Utilizes the ServerAliveInterval for remote ssh commands when deployi…

### DIFF
--- a/.circleci/remote_deploy.sh
+++ b/.circleci/remote_deploy.sh
@@ -26,6 +26,7 @@ chmod 600 infrastructure/data-refinery-key.pem
 
 run_on_deploy_box () {
     ssh -o StrictHostKeyChecking=no \
+        -o ServerAliveInterval=15 \
         -i infrastructure/data-refinery-key.pem \
         ubuntu@"${DEPLOY_IP_ADDRESS}" "cd refinebio && $1"
 }


### PR DESCRIPTION
## Issue Number

N/A, I made this PR rather than an issue.

## Purpose/Implementation Notes

https://circleci.com/gh/AlexsLemonade/refinebio/9888 finished running `deploy.sh`, which is the last step of `run_terraform.sh`, so it should have completed. Instead the process got hung at that point. 

I'm not 100% sure this is what the issue is, but it's my best guess and this is going to be a hard problem to reliably reproduce. The good news is that once we get there the deploy has finished except for a small amount of cleanup and a notification so if this does happen again we can manually clean up after the deploy and it won't really throw a spanner into anything.

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

N/A since this is purely deploy-related. I did make sure that's a valid ssh option though by using it in an SSH connection.

## Checklist

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules
