### PR TITLE
De-thread the foreman and otherwise cleanup/improve it.

### DIFF
--- a/foreman/data_refinery_foreman/foreman/main.py
+++ b/foreman/data_refinery_foreman/foreman/main.py
@@ -1,12 +1,12 @@
 import nomad
 import socket
 import time
+import traceback
+
 from nomad import Nomad
 from nomad.api.exceptions import URLNotFoundNomadException
-from typing import Callable, List, Set
-from threading import Thread
+from typing import List, Set
 from functools import wraps
-from retrying import retry
 from datetime import datetime, timedelta
 from django.conf import settings
 from django.utils import timezone
@@ -45,19 +45,15 @@ MAX_NUM_RETRIES = 2
 # This can be overritten by the env var "MAX_TOTAL_JOBS"
 DEFAULT_MAX_JOBS = 20000
 
-# The fastest each thread will repeat its checks.
-# Could be slower if the thread takes longer than this to check its jobs.
+# The minimum amount of time in between each iteration of the main
+# loop. We could loop much less frequently than every two minutes if
+# the work we do takes longer than 2 minutes, but this will prevent
+# excessive spinning.
 MIN_LOOP_TIME = timedelta(minutes=2)
 
-# The amount of time the main loop will wait in between checking if
-# threads are still alive and then heart beating.
-THREAD_WAIT_TIME = timedelta(minutes=10)
-
-# How frequently we dispatch Janitor jobs.
+# How frequently we dispatch Janitor jobs and clean unplaceable jobs
+# out of the Nomad queue.
 JANITOR_DISPATCH_TIME = timedelta(minutes=30)
-
-# How frequently we clean unplaceable jobs out of the Nomad queue.
-CLEANUP_QUEUE_TIME = timedelta(minutes=30)
 
 
 def read_config_list(config_file: str) -> List[str]:
@@ -81,32 +77,6 @@ HGU133PLUS2_ACCESSION_LIST = read_config_list("config/hgu133plus2_accessions.txt
 ##
 # Utilities
 ##
-
-def do_forever(min_loop_time: timedelta) -> Callable:
-    """Run the wrapped function in a loop forever.
-
-    The function won't be run more often than once per min_loop_time,
-    however if it takes longer to run than min_loop_time, then it will
-    be run less often than once per min_loop_time.
-    """
-    def decorator(function: Callable) -> Callable:
-        @wraps(function)
-        def wrapper(*args, **kwargs):
-            while(True):
-                start_time = timezone.now()
-
-                try:
-                    function(*args, **kwargs)
-                except:
-                    logger.exception("Exception caught by Foreman while running " + function.__name__)
-
-                loop_time = timezone.now() - start_time
-                if loop_time < min_loop_time:
-                    remaining_time = min_loop_time - loop_time
-                    time.sleep(remaining_time.seconds)
-
-        return wrapper
-    return decorator
 
 
 def handle_repeated_failure(job) -> None:
@@ -264,7 +234,6 @@ def prioritize_jobs_by_accession(jobs: List, accession_list: List[str]) -> List:
 ##
 
 
-@retry(stop_max_attempt_number=3)
 @transaction.atomic
 def requeue_downloader_job(last_job: DownloaderJob) -> None:
     """Queues a new downloader job.
@@ -344,7 +313,6 @@ def handle_downloader_jobs(jobs: List[DownloaderJob]) -> None:
 
     return True
 
-@do_forever(MIN_LOOP_TIME)
 def retry_failed_downloader_jobs() -> None:
     """Handle downloader jobs that were marked as a failure."""
     failed_jobs = DownloaderJob.objects.filter(
@@ -363,7 +331,6 @@ def retry_failed_downloader_jobs() -> None:
         handle_downloader_jobs(failed_jobs_list)
 
 
-@do_forever(MIN_LOOP_TIME)
 def retry_hung_downloader_jobs() -> None:
     """Retry downloader jobs that were started but never finished."""
     potentially_hung_jobs = DownloaderJob.objects.filter(
@@ -390,13 +357,14 @@ def retry_hung_downloader_jobs() -> None:
                     hung_jobs.append(job)
         except URLNotFoundNomadException:
             hung_jobs.append(job)
+        except nomad.api.exceptions.BaseNomadException:
+            raise
         except Exception:
             logger.exception("Couldn't query Nomad about Processor Job.", processor_job=job.id)
 
     handle_downloader_jobs(hung_jobs)
 
 
-@do_forever(MIN_LOOP_TIME)
 def retry_lost_downloader_jobs() -> None:
     """Retry downloader jobs that went too long without being started.
 
@@ -451,7 +419,7 @@ def retry_lost_downloader_jobs() -> None:
             )
             lost_jobs.append(job)
         except nomad.api.exceptions.BaseNomadException:
-            logger.info("Problem connecting to Nomad - is Nomad down?", job_id=job.id)
+            raise
         except Exception:
             logger.exception("Couldn't query Nomad about Processor Job.", processor_job=job.id)
 
@@ -463,7 +431,6 @@ def retry_lost_downloader_jobs() -> None:
 ##
 
 
-@retry(stop_max_attempt_number=3)
 @transaction.atomic
 def requeue_processor_job(last_job: ProcessorJob) -> None:
     """Queues a new processor job.
@@ -559,7 +526,7 @@ def handle_processor_jobs(jobs: List[ProcessorJob]) -> None:
 
     return True
 
-@do_forever(MIN_LOOP_TIME)
+
 def retry_failed_processor_jobs() -> None:
     """Handle processor jobs that were marked as a failure.
 
@@ -590,7 +557,6 @@ def retry_failed_processor_jobs() -> None:
         handle_processor_jobs(failed_jobs_list)
 
 
-@do_forever(MIN_LOOP_TIME)
 def retry_hung_processor_jobs() -> None:
     """Retry processor jobs that were started but never finished.
 
@@ -639,6 +605,8 @@ def retry_hung_processor_jobs() -> None:
             #   u = "/".join(args)
             # TypeError: sequence item 1: expected str instance, NoneType found
             logger.info("Couldn't query Nomad about Processor Job.", processor_job=job.id)
+        except nomad.api.exceptions.BaseNomadException:
+            raise
         except Exception:
             logger.exception("Couldn't query Nomad about Processor Job.", processor_job=job.id)
 
@@ -650,7 +618,6 @@ def retry_hung_processor_jobs() -> None:
         handle_processor_jobs(hung_jobs)
 
 
-@do_forever(MIN_LOOP_TIME)
 def retry_lost_processor_jobs() -> None:
     """Retry processor jobs which never even got started for too long.
 
@@ -705,6 +672,8 @@ def retry_lost_processor_jobs() -> None:
                              job_id=job.id
             )
             lost_jobs.append(job)
+        except nomad.api.exceptions.BaseNomadException:
+            raise
         except Exception:
             logger.exception("Couldn't query Nomad about Processor Job.", processor_job=job.id)
 
@@ -719,7 +688,6 @@ def retry_lost_processor_jobs() -> None:
 # Surveyors
 ##
 
