### PR TITLE
Allow supplying ALL as an organism to create_qn_target

### DIFF
--- a/workers/data_refinery_workers/processors/management/commands/create_qn_target.py
+++ b/workers/data_refinery_workers/processors/management/commands/create_qn_target.py
@@ -59,7 +59,7 @@ class Command(BaseCommand):
             logger.error("You must specify an organism or --all")
             sys.exit(1)
 
-        if options["organism"]:
+        if options["organism"] and (options.get('organism', '') != "ALL"):
             organisms = [Organism.get_object_for_name(options["organism"].upper())]
         else:
             organisms = Organism.objects.all()

--- a/workers/nomad-job-specs/create_compendia.nomad.tpl
+++ b/workers/nomad-job-specs/create_compendia.nomad.tpl
@@ -74,8 +74,6 @@ job "CREATE_COMPENDIA" {
         max_file_size = 1
       }
 
-      ${{SMASHER_CONSTRAINT}}
-
       config {
         image = "${{DOCKERHUB_REPO}}/${{COMPENDIA_DOCKER_IMAGE}}"
         force_pull = false


### PR DESCRIPTION
We have support for creating all QN targets at once, although this isn't usable in production since the nomad job spec doesn't support it, and the templating we use couldn't handle it anyway. This is a hack to allow using `ALL` as an organism - we already use `ALL` elsewhere in the app, so at least that's consistent.