### PR TITLE
Make sure that we only count nodes as active if they are 'ready'

### DIFF
--- a/foreman/data_refinery_foreman/foreman/main.py
+++ b/foreman/data_refinery_foreman/foreman/main.py
@@ -112,7 +112,8 @@ def get_active_volumes() -> Set[str]:
     volumes = set()
     for node in nomad_client.nodes.get_nodes():
         node_detail = nomad_client.node.get_node(node["ID"])
-        if 'Meta' in node_detail and 'volume_index' in node_detail['Meta']:
+        if 'Status' in node_detail and node_detail['Status'] == 'ready'
+           and 'Meta' in node_detail and 'volume_index' in node_detail['Meta']:
             volumes.add(node_detail['Meta']['volume_index'])
 
     return volumes


### PR DESCRIPTION
## Issue Number

N/A came up during staging deploy

## Purpose/Implementation Notes

Local tests didn't help with this scenario because there was no way to have 'dead' nodes locally. This filters the nodes that we count as active to only those in the `ready` state.

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

N/A will be tested in staging

## Checklist

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream module
