### PR TITLE
Optimizations for `/samples` endpoint

### DIFF
--- a/api/data_refinery_api/tests.py
+++ b/api/data_refinery_api/tests.py
@@ -55,7 +55,9 @@ class APITestCases(APITestCase):
         # self.user = User.objects.create(username="mike")
 
         experiment = Experiment()
+        experiment.accession_code = "GSE123"
         experiment.save()
+        self.experiment = experiment
 
         experiment_annotation = ExperimentAnnotation()
         experiment_annotation.data = {"hello": "world", "123": 456}
@@ -214,6 +216,16 @@ class APITestCases(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.json()['results'][0]['title'], '123')
 
+    def test_fetching_experiment_samples(self):
+        response = self.client.get(reverse('samples'), {'experiment_accession_code': self.experiment.accession_code})
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.json()['results']), 1)
+        self.assertEqual(response.json()['results'][0]['accession_code'], '789')
+
+        # Expect 404 if the experiment accession code isn't valid
+        response = self.client.get(reverse('samples'), {'experiment_accession_code': 'wrong-accession-code'})
+        self.assertEqual(response.status_code, 404)
+        
 
     def test_search_and_filter(self):
 

--- a/api/data_refinery_api/views.py
+++ b/api/data_refinery_api/views.py
@@ -533,7 +533,10 @@ class SampleList(PaginatedAPIView):
     List all Samples.
 
     Pass in a list of pk to an ids query parameter to filter by id.
-    Can also accept a `dataset_id` field instead of a list of accession codes.
+    
+    Also accepts:
+        - `dataset_id` field instead of a list of accession codes
+        - `experiment_accession_code` to return the samples associated with a given experiment
 
     Append the pk or accession_code to the end of this URL to see a detail view.
 


### PR DESCRIPTION
## Issue Number

#832 

## Purpose/Implementation Notes

Use `prefetch_related` to reduce the number of DB queries that are done when fetching detailed sample information.

Right now, in order to get detailed sample information we have to send the accession codes of all samples, this makes the urls very long and causes issues like https://github.com/AlexsLemonade/refinebio-frontend/issues/121#issuecomment-404906582. To address this, I added here a new parameter `experiment_accession_code` to request the samples associated with a given experiment.

For reference, here are the DB queries for `/samples/?experiment_accession_code=GSE16254&limit=10`.

```sql
(0.019) SELECT "experiments"."id" FROM "experiments" WHERE "experiments"."accession_code" = 'GSE16254'; args=('GSE16254',)
(0.035) SELECT COUNT(*) AS "__count" FROM "samples" INNER JOIN "experiment_sample_associations" ON ("samples"."id" = "experiment_sample_associations"."sample_id") WHERE ("samples"."is_public" = true AND "experiment_sample_associations"."experiment_id" IN (1)); args=(True, 1)
(0.015) SELECT "samples"."id", "samples"."accession_code", "samples"."title", "samples"."organism_id", "samples"."source_database", "samples"."source_archive_url", "samples"."source_filename", "samples"."source_absolute_file_path", "samples"."has_raw", "samples"."platform_accession_code", "samples"."platform_name", "samples"."technology", "samples"."manufacturer", "samples"."protocol_info", "samples"."sex", "samples"."age", "samples"."specimen_part", "samples"."genotype", "samples"."disease", "samples"."disease_stage", "samples"."cell_line", "samples"."treatment", "samples"."race", "samples"."subject", "samples"."compound", "samples"."time", "samples"."is_processed", "samples"."is_public", "samples"."created_at", "samples"."last_modified" FROM "samples" INNER JOIN "experiment_sample_associations" ON ("samples"."id" = "experiment_sample_associations"."sample_id") WHERE ("samples"."is_public" = true AND "experiment_sample_associations"."experiment_id" IN (1)) ORDER BY "samples"."is_processed" DESC  LIMIT 10; args=(True, 1)
(0.012) SELECT "sample_annotations"."id", "sample_annotations"."sample_id", "sample_annotations"."data", "sample_annotations"."is_ccdl", "sample_annotations"."is_public", "sample_annotations"."created_at", "sample_annotations"."last_modified" FROM "sample_annotations" WHERE "sample_annotations"."sample_id" IN (77, 114, 29, 43, 91, 95, 15, 26, 151, 112); args=(77, 114, 29, 43, 91, 95, 15, 26, 151, 112)
(0.022) SELECT "organisms"."id", "organisms"."name", "organisms"."taxonomy_id", "organisms"."is_scientific_name", "organisms"."created_at", "organisms"."last_modified" FROM "organisms" WHERE "organisms"."id" IN (1); args=(1,)
(0.046) SELECT ("sample_result_associations"."sample_id") AS "_prefetch_related_val_sample_id", "computational_results"."id", "computational_results"."commands", "computational_results"."processor_id", "computational_results"."organism_index_id", "computational_results"."is_ccdl", "computational_results"."time_start", "computational_results"."time_end", "computational_results"."is_public", "computational_results"."created_at", "computational_results"."last_modified" FROM "computational_results" INNER JOIN "sample_result_associations" ON ("computational_results"."id" = "sample_result_associations"."result_id") WHERE "sample_result_associations"."sample_id" IN (77, 114, 29, 43, 91, 95, 15, 26, 151, 112); args=(77, 114, 29, 43, 91, 95, 15, 26, 151, 112)
(0.015) SELECT "processors"."id", "processors"."name", "processors"."version", "processors"."docker_image", "processors"."environment" FROM "processors" WHERE "processors"."id" IN (1); args=(1,)
(0.012) SELECT "computational_result_annotations"."id", "computational_result_annotations"."result_id", "computational_result_annotations"."data", "computational_result_annotations"."is_ccdl", "computational_result_annotations"."is_public", "computational_result_annotations"."created_at", "computational_result_annotations"."last_modified" FROM "computational_result_annotations" WHERE "computational_result_annotations"."result_id" IN (1, 2,3, 4, 6, 7, 8, 9, 10, 11); args=(1, 2, 3, 4, 6, 7, 8, 9, 10, 11)
(0.017) SELECT "computed_files"."id", "computed_files"."filename", "computed_files"."absolute_file_path", "computed_files"."size_in_bytes", "computed_files"."sha1", "computed_files"."result_id", "computed_files"."is_smashable", "computed_files"."is_qc", "computed_files"."is_qn_target", "computed_files"."s3_bucket", "computed_files"."s3_key", "computed_files"."is_public", "computed_files"."created_at", "computed_files"."last_modified" FROM "computed_files" WHERE "computed_files"."result_id" IN (1, 2, 3, 4, 6, 7, 8, 9, 10, 11); args=(1, 2, 3, 4, 6, 7, 8, 9, 10, 11)
```

## Types of changes

- Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Functional tests

Test locally

## Checklist

- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules
