### PR TITLE
Actually make the deploy script timeout so it can finish if the API i…

### DIFF
--- a/infrastructure/deploy.sh
+++ b/infrastructure/deploy.sh
@@ -305,6 +305,8 @@ API_IP_ADDRESS=$(terraform output -json api_server_1_ip | jq -c '.value' | tr -d
 # it's not found then grep will return a non-zero exit code so in that
 # case return an empty string.
 container_running=$(ssh -o StrictHostKeyChecking=no \
+                        -o ServerAliveInterval=15 \
+                        -o ConnectTimeout=5 \
                         -i data-refinery-key.pem \
                         ubuntu@$API_IP_ADDRESS  "docker ps -a" | grep dr_api || echo "")
 
@@ -317,18 +319,26 @@ if [[ ! -z $container_running ]]; then
     echo "Restarting API with latest image."
 
     ssh -o StrictHostKeyChecking=no \
+        -o ServerAliveInterval=15 \
+        -o ConnectTimeout=5 \
         -i data-refinery-key.pem \
         ubuntu@$API_IP_ADDRESS  "docker pull $DOCKERHUB_REPO/$API_DOCKER_IMAGE"
 
     ssh -o StrictHostKeyChecking=no \
+        -o ServerAliveInterval=15 \
+        -o ConnectTimeout=5 \
         -i data-refinery-key.pem \
         ubuntu@$API_IP_ADDRESS "docker rm -f dr_api"
 
     scp -o StrictHostKeyChecking=no \
+        -o ServerAliveInterval=15 \
+        -o ConnectTimeout=5 \
         -i data-refinery-key.pem \
         api-configuration/environment ubuntu@$API_IP_ADDRESS:/home/ubuntu/environment
 
     ssh -o StrictHostKeyChecking=no \
+        -o ServerAliveInterval=15 \
+        -o ConnectTimeout=5 \
         -i data-refinery-key.pem \
         ubuntu@$API_IP_ADDRESS "docker run \
        --env-file environment \
@@ -347,6 +357,8 @@ if [[ ! -z $container_running ]]; then
 
     # Don't leave secrets lying around.
     ssh -o StrictHostKeyChecking=no \
+        -o ServerAliveInterval=15 \
+        -o ConnectTimeout=5 \
         -i data-refinery-key.pem \
         ubuntu@$API_IP_ADDRESS "rm -f environment"
 fi


### PR DESCRIPTION
…s being restarted.

## Issue Number

N/A came up during staging deploy

## Purpose/Implementation Notes

The point of the first command to ssh onto the API in the deploy.sh script is to determine whether or not the API is up. However if it's not it just hangs forever causing the deploy to hang and really not accomplishing the point. This hopefully will make it timeout after 5 seconds so that it can just finish and let the API instance worry about starting its container. It also adds a ServerAliveInterval option to additionally make the SSH commands resilient against hanging.

## Types of changes


- Bugfix (non-breaking change which fixes an issue)

## Functional tests

N/A this is deploy only so it will be tested during a deploy.

## Checklist

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules
