### PR TITLE
Use prefetch_related to optimize job prioritization queries

### DIFF
--- a/common/data_refinery_common/job_lookup.py
+++ b/common/data_refinery_common/job_lookup.py
@@ -3,7 +3,12 @@ from typing import List
 
 from data_refinery_common import utils
 from data_refinery_common.logging import get_and_configure_logger
-from data_refinery_common.models import Sample, OriginalFile, OriginalFileSampleAssociation
+from data_refinery_common.models import (
+    OriginalFile,
+    OriginalFileSampleAssociation,
+    ProcessorJob,
+    Sample,
+)
 
 
 logger = get_and_configure_logger(__name__)
@@ -32,6 +37,12 @@ class ProcessorPipeline(PipelineEnums):
     QN_REFERENCE = "QN_REFERENCE"
     JANITOR = "JANITOR"
     NONE = "NONE"
+
+
+def does_processor_job_have_samples(job: ProcessorJob):
+    return not (job.pipeline_applied == ProcessorPipeline.SMASHER.value \
+                or job.pipeline_applied == ProcessorPipeline.JANITOR.value \
+                or job.pipeline_applied == ProcessorPipeline.QN_REFERENCE.value)
 
 
 class DiscoveryPipeline(PipelineEnums):

--- a/foreman/data_refinery_foreman/foreman/main.py
+++ b/foreman/data_refinery_foreman/foreman/main.py
@@ -21,7 +21,13 @@ from data_refinery_common.models import (
     SurveyJobKeyValue
 )
 from data_refinery_common.message_queue import send_job
-from data_refinery_common.job_lookup import ProcessorPipeline, Downloaders, SurveyJobTypes, is_file_rnaseq
+from data_refinery_common.job_lookup import (
+    Downloaders,
+    ProcessorPipeline,
+    SurveyJobTypes,
+    does_processor_job_have_samples,
+    is_file_rnaseq,
+)
 from data_refinery_common.logging import get_and_configure_logger
 from data_refinery_common.utils import get_env_variable, get_env_variable_gracefully
 
@@ -158,9 +164,7 @@ def prioritize_salmon_jobs(jobs: List) -> List:
     prioritized_jobs = []
     for job in jobs:
         try:
-            if job.pipeline_applied == ProcessorPipeline.SMASHER.value \
-               or job.pipeline_applied == ProcessorPipeline.JANITOR.value \
-               or job.pipeline_applied == ProcessorPipeline.QN_REFERENCE.value:
+            if not does_processor_job_have_samples(job):
                 continue
 
             # Salmon jobs are specifc to one sample.
@@ -216,9 +220,7 @@ def prioritize_zebrafish_jobs(jobs: List) -> List:
     zebrafish_jobs = []
     for job in jobs:
         try:
-            if job.pipeline_applied == ProcessorPipeline.SMASHER.value \
-               or job.pipeline_applied == ProcessorPipeline.JANITOR.value \
-               or job.pipeline_applied == ProcessorPipeline.QN_REFERENCE.value:
+            if not does_processor_job_have_samples(job):
                 continue
 
             # There aren't cross-species jobs, so just checking one sample's organism will be sufficient.
@@ -243,9 +245,7 @@ def prioritize_jobs_by_accession(jobs: List, accession_list: List[str]) -> List:
     prioritized_jobs = []
     for job in jobs:
         try:
-            if job.pipeline_applied == ProcessorPipeline.SMASHER.value \
-               or job.pipeline_applied == ProcessorPipeline.JANITOR.value \
-               or job.pipeline_applied == ProcessorPipeline.QN_REFERENCE.value:
+            if not does_processor_job_have_samples(job):
                 continue
 
             # All samples in a job correspond to the same experiment, so just check one sample.

