### PR TITLE
Increase RAM amounts when retrying failed AFFY jobs

### DIFF
--- a/foreman/data_refinery_foreman/foreman/main.py
+++ b/foreman/data_refinery_foreman/foreman/main.py
@@ -484,6 +484,15 @@ def requeue_processor_job(last_job: ProcessorJob) -> None:
         elif new_ram_amount == 12288:
             new_ram_amount = 16384
 
+    # The AFFY pipeline is somewhat RAM-sensitive.
+    # Try it again with an increased RAM amount, if possible.
+    new_ram_amount = last_job.ram_amount
+    if last_job.pipeline_applied == "AFFY_TO_PCL":
+        if new_ram_amount == 2048:
+            new_ram_amount = 4096
+        elif new_ram_amount == 4096:
+            new_ram_amount = 8192
+
     new_job = ProcessorJob(num_retries=num_retries,
                            pipeline_applied=last_job.pipeline_applied,
                            ram_amount=new_ram_amount,

--- a/foreman/data_refinery_foreman/foreman/main.py
+++ b/foreman/data_refinery_foreman/foreman/main.py
@@ -483,11 +483,9 @@ def requeue_processor_job(last_job: ProcessorJob) -> None:
             new_ram_amount = 12288
         elif new_ram_amount == 12288:
             new_ram_amount = 16384
-
     # The AFFY pipeline is somewhat RAM-sensitive.
     # Try it again with an increased RAM amount, if possible.
-    new_ram_amount = last_job.ram_amount
-    if last_job.pipeline_applied == "AFFY_TO_PCL":
+    elif last_job.pipeline_applied == "AFFY_TO_PCL":
         if new_ram_amount == 2048:
             new_ram_amount = 4096
         elif new_ram_amount == 4096:


### PR DESCRIPTION
## Issue Number

n/a

## Purpose/Implementation Notes

Some AFFY jobs are being OOM killed, then retried with the same RAM amount, so they get OOM killed again:

```
$ nomad status a15e2f73
ID                  = a15e2f73
Eval ID             = 4623fa6b
Name                = AFFY_TO_PCL_25_2048/dispatch-1544205942-f5fdcf90.jobs[0]
Node ID             = 313cf4bc
Job ID              = AFFY_TO_PCL_25_2048/dispatch-1544205942-f5fdcf90
Job Version         = 0
Client Status       = failed
Client Description  = <none>
Desired Status      = run
Desired Description = <none>
Created             = 5m54s ago
Modified            = 2m24s ago

Task "affy_to_pcl" is "dead"
Task Resources
CPU       Memory   Disk    IOPS  Addresses
1024 MHz  2.0 GiB  10 MiB  0     

Task Events:
Started At     = 2018-12-07T18:07:56Z
Finished At    = 2018-12-07T18:08:54Z
Total Restarts = 0
Last Restart   = N/A

Recent Events:
Time                  Type            Description
2018-12-07T18:08:54Z  Not Restarting  Policy allows no restarts
2018-12-07T18:08:54Z  Terminated      Exit Code: 137, Exit Message: "OOM Killed"
2018-12-07T18:07:56Z  Started         Task started by client
2018-12-07T18:07:55Z  Task Setup      Building Task Directory
2018-12-07T18:07:55Z  Received        Task received by client
```

This PR ramps up the RAM usage when retrying, just as we do already for SALMON.

## Types of changes
- New feature (non-breaking change which adds functionality)
