### PR TITLE
Kurtwheeler/take foreman to school

### DIFF
--- a/api/requirements.in
+++ b/api/requirements.in
@@ -3,7 +3,7 @@ django
 psycopg2-binary
 boto3
 requests>=2.20.0
-python-nomad
+python-nomad>=1.0.2
 djangorestframework
 djangorestframework-hstore
 django-cors-headers

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -26,7 +26,7 @@ markupsafe==1.0           # via jinja2
 psycopg2-binary==2.7.5
 psycopg2==2.7.5           # via djangorestframework-hstore
 python-dateutil==2.7.3    # via botocore
-python-nomad==0.9.0
+python-nomad==1.0.2
 pytz==2018.5              # via django
 requests==2.20.0
 s3transfer==0.1.13        # via boto3

--- a/common/requirements.in
+++ b/common/requirements.in
@@ -5,5 +5,5 @@ boto3
 requests>=2.20.0
 retrying
 daiquiri
-python-nomad
+python-nomad>=1.0.2
 raven

--- a/common/requirements.txt
+++ b/common/requirements.txt
@@ -16,7 +16,7 @@ idna==2.7                 # via requests
 jmespath==0.9.3           # via boto3, botocore
 psycopg2-binary==2.7.5
 python-dateutil==2.7.3    # via botocore
-python-nomad==0.9.0
+python-nomad==1.0.2
 pytz==2018.5              # via django
 raven==6.9.0
 requests==2.20.0

--- a/foreman/data_refinery_foreman/foreman/main.py
+++ b/foreman/data_refinery_foreman/foreman/main.py
@@ -778,7 +778,7 @@ def cleanup_the_queue():
                 # the job and decrement the retry counter (since it
                 # will be incremented when it is requeued).
                 try:
-                    nomad_client.job.deregister_job(job["ID"])
+                    nomad_client.job.deregister_job(job["ID"], purge=True)
                     job_record = ProcessorJob(nomad_job_id=job["ID"])
                     job_record.num_retries = job_record.num_retries - 1
                     job_record.save()

--- a/foreman/data_refinery_foreman/foreman/main.py
+++ b/foreman/data_refinery_foreman/foreman/main.py
@@ -794,9 +794,6 @@ def cleanup_the_queue():
 
 def monitor_jobs():
     """Runs a thread for each job monitoring loop."""
-    processor_functions = [ retry_failed_processor_jobs,
-                            retry_hung_processor_jobs,
-                            retry_lost_processor_jobs]
 
     threads = []
 
@@ -804,8 +801,17 @@ def monitor_jobs():
     thread = Thread(target=send_janitor_jobs, name="send_janitor_jobs")
     thread.start()
     threads.append(thread)
-    logger.info("Thread started for monitoring function: send_janitor_jobs")
+    logger.info("Thread started for function: send_janitor_jobs")
 
+    # Start the thread to keep the Nomad clean of jobs it cannot place.
+    thread = Thread(target=cleanup_the_queue, name="cleanup_the_queue")
+    thread.start()
+    threads.append(thread)
+    logger.info("Thread started for function: cleanup_the_queue")
+
+    processor_functions = [ retry_failed_processor_jobs,
+                            retry_hung_processor_jobs,
+                            retry_lost_processor_jobs]
 
     for f in processor_functions:
         thread = Thread(target=f, name=f.__name__)

--- a/foreman/data_refinery_foreman/foreman/main.py
+++ b/foreman/data_refinery_foreman/foreman/main.py
@@ -3,7 +3,7 @@ import socket
 import time
 from nomad import Nomad
 from nomad.api.exceptions import URLNotFoundNomadException
-from typing import Callable, List
+from typing import Callable, List, Set
 from threading import Thread
 from functools import wraps
 from retrying import retry
@@ -45,6 +45,9 @@ THREAD_WAIT_TIME = timedelta(minutes=10)
 
 # How frequently we dispatch Janitor jobs.
 JANITOR_DISPATCH_TIME = timedelta(minutes=30)
+
+# How frequently we clean unplaceable jobs out of the Nomad queue.
+CLEANUP_QUEUE_TIME = timedelta(minutes=30)
 
 
 ##
@@ -94,6 +97,23 @@ def handle_repeated_failure(job) -> None:
     # sufficient because all log messages will be closely monitored
     # during early testing stages.
     logger.warn("%s #%d failed %d times!!!", job.__class__.__name__, job.id, MAX_NUM_RETRIES + 1)
+
+
+def get_active_volumes() -> Set[str]:
+    """Returns a Set of indices for volumes that are currently mounted.
+
+    These can be used to determine which jobs would actually be able
+    to be placed if they were queued up.
+    """
+    nomad_host = get_env_variable("NOMAD_HOST")
+    nomad_port = get_env_variable("NOMAD_PORT", "4646")
+    nomad_client = nomad.Nomad(nomad_host, port=int(nomad_port), timeout=30)
+
+    volumes = set()
+    for node in nomad_client.nodes.get_nodes():
+        volumes.add(nomad_client.node.get_node(node["ID"])['Meta']['volume_index'])
+
+    return volumes
 
 
 ##
@@ -365,9 +385,12 @@ def retry_failed_processor_jobs() -> None:
     """Handle processor jobs that were marked as a failure.
 
     Ignores Janitor jobs since they are queued every half hour anyway."""
+    active_volumes = get_active_volumes()
+
     failed_jobs = ProcessorJob.objects.filter(
         success=False,
-        retried=False
+        retried=False,
+        volume_index__in=active_volumes
     ).exclude(
         pipeline_applied="JANITOR"
     )
@@ -385,12 +408,15 @@ def retry_hung_processor_jobs() -> None:
     """Retry processor jobs that were started but never finished.
 
     Ignores Janitor jobs since they are queued every half hour anyway."""
+    active_volumes = get_active_volumes()
+
     potentially_hung_jobs = ProcessorJob.objects.filter(
         success=None,
         retried=False,
         end_time=None,
         start_time__isnull=False,
         no_retry=False,
+        volume_index__in=active_volumes
     ).exclude(
         pipeline_applied="JANITOR"
     )
@@ -426,12 +452,15 @@ def retry_lost_processor_jobs() -> None:
     """Retry processor jobs which never even got started for too long.
 
     Ignores Janitor jobs since they are queued every half hour anyway."""
+    active_volumes = get_active_volumes()
+
     potentially_lost_jobs = ProcessorJob.objects.filter(
         success=None,
         retried=False,
         start_time=None,
         end_time=None,
-        no_retry=False
+        no_retry=False,
+        volume_index__in=active_volumes
     ).exclude(
         pipeline_applied="JANITOR"
     )
@@ -680,26 +709,84 @@ def retry_lost_survey_jobs() -> None:
 @do_forever(JANITOR_DISPATCH_TIME)
 def send_janitor_jobs():
     """Dispatch a Janitor job for each instance in the cluster"""
+    active_volumes = get_active_volumes()
 
-    # This is a fairly hacky way of finding all of our volume indexes
-    indexes = ProcessorJob.objects.all().values_list('volume_index').distinct()
-
-    for index in indexes:
-        actual_index = index[0]
+    for volume_index in active_volumes:
         new_job = ProcessorJob(num_retries=0,
                                pipeline_applied="JANITOR",
                                ram_amount=2048,
-                               volume_index=actual_index)
+                               volume_index=volume_index)
         new_job.save()
         logger.info("Sending Janitor with index: ",
             job_id=new_job.id,
-            index=actual_index
+            index=volume_index
         )
         try:
             send_job(ProcessorPipeline["JANITOR"], job=new_job, is_dispatch=True)
         except Exception as e:
             # If we can't dispatch this job, something else has gone wrong.
             continue
+
+
+##
+# Handling of node cycling
+##
+
+@do_forever(CLEANUP_QUEUE_TIME)
+def cleanup_the_queue():
+    """This cleans up any jobs which cannot currently be queued.
+
+    We often have more volumes than instances because we have enough
+    volumes for the scenario where the entire cluster is using the
+    smallest instance type, however that doesn't happen very
+    often. Therefore it's possible for some volumes to not be mounted,
+    which means that jobs which are constrained to run on instances
+    with those volumes cannot be placed and just clog up the queue.
+
+    Therefore we clear out jobs of that type every once in a while so
+    our queue is dedicated to jobs that can actually be placed.
+    """
+    # Smasher and QN Reference jobs aren't tied to a specific EBS volume.
+    indexed_job_types = [e.value for e in ProcessorPipeline if e.value not in ["SMASHER", "QN_REFERENCE"]]
+    active_volumes = get_active_volumes()
+
+    nomad_host = get_env_variable("NOMAD_HOST")
+    nomad_port = get_env_variable("NOMAD_PORT", "4646")
+    nomad_client = nomad.Nomad(nomad_host, port=int(nomad_port), timeout=30)
+
+    jobs = nomad_client.jobs.get_jobs()
+
+    jobs_to_kill = []
+    for job in jobs:
+        # Skip over the Parameterized Jobs because we need those to
+        # always be running.
+        if not job["ParameterizedJob"]:
+            continue
+
+        for job_type in indexed_job_types:
+            # We're only concerned with jobs that have to be tied to a volume index.
+            if not job["ParentID"].startswith(job_type):
+                pass
+
+            # If this job has an index, then its ParentID will
+            # have the pattern of <job-type>_<index>_<RAM-amount>
+            # and we want to check the value of <index>:
+            index = job["ParentID"].split("_")[-2]
+
+            if index not in active_volumes:
+                # The index for this job isn't currently mounted, kill
+                # the job and decrement the retry counter (since it
+                # will be incremented when it is requeued).
+                try:
+                    nomad_client.job.deregister_job(job["ID"])
+                    job_record = ProcessorJob(nomad_job_id=job["ID"])
+                    job_record.num_retries = job_record.num_retries - 1
+                    job_record.save()
+                except:
+                    # If we can't do this for some reason, we'll get it next loop.
+                    pass
+
+
 
 ##
 # Main loop

--- a/foreman/data_refinery_foreman/foreman/test_main.py
+++ b/foreman/data_refinery_foreman/foreman/test_main.py
@@ -276,6 +276,7 @@ class ForemanTestCase(TestCase):
                            nomad_job_id="PROCESSOR/dispatch-1528945054-e8eaf540",
                            ram_amount=ram_amount,
                            num_retries=0,
+                           volume_index="1",
                            success=None)
         job.save()
 
@@ -303,9 +304,11 @@ class ForemanTestCase(TestCase):
 
         return job
 
+    @patch('data_refinery_foreman.foreman.main.get_active_volumes')
     @patch('data_refinery_foreman.foreman.main.send_job')
-    def test_requeuing_processor_job(self, mock_send_job):
+    def test_requeuing_processor_job(self, mock_send_job, mock_get_active_volumes):
         mock_send_job.return_value = True
+        mock_get_active_volumes.return_value = {"1", "2", "3"}
 
         job = self.create_processor_job()
 
@@ -321,9 +324,11 @@ class ForemanTestCase(TestCase):
         retried_job = jobs[1]
         self.assertEqual(retried_job.num_retries, 1)
 
+    @patch('data_refinery_foreman.foreman.main.get_active_volumes')
     @patch('data_refinery_foreman.foreman.main.send_job')
-    def test_requeuing_processor_job_w_more_ram(self, mock_send_job):
+    def test_requeuing_processor_job_w_more_ram(self, mock_send_job, mock_get_active_volumes):
         mock_send_job.return_value = True
+        mock_get_active_volumes.return_value = {"1", "2", "3"}
 
         job = self.create_processor_job(pipeline="SALMON", ram_amount=8192)
 
@@ -340,9 +345,11 @@ class ForemanTestCase(TestCase):
         self.assertEqual(original_job.ram_amount, 8192)
         self.assertEqual(retried_job.ram_amount, 12288)
 
+    @patch('data_refinery_foreman.foreman.main.get_active_volumes')
     @patch('data_refinery_foreman.foreman.main.send_job')
-    def test_repeated_processor_failures(self, mock_send_job):
+    def test_repeated_processor_failures(self, mock_send_job, mock_get_active_volumes):
         mock_send_job.return_value = True
+        mock_get_active_volumes.return_value = {"1", "2", "3"}
 
         """Jobs will be repeatedly retried."""
         job = self.create_processor_job()
@@ -369,9 +376,11 @@ class ForemanTestCase(TestCase):
         self.assertEqual(last_job.num_retries, main.MAX_NUM_RETRIES)
         self.assertFalse(last_job.success)
 
+    @patch('data_refinery_foreman.foreman.main.get_active_volumes')
     @patch('data_refinery_foreman.foreman.main.send_job')
-    def test_retrying_failed_processor_jobs(self, mock_send_job):
+    def test_retrying_failed_processor_jobs(self, mock_send_job, mock_get_active_volumes):
         mock_send_job.return_value = True
+        mock_get_active_volumes.return_value = {"1", "2", "3"}
 
         job = self.create_processor_job()
         job.success = False
@@ -391,10 +400,36 @@ class ForemanTestCase(TestCase):
         retried_job = jobs[1]
         self.assertEqual(retried_job.num_retries, 1)
 
+    @patch('data_refinery_foreman.foreman.main.get_active_volumes')
+    @patch('data_refinery_foreman.foreman.main.send_job')
+    def test_not_retrying_wrong_volume_index(self, mock_send_job, mock_get_active_volumes):
+        """If a volume isn't mounted then we shouldn't queue jobs for it."""
+        mock_send_job.return_value = True
+        mock_get_active_volumes.return_value = {"2", "3"}
+
+        job = self.create_processor_job()
+        job.success = False
+        job.save()
+
+        # Just run it once, not forever so get the function that is
+        # decorated with @do_forever
+        main.retry_failed_processor_jobs.__wrapped__()
+        self.assertEqual(len(mock_send_job.mock_calls), 0)
+
+        jobs = ProcessorJob.objects.order_by('id')
+        original_job = jobs[0]
+        self.assertFalse(original_job.retried)
+        self.assertEqual(original_job.num_retries, 0)
+        self.assertFalse(original_job.success)
+
+        self.assertEqual(len(jobs), 1)
+
+    @patch('data_refinery_foreman.foreman.main.get_active_volumes')
     @patch('data_refinery_foreman.foreman.main.send_job')
     @patch('data_refinery_foreman.foreman.main.Nomad')
-    def test_retrying_hung_processor_jobs(self, mock_nomad, mock_send_job):
+    def test_retrying_hung_processor_jobs(self, mock_nomad, mock_send_job, mock_get_active_volumes):
         mock_send_job.return_value = True
+        mock_get_active_volumes.return_value = {"1", "2", "3"}
 
         def mock_init_nomad(host, port=0, timeout=0):
             ret_value = MagicMock()
@@ -423,10 +458,12 @@ class ForemanTestCase(TestCase):
         retried_job = jobs[1]
         self.assertEqual(retried_job.num_retries, 1)
 
+    @patch('data_refinery_foreman.foreman.main.get_active_volumes')
     @patch('data_refinery_foreman.foreman.main.send_job')
     @patch('data_refinery_foreman.foreman.main.Nomad')
-    def test_not_retrying_hung_processor_jobs(self, mock_nomad, mock_send_job):
+    def test_not_retrying_hung_processor_jobs(self, mock_nomad, mock_send_job, mock_get_active_volumes):
         mock_send_job.return_value = True
+        mock_get_active_volumes.return_value = {"1", "2", "3"}
 
         """Tests that we don't restart processor jobs that are still running."""
         def mock_init_nomad(host, port=0, timeout=0):
@@ -455,10 +492,12 @@ class ForemanTestCase(TestCase):
 
         self.assertEqual(jobs.count(), 1)
 
+    @patch('data_refinery_foreman.foreman.main.get_active_volumes')
     @patch('data_refinery_foreman.foreman.main.send_job')
     @patch('data_refinery_foreman.foreman.main.Nomad')
-    def test_retrying_lost_processor_jobs(self, mock_nomad, mock_send_job):
+    def test_retrying_lost_processor_jobs(self, mock_nomad, mock_send_job, mock_get_active_volumes):
         mock_send_job.return_value = True
+        mock_get_active_volumes.return_value = {"1", "2", "3"}
 
         def mock_init_nomad(host, port=0, timeout=0):
             ret_value = MagicMock()
@@ -488,11 +527,13 @@ class ForemanTestCase(TestCase):
         retried_job = jobs[1]
         self.assertEqual(retried_job.num_retries, 1)
 
+    @patch('data_refinery_foreman.foreman.main.get_active_volumes')
     @patch('data_refinery_foreman.foreman.main.send_job')
     @patch('data_refinery_foreman.foreman.main.Nomad')
-    def test_not_retrying_lost_processor_jobs(self, mock_nomad, mock_send_job):
+    def test_not_retrying_lost_processor_jobs(self, mock_nomad, mock_send_job, mock_get_active_volumes):
         """Make sure that we don't retry processor jobs we shouldn't."""
         mock_send_job.return_value = True
+        mock_get_active_volumes.return_value = {"1", "2", "3"}
 
         def mock_init_nomad(host, port=0, timeout=0):
             ret_value = MagicMock()
@@ -521,9 +562,11 @@ class ForemanTestCase(TestCase):
         # Make sure no additional job was created.
         self.assertEqual(jobs.count(), 1)
 
+    @patch('data_refinery_foreman.foreman.main.get_active_volumes')
     @patch('data_refinery_foreman.foreman.main.send_job')
-    def test_retrying_lost_processor_jobs_time(self, mock_send_job):
+    def test_retrying_lost_processor_jobs_time(self, mock_send_job, mock_get_active_volumes):
         mock_send_job.return_value = True