--- a/foreman/data_refinery_foreman/foreman/main.py
+++ b/foreman/data_refinery_foreman/foreman/main.py
@@ -265,7 +265,7 @@ def prioritize_jobs_by_accession(jobs: List, accession_list: List[str]) -> List:
                         is_prioritized_job = True
                         break
         except:
-            logger.exception("Exception caught while prioritizing zebrafish jobs!", job=job)
+            logger.exception("Exception caught while prioritizing jobs by accession!", job=job)
 
     # Remove all the jobs we're moving to the front of the list
     for job in prioritized_jobs:

--- a/foreman/data_refinery_foreman/foreman/main.py
+++ b/foreman/data_refinery_foreman/foreman/main.py
@@ -158,6 +158,11 @@ def prioritize_salmon_jobs(jobs: List) -> List:
     prioritized_jobs = []
     for job in jobs:
         try:
+            if job.pipeline_applied == ProcessorPipeline.SMASHER.value \
+               or job.pipeline_applied == ProcessorPipeline.JANITOR.value \
+               or job.pipeline_applied == ProcessorPipeline.QN_REFERENCE.value:
+                continue
+
             # Salmon jobs are specifc to one sample.
             sample = job.get_samples().pop()
 
@@ -194,7 +199,7 @@ def prioritize_salmon_jobs(jobs: List) -> List:
             experiment_completion_percent = processed_samples / len(related_samples)
             prioritized_jobs.append({"job": job, "priority": experiment_completion_percent})
         except:
-            logger.exception("Exception caught while prioritizing salmon jobs!")
+            logger.exception("Exception caught while prioritizing salmon jobs!", job=job)
 
     sorted_job_mappings = sorted(prioritized_jobs, reverse=True, key=lambda k: k["priority"])
     sorted_jobs = [job_mapping["job"] for job_mapping in sorted_job_mappings]
@@ -211,6 +216,11 @@ def prioritize_zebrafish_jobs(jobs: List) -> List:
     zebrafish_jobs = []
     for job in jobs:
         try:
+            if job.pipeline_applied == ProcessorPipeline.SMASHER.value \
+               or job.pipeline_applied == ProcessorPipeline.JANITOR.value \
+               or job.pipeline_applied == ProcessorPipeline.QN_REFERENCE.value:
+                continue
+
             # There aren't cross-species jobs, so just checking one sample's organism will be sufficient.
             samples = job.get_samples()
 
@@ -219,7 +229,7 @@ def prioritize_zebrafish_jobs(jobs: List) -> List:
                     zebrafish_jobs.append(job)
                     break
         except:
-            logger.exception("Exception caught while prioritizing zebrafish jobs!")
+            logger.exception("Exception caught while prioritizing zebrafish jobs!", job=job)
 
     # Remove all the jobs we're moving to the front of the list
     for job in zebrafish_jobs:
@@ -233,6 +243,11 @@ def prioritize_jobs_by_accession(jobs: List, accession_list: List[str]) -> List:
     prioritized_jobs = []
     for job in jobs:
         try:
+            if job.pipeline_applied == ProcessorPipeline.SMASHER.value \
+               or job.pipeline_applied == ProcessorPipeline.JANITOR.value \
+               or job.pipeline_applied == ProcessorPipeline.QN_REFERENCE.value:
+                continue
+
             # All samples in a job correspond to the same experiment, so just check one sample.
             samples = job.get_samples()
 
@@ -250,7 +265,7 @@ def prioritize_jobs_by_accession(jobs: List, accession_list: List[str]) -> List:
                         is_prioritized_job = True
                         break
         except:
-            logger.exception("Exception caught while prioritizing zebrafish jobs!")
+            logger.exception("Exception caught while prioritizing zebrafish jobs!", job=job)
 
     # Remove all the jobs we're moving to the front of the list
     for job in prioritized_jobs:
@@ -347,7 +362,12 @@ def handle_downloader_jobs(jobs: List[DownloaderJob]) -> None:
 @do_forever(MIN_LOOP_TIME)
 def retry_failed_downloader_jobs() -> None:
     """Handle downloader jobs that were marked as a failure."""
-    failed_jobs = DownloaderJob.objects.filter(success=False, retried=False)
+    failed_jobs = DownloaderJob.objects.filter(
+        success=False,
+        retried=False
+    ).prefetch_related(
+        "original_files__samples"
+    )
     failed_jobs_list = [job for job in failed_jobs]
 
     if failed_jobs_list:
@@ -367,6 +387,8 @@ def retry_hung_downloader_jobs() -> None:
         end_time=None,
         start_time__isnull=False,
         no_retry=False
+    ).prefetch_related(
+        "original_files__samples"
     )
 
     nomad_host = get_env_variable("NOMAD_HOST")
@@ -406,6 +428,8 @@ def retry_lost_downloader_jobs() -> None:
         start_time=None,
         end_time=None,
         no_retry=False
+    ).prefetch_related(
+        "original_files__samples"
     )
 
     nomad_host = get_env_variable("NOMAD_HOST")
@@ -567,6 +591,8 @@ def retry_failed_processor_jobs() -> None:
         volume_index__in=active_volumes
     ).exclude(
         pipeline_applied="JANITOR"
+    ).prefetch_related(
+        "original_files__samples"
     )
 
     failed_jobs_list = [job for job in failed_jobs]
@@ -599,6 +625,8 @@ def retry_hung_processor_jobs() -> None:
         volume_index__in=active_volumes
     ).exclude(
         pipeline_applied="JANITOR"
+    ).prefetch_related(
+        "original_files__samples"
     )
 
 
@@ -657,6 +685,8 @@ def retry_lost_processor_jobs() -> None:
         volume_index__in=active_volumes
     ).exclude(
         pipeline_applied="JANITOR"
+    ).prefetch_related(
+        "original_files__samples"
     )
 
     nomad_host = get_env_variable("NOMAD_HOST")


### PR DESCRIPTION
## Issue Number

#886 

## Purpose/Implementation Notes

The foreman made way too many queries while prioritizing jobs. This should make it just a few queries per retry function. Hopefully this is efficient enough to work in prod, but it's hard to be sure without the full scale that prod has.

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

I tested this locally on ~6.5k downloader jobs using the `retry_failed_downloader_jobs` function. I used `cProfile` to check both the overall runtime and then the runtime for `prioritize_salmon_jops`. these were the results without the change:

For the full function:
```
ncalls  tottime  percall  cumtime  percall filename:lineno(function)
      3/1    0.000    0.000  126.338  126.338 {built-in method builtins.exec}
        1    0.000    0.000  126.338  126.338 /home/user/data_refinery_foreman/foreman/main.py:357(retry_failed_downloader_jobs)
```

for just prioritize salmon jobs:
```
ncalls  tottime  percall  cumtime  percall filename:lineno(function)
        1    0.000    0.000   30.762   30.762 {built-in method builtins.exec}
        1    0.000    0.000   30.761   30.761 <string>:1(<module>)
        1    0.165    0.165   30.761   30.761 /home/user/data_refinery_foreman/foreman/main.py:146(prioritize_salmon_jobs)
```

With the changes:

Full function:
```
   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
      3/1    0.000    0.000   50.234   50.234 {built-in method builtins.exec}
        1    0.000    0.000   50.234   50.234 <string>:1(<module>)
        1    0.000    0.000   50.234   50.234 /home/user/data_refinery_foreman/foreman/main.py:357(retry_failed_downloader_jobs)
```

for just prioritize salmon jobs:
```
   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
        1    0.000    0.000    9.682    9.682 {built-in method builtins.exec}
        1    0.000    0.000    9.682    9.682 <string>:1(<module>)
        1    0.110    0.110    9.682    9.682 /home/user/data_refinery_foreman/foreman/main.py:146(prioritize_salmon_jobs)
```

## Checklist

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules
