### PR TITLE
Make Janitor Purge Jobs Which Have Been GCd, Bump python-nomad Packag…

### DIFF
--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -26,7 +26,7 @@ markupsafe==1.0           # via jinja2
 psycopg2-binary==2.7.5
 psycopg2==2.7.5           # via djangorestframework-hstore
 python-dateutil==2.7.3    # via botocore
-python-nomad==1.0.2
+python-nomad>=1.0.2
 pytz==2018.5              # via django
 requests==2.20.0
 s3transfer==0.1.13        # via boto3

--- a/common/requirements.txt
+++ b/common/requirements.txt
@@ -16,7 +16,7 @@ idna==2.7                 # via requests
 jmespath==0.9.3           # via boto3, botocore
 psycopg2-binary==2.7.5
 python-dateutil==2.7.3    # via botocore
-python-nomad==1.0.2
+python-nomad>=1.0.2
 pytz==2018.5              # via django
 raven==6.9.0
 requests==2.20.0

--- a/foreman/requirements.txt
+++ b/foreman/requirements.txt
@@ -15,7 +15,7 @@ numpy==1.15.2             # via biopython, geoparse, pandas
 pandas==0.23.4            # via geoparse
 psycopg2-binary==2.7.5
 python-dateutil==2.7.3
-python-nomad==1.0.2
+python-nomad>=1.0.2
 pytz==2018.5              # via django, pandas
 raven==6.9.0
 requests==2.20.0

--- a/workers/data_refinery_workers/downloaders/requirements.txt
+++ b/workers/data_refinery_workers/downloaders/requirements.txt
@@ -13,7 +13,7 @@ docopt==0.6.2             # via coveralls
 idna==2.7                 # via requests
 psutil==5.4.7
 psycopg2-binary==2.7.5
-python-nomad==1.0.2
+python-nomad>=1.0.2
 pytz==2018.5              # via django
 requests==2.20.0
 retrying==1.3.3

--- a/workers/data_refinery_workers/processors/janitor.py
+++ b/workers/data_refinery_workers/processors/janitor.py
@@ -60,9 +60,9 @@ def _find_and_remove_expired_jobs(job_context):
                     if job_status == "running":
                         continue
                 except URLNotFoundNomadException as e:
-                    # If we can't currently access Nomad,
-                    # just continue until we can again.
-                    continue
+                    # Nomad has no record of this job, meaning it has likely been GC'd after death.
+                    # It can be purged.
+                    pass
                 except BaseNomadException as e:
                     # If we can't currently access Nomad,
                     # just continue until we can again.

--- a/workers/data_refinery_workers/processors/requirements.txt
+++ b/workers/data_refinery_workers/processors/requirements.txt
@@ -34,7 +34,7 @@ pandas==0.23.4
 psycopg2-binary==2.7.5
 pyparsing==2.2.2          # via matplotlib
 python-dateutil==2.7.3    # via botocore, matplotlib, pandas
-python-nomad==1.0.2
+python-nomad>=1.0.2
 pytz==2018.5              # via django, pandas
 pyyaml==3.13              # via multiqc
 requests==2.20.0


### PR DESCRIPTION
…e Version

## Issue Number
n/a

## Purpose/Implementation Notes
Changes the behavior in the Janitor when polling a job id in Nomad returns a `URLNotFoundNomadException`. We'll treat this as something that needs a purge rather than an error which will be re-addressed later.

Also bumps python-nomad package version.

## Types of changes
- Bugfix (non-breaking change which fixes an issue)