-@retry(stop_max_attempt_number=3)
 @transaction.atomic
 def requeue_survey_job(last_job: SurveyJob) -> None:
     """Queues a new survey job.
@@ -806,7 +774,7 @@ def handle_survey_jobs(jobs: List[SurveyJob]) -> None:
 
     return True
 
-@do_forever(MIN_LOOP_TIME)
+
 def retry_failed_survey_jobs() -> None:
     """Handle survey jobs that were marked as a failure."""
     failed_jobs = SurveyJob.objects.filter(success=False, retried=False).order_by('pk')
@@ -818,7 +786,6 @@ def retry_failed_survey_jobs() -> None:
         handle_survey_jobs(failed_jobs)
 
 
-@do_forever(MIN_LOOP_TIME)
 def retry_hung_survey_jobs() -> None:
     """Retry survey jobs that were started but never finished."""
     potentially_hung_jobs = SurveyJob.objects.filter(
@@ -849,6 +816,8 @@ def retry_hung_survey_jobs() -> None:
                     hung_jobs.append(job)
         except URLNotFoundNomadException:
             hung_jobs.append(job)
+        except nomad.api.exceptions.BaseNomadException:
+            raise
         except Exception:
             logger.exception("Couldn't query Nomad about SurveyJob Job.", survey_job=job.id)
 
@@ -860,7 +829,6 @@ def retry_hung_survey_jobs() -> None:
         handle_survey_jobs(hung_jobs)
 
 
-@do_forever(MIN_LOOP_TIME)
 def retry_lost_survey_jobs() -> None:
     """Retry survey jobs which never even got started for too long."""
     potentially_lost_jobs = SurveyJob.objects.filter(
@@ -901,6 +869,8 @@ def retry_lost_survey_jobs() -> None:
                          job_id=job.id
             )
             lost_jobs.append(job)
+        except nomad.api.exceptions.BaseNomadException:
+            raise
         except Exception:
             logger.exception("Couldn't query Nomad about Processor Job.", survey_job=job.id)
 
@@ -915,7 +885,6 @@ def retry_lost_survey_jobs() -> None:
 # Janitor
 ##
 
-@do_forever(JANITOR_DISPATCH_TIME)
 def send_janitor_jobs():
     """Dispatch a Janitor job for each instance in the cluster"""
     try:
@@ -945,7 +914,6 @@ def send_janitor_jobs():
 # Handling of node cycling
 ##
 
-@do_forever(CLEANUP_QUEUE_TIME)
 def cleanup_the_queue():
     """This cleans up any jobs which cannot currently be queued.
 
@@ -971,7 +939,7 @@ def cleanup_the_queue():
         jobs = nomad_client.jobs.get_jobs()
     except:
         # If we cannot reach Nomad now then we can wait until a later loop.
-        pass
+        return
 
 
     jobs_to_kill = []
@@ -1015,63 +983,22 @@ def cleanup_the_queue():
 ##
 
 def monitor_jobs():
-    """Runs a thread for each job monitoring loop."""
+    """Main Foreman thread that helps manage the Nomad job queue.
 
-    threads = []
+    Will find jobs that failed, hung, or got lost and requeue them.
 
-    # Start the thread to dispatch Janitor jobs.
-    thread = Thread(target=send_janitor_jobs, name="send_janitor_jobs")
-    thread.start()
-    threads.append(thread)
-    logger.info("Thread started for function: send_janitor_jobs")
+    Also will queue up Janitor jobs regularly to free up disk space.
 
-    # Start the thread to keep the Nomad clean of jobs it cannot place.
-    thread = Thread(target=cleanup_the_queue, name="cleanup_the_queue")
-    thread.start()
-    threads.append(thread)
-    logger.info("Thread started for function: cleanup_the_queue")
+    Also cleans jobs out of the Nomad queue which cannot be queued
+    because the volume containing the job's data isn't mounted.
 
-    processor_functions = [ retry_failed_processor_jobs,
-                            retry_hung_processor_jobs,
-                            retry_lost_processor_jobs]
-
-    for f in processor_functions:
-        thread = Thread(target=f, name=f.__name__)
-        thread.start()
-        threads.append(thread)
-        logger.info("Thread started for monitoring function: %s", f.__name__)
-
-    # This is only a concern when running at scale.
-    if settings.RUNNING_IN_CLOUD:
-        # We start the processor threads first so that we don't
-        # accidentally queue too many downloader jobs and knock down our
-        # source databases. They may take a while to run, and this
-        # function only runs once per deploy, so give a generous amount of
-        # time, say 5 minutes:
-        time.sleep(60*5)
-
-    downloader_functions = [retry_failed_downloader_jobs,
-                            retry_hung_downloader_jobs,
-                            retry_lost_downloader_jobs]
-
-    for f in downloader_functions:
-        thread = Thread(target=f, name=f.__name__)
-        thread.start()
-        threads.append(thread)
-        logger.info("Thread started for monitoring function: %s", f.__name__)
-
-    survey_functions = [retry_failed_survey_jobs,
-                            retry_hung_survey_jobs,
-                            retry_lost_survey_jobs]
-
-    for f in survey_functions:
-        thread = Thread(target=f, name=f.__name__)
-        thread.start()
-        threads.append(thread)
-        logger.info("Thread started for monitoring function: %s", f.__name__)
-
-    # Make sure that no threads die quietly.
+    It does so on a loop forever that won't spin faster than
+    MIN_LOOP_TIME, but it may spin slower than that.
+    """
+    last_janitorial_time = None
     while(True):
+        # Perform two heartbeats, one for the logs and one for Monit:
+        logger.info("The Foreman's heart is beating, but he does not feel.")
 
         # Write the health file for Monit to check
         now_secs = int(time.time())
@@ -1080,13 +1007,37 @@ def monitor_jobs():
 
         start_time = timezone.now()
 
-        for thread in threads:
-            if not thread.is_alive():
-                logger.error("Foreman Thread for the function %s has died!!!!", thread.name)
+        # Requeue jobs of each failure class for each job type.
+        # The order of processor -> downloader -> surveyor is intentional.
+        # Processors go first so we process data sitting on disk.
+        # Downloaders go first so we actually queue up the jobs in the database.
+        # Surveyors go last so we don't end up with tons and tons of unqueued jobs.
+        requeuing_functions_in_order = [
+            retry_failed_processor_jobs,
+            retry_hung_processor_jobs,
+            retry_lost_processor_jobs,
+            retry_failed_downloader_jobs,
+            retry_hung_downloader_jobs,
+            retry_lost_downloader_jobs,
+            retry_failed_survey_jobs,
+            retry_hung_survey_jobs,
+            retry_lost_survey_jobs
+        ]
+
+        for function in requeuing_functions_in_order:
+            try:
+                function()
+            except Exception as e:
+                logger.error("Caught exception in %s: ", function.__name__)
+                traceback.print_exc(chain=False)
+
+        if not last_janitorial_time \
+           or timezone.now() - last_janitorial_time > JANITOR_DISPATCH_TIME:
+            send_janitor_jobs()
+            cleanup_the_queue()
+            last_janitorial_time = timezone.now()
 
         loop_time = timezone.now() - start_time
-        if loop_time < THREAD_WAIT_TIME:
-            remaining_time = THREAD_WAIT_TIME - loop_time
+        if loop_time < MIN_LOOP_TIME:
+            remaining_time = MIN_LOOP_TIME - loop_time
             time.sleep(remaining_time.seconds)
-
-        logger.info("The Foreman's heart is beating, but he does not feel.")

--- a/foreman/data_refinery_foreman/foreman/test_main.py
+++ b/foreman/data_refinery_foreman/foreman/test_main.py
@@ -113,7 +113,7 @@ class ForemanTestCase(TestCase):
 
         # Just run it once, not forever so get the function that is
         # decorated with @do_forever
-        main.retry_failed_downloader_jobs.__wrapped__()
+        main.retry_failed_downloader_jobs()
         self.assertEqual(len(mock_send_job.mock_calls), 1)
 
         jobs = DownloaderJob.objects.order_by('id')
@@ -145,7 +145,7 @@ class ForemanTestCase(TestCase):
 
         # Just run it once, not forever so get the function that is
         # decorated with @do_forever
-        main.retry_hung_downloader_jobs.__wrapped__()
+        main.retry_hung_downloader_jobs()
         self.assertEqual(len(mock_send_job.mock_calls), 1)
 
         jobs = DownloaderJob.objects.order_by('id')
@@ -178,7 +178,7 @@ class ForemanTestCase(TestCase):
 
         # Just run it once, not forever so get the function that is
         # decorated with @do_forever
-        main.retry_hung_downloader_jobs.__wrapped__()
+        main.retry_hung_downloader_jobs()
         self.assertEqual(len(mock_send_job.mock_calls), 0)
 
         jobs = DownloaderJob.objects.order_by('id')
