### PR TITLE
Adds timestamps to the S3 keys for transcriptome indices.

### DIFF
--- a/common/data_refinery_common/logging.py
+++ b/common/data_refinery_common/logging.py
@@ -4,16 +4,16 @@ import logging
 import sys
 
 from data_refinery_common.utils import get_env_variable_gracefully
-from data_refinery_common.utils import get_instance_id
+from data_refinery_common.utils import get_instance_id, get_volume_index
 
 
 # Most of the formatting in this string is for the logging system. All
 # that the call to format() does is replace the "{0}" in the string
 # with the worker id.
 FORMAT_STRING = (
-    "%(asctime)s {0} %(name)s %(color)s%(levelname)s%(extras)s"
+    "%(asctime)s {0} [volume: {1}] %(name)s %(color)s%(levelname)s%(extras)s"
     ": %(message)s%(color_stop)s"
-).format(get_instance_id())
+).format(get_instance_id(), get_volume_index())
 LOG_LEVEL = None
 
 

--- a/common/data_refinery_common/utils.py
+++ b/common/data_refinery_common/utils.py
@@ -68,10 +68,10 @@ def get_volume_index(default="0", path='/home/user/data_store/VOLUME_INDEX') -> 
             v_id = f.read().strip()
             return v_id
     except Exception as e:
-        # Logger needs util, so we do this at runtime
-        from data_refinery_common.logging import get_and_configure_logger
-        logger = get_and_configure_logger(__name__)
-        logger.info("Could not read volume index file, using default", default=default)
+        # Our configured logger needs util, so we use the standard logging library for just this.
+        import logging
+        logger = logging.getLogger(__name__)
+        logger.info("Could not read volume index file, using default: {}", default)
         logger.info(str(e))
 
     return default

--- a/workers/data_refinery_workers/processors/transcriptome_index.py
+++ b/workers/data_refinery_workers/processors/transcriptome_index.py
@@ -353,7 +353,8 @@ def _populate_index_object(job_context: Dict) -> Dict:
 
     if S3_TRANSCRIPTOME_INDEX_BUCKET_NAME:
         logger.info("Uploading %s %s to s3", job_context['organism_name'], job_context['length'], processor_job=job_context["job_id"])
-        s3_key = organism_object.name + '_' + index_object.index_type + '.tar.gz'
+        timestamp = str(timezone.now().timestamp()).split('.')[0]
+        s3_key = organism_object.name + '_' + index_object.index_type + "_" + timestamp + '.tar.gz'
         sync_result = computed_file.sync_to_s3(S3_TRANSCRIPTOME_INDEX_BUCKET_NAME, s3_key)
         if sync_result:
             computed_file.delete_local_file()


### PR DESCRIPTION
## Issue Number

N/A came up because we think we need to recreate a few transcriptome indices but don't want to lose the ones we have.

## Purpose/Implementation Notes

We don't want to lose data, but every time a transcriptome index is created it replaces the last one for its organism/length. This adds a timestamp so we don't overwrite S3 objects.

## Types of changes

- New feature (non-breaking change which adds functionality)

## Functional tests

None yet, this is only applicable in the cloud so I either need to test it in a dev stack or in the staging stack.

## Checklist

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules
