### PR TITLE
Fix direct access on staging

### DIFF
--- a/infrastructure/networking.tf
+++ b/infrastructure/networking.tf
@@ -232,6 +232,12 @@ resource "aws_cloudfront_distribution" "static-distribution" {
     response_code = 200
     response_page_path = "/index.html"
   }
+  custom_error_response {
+    error_caching_min_ttl = 0
+    error_code = 403
+    response_code = 200
+    response_page_path = "/index.html"
+  }
 
   default_cache_behavior {
     allowed_methods  = ["DELETE", "GET", "HEAD", "OPTIONS", "PATCH", "POST", "PUT"]


### PR DESCRIPTION
## Issue Number

N/A

## Purpose/Implementation Notes

Create a new redirection rule, that shows `/index.html` for 403 errors. Since all errors are handled in the frontend.

## Functional tests

We should test this on staging.

## Screenshots

The config that will be created:

![image](https://user-images.githubusercontent.com/1882507/51864726-82a8e100-2312-11e9-8b61-f3779f394349.png)
