### PR TITLE
Add Support for Purging Complete SRR/ERR/DRR Objects in JANITOR

### DIFF
--- a/workers/data_refinery_workers/processors/janitor.py
+++ b/workers/data_refinery_workers/processors/janitor.py
@@ -94,8 +94,8 @@ def _find_and_remove_expired_jobs(job_context):
                 # This job is likely vanished. No need for this directory.
                 pass
 
-        # There may be successful processors 
-        if 'SRP' in item or 'ERP' in item:
+        # There may be successful processors
+        if 'SRP' in item or 'ERP' in item or 'DRR' in item:
             sub_path = os.path.join(LOCAL_ROOT_DIR, item)
             for sub_item in os.listdir(sub_path):
                 try:

--- a/workers/data_refinery_workers/processors/janitor.py
+++ b/workers/data_refinery_workers/processors/janitor.py
@@ -18,6 +18,7 @@ from data_refinery_common.models import (
     ComputedFile,
     Pipeline,
     Processor,
+    Sample,
     SampleComputedFileAssociation,
     SampleResultAssociation,
     ProcessorJob
@@ -39,6 +40,8 @@ def _find_and_remove_expired_jobs(job_context):
     job_context['deleted_items'] = []
 
     for item in os.listdir(LOCAL_ROOT_DIR):
+
+        # Processor job working directories
         if 'processor_job_' in item:
 
             # TX Index jobs are the only ones who are allowed to hang around
@@ -74,7 +77,7 @@ def _find_and_remove_expired_jobs(job_context):
                     continue
             except ProcessorJob.DoesNotExist:
                 # This job has vanished from the DB - clean it up!
-                logger.exception("Janitor found no record of " + item + " - why?")
+                logger.error("Janitor found no record of " + item + " - why?")
                 pass
             except Exception:
                 # We're unable to connect to the DB right now (or something), so hold onto it for right now.
@@ -90,6 +93,31 @@ def _find_and_remove_expired_jobs(job_context):
             except Exception as e:
                 # This job is likely vanished. No need for this directory.
                 pass
+
+        # There may be successful processors 
+        if 'SRP' in item or 'ERP' in item:
+            sub_path = os.path.join(LOCAL_ROOT_DIR, item)
+            for sub_item in os.listdir(sub_path):
+                try:
+                    sample = Sample.objects.get(accession_code=sub_item)
+                    if sample.computed_files.count() == 0:
+                        # This doesn't have any associated computed files - leave it be.
+                        continue
+                except Sample.DoesNotExist:
+                    # Interesting. This shouldn't happen at all.
+                    continue
+                except Exception:
+                    # We can't contact the DB right now, skip deletion.
+                    continue
+
+                try:
+                    sub_item_path = os.path.join(sub_path, sub_item)
+                    logger.info("Janitor deleting " + sub_item_path, contents=str(os.listdir(sub_item_path)))
+                    shutil.rmtree(sub_item_path)
+                    job_context['deleted_items'].append(sub_item_path)
+                except Exception as e:
+                    # This job is likely vanished. No need for this directory.
+                    pass
 
     job_context['success'] = True
     return job_context

--- a/workers/data_refinery_workers/processors/test_janitor.py
+++ b/workers/data_refinery_workers/processors/test_janitor.py
@@ -40,7 +40,11 @@ def prepare_job():
 
     # Create 10 job directories
     for i in range(0, JOBS):
+
         os.makedirs(LOCAL_ROOT_DIR + '/processor_job_' + str(i), exist_ok=True)
+
+        # These live on prod volumes at locations such as:
+        # /var/ebs/SRP057116/SRR1972985/SRR1972985.sra
         os.makedirs(LOCAL_ROOT_DIR + '/SRP' + str(i), exist_ok=True)
         os.makedirs(LOCAL_ROOT_DIR + '/SRP' + str(i) + '/SRR' + str(i), exist_ok=True)
 

--- a/workers/data_refinery_workers/processors/test_janitor.py
+++ b/workers/data_refinery_workers/processors/test_janitor.py
@@ -41,11 +41,35 @@ def prepare_job():
     # Create 10 job directories
     for i in range(0, JOBS):
         os.makedirs(LOCAL_ROOT_DIR + '/processor_job_' + str(i), exist_ok=True)
+        os.makedirs(LOCAL_ROOT_DIR + '/SRP' + str(i), exist_ok=True)
+        os.makedirs(LOCAL_ROOT_DIR + '/SRP' + str(i) + '/SRR' + str(i), exist_ok=True)
+
+        sample = Sample()
+        sample.accession_code = "SRR" + str(i)
+        sample.save()
+
+        cr = ComputationalResult()
+        cr.save()
+
+        cf = ComputedFile()
+        cf.result = cr
+        cf.size_in_bytes = 666
+        cf.save()
+
+        scfa = SampleComputedFileAssociation()
+        scfa.sample = sample
+        scfa.computed_file = cf
+        scfa.save()
 
     # Create a job out of the range with index in it to make sure we
     # don't delete index directories since that's where transcriptome
     # indices get downloaded to.
     os.makedirs(LOCAL_ROOT_DIR + '/processor_job_' + str(JOBS+1) + '_index', exist_ok=True)
+
+    os.makedirs(LOCAL_ROOT_DIR + '/SRP' + str(JOBS+1) + '/SRR' + str(JOBS+1), exist_ok=True)
+    sample = Sample()
+    sample.accession_code = "SRR" + str(JOBS+1)
+    sample.save()
 
     # Save two jobs so that we trigger two special circumstances, one
     # where the job is still running and the other where querying
@@ -96,7 +120,10 @@ class JanitorTestCase(TestCase):
             else:
                 self.assertFalse(os.path.exists(LOCAL_ROOT_DIR + '/processor_job_' + str(i)))
 
+            self.assertFalse(os.path.exists(LOCAL_ROOT_DIR + '/SRP' + str(i) + '/SRR' + str(i)))
+
         self.assertTrue(os.path.exists(LOCAL_ROOT_DIR + '/processor_job_11_index'))
+        self.assertTrue(os.path.exists(LOCAL_ROOT_DIR + '/SRP' + str(JOBS+1) + '/SRR' + str(JOBS+1)))
 
         # Deleted all the working directories except for the one that's still running.
-        self.assertEqual(len(final_context['deleted_items']), JOBS-1)
+        self.assertEqual(len(final_context['deleted_items']), (JOBS*2)-1)


### PR DESCRIPTION
## Issue Number
n/a

## Purpose/Implementation Notes
Many of the volumes were filling due to old .sra files from September, etc. This gives the Janitor the ability to purge them.

## Methods
Please read this code thoroughly to make sure this all works as intended!

## Types of changes
- New feature (non-breaking change which adds functionality)

## Functional tests
New assertions
