### PR TITLE
Fix transcriptome test that is failing in dev

### DIFF
--- a/foreman/data_refinery_foreman/surveyor/test_transcriptome_index.py
+++ b/foreman/data_refinery_foreman/surveyor/test_transcriptome_index.py
@@ -81,7 +81,7 @@ class SurveyTestCase(TestCase):
 
         key_value_pair = SurveyJobKeyValue(survey_job=survey_job,
                                                 key="organism_name",
-                                                value="Caenorhabditis elegans")
+                                                value="Octopus bimaculoides")
         key_value_pair.save()
 
         surveyor = TranscriptomeIndexSurveyor(self.survey_job)


### PR DESCRIPTION
## Issue Number

N/A tests are failing in dev

## Purpose/Implementation Notes

Either I'm crazy or C. elegans got put in a different Ensembl division overnight...

The whole reason I fixed #709 with #973 was because I wanted to add some tests to my tximport branch for the C. elegans organism so I needed to create a transcriptome index for it because it was in the EnsemblMetazoa division. So like, I'm pretty sure it was in there, especially because I ran that test yesterday before I committed it and it passed. So I guess they decided to move C. Elegans from EnsemblMetazoa to Ensembl, which broke the tests.

This just uses another organism that actually is in the EnsemblMetazoa division to test that the division works.

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

Tests pass

## Checklist

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules
