### PR TITLE
Add system version to every API response as X-Source-Revision Header.

### DIFF
--- a/api/data_refinery_api/middleware.py
+++ b/api/data_refinery_api/middleware.py
@@ -1,5 +1,6 @@
 import logging
 from django.utils.deprecation import MiddlewareMixin
+from data_refinery_common.utils import get_env_variable_gracefully
 
 class SentryCatchBadRequestMiddleware(MiddlewareMixin):
     def process_response(self, request, response):
@@ -44,3 +45,8 @@ class SentryCatchBadRequestMiddleware(MiddlewareMixin):
         })
 
         client.captureMessage(message=str(exception), data=data)
+
+class RevisionMiddleware(MiddlewareMixin):
+    def process_response(self, request, response):
+        response['X-Source-Revision'] = get_env_variable_gracefully("SYSTEM_VERSION")
+        return response

--- a/api/data_refinery_api/settings.py
+++ b/api/data_refinery_api/settings.py
@@ -57,6 +57,7 @@ INSTALLED_APPS = [
 ]
 
 MIDDLEWARE = [
+    'data_refinery_api.middleware.RevisionMiddleware',
     'data_refinery_api.middleware.SentryCatchBadRequestMiddleware',
     'django.middleware.security.SecurityMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',

--- a/api/data_refinery_api/tests.py
+++ b/api/data_refinery_api/tests.py
@@ -25,6 +25,7 @@ from data_refinery_api.serializers import (
     SurveyJobSerializer,
 )
 from data_refinery_api.views import ExperimentList
+from data_refinery_common.utils import get_env_variable
 from data_refinery_common.models import (
     ComputationalResult,
     Dataset,
@@ -127,6 +128,7 @@ class APITestCases(APITestCase):
     def test_all_endpoints(self):
         response = self.client.get(reverse('experiments'))
         self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response['X-Source-Revision'], get_env_variable('SYSTEM_VERSION'))
 
         response = self.client.get(reverse('experiments'), kwargs={'page': 1})
         self.assertEqual(response.status_code, status.HTTP_200_OK)


### PR DESCRIPTION
## Issue Number

#777 

## Purpose/Implementation Notes

We want to have the system version in the header of every response coming out of the API. This adds the `X-Source-Revision` header set to the system version on every response.

## Types of changes

- New feature (non-breaking change which adds functionality)

## Functional tests

I hit the experiments endpoint and checked out the headers. Screenshot attached. (The version local1543270996 is correct, it gets generated for running things locally.)

## Checklist

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules

## Screenshots

![image](https://user-images.githubusercontent.com/4026833/49045921-71bbe200-f1a0-11e8-99b7-6d132df927cb.png)