+        mock_get_active_volumes.return_value = {"1", "2", "3"}
 
         job = self.create_processor_job()
         job.created_at = timezone.now() - (main.MIN_LOOP_TIME + timedelta(minutes=1))
@@ -544,9 +587,11 @@ class ForemanTestCase(TestCase):
         self.assertEqual(retried_job.num_retries, 1)
 
 
+    @patch('data_refinery_foreman.foreman.main.get_active_volumes')
     @patch('data_refinery_foreman.foreman.main.send_job')
-    def test_not_retrying_janitor_jobs(self, mock_send_job):
+    def test_not_retrying_janitor_jobs(self, mock_send_job, mock_get_active_volumes):
         mock_send_job.return_value = True
+        mock_get_active_volumes.return_value = {"1", "2", "3"}
 
         job = self.create_processor_job(pipeline="JANITOR")
         job.created_at = timezone.now() - (main.MIN_LOOP_TIME + timedelta(minutes=1))
@@ -810,9 +855,11 @@ class ForemanTestCase(TestCase):
         retried_job = jobs[1]
         self.assertEqual(retried_job.num_retries, 1)
 
+    @patch('data_refinery_foreman.foreman.main.get_active_volumes')
     @patch('data_refinery_foreman.foreman.main.send_job')
-    def test_janitor(self, mock_send_job):
+    def test_janitor(self, mock_send_job, mock_get_active_volumes):
         mock_send_job.return_value = True
+        mock_send_job.return_value = {"1", "2", "3"}
 
         for p in ["1", "2", "3"]:
             pj = ProcessorJob()

--- a/foreman/requirements.in
+++ b/foreman/requirements.in
@@ -2,7 +2,7 @@ django
 psycopg2-binary
 requests>=2.20.0
 retrying
-python-nomad
+python-nomad>=1.0.2
 coverage
 GEOparse
 python-dateutil

--- a/foreman/requirements.txt
+++ b/foreman/requirements.txt
@@ -15,7 +15,7 @@ numpy==1.15.2             # via biopython, geoparse, pandas
 pandas==0.23.4            # via geoparse
 psycopg2-binary==2.7.5
 python-dateutil==2.7.3
-python-nomad==0.9.0
+python-nomad==1.0.2
 pytz==2018.5              # via django, pandas
 raven==6.9.0
 requests==2.20.0

--- a/workers/data_refinery_workers/downloaders/requirements.in
+++ b/workers/data_refinery_workers/downloaders/requirements.in
@@ -2,6 +2,6 @@ django
 requests>=2.20.0
 psycopg2-binary
 retrying
-python-nomad
+python-nomad>=1.0.2
 coveralls
 psutil

--- a/workers/data_refinery_workers/downloaders/requirements.txt
+++ b/workers/data_refinery_workers/downloaders/requirements.txt
@@ -13,7 +13,7 @@ docopt==0.6.2             # via coveralls
 idna==2.7                 # via requests
 psutil==5.4.7
 psycopg2-binary==2.7.5
-python-nomad==0.9.0
+python-nomad==1.0.2
 pytz==2018.5              # via django
 requests==2.20.0
 retrying==1.3.3

--- a/workers/data_refinery_workers/processors/requirements.in
+++ b/workers/data_refinery_workers/processors/requirements.in
@@ -3,7 +3,7 @@ requests>=2.20.0
 psycopg2-binary
 boto3
 retrying
-python-nomad
+python-nomad>=1.0.2
 coveralls
 multiqc
 numpy

--- a/workers/data_refinery_workers/processors/requirements.txt
+++ b/workers/data_refinery_workers/processors/requirements.txt
@@ -34,7 +34,7 @@ pandas==0.23.4
 psycopg2-binary==2.7.5
 pyparsing==2.2.2          # via matplotlib
 python-dateutil==2.7.3    # via botocore, matplotlib, pandas
-python-nomad==0.9.0
+python-nomad==1.0.2
 pytz==2018.5              # via django, pandas
 pyyaml==3.13              # via multiqc
 requests==2.20.0


### PR DESCRIPTION
## Issue Number

N/A stopped processing over the holiday.

## Purpose/Implementation Notes

This does two things:
  1. Makes the Foreman only requeue jobs that require a volume that is currently mounted.
  2. Adds a new thread to the Foreman that clears out jobs which cannot be placed because the volume they need isn't mounted.

## Types of changes

- New feature (non-breaking change which adds functionality)

## Functional tests

None yet, we're gonna test this on staging cause we need it out!

## Checklist

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules
