### PR TITLE
Adds Ordering by Source First Published

### DIFF
--- a/api/data_refinery_api/serializers.py
+++ b/api/data_refinery_api/serializers.py
@@ -312,6 +312,8 @@ class ExperimentSerializer(serializers.ModelSerializer):
                     'submitter_institution',
                     'created_at',
                     'last_modified',
+                    'source_first_published',
+                    'source_last_modified',
                     'sample_metadata',
                     'technologies'
                 )
@@ -718,6 +720,7 @@ class ExperimentDocumentSerializer(serializers.Serializer):
     pubmed_id = serializers.CharField(read_only=True)
     num_total_samples = serializers.IntegerField(read_only=True)
     num_processed_samples = serializers.IntegerField(read_only=True)
+    source_first_published = serializers.DateField(read_only=True)
 
     # FK/M2M
     # We don't use any ForgeinKey serializers right now, but if we did, we'd do it like this:

--- a/api/data_refinery_api/views.py
+++ b/api/data_refinery_api/views.py
@@ -140,6 +140,7 @@ class ExperimentDocumentView(DocumentViewSet):
         ?search=medulloblastoma
         ?id=1
         ?search=medulloblastoma&technology=microarray&has_publication=true
+        ?ordering=source_first_published
 
     Full examples can be found in the Django-ES-DSL-DRF docs:
         https://django-elasticsearch-dsl-drf.readthedocs.io/en/0.17.1/filtering_usage_examples.html#filtering
@@ -207,11 +208,12 @@ class ExperimentDocumentView(DocumentViewSet):
         'title': 'title.raw',
         'description': 'description.raw',
         'num_total_samples': 'num_total_samples',
-        'num_processed_samples': 'num_processed_samples'
+        'num_processed_samples': 'num_processed_samples',
+        'source_first_published': 'source_first_published'
     }
 
     # Specify default ordering
-    ordering = ('-num_total_samples', 'id', 'title', 'description')
+    ordering = ('-num_total_samples', 'id', 'title', 'description', '-source_first_published')
 
     # Facets (aka Aggregations) provide statistics about the query result set in the API response.
     # More information here: https://github.com/barseghyanartur/django-elasticsearch-dsl-drf/blob/03a3aa716db31868ca3a71340513a993741a4177/src/django_elasticsearch_dsl_drf/filter_backends/faceted_search.py#L24

--- a/common/data_refinery_common/models/documents.py
+++ b/common/data_refinery_common/models/documents.py
@@ -88,6 +88,7 @@ class ExperimentDocument(DocType):
     pubmed_id = fields.TextField()
     num_total_samples = fields.IntegerField()
     num_processed_samples = fields.IntegerField()
+    source_first_published = fields.DateField()
 
     # FK/M2M
     # We actually don't use any ForeignKeys in our Experiment document,


### PR DESCRIPTION
## Issue Number
https://github.com/AlexsLemonade/refinebio/issues/1018

## Purpose/Implementation Notes

Append `?ordering=source_first_published` or `?ordering=-source_first_published` to use in queries.

The bigger issue may be that we're not doing a great job of scraping this information, so it's quite possible we're not going to get good ordering values.
