### PR TITLE
Hush Up the Foreman

### DIFF
--- a/foreman/data_refinery_foreman/foreman/main.py
+++ b/foreman/data_refinery_foreman/foreman/main.py
@@ -685,7 +685,7 @@ def retry_lost_processor_jobs() -> None:
                 if timezone.now() - job.created_at > MIN_LOOP_TIME:
                     lost_jobs.append(job)
         except URLNotFoundNomadException:
-            logger.exception(("Determined that a processor job needs to be requeued because "
+            logger.debug(("Determined that a processor job needs to be requeued because "
                               "querying for its Nomad job failed: "),
                              job_id=job.id
             )

--- a/workers/data_refinery_workers/processors/no_op.py
+++ b/workers/data_refinery_workers/processors/no_op.py
@@ -138,6 +138,7 @@ def _prepare_files(job_context: Dict) -> Dict:
         job_context["internal_accession"] = get_internal_microarray_accession(job_context["platform"])
         if not job_context["internal_accession"]:
             logger.error("Failed to find internal accession for code", code=job_context["platform"])
+            job_context["job"].failure_reason = "Failed to find internal accession for code" + job_context["platform"]
             job_context['success'] = False
             job_context["job"].no_retry = True
     except Exception as e:
@@ -159,6 +160,14 @@ def _convert_genes(job_context: Dict) -> Dict:
 
 def _convert_affy_genes(job_context: Dict) -> Dict:
     """ Convert to Ensembl genes if we can"""
+
+    if 'internal_accession' not in job_context:
+        error_msg = "Told to convert AFFY genes without an internal_accession - how did this happen?"
+        logger.error(error_msg, job_context=job_context)
+        job_context["job"].failure_reason = str(error_msg)
+        job_context['success'] = False
+        job_context["job"].no_retry = True
+        return job_context
 
     gene_index_path = "/home/user/gene_indexes/" + job_context["internal_accession"] + ".tsv.gz"
     if not os.path.exists(gene_index_path):

--- a/workers/data_refinery_workers/processors/no_op.py
+++ b/workers/data_refinery_workers/processors/no_op.py
@@ -161,7 +161,7 @@ def _convert_genes(job_context: Dict) -> Dict:
 def _convert_affy_genes(job_context: Dict) -> Dict:
     """ Convert to Ensembl genes if we can"""
 
-    if 'internal_accession' not in job_context:
+    if 'internal_accession' not in job_context or not job_context['internal_accession']:
         error_msg = "Told to convert AFFY genes without an internal_accession - how did this happen?"
         logger.error(error_msg, job_context=job_context)
         job_context["job"].failure_reason = str(error_msg)

--- a/workers/data_refinery_workers/processors/salmon.py
+++ b/workers/data_refinery_workers/processors/salmon.py
@@ -288,6 +288,7 @@ def _find_or_download_index(job_context: Dict) -> Dict:
 
         # Something very bad happened and now there are corrupt indexes installed. Nuke 'em. 
         if os.path.exists(version_info_path) and (os.path.getsize(version_info_path) == 0):
+            logger.error("We have to nuke a zero-valued index directory: " + version_info_path)
             shutil.rmtree(job_context["index_directory"], ignore_errors=True)
             os.makedirs(job_context["index_directory"], exist_ok=True)
 


### PR DESCRIPTION
## Issue Number

Foreman is polluting the prod logs.

Also includes an explicit death check for missing `'internal_accession'` in AFFY, a logger error message for zerobyte t-indexes and sets a missing `job_context["job"].failure_reason`

## Purpose/Implementation Notes

- Bugfix (non-breaking change which fixes an issue)
