### PR TITLE
Api optimizations

### DIFF
--- a/api/data_refinery_api/serializers.py
+++ b/api/data_refinery_api/serializers.py
@@ -146,36 +146,6 @@ class SampleSerializer(serializers.ModelSerializer):
                     'last_modified',
                 )
 
-class SearchSampleSerializer(serializers.ModelSerializer):
-
-    class Meta:
-        model = Sample
-        fields = (
-                    'id',
-                    'title',
-                    'accession_code',
-                    'source_database',
-                    'platform_accession_code',
-                    'platform_name',
-                    'pretty_platform',
-                    'technology',
-                    'sex',
-                    'age',
-                    'specimen_part',
-                    'genotype',
-                    'disease',
-                    'disease_stage',
-                    'cell_line',
-                    'treatment',
-                    'race',
-                    'subject',
-                    'compound',
-                    'time',
-                    'is_processed',
-                    'created_at',
-                    'last_modified',
-                )
-
 class SampleAnnotationSerializer(serializers.ModelSerializer):
 
     class Meta:
@@ -291,9 +261,21 @@ class ExperimentAnnotationSerializer(serializers.ModelSerializer):
                     'last_modified',
                 )
 
+class DetailedExperimentSampleSerializer(serializers.ModelSerializer):
+
+    class Meta:
+        model = Sample
+        fields = (
+                    'accession_code',
+                    'platform_name',
+                    'pretty_platform',
+                    'technology',
+                    'is_processed',
+                )
+
 class DetailedExperimentSerializer(serializers.ModelSerializer):
     annotations = ExperimentAnnotationSerializer(many=True, source='experimentannotation_set')
-    samples = SampleSerializer(many=True)
+    samples = DetailedExperimentSampleSerializer(many=True)
     organisms = OrganismSerializer(many=True)
     sample_metadata = serializers.ReadOnlyField(source='get_sample_metadata_fields')
 

--- a/api/data_refinery_api/serializers.py
+++ b/api/data_refinery_api/serializers.py
@@ -233,13 +233,14 @@ class DetailedSampleSerializer(serializers.ModelSerializer):
 
 class ExperimentSerializer(serializers.ModelSerializer):
     organisms = serializers.StringRelatedField(many=True, read_only=True)
-    samples = SearchSampleSerializer(many=True, read_only=True)
+    platforms = serializers.ReadOnlyField()
+    processed_samples = serializers.StringRelatedField(many=True)
     total_samples_count = serializers.IntegerField(
                         read_only=True
                     )
-    processed_samples_count = serializers.IntegerField(
-                        read_only=True
-                    )
+    sample_metadata = serializers.ReadOnlyField(source='get_sample_metadata_fields')
+    technologies = serializers.ReadOnlyField(source='get_sample_technologies')
+    pretty_platforms = serializers.ReadOnlyField()
 
     class Meta:
         model = Experiment
@@ -251,18 +252,21 @@ class ExperimentSerializer(serializers.ModelSerializer):
                     'alternate_accession_code',
                     'source_database',
                     'source_url',
+                    'platforms',
+                    'pretty_platforms',
+                    'processed_samples',
                     'has_publication',
                     'publication_title',
                     'publication_doi',
                     'publication_authors',
                     'pubmed_id',
-                    'samples',
                     'total_samples_count',
-                    'processed_samples_count',
                     'organisms',
                     'submitter_institution',
                     'created_at',
                     'last_modified',
+                    'sample_metadata',
+                    'technologies'
                 )
 
     def setup_eager_loading(queryset):


### PR DESCRIPTION
## Issue Number

close #832 

## Purpose/Implementation Notes

Changes the result of the search and experiments endpoints.

- For the search endpoint, on each experiment, removes the samples and only sends the accession codes of the processed ones.

- For the experiments endpoint, uses a custom serializer for the samples to reduce the amount of information that is sent. Consumers of the API can query the detailed samples endpoint to get all information for each sample.

These changes will break the frontend, I'll file a PR there in a moment.

## Types of changes

- Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots

Search endpoint:
![image](https://user-images.githubusercontent.com/1882507/48856761-4e023180-ed85-11e8-9554-6b4e5cb3c2eb.png)

Experiments:
![image](https://user-images.githubusercontent.com/1882507/48856805-68d4a600-ed85-11e8-84c1-0ffb3fca1b8a.png)
