### PR TITLE
Prevent surveyor jobs from requeuing work we've already done.

### DIFF
--- a/foreman/data_refinery_foreman/surveyor/external_source.py
+++ b/foreman/data_refinery_foreman/surveyor/external_source.py
@@ -111,6 +111,15 @@ class ExternalSourceSurveyor:
                                                 ):
         """Creates a single DownloaderJob with multiple files to download.
         """
+        source_urls = [original_file.source_url for original_file in original_files]
+        # There is already a downloader job associated with this file.
+        old_assocs = DownloaderJobOriginalFileAssociation.objects.filter(
+            original_file__source_url__in=source_urls)
+        if len(old_assocs) > 0:
+            logger.debug("We found an existing DownloaderJob for these urls.",
+                         source_urls=source_urls)
+            return False
+
         # Transcriptome is a special case because there's no sample_object.
         if is_transcriptome:
             downloader_task = job_lookup.Downloaders.TRANSCRIPTOME_INDEX

--- a/foreman/data_refinery_foreman/surveyor/test_external_source.py
+++ b/foreman/data_refinery_foreman/surveyor/test_external_source.py
@@ -2,14 +2,14 @@ from unittest.mock import Mock, patch, call
 from django.test import TestCase
 from data_refinery_foreman.surveyor.sra import SraSurveyor
 from data_refinery_common.models import (
-    SurveyJob,
+    DownloaderJob,
+    DownloaderJobOriginalFileAssociation,
     Experiment,
     ExperimentSampleAssociation,
-    Sample,
     OriginalFile,
     OriginalFileSampleAssociation,
-    DownloaderJob
-
+    Sample,
+    SurveyJob,
 )
 
 class SraSurveyorTestCase(TestCase):
@@ -116,3 +116,71 @@ class SraSurveyorTestCase(TestCase):
                                                          experiment_object.accession_code)
 
         self.assertEqual(DownloaderJob.objects.all().count(), 2)
+
+    def test_no_repeat_jobs(self):
+        """Make sure that queue_downloader_jobs queues all expected Downloader
+        jobs for a given experiment.
+        """
+        # First, create an experiment with two samples associated with it
+        # and create two original files for each of those samples.
+        experiment_object = Experiment()
+        experiment_object.accession_code = "Experiment1"
+        experiment_object.save()
+
+        sample_object = Sample()
+        sample_object.accession_code = "Sample1"
+        sample_object.platform_accession_code = "Illumina Genome Analyzer"
+        sample_object.platform_accession_name = "Illumina Genome Analyzer"
+        sample_object.technology = "RNA-SEQ"
+        sample_object.manufacturer = "ILLUMINA"
+        sample_object.source_database = "SRA"
+        sample_object.save()
+
+        original_file_1 = OriginalFile()
+        original_file_1.source_url = "first_url"
+        original_file_1.source_filename = "first_filename"
+        original_file_1.is_downloaded = False
+        original_file_1.has_raw = True
+        original_file_1.save()
+
+        original_file_sample_association = OriginalFileSampleAssociation()
+        original_file_sample_association.original_file = original_file_1
+        original_file_sample_association.sample = sample_object
+        original_file_sample_association.save()
+
+        original_file_2 = OriginalFile()
+        original_file_2.source_url = "second_url"
+        original_file_2.source_filename = "second_filename"
+        original_file_2.is_downloaded = False
+        original_file_2.has_raw = True
+        original_file_2.save()
+
+        original_file_sample_association = OriginalFileSampleAssociation()
+        original_file_sample_association.original_file = original_file_2
+        original_file_sample_association.sample = sample_object
+        original_file_sample_association.save()
+
+        dlj = DownloaderJob()
+        dlj.save()
+
+        DownloaderJobOriginalFileAssociation(
+            downloader_job=dlj,
+            original_file=original_file_1
+        ).save()
+
+        DownloaderJobOriginalFileAssociation(
+            downloader_job=dlj,
+            original_file=original_file_2
+        ).save()
+
+        survey_job = SurveyJob(source_type="SRA")
+        survey_job.save()
+        surveyor = SraSurveyor(survey_job)
+
+        surveyor.queue_downloader_job_for_original_files([original_file_1, original_file_2],
+                                                         experiment_object.accession_code)
+
+        # We made one DownloaderJob in this test, so
+        # queue_downloader_job_for_original_files didn't have anything
+        # to do, so there should still be only one:
+        self.assertEqual(1, DownloaderJob.objects.all().count())


### PR DESCRIPTION
## Issue Number

N/A came up while I was considering what to queue next.

## Purpose/Implementation Notes

 Turns out we haven't surveyed all the experiments we wanted to thus far, so we should requeue them, but this means we wanna make we don't requeue the work we've already done.

The other function that queues Downloader jobs was already making this check, but this one wasn't.

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

I think the unit test covers this well.

## Checklist

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules
