### PR TITLE
Raise Smasher Instance Type

### DIFF
--- a/infrastructure/variables.tf
+++ b/infrastructure/variables.tf
@@ -119,9 +119,8 @@ variable "client_instance_type" {
   default = "m5.4xlarge"
 }
 
-# Has 8 GB, which should be enough to run 2 smasher jobs at once.
 variable "smasher_instance_type" {
-  default = "t3.large"
+  default = "t3.xlarge"
 }
 
 variable "spot_price" {


### PR DESCRIPTION
Current Smasher instance type simply isn't large enough to Smash large experiments without OOMing.