### PR TITLE
Wait for nomad to come online while deploying and also in run_nomad.sh

### DIFF
--- a/common.sh
+++ b/common.sh
@@ -56,3 +56,12 @@ get_master_or_dev() {
         exit 1
     fi
 }
+
+# This function checks what the status of the Nomad agent is.
+# Returns an HTTP response code. i.e. 200 means everything is ok.
+check_nomad_status () {
+    echo $(curl --write-out %{http_code} \
+                  --silent \
+                  --output /dev/null \
+                  $NOMAD_ADDR/v1/status/leader)
+}

--- a/infrastructure/deploy.sh
+++ b/infrastructure/deploy.sh
@@ -271,6 +271,16 @@ mkdir -p nomad-job-specs
 # Don't leave secrets lying around!
 rm -f prod_env
 
+# Wait for Nomad to get started.
+## A maximum of 10 minutes, since if a deploy necessitates new nomad
+## servers they can take a bit to come up.
+END_SECONDS=$(($SECONDS+600))
+nomad_status=$(check_nomad_status)
+while [ $nomad_status != "200" ] && [ $SECONDS -lt $END_SECONDS ]; do
+    sleep 1
+    nomad_status=$(check_nomad_status)
+done
+
 # Re-register Nomad jobs.
 echo "Registering new job specifications.."
 nomad_job_specs=nomad-job-specs/*

--- a/run_nomad.sh
+++ b/run_nomad.sh
@@ -109,18 +109,11 @@ if [[ -z $(docker ps | grep "image-registry") ]]; then
     docker run -d -p 5000:5000 --restart=always --name image-registry registry:2
 fi
 
-# This function checks what the status of the Nomad agent is.
-# Returns an HTTP response code. i.e. 200 means everything is ok.
-check_nomad_status () {
-    echo $(curl --write-out %{http_code} \
-                  --silent \
-                  --output /dev/null \
-                  $NOMAD_ADDR/v1/status/leader)
-}
-
 # Wait for Nomad to get started.
+## A maximum of 1 minute, since it shouldn't take longer than that.
+END_SECONDS=$(($SECONDS+60))
 nomad_status=$(check_nomad_status)
-while [ $nomad_status != "200" ]; do
+while [ $nomad_status != "200" ] && [ $SECONDS -lt $END_SECONDS ]; do
     sleep 1
     nomad_status=$(check_nomad_status)
 done


### PR DESCRIPTION
## Issue Number

N/A came up while running a deploy yesterday

## Purpose/Implementation Notes

We had a deploy fail because it couldn't register the nomad jobs. This was because the nomad servers were still spinning up. Therefore, this PR adds a loop to wait on Nomad coming up before trying to register the jobs.

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

I've tested the loop structure, but it needs a deploy to really be tested. Should I do one on a dev stack?

## Checklist

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules
