### PR TITLE
Improve downloads API

### DIFF
--- a/api/data_refinery_api/serializers.py
+++ b/api/data_refinery_api/serializers.py
@@ -456,18 +456,15 @@ class DatasetDetailsExperimentSerializer(serializers.ModelSerializer):
     page
     """
     organisms = serializers.StringRelatedField(many=True)
-    processed_samples = serializers.StringRelatedField(many=True)
     sample_metadata = serializers.ReadOnlyField(source='get_sample_metadata_fields')
     pretty_platforms = serializers.ReadOnlyField()
 
     class Meta:
         model = Experiment
         fields = (
-                    'id',
                     'title',
                     'accession_code',
                     'pretty_platforms',
-                    'processed_samples',
                     'organisms',
                     'sample_metadata',
                 )

--- a/api/data_refinery_api/serializers.py
+++ b/api/data_refinery_api/serializers.py
@@ -18,6 +18,7 @@ from data_refinery_common.models import (
     Dataset,
     APIToken
 )
+from collections import defaultdict 
 
 ##
 # Organism
@@ -450,9 +451,43 @@ class CreateDatasetSerializer(serializers.ModelSerializer):
             raise
         return data
 
-class DatasetSerializer(serializers.ModelSerializer):
+class DatasetDetailsExperimentSerializer(serializers.ModelSerializer):
+    """ This serializer contains all of the information about an experiment needed for the download
+    page
+    """
+    organisms = serializers.StringRelatedField(many=True)
+    processed_samples = serializers.StringRelatedField(many=True)
+    sample_metadata = serializers.ReadOnlyField(source='get_sample_metadata_fields')
+    pretty_platforms = serializers.ReadOnlyField()
 
+    class Meta:
+        model = Experiment
+        fields = (
+                    'id',
+                    'title',
+                    'accession_code',
+                    'pretty_platforms',
+                    'processed_samples',
+                    'organisms',
+                    'sample_metadata',
+                )
+
+class DatasetSerializer(serializers.ModelSerializer):
     start = serializers.NullBooleanField(required=False)
+    experiments = DatasetDetailsExperimentSerializer(read_only=True, many=True, source='get_experiments')
+    organisms_samples = serializers.SerializerMethodField()
+
+    def __init__(self, *args, **kwargs):
+        super(DatasetSerializer, self).__init__(*args, **kwargs)
+
+        # only inclue the fields `experiments` and `organisms_samples` when the param `?details=true` 
+        # is provided. This is used on the frontend to render the downloads page
+        # thanks to https://django.cowhite.com/blog/dynamically-includeexclude-fields-to-django-rest-framwork-serializers-based-on-user-requests/
+        if 'context' in kwargs:
+            if 'request' in kwargs['context']:
+                if 'details' not in kwargs['context']['request'].query_params:
+                    self.fields.pop('experiments')
+                    self.fields.pop('organisms_samples')
 
     class Meta:
         model = Dataset
@@ -472,7 +507,9 @@ class DatasetSerializer(serializers.ModelSerializer):
                     'failure_reason',
                     'created_at',
                     'last_modified',
-                    'start'
+                    'start',
+                    'experiments',
+                    'organisms_samples'
             )
         extra_kwargs = {
                         'id': {
@@ -520,64 +557,27 @@ class DatasetSerializer(serializers.ModelSerializer):
             raise
         return data
 
-class DatasetDetailsSampleSerializer(serializers.ModelSerializer):
-    """ This serializer contains all of the information about a sample needed for the download page
-    """
-    organism = OrganismSerializer(many=False)
+    def get_organisms_samples(self, obj):
+        """
+        Groups the sample accession codes inside a dataset by their organisms, eg:
+        { HOMO_SAPIENS: [S1, S2], DANIO: [S3] }
+        Useful to avoid sending sample information on the downloads page
+        """
+        all_samples = []
+        for sample_list in obj.data.values():
+            all_samples = all_samples + sample_list
+        all_samples = list(set(all_samples))
 
-    class Meta:
-        model = Sample
-        fields = (
-                    'accession_code',
-                    'organism',
-                )
+        samples = Sample.objects.filter(accession_code__in=all_samples) \
+                        .values('organism__name', 'accession_code') \
+                        .order_by('organism__name', 'accession_code') \
+                        .prefetch_related('organism')
 
-class DatasetDetailsExperimentSerializer(serializers.ModelSerializer):
-    """ This serializer contains all of the information about an experiment needed for the download
-    page
-    """
-    organisms = serializers.StringRelatedField(many=True)
-    samples = serializers.StringRelatedField(many=True)
-    sample_metadata = serializers.ReadOnlyField(source='get_sample_metadata_fields')
-    pretty_platforms = serializers.ReadOnlyField()
+        result = defaultdict(list)
+        for sample in samples:
+            result[sample['organism__name']].append(sample['accession_code'])
 
-    class Meta:
-        model = Experiment
-        fields = (
-                    'id',
-                    'title',
-                    'accession_code',
-                    'pretty_platforms',
-                    'samples',
-                    'organisms',
-                    'sample_metadata',
-                )
-
-class DatasetDetailsSerializer(serializers.ModelSerializer):
-    """ This serializer contains all of the information about a dataset needed for the download page
-    """
-    samples = DatasetDetailsSampleSerializer(read_only=True, many=True, source='get_samples')
-    experiments = DatasetDetailsExperimentSerializer(read_only=True, many=True, source='get_experiments')
-
-    class Meta:
-        model = Dataset
-        fields = (
-                    'data',
-                    'aggregate_by',
-                    'scale_by',
-                    'is_processing',
-                    'is_processed',
-                    'experiments',
-                    'samples'
-            )
-        extra_kwargs = {
-                        'is_processing': {
-                            'read_only': True,
-                        },
-                        'is_processed': {
-                            'read_only': True,
-                        },
-                    }
+        return result
 
 class APITokenSerializer(serializers.ModelSerializer):
 

--- a/api/data_refinery_api/views.py
+++ b/api/data_refinery_api/views.py
@@ -40,7 +40,6 @@ from data_refinery_api.serializers import (
     # Dataset
     APITokenSerializer,
     CreateDatasetSerializer,
-    DatasetDetailsSerializer,
     DatasetSerializer,
 )
 from data_refinery_common.job_lookup import ProcessorPipeline
@@ -328,11 +327,6 @@ class DatasetView(generics.RetrieveUpdateAPIView):
     queryset = Dataset.objects.all()
     serializer_class = DatasetSerializer
     lookup_field = 'id'
-
-    def get_serializer_class(self):
-        if 'details' in self.request.query_params:
-            return DatasetDetailsSerializer
-        return self.serializer_class
 
     def perform_update(self, serializer):
         """ If `start` is set, fire off the job. Disables dataset data updates after that. """

--- a/common/data_refinery_common/models/models.py
+++ b/common/data_refinery_common/models/models.py
@@ -914,16 +914,6 @@ class Dataset(models.Model):
         self.last_modified = current_time
         return super(Dataset, self).save(*args, **kwargs)
 
-    def get_samples(self):
-        """ Retuns all of the Sample objects in this Dataset """
-
-        all_samples = []
-        for sample_list in self.data.values():
-            all_samples = all_samples + sample_list
-        all_samples = list(set(all_samples))
-
-        return Sample.objects.filter(accession_code__in=all_samples)
-
     def get_experiments(self):
         """ Retuns all of the Experiments objects in this Dataset """
 

--- a/common/data_refinery_common/models/models.py
+++ b/common/data_refinery_common/models/models.py
@@ -914,14 +914,18 @@ class Dataset(models.Model):
         self.last_modified = current_time
         return super(Dataset, self).save(*args, **kwargs)
 
+    def get_samples(self):
+        """ Retuns all of the Sample objects in this Dataset """
+        all_samples = []
+        for sample_list in self.data.values():
+            all_samples = all_samples + sample_list
+        all_samples = list(set(all_samples))
+
+        return Sample.objects.filter(accession_code__in=all_samples)
+
     def get_experiments(self):
         """ Retuns all of the Experiments objects in this Dataset """
-
-        all_experiments = []
-        for experiment in self.data.keys():
-            all_experiments.append(experiment)
-        all_experiments = list(set(all_experiments))
-
+        all_experiments = self.data.keys()
         return Experiment.objects.filter(accession_code__in=all_experiments)
 
     def get_samples_by_experiment(self):


### PR DESCRIPTION
## Issue Number

https://github.com/AlexsLemonade/refinebio-frontend/issues/472

## Purpose/Implementation Notes

Right now, to render all the information in the downloads page we have to make two requests for information about a dataset:

- `/dataset/${dataset_id}`
- `/dataset/${dataset_id}/?details=true`

This PR changes it so that all information can be returned when making a single request to the second one. This urls avoids returning details for each samples and instead returns the accession codes of the samples grouped by organisms. This is needed for this section:

![image](https://user-images.githubusercontent.com/1882507/50486289-4f97c880-09c7-11e9-877f-466588232d66.png)

Also added some optimizations to the queries with `prefetch_related`

## Types of changes

- Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Functional tests

Api

## Checklist

- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules
