### PR TITLE
Make QN Target Endpoint Include Annotations

### DIFF
--- a/api/data_refinery_api/serializers.py
+++ b/api/data_refinery_api/serializers.py
@@ -98,22 +98,6 @@ class ComputedFileSerializer(serializers.ModelSerializer):
                     'last_modified'
                 )
 
-class QNTargetSerializer(serializers.ModelSerializer):
-    class Meta:
-        model = ComputedFile
-        fields = (
-                    'id',
-                    'filename',
-                    'size_in_bytes',
-                    'is_qn_target',
-                    'sha1',
-                    's3_bucket',
-                    's3_key',
-                    's3_url',
-                    'created_at',
-                    'last_modified'
-                )
-
 class ComputationalResultSerializer(serializers.ModelSerializer):
     annotations = ComputationalResultAnnotationSerializer(many=True, source='computationalresultannotation_set')
     files = ComputedFileSerializer(many=True, source='computedfile_set')
@@ -136,6 +120,44 @@ class ComputationalResultSerializer(serializers.ModelSerializer):
                     'last_modified'
                 )
 
+class ComputationalResultNoFilesSerializer(serializers.ModelSerializer):
+    annotations = ComputationalResultAnnotationSerializer(many=True, source='computationalresultannotation_set')
+    processor = ProcessorSerializer(many=False)
+    organism_index = OrganismIndexSerializer(many=False)
+
+    class Meta:
+        model = ComputationalResult
+        fields = (
+                    'id',
+                    'commands',
+                    'processor',
+                    'is_ccdl',
+                    'annotations',
+                    'organism_index',
+                    'time_start',
+                    'time_end',
+                    'created_at',
+                    'last_modified'
+                )
+
+class QNTargetSerializer(serializers.ModelSerializer):
+    result = ComputationalResultNoFilesSerializer(many=False)
+
+    class Meta:
+        model = ComputedFile
+        fields = (
+                    'id',
+                    'filename',
+                    'size_in_bytes',
+                    'is_qn_target',
+                    'sha1',
+                    's3_bucket',
+                    's3_key',
+                    's3_url',
+                    'created_at',
+                    'last_modified',
+                    'result'
+                )
 
 ##
 # Samples

--- a/api/data_refinery_api/tests.py
+++ b/api/data_refinery_api/tests.py
@@ -30,6 +30,7 @@ from data_refinery_common.utils import get_env_variable
 from data_refinery_common.models import (
     ComputationalResult,
     ComputedFile,
+    ComputationalResultAnnotation,
     Dataset,
     DownloaderJob,
     DownloaderJobOriginalFileAssociation,
@@ -525,6 +526,11 @@ class APITestCases(APITestCase):
 
         cr = ComputationalResult()
         cr.save()
+
+        cra = ComputationalResultAnnotation()
+        cra.result = cr
+        cra.data = {"organism": "Ailuropoda melanoleuca"}
+        cra.save()
 
         qni = ComputedFile()
         qni.is_qn_target = True


### PR DESCRIPTION
## Issue Number
n/a

## Purpose/Implementation Notes

Investigating https://github.com/AlexsLemonade/refinebio/issues/1001 is hampered because then QN target endpoint isn't very helpful. This adds more information so that it is.

## Types of changes
- New feature (non-breaking change which adds functionality)
