### PR TITLE
Add Health Monitoring to Foreman Process with Monit

### DIFF
--- a/foreman/data_refinery_foreman/foreman/main.py
+++ b/foreman/data_refinery_foreman/foreman/main.py
@@ -761,7 +761,7 @@ def monitor_jobs():
         # Write the health file for Monit to check
         now_secs = int(time.time())
         with open('/tmp/foreman_last_time', 'w') as timefile:
-            timefile.write(now_secs)
+            timefile.write(str(now_secs))
 
         start_time = timezone.now()
 

--- a/foreman/data_refinery_foreman/foreman/main.py
+++ b/foreman/data_refinery_foreman/foreman/main.py
@@ -769,3 +769,7 @@ def monitor_jobs():
             time.sleep(remaining_time.seconds)
 
         logger.info("The Foreman's heart is beating, but he does not feel.")
+
+        now_secs = int(time.time())
+        with open('/tmp/foreman_last', 'w') as timefile:
+            timefile.write(now_secs)

--- a/foreman/data_refinery_foreman/foreman/main.py
+++ b/foreman/data_refinery_foreman/foreman/main.py
@@ -757,6 +757,12 @@ def monitor_jobs():
 
     # Make sure that no threads die quietly.
     while(True):
+
+        # Write the health file for Monit to check
+        now_secs = int(time.time())
+        with open('/tmp/foreman_last_time', 'w') as timefile:
+            timefile.write(now_secs)
+
         start_time = timezone.now()
 
         for thread in threads:
@@ -769,7 +775,3 @@ def monitor_jobs():
             time.sleep(remaining_time.seconds)
 
         logger.info("The Foreman's heart is beating, but he does not feel.")
-
-        now_secs = int(time.time())
-        with open('/tmp/foreman_last', 'w') as timefile:
-            timefile.write(now_secs)

--- a/infrastructure/foreman-configuration/foreman-server-instance-user-data.tpl.sh
+++ b/infrastructure/foreman-configuration/foreman-server-instance-user-data.tpl.sh
@@ -19,6 +19,9 @@ EOF
 
 # These database values are created after TF
 # is run, so we have to pass them in programatically
+echo "
+docker kill $(docker ps -q)
+sleep 120
 docker run \
        --env-file environment \
        -e DATABASE_HOST=${database_host} \
@@ -31,7 +34,35 @@ docker run \
        --log-opt awslogs-group=${log_group} \
        --log-opt awslogs-stream=log-stream-foreman-${user}-${stage} \
        -it -d ${dockerhub_repo}/${foreman_docker_image} python3 manage.py retry_jobs
+" >> /home/ubuntu/run_foreman.sh
+chmod +x /home/ubuntu/run_foreman.sh
+/home/ubuntu/run_foreman.sh
 
+# Start the Nomad agent in server mode via Monit
+apt-get -y install monit htop
+
+echo '
+#!/bin/sh
+lasttime=$(</tmp/foreman_last)
+nowtime=`date +%s`
+let "difftime=$nowtime-$lasttime"
+if [difftime -gt 600]:
+then
+  exit 1;
+fi
+exit 0;
+' >> /home/ubuntu/foreman_status.sh
+chmod +x /home/ubuntu/foreman_status.sh
+
+echo '
+check program foreman with path "/bin/bash /home/ubuntu/foreman_status.sh" as uid 0 and with gid 0
+    start program = "/home/ubuntu/run_foreman.sh" as uid 0 and with gid 0
+    if status != 0
+        then restart
+set daemon 300
+' >> /etc/monit/monitrc
+
+service monit restart
 
 # Delete the cloudinit and syslog in production.
 export STAGE=${stage}

--- a/infrastructure/foreman-configuration/foreman-server-instance-user-data.tpl.sh
+++ b/infrastructure/foreman-configuration/foreman-server-instance-user-data.tpl.sh
@@ -39,6 +39,7 @@ chmod +x /home/ubuntu/run_foreman.sh
 /home/ubuntu/run_foreman.sh
 
 # Start the Nomad agent in server mode via Monit
+apt-get -y update
 apt-get -y install monit htop
 
 date +%s > /tmp/foreman_last_time

--- a/infrastructure/foreman-configuration/foreman-server-instance-user-data.tpl.sh
+++ b/infrastructure/foreman-configuration/foreman-server-instance-user-data.tpl.sh
@@ -43,6 +43,7 @@ apt-get -y update
 apt-get -y install monit htop
 
 date +%s > /tmp/foreman_last_time
+chown ubuntu:ubuntu /tmp/foreman_last_time
 echo '
 #!/bin/sh
 lasttime=$(</tmp/foreman_last_time);

--- a/infrastructure/foreman-configuration/foreman-server-instance-user-data.tpl.sh
+++ b/infrastructure/foreman-configuration/foreman-server-instance-user-data.tpl.sh
@@ -20,6 +20,7 @@ EOF
 # These database values are created after TF
 # is run, so we have to pass them in programatically
 echo "
+#!/bin/sh
 docker kill \$(docker ps -q)
 sleep 120
 docker run \\

--- a/infrastructure/foreman-configuration/foreman-server-instance-user-data.tpl.sh
+++ b/infrastructure/foreman-configuration/foreman-server-instance-user-data.tpl.sh
@@ -28,6 +28,7 @@ docker run \\
        -e DATABASE_NAME=${database_name} \\
        -e DATABASE_USER=${database_user} \\
        -e DATABASE_PASSWORD=${database_password} \\
+       -v /tmp:/tmp \\
        --add-host=nomad:${nomad_lead_server_ip} \\
        --log-driver=awslogs \\
        --log-opt awslogs-region=${region} \\

--- a/infrastructure/foreman-configuration/foreman-server-instance-user-data.tpl.sh
+++ b/infrastructure/foreman-configuration/foreman-server-instance-user-data.tpl.sh
@@ -20,19 +20,19 @@ EOF
 # These database values are created after TF
 # is run, so we have to pass them in programatically
 echo "
-docker kill $(docker ps -q)
+docker kill \$(docker ps -q)
 sleep 120
-docker run \
-       --env-file environment \
-       -e DATABASE_HOST=${database_host} \
-       -e DATABASE_NAME=${database_name} \
-       -e DATABASE_USER=${database_user} \
-       -e DATABASE_PASSWORD=${database_password} \
-       --add-host=nomad:${nomad_lead_server_ip}\
-       --log-driver=awslogs \
-       --log-opt awslogs-region=${region} \
-       --log-opt awslogs-group=${log_group} \
-       --log-opt awslogs-stream=log-stream-foreman-${user}-${stage} \
+docker run \\
+       --env-file environment \\
+       -e DATABASE_HOST=${database_host} \\
+       -e DATABASE_NAME=${database_name} \\
+       -e DATABASE_USER=${database_user} \\
+       -e DATABASE_PASSWORD=${database_password} \\
+       --add-host=nomad:${nomad_lead_server_ip} \\
+       --log-driver=awslogs \\
+       --log-opt awslogs-region=${region} \\
+       --log-opt awslogs-group=${log_group} \\
+       --log-opt awslogs-stream=log-stream-foreman-${user}-${stage} \\
        -it -d ${dockerhub_repo}/${foreman_docker_image} python3 manage.py retry_jobs
 " >> /home/ubuntu/run_foreman.sh
 chmod +x /home/ubuntu/run_foreman.sh

--- a/infrastructure/foreman-configuration/foreman-server-instance-user-data.tpl.sh
+++ b/infrastructure/foreman-configuration/foreman-server-instance-user-data.tpl.sh
@@ -21,10 +21,9 @@ EOF
 # is run, so we have to pass them in programatically
 echo "
 #!/bin/sh
-docker kill \$(docker ps -q)
-sleep 120
+docker kill \$(docker ps -q) || true
 docker run \\
-       --env-file environment \\
+       --env-file /home/ubuntu/environment \\
        -e DATABASE_HOST=${database_host} \\
        -e DATABASE_NAME=${database_name} \\
        -e DATABASE_USER=${database_user} \\
@@ -60,10 +59,10 @@ chmod +x /home/ubuntu/foreman_status.sh
 
 echo '
 check program foreman with path "/bin/bash /home/ubuntu/foreman_status.sh" as uid 0 and with gid 0
-    start program = "/home/ubuntu/run_foreman.sh" as uid 0 and with gid 0
+    start program = "/bin/bash /home/ubuntu/run_foreman.sh" as uid 0 and with gid 0
     if status != 0
         then restart
-set daemon 300
+set daemon 900
 ' >> /etc/monit/monitrc
 
 service monit restart

--- a/infrastructure/foreman-configuration/foreman-server-instance-user-data.tpl.sh
+++ b/infrastructure/foreman-configuration/foreman-server-instance-user-data.tpl.sh
@@ -41,13 +41,13 @@ chmod +x /home/ubuntu/run_foreman.sh
 # Start the Nomad agent in server mode via Monit
 apt-get -y install monit htop
 
+date +%s > /tmp/foreman_last_time
 echo '
 #!/bin/sh
-lasttime=$(</tmp/foreman_last)
-nowtime=`date +%s`
-let "difftime=$nowtime-$lasttime"
-if [difftime -gt 600]:
-then
+lasttime=$(</tmp/foreman_last_time);
+nowtime=`date +%s`;
+((difftime = $nowtime - $lasttime));
+if (( $difftime > 1800 )); then
   exit 1;
 fi
 exit 0;


### PR DESCRIPTION
## Issue Number

The foreman process died inexplicably (via a hang), and it was not able to automatically recover.

This adds a time-based health heartbeat and uses `monit` to monitor and restart the foreman process based on this health information. 

## Purpose/Implementation Notes

We already use `monit` elsewhere, this uses a similar pattern.

## Types of changes

- New feature (non-breaking change which adds functionality)

## Functional tests

Testing now with a dev stack now..