@@ -209,7 +209,7 @@ class ForemanTestCase(TestCase):
 
         # Just run it once, not forever so get the function that is
         # decorated with @do_forever
-        main.retry_lost_downloader_jobs.__wrapped__()
+        main.retry_lost_downloader_jobs()
         self.assertEqual(len(mock_send_job.mock_calls), 1)
 
         jobs = DownloaderJob.objects.order_by('id')
@@ -231,7 +231,7 @@ class ForemanTestCase(TestCase):
 
         # Just run it once, not forever so get the function that is
         # decorated with @do_forever
-        main.retry_lost_downloader_jobs.__wrapped__()
+        main.retry_lost_downloader_jobs()
         self.assertEqual(len(mock_send_job.mock_calls), 1)
 
         jobs = DownloaderJob.objects.order_by('id')
@@ -264,7 +264,7 @@ class ForemanTestCase(TestCase):
 
         # Just run it once, not forever so get the function that is
         # decorated with @do_forever
-        main.retry_lost_downloader_jobs.__wrapped__()
+        main.retry_lost_downloader_jobs()
         self.assertEqual(len(mock_send_job.mock_calls), 0)
 
         jobs = DownloaderJob.objects.order_by('id')
@@ -393,7 +393,7 @@ class ForemanTestCase(TestCase):
 
         # Just run it once, not forever so get the function that is
         # decorated with @do_forever
-        main.retry_failed_processor_jobs.__wrapped__()
+        main.retry_failed_processor_jobs()
         self.assertEqual(len(mock_send_job.mock_calls), 1)
 
         jobs = ProcessorJob.objects.order_by('id')
@@ -418,7 +418,7 @@ class ForemanTestCase(TestCase):
 
         # Just run it once, not forever so get the function that is
         # decorated with @do_forever
-        main.retry_failed_processor_jobs.__wrapped__()
+        main.retry_failed_processor_jobs()
         self.assertEqual(len(mock_send_job.mock_calls), 0)
 
         jobs = ProcessorJob.objects.order_by('id')
@@ -451,7 +451,7 @@ class ForemanTestCase(TestCase):
 
         # Just run it once, not forever so get the function that is
         # decorated with @do_forever
-        main.retry_hung_processor_jobs.__wrapped__()
+        main.retry_hung_processor_jobs()
         self.assertEqual(len(mock_send_job.mock_calls), 1)
 
         jobs = ProcessorJob.objects.order_by('id')
@@ -486,7 +486,7 @@ class ForemanTestCase(TestCase):
 
         # Just run it once, not forever so get the function that is
         # decorated with @do_forever
-        main.retry_hung_processor_jobs.__wrapped__()
+        main.retry_hung_processor_jobs()
         self.assertEqual(len(mock_send_job.mock_calls), 0)
 
         jobs = ProcessorJob.objects.order_by('id')
@@ -519,7 +519,7 @@ class ForemanTestCase(TestCase):
 
         # Just run it once, not forever so get the function that is
         # decorated with @do_forever
-        main.retry_lost_processor_jobs.__wrapped__()
+        main.retry_lost_processor_jobs()
 
         self.assertEqual(len(mock_send_job.mock_calls), 1)
 
@@ -555,7 +555,7 @@ class ForemanTestCase(TestCase):
 
         # Just run it once, not forever so get the function that is
         # decorated with @do_forever
-        main.retry_lost_processor_jobs.__wrapped__()
+        main.retry_lost_processor_jobs()
         self.assertEqual(len(mock_send_job.mock_calls), 0)
 
         jobs = ProcessorJob.objects.order_by('id')
@@ -579,7 +579,7 @@ class ForemanTestCase(TestCase):
 
         # Just run it once, not forever so get the function that is
         # decorated with @do_forever
-        main.retry_lost_processor_jobs.__wrapped__()
+        main.retry_lost_processor_jobs()
         self.assertEqual(len(mock_send_job.mock_calls), 1)
 
         jobs = ProcessorJob.objects.order_by('id')
@@ -604,7 +604,7 @@ class ForemanTestCase(TestCase):
 
         # Just run it once, not forever so get the function that is
         # decorated with @do_forever
-        main.retry_lost_processor_jobs.__wrapped__()
+        main.retry_lost_processor_jobs()
         self.assertEqual(len(mock_send_job.mock_calls), 0)
 
         jobs = ProcessorJob.objects.order_by('id')
@@ -696,7 +696,7 @@ class ForemanTestCase(TestCase):
 
         # Just run it once, not forever so get the function that is
         # decorated with @do_forever
-        main.retry_failed_survey_jobs.__wrapped__()
+        main.retry_failed_survey_jobs()
         self.assertEqual(len(mock_send_job.mock_calls), 1)
 
         jobs = SurveyJob.objects.order_by('id')
@@ -728,7 +728,7 @@ class ForemanTestCase(TestCase):
 
         # Just run it once, not forever so get the function that is
         # decorated with @do_forever
-        main.retry_hung_survey_jobs.__wrapped__()
+        main.retry_hung_survey_jobs()
         self.assertEqual(len(mock_send_job.mock_calls), 1)
 
         jobs = SurveyJob.objects.order_by('id')
@@ -761,7 +761,7 @@ class ForemanTestCase(TestCase):
 
         # Just run it once, not forever so get the function that is
         # decorated with @do_forever
-        main.retry_hung_survey_jobs.__wrapped__()
+        main.retry_hung_survey_jobs()
         self.assertEqual(len(mock_send_job.mock_calls), 0)
 
         jobs = SurveyJob.objects.order_by('id')
@@ -792,7 +792,7 @@ class ForemanTestCase(TestCase):
 
         # Just run it once, not forever so get the function that is
         # decorated with @do_forever
-        main.retry_lost_survey_jobs.__wrapped__()
+        main.retry_lost_survey_jobs()
 
         self.assertEqual(len(mock_send_job.mock_calls), 1)
 
@@ -826,7 +826,7 @@ class ForemanTestCase(TestCase):
 
         # Just run it once, not forever so get the function that is
         # decorated with @do_forever
-        main.retry_lost_survey_jobs.__wrapped__()
+        main.retry_lost_survey_jobs()
         self.assertEqual(len(mock_send_job.mock_calls), 0)
 
         jobs = SurveyJob.objects.order_by('id')
@@ -848,7 +848,7 @@ class ForemanTestCase(TestCase):
 
         # Just run it once, not forever so get the function that is
         # decorated with @do_forever
-        main.retry_lost_survey_jobs.__wrapped__()
+        main.retry_lost_survey_jobs()
         self.assertEqual(len(mock_send_job.mock_calls), 1)
 
         jobs = SurveyJob.objects.order_by('id')
@@ -873,7 +873,7 @@ class ForemanTestCase(TestCase):
 
         # Just run it once, not forever so get the function that is
         # decorated with @do_forever
-        main.send_janitor_jobs.__wrapped__()
+        main.send_janitor_jobs()
 
         self.assertEqual(ProcessorJob.objects.all().count(), 6)
         self.assertEqual(ProcessorJob.objects.filter(pipeline_applied="JANITOR").count(), 3)


### PR DESCRIPTION
## Issue Number

#902 

## Purpose/Implementation Notes

So I'm not sure if this will actually prevent the bug that caused #902 or not, but I cannot reproduce the bug so I can't verify that I've fixed it. However https://stackoverflow.com/questions/8242837/django-multiprocessing-and-database-connections makes me think that Django database connections may have issues with multi-threading, and there's not really any good reason for the Foreman to use threads anyway, so I think this is a good change that may or may not fix the issue in #902.

I've also made sure the logging isn't too excessive when Nomad is down.

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

I've tested how the Foreman behaves when Nomad is down and I've seen it queue some downloader jobs but I should probably run a few more tests once I'm done testing #904 

## Checklist

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules
