### PR TITLE
Escalate troublesome salmon jobs to 32GB!

### DIFF
--- a/foreman/data_refinery_foreman/foreman/main.py
+++ b/foreman/data_refinery_foreman/foreman/main.py
@@ -480,9 +480,7 @@ def requeue_processor_job(last_job: ProcessorJob) -> None:
         if new_ram_amount == 4096:
             new_ram_amount = 8192
         elif new_ram_amount == 8192:
-            new_ram_amount = 12288
-        elif new_ram_amount == 12288:
-            new_ram_amount = 16384
+            new_ram_amount = 32768
     # The AFFY pipeline is somewhat RAM-sensitive.
     # Try it again with an increased RAM amount, if possible.
     elif last_job.pipeline_applied == "AFFY_TO_PCL":

--- a/format_nomad_with_env.sh
+++ b/format_nomad_with_env.sh
@@ -246,7 +246,7 @@ if [[ $project == "workers" ]]; then
         else
             export_log_conf "processor"
             # rams=(1024 2048 3072 4096 5120 6144 7168 8192 9216 10240 11264 12288 13312)
-            rams=(2048 3072 4096 8192 12288 16384)
+            rams=(2048 3072 4096 8192 12288 16384 32768)
             for r in "${rams[@]}"
             do
                 for ((j=0; j<MAX_CLIENTS; j++));


### PR DESCRIPTION
## Issue Number

N/A this is trying to solve us not being able to finish all the work we have in the system.

## Purpose/Implementation Notes

We've had a lot of jobs repeatedly fail without even setting end_time, success, or failure_reason. Unless docker is really really misbehaving and killing them the most likely culprit is that the jobs are running out of RAM and getting OOM-killed. Seems like this is happening for Salmon and Affy jobs. #905 took care of Affy jobs. This ups the limits for salmon jobs.

## Types of changes

- New feature (non-breaking change which adds functionality)

## Functional tests

N/A, unit tests will cover this once I fix them.

## Checklist

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules
