### PR TITLE
Fixes filter count on search page

### DIFF
--- a/api/data_refinery_api/views.py
+++ b/api/data_refinery_api/views.py
@@ -268,36 +268,35 @@ class SearchAndFilter(generics.ListAPIView):
 
         if 'technology' in filters_to_calculate:
             # Technology
-            techs = queryset.values('technology').annotate(Count('technology', unique=True))
+            techs = queryset.values('technology').annotate(count=Count('sample__id', distinct=True))
             for tech in techs:
                 if not tech['technology'] or not tech['technology'].strip():
                     continue
-                result['technology'][tech['technology']] = tech['technology__count']
+                result['technology'][tech['technology']] = tech['count']
 
         if 'has_publication' in filters_to_calculate:
             # Publication
-            pubs = queryset.values('has_publication').annotate(Count('has_publication', unique=True))
+            pubs = queryset.values('has_publication').annotate(count=Count('sample__id', distinct=True))
             for pub in pubs:
                 if pub['has_publication']:
-                    result['publication']['has_publication'] = pub['has_publication__count']
+                    result['publication']['has_publication'] = pub['count']
 
         if 'organisms__name' in filters_to_calculate:
             # Organisms
-            organisms = queryset.values('organisms__name').annotate(Count('organisms__name', unique=True))
+            organisms = queryset.values('organisms__name').annotate(count=Count('sample__id', distinct=True))
             for organism in organisms:
                 # This experiment has no ExperimentOrganism-association, which is bad.
                 # This information may still live on the samples though.
                 if not organism['organisms__name']:
                     continue
-
-                result['organism'][organism['organisms__name']] = organism['organisms__name__count']
+                result['organism'][organism['organisms__name']] = organism['count']
 
         if 'platform' in filters_to_calculate:
             # Platforms
-            platforms = queryset.values('samples__platform_name').annotate(Count('samples__platform_name', unique=True))
+            platforms = queryset.values('samples__platform_name').annotate(count=Count('sample__id', distinct=True))
             for plat in platforms:
                 if plat['samples__platform_name']:
-                    result['platforms'][plat['samples__platform_name']] = plat['samples__platform_name__count']
+                    result['platforms'][plat['samples__platform_name']] = plat['count']
 
         return result
 


### PR DESCRIPTION
## Issue Number

N/A

## Purpose/Implementation Notes

Avoids counting duplicate samples on the search filters. The SQL query to calculate the technology filter group is as follows (the others are similar):

```sql
SELECT "experiments"."technology", COUNT(DISTINCT "experiment_sample_associations"."sample_id") AS "count" 
FROM "experiments" LEFT OUTER JOIN "experiment_sample_associations" ON ("experiments"."id" = "experiment_sample_associations"."experiment_id") LEFT OUTER JOIN "samples" ON ("experiment_sample_associations"."sample_id" = "samples"."id") 
WHERE ("experiments"."is_public" = true AND "samples"."is_processed" = true AND "samples"."is_public" = true) 
GROUP BY "experiments"."technology"; args=(True, True, True)
```

The key difference is the `COUNT(DISTINCT sample_id)` which counts the samples correctly, but impacts the performance of the search negatively. It would be good to see if we can come up with a better solution.

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Checklist

- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules

## Screenshots

Local filters before:
![image](https://user-images.githubusercontent.com/1882507/50404612-e8d0a000-0777-11e9-91c3-a22d87fd2ba9.png)

Local filters after:
![image](https://user-images.githubusercontent.com/1882507/50404631-22a1a680-0778-11e9-9bdd-6b23a2915bcb.png)

