### PR TITLE
Prevent Mislabeled Samples From Causing Bad Smashing and QN Target Creation

### DIFF
--- a/workers/run_tests.sh
+++ b/workers/run_tests.sh
@@ -255,6 +255,13 @@ if [[ -z $tag || $tag == "smasher" ]]; then
     pcl_test_data_ts1="$pcl_test_raw_dir/$pcl_name_ts1"
     pcl_test_data_ts2="$pcl_test_raw_dir/$pcl_name_ts2"
     pcl_test_data_ta1="$pcl_test_raw_dir/$pcl_name_ta1"
+    bad_test_raw_dir="$volume_directory/BADSMASH"
+    bad_name="big.PCL"
+    bad_name2="small.PCL"
+    bad_name3="bad.PCL"
+    bad_test_data_1="$bad_test_raw_dir/$bad_name"
+    bad_test_data_2="$bad_test_raw_dir/$bad_name2"
+    bad_test_data_3="$bad_test_raw_dir/$bad_name3"
     if [ ! -e "$pcl_test_data_1" ]; then
         mkdir -p $pcl_test_raw_dir
         echo "Downloading PCL for tests."
@@ -315,6 +322,24 @@ if [[ -z $tag || $tag == "smasher" ]]; then
         echo "Downloading PCLTA1 for tests."
         wget -q -O $pcl_test_data_ta1 \
              "$test_data_repo/$pcl_name_ta1"
+    fi
+    if [ ! -e "$bad_test_data_1" ]; then
+        mkdir -p $bad_test_raw_dir
+        echo "Downloading Bad PCL for tests."
+        wget -q -O $bad_test_data_1 \
+             "$test_data_repo/$bad_name"
+    fi
+    if [ ! -e "$bad_test_data_2" ]; then
+        mkdir -p $bad_test_raw_dir
+        echo "Downloading Bad PCL for tests."
+        wget -q -O $bad_test_data_2 \
+             "$test_data_repo/$bad_name2"
+    fi
+    if [ ! -e "$bad_test_data_3" ]; then
+        mkdir -p $bad_test_raw_dir
+        echo "Downloading Bad PCL for tests."
+        wget -q -O $bad_test_data_3 \
+             "$test_data_repo/$bad_name3"
     fi
     if [[ -z $AWS_ACCESS_KEY_ID ]]; then
         export AWS_ACCESS_KEY_ID=`~/bin/aws configure get default.aws_access_key_id`


### PR DESCRIPTION
## Issue Number

https://github.com/AlexsLemonade/refinebio/issues/944

## Purpose/Implementation Notes

A single mislabeled sample can cause a whole Smasher to output nothing, as there are no overlapping identifiers.

This change makes it such that if smashing a frame causes the length to drop to zero, that frame is reverted and added to the unsmashable samples list.

## Types of changes
- Bugfix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Functional tests

New test
