### PR TITLE
Add support for num_processed_samples__gt=0

### DIFF
--- a/api/data_refinery_api/views.py
+++ b/api/data_refinery_api/views.py
@@ -184,13 +184,21 @@ class ExperimentDocumentView(DocumentViewSet):
             'field': '_id',
             'lookups': [
                 LOOKUP_FILTER_RANGE,
-                LOOKUP_QUERY_IN,
+                LOOKUP_QUERY_IN
             ],
         },
         'technology': 'technology',
         'has_publication': 'has_publication',
         'platform': 'platform_accesion_codes',
-        'organism': 'organism_names'
+        'organism': 'organism_names',
+        'num_processed_samples': {
+            'field': 'num_processed_samples',
+            'lookups': [
+                LOOKUP_FILTER_RANGE,
+                LOOKUP_QUERY_IN,
+                LOOKUP_QUERY_GT
+            ],
+        }
     }
 
     # Define ordering fields


### PR DESCRIPTION
This is a really cool ES feature.

The problem is we're currently ordering experiments by the total number of samples, including those unprocessed. This lets us affix `&num_processed_samples__gt=0` to our query string to filter those out.

FRIGGIN RAD
