### PR TITLE
Kurtwheeler/pin r version

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,10 +25,10 @@ Refine.bio currently has four sub-projects contained within this repo:
     - [Linux](#linux)
     - [Mac](#mac)
     - [Virtual Environment](#virtual-environment)
-    - [Common Dependecies](#common-dependecies)
     - [Services](#services)
       - [Postgres](#postgres)
       - [Nomad](#nomad)
+    - [Common Dependecies](#common-dependecies)
   - [Testing](#testing)
     - [API](#api)
     - [Common](#common)
@@ -36,6 +36,7 @@ Refine.bio currently has four sub-projects contained within this repo:
     - [Workers](#workers)
   - [Style](#style)
   - [Gotchas](#gotchas)
+    - [R](#r)
 - [Running Locally](#running-locally)
   - [Surveyor Jobs](#surveyor-jobs)
     - [Sequence Read Archive](#sequence-read-archive)
@@ -46,11 +47,12 @@ Refine.bio currently has four sub-projects contained within this repo:
   - [Checking on Local Jobs](#checking-on-local-jobs)
   - [Development Helpers](#development-helpers)
 - [Cloud Deployment](#cloud-deployment)
-  - [Terraform](#terraform)
   - [Docker Images](#docker-images)
   - [Autoscaling and Setting Spot Prices](#autoscaling-and-setting-spot-prices)
+  - [Terraform](#terraform)
   - [Running Jobs](#running-jobs)
   - [Log Consumption](#log-consumption)
+  - [Dumping and Restoring Database Backups](#dumping-and-restoring-database-backups)
   - [Tearing Down](#tearing-down)
 - [Support](#support)
 - [Meta-README](#meta-readme)
@@ -299,6 +301,21 @@ be the result of Docker's `Docker.qcow2` or `Docker.raw` file filling. You
 can prune old images with `docker system prune -a`.
   - If it's killed abruptly, the containerized Postgres images can be
   left in an unrecoverable state. Annoying.
+
+#### R
+
+The R language is not really production grade, however there are a lot of packages we need that only exist within its ecosystem.
+We have created some utilities to help us keep R stable, reliable, and from periodically causing build errors related to version incompatibilites.
+The primary goal of these is to pin the version for every R package that we have.
+The R package `devtools` is useful for this, but in order to be able to install a specific version of it, we've created the R script `common/install_devtools.R`.
+
+There is annother gotcha to be aware of should you ever need to modify versions of R or its packages.
+In Dockerfiles for images that need the R language, we install apt packages that look like `r-base-core=3.4.2-1xenial1`.
+It's unclear why the version for these is so weird, but it was determined by visiting the package list here: https://cran.revolutionanalytics.com/bin/linux/ubuntu/xenial/
+If it needs to be updated then a version should be selected from that list.
+
+Additionally there are two apt packages, r-base and r-base-core, which seem to be very similar except that r-base-core is slimmed down some by not including some additional packages.
+For a while we were using r-base, but we switched to r-base-core when we pinned the version of the R language because the r-base package caused an apt error.
 
 ## Running Locally
 

--- a/common/dockerfiles/Dockerfile.common_tests
+++ b/common/dockerfiles/Dockerfile.common_tests
@@ -32,7 +32,7 @@ RUN \
   python3 \
   python3-pip \
   r-base-core=3.4.2-1xenial1 \
-  r-base-dev==3.4.2-1xenial1 \
+  r-base-dev=3.4.2-1xenial1 \
   libpq-dev \
   libxml2-dev \
   libssl-dev \

--- a/common/dockerfiles/Dockerfile.common_tests
+++ b/common/dockerfiles/Dockerfile.common_tests
@@ -6,11 +6,23 @@ RUN add-apt-repository ppa:apt-fast/stable
 RUN apt-get update -qq
 RUN apt-get -y install apt-fast
 
+# The version for r-base-core is weird, I'm not sure why it's named
+# that way. I found it here:
+# https://cran.revolutionanalytics.com/bin/linux/ubuntu/xenial/
+# If it needs to be updated then a version should be selected from
+# that list.
+
+# I am not entirely sure what the difference between r-base and r-base
+# core is, except that r-base is supposed to have some extra utilities
+# which increases the size of the package. However we don't get a ton
+# of choice because trying to use r-base causes a "you have held
+# broken pacakges" error.
+
 COPY workers/CRAN.gpg .
 RUN \
   apt-fast update -qq && \
   apt-fast install -y lsb-release && \
-  echo "deb http://archive.linux.duke.edu/cran/bin/linux/ubuntu $(lsb_release -sc)/" \
+  echo "deb https://cran.revolutionanalytics.com/bin/linux/ubuntu $(lsb_release -sc)/" \
       >> /etc/apt/sources.list.d/added_repos.list && \
   apt-key add CRAN.gpg && \
   apt-fast update -qq && \
@@ -19,8 +31,8 @@ RUN \
   git \
   python3 \
   python3-pip \
-  r-base \
-  r-base-dev \
+  r-base-core=3.4.2-1xenial1 \
+  r-base-dev==3.4.2-1xenial1 \
   libpq-dev \
   libxml2-dev \
   libssl-dev \

--- a/common/dockerfiles/Dockerfile.common_tests
+++ b/common/dockerfiles/Dockerfile.common_tests
@@ -21,6 +21,7 @@ RUN apt-get -y install apt-fast
 COPY workers/CRAN.gpg .
 RUN \
   apt-fast update -qq && \
+  apt-get install -y apt-transport-https && \
   apt-fast install -y lsb-release && \
   echo "deb https://cran.revolutionanalytics.com/bin/linux/ubuntu $(lsb_release -sc)/" \
       >> /etc/apt/sources.list.d/added_repos.list && \

--- a/common/dockerfiles/Dockerfile.common_tests
+++ b/common/dockerfiles/Dockerfile.common_tests
@@ -6,17 +6,7 @@ RUN add-apt-repository ppa:apt-fast/stable
 RUN apt-get update -qq
 RUN apt-get -y install apt-fast
 
-# The version for r-base-core is weird, I'm not sure why it's named
-# that way. I found it here:
-# https://cran.revolutionanalytics.com/bin/linux/ubuntu/xenial/
-# If it needs to be updated then a version should be selected from
-# that list.
-
-# I am not entirely sure what the difference between r-base and r-base
-# core is, except that r-base is supposed to have some extra utilities
-# which increases the size of the package. However we don't get a ton
-# of choice because trying to use r-base causes a "you have held
-# broken pacakges" error.
+# The packages related to R are somewhat weird, see the README for more details.
 
 COPY workers/CRAN.gpg .
 RUN \

--- a/workers/dockerfiles/Dockerfile.affymetrix
+++ b/workers/dockerfiles/Dockerfile.affymetrix
@@ -6,17 +6,7 @@ RUN add-apt-repository ppa:apt-fast/stable
 RUN apt-get update -qq
 RUN apt-get -y install apt-fast
 
-# The version for r-base-core is weird, I'm not sure why it's named
-# that way. I found it here:
-# https://cran.revolutionanalytics.com/bin/linux/ubuntu/xenial/
-# If it needs to be updated then a version should be selected from
-# that list.
-
-# I am not entirely sure what the difference between r-base and r-base
-# core is, except that r-base is supposed to have some extra utilities
-# which increases the size of the package. However we don't get a ton
-# of choice because trying to use r-base causes a "you have held
-# broken pacakges" error.
+# The packages related to R are somewhat weird, see the README for more details.
 
 COPY workers/CRAN.gpg .
 RUN \

--- a/workers/dockerfiles/Dockerfile.affymetrix
+++ b/workers/dockerfiles/Dockerfile.affymetrix
@@ -37,7 +37,7 @@ RUN \
   python3 \
   python3-pip \
   r-base-core=3.4.2-1xenial1 \
-  r-base-dev==3.4.2-1xenial1 \
+  r-base-dev=3.4.2-1xenial1 \
   libpq-dev \
   libxml2-dev \
   libssl-dev \

--- a/workers/dockerfiles/Dockerfile.affymetrix
+++ b/workers/dockerfiles/Dockerfile.affymetrix
@@ -6,14 +6,24 @@ RUN add-apt-repository ppa:apt-fast/stable
 RUN apt-get update -qq
 RUN apt-get -y install apt-fast
 
+# The version for r-base-core is weird, I'm not sure why it's named
+# that way. I found it here:
+# https://cran.revolutionanalytics.com/bin/linux/ubuntu/xenial/
+# If it needs to be updated then a version should be selected from
+# that list.
+
+# I am not entirely sure what the difference between r-base and r-base
+# core is, except that r-base is supposed to have some extra utilities
+# which increases the size of the package. However we don't get a ton
+# of choice because trying to use r-base causes a "you have held
+# broken pacakges" error.
+
 COPY workers/CRAN.gpg .
 RUN \
   apt-fast update -qq && \
   apt-get install -y apt-transport-https && \
   apt-fast install -y lsb-release && \
-  echo "deb http://archive.linux.duke.edu/cran/bin/linux/ubuntu $(lsb_release -sc)/" \
-      >> /etc/apt/sources.list.d/added_repos.list && \
-  echo "deb https://cloud.r-project.org/bin/linux/ubuntu $(lsb_release -sc)/" \
+  echo "deb https://cran.revolutionanalytics.com/bin/linux/ubuntu $(lsb_release -sc)/" \
       >> /etc/apt/sources.list.d/added_repos.list && \
   apt-key add CRAN.gpg && \
   apt-fast update -qq && \
@@ -26,8 +36,8 @@ RUN \
   lsb-release \
   python3 \
   python3-pip \
-  r-base \
-  r-base-dev \
+  r-base-core=3.4.2-1xenial1 \
+  r-base-dev==3.4.2-1xenial1 \
   libpq-dev \
   libxml2-dev \
   libssl-dev \

--- a/workers/dockerfiles/Dockerfile.downloaders
+++ b/workers/dockerfiles/Dockerfile.downloaders
@@ -33,7 +33,7 @@ RUN \
   python3 \
   python3-pip \
   r-base-core=3.4.2-1xenial1 \
-  r-base-dev==3.4.2-1xenial1 \
+  r-base-dev=3.4.2-1xenial1 \
   libpq-dev \
   libxml2-dev \
   libssl-dev \

--- a/workers/dockerfiles/Dockerfile.downloaders
+++ b/workers/dockerfiles/Dockerfile.downloaders
@@ -6,17 +6,7 @@ RUN add-apt-repository ppa:apt-fast/stable
 RUN apt-get update -qq
 RUN apt-get -y install apt-fast
 
-# The version for r-base-core is weird, I'm not sure why it's named
-# that way. I found it here:
-# https://cran.revolutionanalytics.com/bin/linux/ubuntu/xenial/
-# If it needs to be updated then a version should be selected from
-# that list.
-
-# I am not entirely sure what the difference between r-base and r-base
-# core is, except that r-base is supposed to have some extra utilities
-# which increases the size of the package. However we don't get a ton
-# of choice because trying to use r-base causes a "you have held
-# broken pacakges" error.
+# The packages related to R are somewhat weird, see the README for more details.
 
 COPY workers/CRAN.gpg .
 RUN \

--- a/workers/dockerfiles/Dockerfile.downloaders
+++ b/workers/dockerfiles/Dockerfile.downloaders
@@ -6,14 +6,24 @@ RUN add-apt-repository ppa:apt-fast/stable
 RUN apt-get update -qq
 RUN apt-get -y install apt-fast
 
+# The version for r-base-core is weird, I'm not sure why it's named
+# that way. I found it here:
+# https://cran.revolutionanalytics.com/bin/linux/ubuntu/xenial/
+# If it needs to be updated then a version should be selected from
+# that list.
+
+# I am not entirely sure what the difference between r-base and r-base
+# core is, except that r-base is supposed to have some extra utilities
+# which increases the size of the package. However we don't get a ton
+# of choice because trying to use r-base causes a "you have held
+# broken pacakges" error.
+
 COPY workers/CRAN.gpg .
 RUN \
   apt-fast update -qq && \
   apt-get install -y apt-transport-https && \
   apt-fast install -y lsb-release && \
-  echo "deb http://archive.linux.duke.edu/cran/bin/linux/ubuntu $(lsb_release -sc)/" \
-      >> /etc/apt/sources.list.d/added_repos.list && \
-  echo "deb https://cloud.r-project.org/bin/linux/ubuntu $(lsb_release -sc)/" \
+  echo "deb https://cran.revolutionanalytics.com/bin/linux/ubuntu $(lsb_release -sc)/" \
       >> /etc/apt/sources.list.d/added_repos.list && \
   apt-key add CRAN.gpg && \
   apt-fast update -qq && \
@@ -22,8 +32,8 @@ RUN \
   git \
   python3 \
   python3-pip \
-  r-base \
-  r-base-dev \
+  r-base-core=3.4.2-1xenial1 \
+  r-base-dev==3.4.2-1xenial1 \
   libpq-dev \
   libxml2-dev \
   libssl-dev \

--- a/workers/dockerfiles/Dockerfile.illumina
+++ b/workers/dockerfiles/Dockerfile.illumina
@@ -6,17 +6,7 @@ RUN add-apt-repository ppa:apt-fast/stable
 RUN apt-get update -qq
 RUN apt-get -y install apt-fast
 
-# The version for r-base-core is weird, I'm not sure why it's named
-# that way. I found it here:
-# https://cran.revolutionanalytics.com/bin/linux/ubuntu/xenial/
-# If it needs to be updated then a version should be selected from
-# that list.
-
-# I am not entirely sure what the difference between r-base and r-base
-# core is, except that r-base is supposed to have some extra utilities
-# which increases the size of the package. However we don't get a ton
-# of choice because trying to use r-base causes a "you have held
-# broken pacakges" error.
+# The packages related to R are somewhat weird, see the README for more details.
 
 COPY workers/CRAN.gpg .
 RUN \

--- a/workers/dockerfiles/Dockerfile.illumina
+++ b/workers/dockerfiles/Dockerfile.illumina
@@ -37,7 +37,7 @@ RUN \
   python3 \
   python3-pip \
   r-base-core=3.4.2-1xenial1 \
-  r-base-dev==3.4.2-1xenial1 \
+  r-base-dev=3.4.2-1xenial1 \
   libpq-dev \
   libxml2-dev \
   libssl-dev \

--- a/workers/dockerfiles/Dockerfile.illumina
+++ b/workers/dockerfiles/Dockerfile.illumina
@@ -6,14 +6,24 @@ RUN add-apt-repository ppa:apt-fast/stable
 RUN apt-get update -qq
 RUN apt-get -y install apt-fast
 
+# The version for r-base-core is weird, I'm not sure why it's named
+# that way. I found it here:
+# https://cran.revolutionanalytics.com/bin/linux/ubuntu/xenial/
+# If it needs to be updated then a version should be selected from
+# that list.
+
+# I am not entirely sure what the difference between r-base and r-base
+# core is, except that r-base is supposed to have some extra utilities
+# which increases the size of the package. However we don't get a ton
+# of choice because trying to use r-base causes a "you have held
+# broken pacakges" error.
+
 COPY workers/CRAN.gpg .
 RUN \
   apt-fast update -qq && \
   apt-get install -y apt-transport-https && \
   apt-fast install -y lsb-release && \
-  echo "deb http://archive.linux.duke.edu/cran/bin/linux/ubuntu $(lsb_release -sc)/" \
-      >> /etc/apt/sources.list.d/added_repos.list && \
-  echo "deb https://cloud.r-project.org/bin/linux/ubuntu $(lsb_release -sc)/" \
+  echo "deb https://cran.revolutionanalytics.com/bin/linux/ubuntu $(lsb_release -sc)/" \
       >> /etc/apt/sources.list.d/added_repos.list && \
   apt-key add CRAN.gpg && \
   apt-fast update -qq && \
@@ -26,8 +36,8 @@ RUN \
   lsb-release \
   python3 \
   python3-pip \
-  r-base \
-  r-base-dev \
+  r-base-core=3.4.2-1xenial1 \
+  r-base-dev==3.4.2-1xenial1 \
   libpq-dev \
   libxml2-dev \
   libssl-dev \

--- a/workers/dockerfiles/Dockerfile.no_op
+++ b/workers/dockerfiles/Dockerfile.no_op
@@ -6,17 +6,7 @@ RUN add-apt-repository ppa:apt-fast/stable
 RUN apt-get update -qq
 RUN apt-get -y install apt-fast
 
-# The version for r-base-core is weird, I'm not sure why it's named
-# that way. I found it here:
-# https://cran.revolutionanalytics.com/bin/linux/ubuntu/xenial/
-# If it needs to be updated then a version should be selected from
-# that list.
-
-# I am not entirely sure what the difference between r-base and r-base
-# core is, except that r-base is supposed to have some extra utilities
-# which increases the size of the package. However we don't get a ton
-# of choice because trying to use r-base causes a "you have held
-# broken pacakges" error.
+# The packages related to R are somewhat weird, see the README for more details.
 
 COPY workers/CRAN.gpg .
 RUN \

--- a/workers/dockerfiles/Dockerfile.no_op
+++ b/workers/dockerfiles/Dockerfile.no_op
@@ -37,7 +37,7 @@ RUN \
   python3 \
   python3-pip \
   r-base-core=3.4.2-1xenial1 \
-  r-base-dev==3.4.2-1xenial1 \
+  r-base-dev=3.4.2-1xenial1 \
   libpq-dev \
   libxml2-dev \
   libssl-dev \

--- a/workers/dockerfiles/Dockerfile.no_op
+++ b/workers/dockerfiles/Dockerfile.no_op
@@ -6,14 +6,24 @@ RUN add-apt-repository ppa:apt-fast/stable
 RUN apt-get update -qq
 RUN apt-get -y install apt-fast
 
+# The version for r-base-core is weird, I'm not sure why it's named
+# that way. I found it here:
+# https://cran.revolutionanalytics.com/bin/linux/ubuntu/xenial/
+# If it needs to be updated then a version should be selected from
+# that list.
+
+# I am not entirely sure what the difference between r-base and r-base
+# core is, except that r-base is supposed to have some extra utilities
+# which increases the size of the package. However we don't get a ton
+# of choice because trying to use r-base causes a "you have held
+# broken pacakges" error.
+
 COPY workers/CRAN.gpg .
 RUN \
   apt-fast update -qq && \
   apt-get install -y apt-transport-https && \
   apt-fast install -y lsb-release && \
-  echo "deb http://archive.linux.duke.edu/cran/bin/linux/ubuntu $(lsb_release -sc)/" \
-      >> /etc/apt/sources.list.d/added_repos.list && \
-  echo "deb https://cloud.r-project.org/bin/linux/ubuntu $(lsb_release -sc)/" \
+  echo "deb https://cran.revolutionanalytics.com/bin/linux/ubuntu $(lsb_release -sc)/" \
       >> /etc/apt/sources.list.d/added_repos.list && \
   apt-key add CRAN.gpg && \
   apt-fast update -qq && \
@@ -26,8 +36,8 @@ RUN \
   lsb-release \
   python3 \
   python3-pip \
-  r-base \
-  r-base-dev \
+  r-base-core=3.4.2-1xenial1 \
+  r-base-dev==3.4.2-1xenial1 \
   libpq-dev \
   libxml2-dev \
   libssl-dev \

--- a/workers/dockerfiles/Dockerfile.salmon
+++ b/workers/dockerfiles/Dockerfile.salmon
@@ -6,14 +6,24 @@ RUN add-apt-repository ppa:apt-fast/stable
 RUN apt-get update -qq
 RUN apt-get -y install apt-fast
 
+# The version for r-base-core is weird, I'm not sure why it's named
+# that way. I found it here:
+# https://cran.revolutionanalytics.com/bin/linux/ubuntu/xenial/
+# If it needs to be updated then a version should be selected from
+# that list.
+
+# I am not entirely sure what the difference between r-base and r-base
+# core is, except that r-base is supposed to have some extra utilities
+# which increases the size of the package. However we don't get a ton
+# of choice because trying to use r-base causes a "you have held
+# broken pacakges" error.
+
 COPY workers/CRAN.gpg .
 RUN \
   apt-fast update -qq && \
   apt-get install -y apt-transport-https && \
   apt-fast install -y lsb-release && \
-  echo "deb http://archive.linux.duke.edu/cran/bin/linux/ubuntu $(lsb_release -sc)/" \
-      >> /etc/apt/sources.list.d/added_repos.list && \
-  echo "deb https://cloud.r-project.org/bin/linux/ubuntu $(lsb_release -sc)/" \
+  echo "deb https://cran.revolutionanalytics.com/bin/linux/ubuntu $(lsb_release -sc)/" \
       >> /etc/apt/sources.list.d/added_repos.list && \
   apt-key add CRAN.gpg && \
   apt-fast update -qq && \
@@ -28,7 +38,7 @@ RUN \
   python3-pip \
   libxml2-dev \
   cmake \
-  r-base \
+  r-base-core=3.4.2-1xenial1 \
   libssl-dev \
   libcurl4-openssl-dev \
   curl \

--- a/workers/dockerfiles/Dockerfile.salmon
+++ b/workers/dockerfiles/Dockerfile.salmon
@@ -6,17 +6,7 @@ RUN add-apt-repository ppa:apt-fast/stable
 RUN apt-get update -qq
 RUN apt-get -y install apt-fast
 
-# The version for r-base-core is weird, I'm not sure why it's named
-# that way. I found it here:
-# https://cran.revolutionanalytics.com/bin/linux/ubuntu/xenial/
-# If it needs to be updated then a version should be selected from
-# that list.
-
-# I am not entirely sure what the difference between r-base and r-base
-# core is, except that r-base is supposed to have some extra utilities
-# which increases the size of the package. However we don't get a ton
-# of choice because trying to use r-base causes a "you have held
-# broken pacakges" error.
+# The packages related to R are somewhat weird, see the README for more details.
 
 COPY workers/CRAN.gpg .
 RUN \

--- a/workers/dockerfiles/Dockerfile.smasher
+++ b/workers/dockerfiles/Dockerfile.smasher
@@ -6,7 +6,7 @@ RUN add-apt-repository ppa:apt-fast/stable
 RUN apt-get update -qq
 RUN apt-get -y install apt-fast
 
-# The packages related to R are somewhat weird, see the README for more details.w
+# The packages related to R are somewhat weird, see the README for more details.
 
 COPY workers/CRAN.gpg .
 RUN \

--- a/workers/dockerfiles/Dockerfile.smasher
+++ b/workers/dockerfiles/Dockerfile.smasher
@@ -6,17 +6,7 @@ RUN add-apt-repository ppa:apt-fast/stable
 RUN apt-get update -qq
 RUN apt-get -y install apt-fast
 
-# The version for r-base-core is weird, I'm not sure why it's named
-# that way. I found it here:
-# https://cran.revolutionanalytics.com/bin/linux/ubuntu/xenial/
-# If it needs to be updated then a version should be selected from
-# that list.
-
-# I am not entirely sure what the difference between r-base and r-base
-# core is, except that r-base is supposed to have some extra utilities
-# which increases the size of the package. However we don't get a ton
-# of choice because trying to use r-base causes a "you have held
-# broken pacakges" error.
+# The packages related to R are somewhat weird, see the README for more details.w
 
 COPY workers/CRAN.gpg .
 RUN \

--- a/workers/dockerfiles/Dockerfile.smasher
+++ b/workers/dockerfiles/Dockerfile.smasher
@@ -35,7 +35,7 @@ RUN \
   libcurl4-openssl-dev \
   libpq-dev \
   r-base-core=3.4.2-1xenial1 \
-  r-base-dev==3.4.2-1xenial1 \
+  r-base-dev=3.4.2-1xenial1 \
   libpq-dev \
   libxml2-dev \
   libssl-dev \

--- a/workers/dockerfiles/Dockerfile.smasher
+++ b/workers/dockerfiles/Dockerfile.smasher
@@ -6,14 +6,24 @@ RUN add-apt-repository ppa:apt-fast/stable
 RUN apt-get update -qq
 RUN apt-get -y install apt-fast
 
+# The version for r-base-core is weird, I'm not sure why it's named
+# that way. I found it here:
+# https://cran.revolutionanalytics.com/bin/linux/ubuntu/xenial/
+# If it needs to be updated then a version should be selected from
+# that list.
+
+# I am not entirely sure what the difference between r-base and r-base
+# core is, except that r-base is supposed to have some extra utilities
+# which increases the size of the package. However we don't get a ton
+# of choice because trying to use r-base causes a "you have held
+# broken pacakges" error.
+
 COPY workers/CRAN.gpg .
 RUN \
   apt-fast update -qq && \
   apt-get install -y apt-transport-https && \
   apt-fast install -y lsb-release && \
-  echo "deb http://archive.linux.duke.edu/cran/bin/linux/ubuntu $(lsb_release -sc)/" \
-      >> /etc/apt/sources.list.d/added_repos.list && \
-  echo "deb https://cloud.r-project.org/bin/linux/ubuntu $(lsb_release -sc)/" \
+  echo "deb https://cran.revolutionanalytics.com/bin/linux/ubuntu $(lsb_release -sc)/" \
       >> /etc/apt/sources.list.d/added_repos.list && \
   apt-key add CRAN.gpg && \
   apt-fast update -qq && \
@@ -24,8 +34,8 @@ RUN \
   python3-pip \
   libcurl4-openssl-dev \
   libpq-dev \
-  r-base \
-  r-base-dev \
+  r-base-core=3.4.2-1xenial1 \
+  r-base-dev==3.4.2-1xenial1 \
   libpq-dev \
   libxml2-dev \
   libssl-dev \


### PR DESCRIPTION
## Issue Number

N/A Came up cause R deps broke our builds again

## Purpose/Implementation Notes

In the course of #986 we realized that we had all our R packages pinned except the R language itself (probably due to confusion with the rlang package). This pins R to the version that Bioconductor 3.6 specifies as its target.

## Types of changes

- New feature (non-breaking change which adds functionality)

## Functional tests

Unit tests work, it means R is installed

## Checklist

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules
