### PR TITLE
Specifies how to create tx indices in the README, fixes tx indices fo…

### DIFF
--- a/README.md
+++ b/README.md
@@ -337,6 +337,29 @@ Example for an ArrayExpress experiment:
 ./foreman/run_surveyor.sh survey_all --accession E-MTAB-3050
 ```
 
+Transcriptome indices are a bit special.
+For species within the "main" Ensembl division, the species name can be provided like so:
+
+```bash
+./foreman/run_surveyor.sh survey_all --accession "Homo sapiens"
+```
+
+However for species that are in other divisions, the division must follow the species name after a comma like so:
+
+```bash
+./foreman/run_surveyor.sh survey_all --accession "Caenorhabditis elegans, EnsemblMetazoa"
+```
+The possible divisions that can be specified are:
+* Ensembl (this is the "main" division and is the default)
+* EnsemblPlants
+* EnsemblFungi
+* EnsemblBacteria
+* EnsemblProtists
+* EnsemblMetazoa
+
+If you are unsure what division a species falls into, unfortunately the only way to tell is go to check ensembl.com.
+(Although googling the species name + "ensembl" may work pretty well.)
+
 You can also supply a newline-deliminated file to `survey_all` which will
 dispatch survey jobs based on accession codes like so:
 

--- a/foreman/data_refinery_foreman/surveyor/test_transcriptome_index.py
+++ b/foreman/data_refinery_foreman/surveyor/test_transcriptome_index.py
@@ -42,9 +42,9 @@ class SurveyTestCase(TestCase):
 
     def test_correct_index_location(self):
         """ Tests that the files returned actually exist.
-        This will break whenever this is a new Ensembl release.
-        """
 
+        Uses an organism in the main division.
+        """
         survey_job = SurveyJob(source_type="TRANSCRIPTOME_INDEX")
         survey_job.save()
         self.survey_job = survey_job
@@ -62,6 +62,30 @@ class SurveyTestCase(TestCase):
         surveyor = TranscriptomeIndexSurveyor(self.survey_job)
         files = surveyor.discover_species()[0]
 
-        # This will URLError/550 is there is a new release
+        for file in files:
+            urllib.request.urlopen(file.source_url)
+
+    def test_correct_index_location_metazoa(self):
+        """ Tests that the files returned actually exist.
+
+        Tests the Metazoa division instead of the main division.
+        """
+        survey_job = SurveyJob(source_type="TRANSCRIPTOME_INDEX")
+        survey_job.save()
+        self.survey_job = survey_job
+
+        key_value_pair = SurveyJobKeyValue(survey_job=survey_job,
+                                           key="ensembl_division",
+                                           value="EnsemblMetazoa")
+        key_value_pair.save()
+
+        key_value_pair = SurveyJobKeyValue(survey_job=survey_job,
+                                                key="organism_name",
+                                                value="Caenorhabditis elegans")
+        key_value_pair.save()
+
+        surveyor = TranscriptomeIndexSurveyor(self.survey_job)
+        files = surveyor.discover_species()[0]
+
         for file in files:
             urllib.request.urlopen(file.source_url)

--- a/foreman/data_refinery_foreman/surveyor/transcriptome_index.py
+++ b/foreman/data_refinery_foreman/surveyor/transcriptome_index.py
@@ -290,7 +290,11 @@ class TranscriptomeIndexSurveyor(ExternalSourceSurveyor):
         all_new_species = []
         if organism_name:
             for species in specieses:
-                if species['species'] == organism_name:
+                # This key varies based on whether the division is the
+                # main one or not... why couldn't they just make them
+                # consistent?
+                if ('species' in species and species['species'] == organism_name) \
+                   or ('name' in species and species['name'] == organism_name):
                     all_new_species.append(self._generate_files(species))
                     break
         else:

--- a/foreman/data_refinery_foreman/surveyor/transcriptome_index.py
+++ b/foreman/data_refinery_foreman/surveyor/transcriptome_index.py
@@ -41,7 +41,7 @@ DIVISION_LOOKUP = {"EnsemblPlants": "plants",
 # release versions. These urls will return what the most recent
 # release version is.
 MAIN_RELEASE_URL = "https://rest.ensembl.org/info/software?content-type=application/json"
-DIVISION_RELEASE_URL = "https://rest.ensemblgenomes.org/info/software?content-type=application/json"
+DIVISION_RELEASE_URL = "https://rest.ensemblgenomes.org/info/eg_version?content-type=application/json"
 
 
 class EnsemblUrlBuilder(ABC):
@@ -59,7 +59,7 @@ class EnsemblUrlBuilder(ABC):
         self.url_root = "ensemblgenomes.org/pub/release-{assembly_version}/{short_division}"
         self.short_division = DIVISION_LOOKUP[species["division"]]
         self.assembly = species["assembly_name"].replace(" ", "_")
-        self.assembly_version = utils.requests_retry_session().get(DIVISION_RELEASE_URL).json()["release"]
+        self.assembly_version = utils.requests_retry_session().get(DIVISION_RELEASE_URL).json()["version"]
 
         # Some species are nested within a collection directory. If
         # this is the case, then we need to add that extra directory
@@ -233,7 +233,7 @@ class TranscriptomeIndexSurveyor(ExternalSourceSurveyor):
         Surveying here is a bit different than discovering an experiment
         and samples.
         """
-        if source_type is not "TRANSCRIPTOME_INDEX":
+        if source_type != "TRANSCRIPTOME_INDEX":
             return False
 
         try:
@@ -290,7 +290,7 @@ class TranscriptomeIndexSurveyor(ExternalSourceSurveyor):
         all_new_species = []
         if organism_name:
             for species in specieses:
-                if species['name'] == organism_name:
+                if species['species'] == organism_name:
                     all_new_species.append(self._generate_files(species))
                     break
         else:

--- a/foreman/data_refinery_foreman/surveyor/transcriptome_index.py
+++ b/foreman/data_refinery_foreman/surveyor/transcriptome_index.py
@@ -164,7 +164,7 @@ def ensembl_url_builder_factory(species: Dict) -> EnsemblUrlBuilder:
         return EnsemblProtistsUrlBuilder(species)
     elif species["division"] == "EnsemblFungi":
         return EnsemblFungiUrlBuilder(species)
-    elif species["division"] == "Ensembl":
+    elif species["division"] == "EnsemblVertebrates":
         return MainEnsemblUrlBuilder(species)
     else:
         return EnsemblUrlBuilder(species)

--- a/workers/install_gene_convert.R
+++ b/workers/install_gene_convert.R
@@ -4,7 +4,7 @@ devtools::install_version('data.table', version='1.11.0')
 devtools::install_version('optparse', version='1.4.4')
 
 devtools::install_version('tidyverse', version='1.2.1')
-devtools::install_version('rlang', version='0.3.0')
+devtools::install_version('rlang', version='0.3.1')
 
 # devtools::install_url() requires BiocInstaller
 install.packages('https://bioconductor.org/packages/3.6/bioc/src/contrib/BiocInstaller_1.28.0.tar.gz')


### PR DESCRIPTION
…r ensembl divisions other than the main one.

## Issue Number

#709 

## Purpose/Implementation Notes

We were hitting the wrong endpoint to determine the latest "assembly version" so the URL we were building to get the species metadata was wrong, which meant we couldn't run the surveyor for divisions other than the main Ensembl division.

(This came up because I am trying to process some additional data for salmon tests and C. elegans is a good one to use because of its small genome.)

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

I've run this code in a dev stack to create a transcriptome index for C. elegans.

## Checklist

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules
