### PR TITLE
Adds a Nomad Job Specification for Creating QN Targets

### DIFF
--- a/README.md
+++ b/README.md
@@ -450,7 +450,6 @@ Alternately, this can be done as a normal Nomad dispatch jobs:
 nomad job dispatch -meta ORGANISM=DANIO_RERIO CREATE_QN_TARGET
 ```
 
-
 ### Checking on Local Jobs
 
 _Note:_ The following instructions assume you have set the environment

--- a/README.md
+++ b/README.md
@@ -430,23 +430,6 @@ Or for more information run:
 If you want to quantile normalize combined outputs, you'll first need to create a reference target for a given organism. This can be done in a production environment with the following:
 
 ```bash
-docker run --env-file prod_env --volume /var/ebs/:/home/user/data_store -t ccdl/dr_smasher:latest python3 manage.py create_qn_target --organism DANIO_RERIO
-```
-
-Where the prod_env file has been temporarily copied to the host with:
-
-```bash
-scp -i data-refinery-key.pem prod_env ubuntu@<host_address>:/home/ubuntu/prod_env
-```
-
-However two keys in the prod_env file are incorrect.
-These are the `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` values, which are named `AWS_ACCESS_KEY_ID_CLIENT` and `AWS_SECRET_ACCESS_KEY`_CLIENT.
-(This difference is introduced intentionally to avoid conflicting with the environment variables of the developer at deploy time.)
-Therefore, all that needs to be done is to delete the `_CLIENT` part of the keys.
-
-Alternately, this can be done as a normal Nomad dispatch jobs:
-
-```bash
 nomad job dispatch -meta ORGANISM=DANIO_RERIO CREATE_QN_TARGET
 ```
 

--- a/README.md
+++ b/README.md
@@ -444,6 +444,13 @@ These are the `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` values, which are 
 (This difference is introduced intentionally to avoid conflicting with the environment variables of the developer at deploy time.)
 Therefore, all that needs to be done is to delete the `_CLIENT` part of the keys.
 
+Alternately, this can be done as a normal Nomad dispatch jobs:
+
+```bash
+nomad job dispatch -meta ORGANISM=DANIO_RERIO CREATE_QN_TARGET
+```
+
+
 ### Checking on Local Jobs
 
 _Note:_ The following instructions assume you have set the environment

--- a/format_nomad_with_env.sh
+++ b/format_nomad_with_env.sh
@@ -236,7 +236,7 @@ if [[ $project == "workers" ]]; then
                        > "$output_dir/$output_file$TEST_POSTFIX" \
                        2> /dev/null
             echo "Made $output_dir/$output_file$TEST_POSTFIX"
-        elif [ $output_file == "smasher.nomad" ]; then
+        elif [ $output_file == "smasher.nomad" ] || [ $output_file == "create_qn_target.nomad" ]; then
             export_log_conf "processor"
             cat nomad-job-specs/$template \
                 | perl -p -e 's/\$\{\{([^}]+)\}\}/defined $ENV{$1} ? $ENV{$1} : $&/eg' \

--- a/workers/nomad-job-specs/create_qn_target.nomad.tpl
+++ b/workers/nomad-job-specs/create_qn_target.nomad.tpl
@@ -9,7 +9,7 @@ job "CREATE_QN_TARGET" {
 
   parameterized {
     payload       = "forbidden"
-    meta_required = ["JOB_NAME", "JOB_ID"]
+    meta_required = ["ORGANISM"]
   }
 
   group "jobs" {

--- a/workers/nomad-job-specs/create_qn_target.nomad.tpl
+++ b/workers/nomad-job-specs/create_qn_target.nomad.tpl
@@ -1,0 +1,96 @@
+job "CREATE_QN_TARGET" {
+  datacenters = ["dc1"]
+
+  type = "batch"
+
+  # These are high priority because if we've dispatched them,
+  # we need them.
+  priority = 80
+
+  parameterized {
+    payload       = "forbidden"
+    meta_required = ["JOB_NAME", "JOB_ID"]
+  }
+
+  group "jobs" {
+    restart {
+      attempts = 0
+      mode = "fail"
+    }
+
+    reschedule {
+      attempts = 0
+      unlimited = false
+    }
+
+    ephemeral_disk {
+      size = "10"
+    }
+
+    task "create_qn_target" {
+      driver = "docker"
+
+      kill_timeout = "30s"
+
+      # This env will be passed into the container for the job.
+      env {
+        ${{AWS_CREDS}}
+        DJANGO_SECRET_KEY = "${{DJANGO_SECRET_KEY}}"
+        DJANGO_DEBUG = "${{DJANGO_DEBUG}}"
+
+        DATABASE_NAME = "${{DATABASE_NAME}}"
+        DATABASE_USER = "${{DATABASE_USER}}"
+        DATABASE_PASSWORD = "${{DATABASE_PASSWORD}}"
+        DATABASE_HOST = "${{DATABASE_HOST}}"
+        DATABASE_PORT = "${{DATABASE_PORT}}"
+        DATABASE_TIMEOUT = "${{DATABASE_TIMEOUT}}"
+
+        RAVEN_DSN="${{RAVEN_DSN}}"
+        RAVEN_DSN_API="${{RAVEN_DSN_API}}"
+
+        NOMAD_HOST = "${{NOMAD_HOST}}"
+        NOMAD_PORT = "${{NOMAD_PORT}}"
+
+        RUNNING_IN_CLOUD = "${{RUNNING_IN_CLOUD}}"
+
+        USE_S3 = "${{USE_S3}}"
+        S3_BUCKET_NAME = "${{S3_BUCKET_NAME}}"
+        LOCAL_ROOT_DIR = "${{LOCAL_ROOT_DIR}}"
+        MAX_DOWNLOADER_JOBS_PER_NODE = "${{MAX_DOWNLOADER_JOBS_PER_NODE}}"
+
+        LOG_LEVEL = "${{LOG_LEVEL}}"
+      }
+
+      # The resources the job will require.
+      resources {
+        # CPU is in AWS's CPU units.
+        cpu = 1024
+        # Memory is in MB of RAM.
+        memory = 16384
+      }
+
+      logs {
+        max_files = 1
+        max_file_size = 1
+      }
+
+      ${{SMASHER_CONSTRAINT}}
+
+      config {
+        image = "${{DOCKERHUB_REPO}}/${{SMASHER_DOCKER_IMAGE}}"
+        force_pull = false
+
+        # The args to pass to the Docker container's entrypoint.
+        args = [
+          "python3",
+          "manage.py",
+          "create_qn_target",
+          "--organism", "${NOMAD_META_ORGANISM}",
+        ]
+        ${{EXTRA_HOSTS}}
+        volumes = ["${{VOLUME_DIR}}:/home/user/data_store"]
+        ${{LOGGING_CONFIG}}
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Issue Number

n/a

## Purpose/Implementation Notes

It's a pain in the butt to copy the prod env to a client to create a prod QN target, so this creates a nomad job spec for creating QN targets.

It'd be great if you could test this locally since our Nomad job register setup doesn't work on OSX, so I haven't tested this yet.

## Types of changes

- New feature (non-breaking change which adds functionality)
