### PR TITLE
Remove Smasher Constraint from QN Target Jobs

### DIFF
--- a/workers/nomad-job-specs/create_qn_target.nomad.tpl
+++ b/workers/nomad-job-specs/create_qn_target.nomad.tpl
@@ -74,8 +74,6 @@ job "CREATE_QN_TARGET" {
         max_file_size = 1
       }
 
-      ${{SMASHER_CONSTRAINT}}
-
       config {
         image = "${{DOCKERHUB_REPO}}/${{SMASHER_DOCKER_IMAGE}}"
         force_pull = false


### PR DESCRIPTION
## Issue Number

n/a

## Purpose/Implementation Notes

QN Target job spec has a Smasher requirement, but even the prod smasher instance doesn't have the RAM needed to run the QN Target command. This removes the constraint.

## Types of changes
- Bugfix (non-breaking change which fixes an issue)
