### PR TITLE
Increase Smasher RAM

### DIFF
--- a/workers/nomad-job-specs/create_qn_target.nomad.tpl
+++ b/workers/nomad-job-specs/create_qn_target.nomad.tpl
@@ -64,9 +64,9 @@ job "CREATE_QN_TARGET" {
       # The resources the job will require.
       resources {
         # CPU is in AWS's CPU units.
-        cpu = 1024
+        cpu = 2048
         # Memory is in MB of RAM.
-        memory = 16384
+        memory = 131072
       }
 
       logs {

--- a/workers/nomad-job-specs/smasher.nomad.tpl
+++ b/workers/nomad-job-specs/smasher.nomad.tpl
@@ -64,7 +64,7 @@ job "SMASHER" {
         # CPU is in AWS's CPU units.
         cpu = 1024
         # Memory is in MB of RAM.
-        memory = 4096
+        memory = 12288
       }
 
       logs {


### PR DESCRIPTION
## Issue Number

https://github.com/AlexsLemonade/refinebio/issues/944

## Purpose/Implementation Notes

This is not a fantastic solution so far, a simply bump of the smasher job size.

It won't help with notifications after OOM, and it's not even that much more RAM - the t3 large only has 16GB total, so I don't think we'll be able to realistically allocate more than 12 or so without having to worry about the system baseline usage. If we need more, we'll need to increase the smasher instance size (and elasticity) or do a deep dive into how the smasher process uses RAM.
