### PR TITLE
Try to make jobs die more gracefully.

### DIFF
--- a/foreman/nomad-job-specs/surveyor.nomad.tpl
+++ b/foreman/nomad-job-specs/surveyor.nomad.tpl
@@ -26,6 +26,8 @@ job "SURVEYOR_${{RAM}}" {
     task "surveyor" {
       driver = "docker"
 
+      kill_timeout = "30s"
+
       # This env will be passed into the container for the job.
       env {
         ${{AWS_CREDS}}

--- a/format_nomad_with_env.sh
+++ b/format_nomad_with_env.sh
@@ -22,7 +22,7 @@ print_options() {
     echo "                     path to another directory (trailing / must be included)."
 }
 
-while getopts ":p:e:o:h" opt; do
+while getopts ":p:e:o:v:h" opt; do
     case $opt in
     p)
         export project=$OPTARG
@@ -32,6 +32,9 @@ while getopts ":p:e:o:h" opt; do
         ;;
     o)
         export output_dir=$OPTARG
+        ;;
+    v)
+        export system_version=$OPTARG
         ;;
     h)
         print_description
@@ -65,6 +68,10 @@ if [[ -z $MAX_CLIENTS ]]; then
     MAX_CLIENTS="1"
 fi
 
+if [[ -z $system_version ]]; then
+    system_version="latest"
+fi
+
 # Default docker repo.
 # This are very sensible defaults, but we want to let these be set
 # outside the script so only set them if they aren't already set.
@@ -78,28 +85,28 @@ if [[ -z $DOCKERHUB_REPO ]]; then
     fi
 fi
 if [[ -z $FOREMAN_DOCKER_IMAGE ]]; then
-    export FOREMAN_DOCKER_IMAGE=dr_foreman:latest
+    export FOREMAN_DOCKER_IMAGE=dr_foreman:$system_version
 fi
 if [[ -z $DOWNLOADERS_DOCKER_IMAGE ]]; then
-    export DOWNLOADERS_DOCKER_IMAGE=dr_downloaders:latest
+    export DOWNLOADERS_DOCKER_IMAGE=dr_downloaders:$system_version
 fi
 if [[ -z $TRANSCRIPTOME_DOCKER_IMAGE ]]; then
-    export TRANSCRIPTOME_DOCKER_IMAGE=dr_transcriptome:latest
+    export TRANSCRIPTOME_DOCKER_IMAGE=dr_transcriptome:$system_version
 fi
 if [[ -z $SALMON_DOCKER_IMAGE ]]; then
-    export SALMON_DOCKER_IMAGE=dr_salmon:latest
+    export SALMON_DOCKER_IMAGE=dr_salmon:$system_version
 fi
 if [[ -z $SMASHER_DOCKER_IMAGE ]]; then
-    export SMASHER_DOCKER_IMAGE=dr_smasher:latest
+    export SMASHER_DOCKER_IMAGE=dr_smasher:$system_version
 fi
 if [[ -z $AFFYMETRIX_DOCKER_IMAGE ]]; then
-    export AFFYMETRIX_DOCKER_IMAGE=dr_affymetrix:latest
+    export AFFYMETRIX_DOCKER_IMAGE=dr_affymetrix:$system_version
 fi
 if [[ -z $ILLUMINA_DOCKER_IMAGE ]]; then
-    export ILLUMINA_DOCKER_IMAGE=dr_illumina:latest
+    export ILLUMINA_DOCKER_IMAGE=dr_illumina:$system_version
 fi
 if [[ -z $NO_OP_DOCKER_IMAGE ]]; then
-    export NO_OP_DOCKER_IMAGE=dr_no_op:latest
+    export NO_OP_DOCKER_IMAGE=dr_no_op:$system_version
 fi
 
 

--- a/run_nomad.sh
+++ b/run_nomad.sh
@@ -19,10 +19,13 @@ print_options() {
     echo "                     The other options are 'prod' and 'test'"
 }
 
-while getopts ":e:h" opt; do
+while getopts ":e:v:h" opt; do
     case $opt in
         e)
             env=$OPTARG
+            ;;
+        v)
+            export system_version=$OPTARG
             ;;
         h)
             print_description
@@ -45,6 +48,10 @@ done
 
 if [[ -z $env ]]; then
     env="local"
+fi
+
+if [[ -z $system_version ]]; then
+    system_version="latest"
 fi
 
 # Figure out the right location to put the nomad directory.
@@ -127,8 +134,8 @@ done
 
 echo "Nomad is online. Registering jobs."
 
-./format_nomad_with_env.sh -p workers -e $env
-./format_nomad_with_env.sh -p surveyor -e $env
+./format_nomad_with_env.sh -p workers -e $env -v $system_version
+./format_nomad_with_env.sh -p surveyor -e $env -v $system_version
 
 # Register the jobs for dispatching.
 for job_spec in $(ls -1 workers/nomad-job-specs/*.nomad$TEST_POSTFIX); do

--- a/workers/data_refinery_workers/downloaders/utils.py
+++ b/workers/data_refinery_workers/downloaders/utils.py
@@ -53,8 +53,8 @@ def get_max_jobs_for_current_node():
 
 MAX_DOWNLOADER_JOBS_PER_NODE = get_max_jobs_for_current_node()
 
-def sigterm_handler(sig, frame):
-    """ SIGTERM Handler """
+def signal_handler(sig, frame):
+    """Signal Handler, works for both SIGTERM and SIGINT"""
     global CURRENT_JOB
     if not CURRENT_JOB:
         sys.exit(0)
@@ -108,7 +108,9 @@ def start_job(job_id: int, max_downloader_jobs_per_node=MAX_DOWNLOADER_JOBS_PER_
 
     # Set up the SIGTERM handler so we can appropriately handle being interrupted.
     # (`docker stop` uses SIGTERM, not SIGINT.)
-    signal.signal(signal.SIGTERM, sigterm_handler)
+    # (however, Nomad sends an SIGINT so catch both.)
+    signal.signal(signal.SIGTERM, signal_handler)
+    signal.signal(signal.SIGINT, signal_handler)
 
     job.worker_id = worker_id
     job.worker_version = SYSTEM_VERSION

--- a/workers/data_refinery_workers/processors/utils.py
+++ b/workers/data_refinery_workers/processors/utils.py
@@ -37,8 +37,8 @@ DIRNAME = os.path.dirname(os.path.abspath(__file__))
 CURRENT_JOB = None
 
 
-def sigterm_handler(sig, frame):
-    """ SIGTERM Handler """
+def signal_handler(sig, frame):
+    """Signal Handler, works for both SIGTERM and SIGINT"""
     global CURRENT_JOB
     if not CURRENT_JOB:
         sys.exit(0)
@@ -120,7 +120,9 @@ def start_job(job_context: Dict):
 
     # Set up the SIGTERM handler so we can appropriately handle being interrupted.
     # (`docker stop` uses SIGTERM, not SIGINT.)
-    signal.signal(signal.SIGTERM, sigterm_handler)
+    # (however, Nomad sends an SIGINT so catch both.)
+    signal.signal(signal.SIGTERM, signal_handler)
+    signal.signal(signal.SIGINT, signal_handler)
 
     job.worker_id = get_instance_id()
     job.worker_version = SYSTEM_VERSION

--- a/workers/nomad-job-specs/affymetrix.nomad.tpl
+++ b/workers/nomad-job-specs/affymetrix.nomad.tpl
@@ -27,6 +27,8 @@ job "AFFY_TO_PCL_${{INDEX}}_${{RAM}}" {
     task "affy_to_pcl" {
       driver = "docker"
 
+      kill_timeout = "30s"
+
       # This env will be passed into the container for the job.
       env {
         ${{AWS_CREDS}}

--- a/workers/nomad-job-specs/downloader.nomad.tpl
+++ b/workers/nomad-job-specs/downloader.nomad.tpl
@@ -33,6 +33,8 @@ job "DOWNLOADER" {
     task "downloader" {
       driver = "docker"
 
+      kill_timeout = "30s"
+
       # This env will be passed into the container for the job.
       env {
         ${{AWS_CREDS}}

--- a/workers/nomad-job-specs/illumina.nomad.tpl
+++ b/workers/nomad-job-specs/illumina.nomad.tpl
@@ -27,6 +27,8 @@ job "ILLUMINA_TO_PCL_${{INDEX}}_${{RAM}}" {
     task "illumina_to_pcl" {
       driver = "docker"
 
+      kill_timeout = "30s"
+
       # This env will be passed into the container for the job.
       env {
         ${{AWS_CREDS}}

--- a/workers/nomad-job-specs/janitor.nomad.tpl
+++ b/workers/nomad-job-specs/janitor.nomad.tpl
@@ -27,6 +27,8 @@ job "JANITOR_${{INDEX}}_${{RAM}}" {
     task "janitor" {
       driver = "docker"
 
+      kill_timeout = "30s"
+
       # This env will be passed into the container for the job.
       env {
         ${{AWS_CREDS}}

--- a/workers/nomad-job-specs/no_op.nomad.tpl
+++ b/workers/nomad-job-specs/no_op.nomad.tpl
@@ -27,6 +27,8 @@ job "NO_OP_${{INDEX}}_${{RAM}}" {
     task "no_op" {
       driver = "docker"
 
+      kill_timeout = "30s"
+
       # This env will be passed into the container for the job.
       env {
         ${{AWS_CREDS}}

--- a/workers/nomad-job-specs/salmon.nomad.tpl
+++ b/workers/nomad-job-specs/salmon.nomad.tpl
@@ -27,6 +27,8 @@ job "SALMON_${{INDEX}}_${{RAM}}" {
     task "salmon" {
       driver = "docker"
 
+      kill_timeout = "30s"
+
       # This env will be passed into the container for the job.
       env {
         ${{AWS_CREDS}}

--- a/workers/nomad-job-specs/smasher.nomad.tpl
+++ b/workers/nomad-job-specs/smasher.nomad.tpl
@@ -27,6 +27,8 @@ job "SMASHER" {
     task "smasher" {
       driver = "docker"
 
+      kill_timeout = "30s"
+
       # This env will be passed into the container for the job.
       env {
         ${{AWS_CREDS}}

--- a/workers/nomad-job-specs/transcriptome.nomad.tpl
+++ b/workers/nomad-job-specs/transcriptome.nomad.tpl
@@ -27,6 +27,8 @@ job "TRANSCRIPTOME_INDEX_${{INDEX}}_${{RAM}}" {
     task "transcriptome_index" {
       driver = "docker"
 
+      kill_timeout = "30s"
+
       # This env will be passed into the container for the job.
       env {
         ${{AWS_CREDS}}


### PR DESCRIPTION
## Issue Number

N/A, just trying to make things better

## Purpose/Implementation Notes

Handles SIGINT as well as SIGTERM, sets kill_timeout to 30s, makes system_version configurable when running run_nomad.sh locally.

I noticed on a nomad-spawned docker container that the `StopTimeout` setting was only 5 seconds. I feel like I sometimes see our jobs die in a non-graceful fashion. It makes me sad so I decided to try and figure out if I could change the StopTimeout. I could and while I was at it I noticed that Nomad sends tasks SIGINT instead of SIGTERM. I'm not super sure what that ends up meaning for the containerized process, but why not handle both? It's easy!

## Types of changes

- New feature (non-breaking change which adds functionality)

## Functional tests

WIP

## Checklist

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules
