### PR TITLE
Lower Nomad Garbage Collection Interval

### DIFF
--- a/infrastructure/nomad-configuration/lead_server.hcl
+++ b/infrastructure/nomad-configuration/lead_server.hcl
@@ -10,6 +10,9 @@ data_dir = "/tmp/nomad_server1"
 server {
     enabled = true
 
+    # Clean out old jobs sooner
+    job_gc_threshold = "5m"
+
     # Only 1 for the lead server, 3 for the others. Tx Kurt.
     bootstrap_expect = 1
 }

--- a/infrastructure/nomad-configuration/server.tpl.hcl
+++ b/infrastructure/nomad-configuration/server.tpl.hcl
@@ -13,6 +13,9 @@ server {
   # Self-elect, should be 3 or 5 for production
   bootstrap_expect = 3
 
+  # Clean out old jobs quickly
+  job_gc_threshold = "5m"
+
   # This is the IP address of the first server we provisioned
   retry_join = ["${nomad_lead_server_ip}:4648"]
 }


### PR DESCRIPTION
## Issue Number
n/a

## Purpose/Implementation Notes
Lowers the Nomad GC interval from the default 4h to 5m. This uses less resources and gives us much more time to allocate jobs before hitting our self-impose ceiling.

- New feature (non-breaking change which adds functionality)
