### PR TITLE
Skip Missing Smash Files Rather Than Failing Totally

### DIFF
--- a/README.md
+++ b/README.md
@@ -524,7 +524,6 @@ We have two different version counters, one for `dev` and one for `master` so a 
 * v1.1.3
 * v1.1.3-dev
 
-
 However you may see that the `dev` counter is way ahead, because we often need more than one staging deploy to be ready for a production deploy.
 This is okay, just find the latest version of the type you want to deploy and increment that to get your version.
 For example, if you wanted to deploy to staging and the above versions were the largest that `git tag --list` output, you would increment `v1.1.3-dev` to get `v1.1.4-dev`.

--- a/workers/data_refinery_workers/processors/smasher.py
+++ b/workers/data_refinery_workers/processors/smasher.py
@@ -53,6 +53,7 @@ def _prepare_files(job_context: Dict) -> Dict:
         smashable_files = []
         for sample in samples:
             smashable_file = sample.get_most_recent_smashable_result_file()
+
             if smashable_file is not None:
                 smashable_files = smashable_files + [smashable_file]
         smashable_files = list(set(smashable_files))
@@ -345,7 +346,13 @@ def _smash(job_context: Dict) -> Dict:
 
                 # Bail appropriately if this isn't a real file.
                 if not computed_file_path or not os.path.exists(computed_file_path):
-                    raise ValueError("Smasher received non-existent file path.")
+                    unsmashable_files.append(computed_file_path)
+                    logger.error("Smasher received non-existent file path.",
+                        computed_file_path=computed_file_path,
+                        computed_file=computed_file,
+                        dataset=job_context['dataset'],
+                        )
+                    continue
 
                 try:
                     data = pd.read_csv(computed_file_path, sep='\t', header=0, index_col=0, error_bad_lines=False)
@@ -596,6 +603,7 @@ def _smash(job_context: Dict) -> Dict:
                     job_context['job'].success = False
                     job_context['failure_reason'] = str(e)
                     return job_context
+            # End QN
 
             # Transpose before scaling
             # Do this even if we don't want to scale in case transpose

--- a/workers/data_refinery_workers/processors/smasher.py
+++ b/workers/data_refinery_workers/processors/smasher.py
@@ -696,6 +696,7 @@ def _smash(job_context: Dict) -> Dict:
         return job_context
 
     job_context['metadata'] = metadata
+    job_context['unsmashable_files'] = unsmashable_files
     job_context['dataset'].success = True
     job_context['dataset'].save()
 

--- a/workers/data_refinery_workers/processors/test_smasher.py
+++ b/workers/data_refinery_workers/processors/test_smasher.py
@@ -406,8 +406,7 @@ class SmasherTestCase(TestCase):
         ds = Dataset.objects.get(id=dsid)
         print(ds.failure_reason)
         print(final_context['dataset'].failure_reason)
-        self.assertFalse(ds.success)
-        self.assertNotEqual(ds.failure_reason, "")
+        self.assertNotEqual(final_context['unsmashable_files'], [])
 
     @tag("smasher")
     def test_no_smash_all_diff_species(self):

--- a/workers/data_refinery_workers/processors/test_utils.py
+++ b/workers/data_refinery_workers/processors/test_utils.py
@@ -87,13 +87,7 @@ class StartJobTestCase(TestCase):
             job.save()
             job_context = utils.start_job({"job": job})
 
-            try:
-                job = ProcessorJob()
-                job.start_time = timezone.now()
-                job.success = None
-                job.save()
             self.assertRaises(utils.start_job({"job": job}))
-            except Exception
 
 class RunPipelineTestCase(TestCase):
     def test_no_job(self):


### PR DESCRIPTION
## Issue Number
https://api.refine.bio/dataset/3ce6efda-1116-446e-8613-d72e5fb0c49e/?format=json

## Purpose/Implementation Notes

A missing file causes total smash failure, which sucks. This errors and continues smashing rather than failing totally.

## Types of changes
- Bugfix (non-breaking change which fixes an issue)
