### PR TITLE
[HOTFIX] Fixes a couple places where we aren't passing env vars correctly.

### DIFF
--- a/infrastructure/deploy.sh
+++ b/infrastructure/deploy.sh
@@ -346,6 +346,8 @@ if [[ ! -z $container_running ]]; then
        -e DATABASE_NAME=$DATABASE_NAME \
        -e DATABASE_USER=$DATABASE_USER \
        -e DATABASE_PASSWORD=$DATABASE_PASSWORD \
+       -e ELASTICSEARCH_HOST=$ELASTICSEARCH_HOST \
+       -e ELASTICSEARCH_PORT=$ELASTICSEARCH_PORT \
        -v /tmp/volumes_static:/tmp/www/static \
        --log-driver=awslogs \
        --log-opt awslogs-region=$REGION \

--- a/infrastructure/instances.tf
+++ b/infrastructure/instances.tf
@@ -795,6 +795,7 @@ data "template_file" "foreman_server_script_smusher" {
     database_password = "${var.database_password}"
     database_name = "${aws_db_instance.postgres_db.name}"
     elasticsearch_host = "${aws_elasticsearch_domain.es.endpoint}"
+    elasticsearch_port = "${var.elasticsearch_port}"
     log_group = "${aws_cloudwatch_log_group.data_refinery_log_group.name}"
   }
 }


### PR DESCRIPTION
## Issue Number

N/A came up during most recent deploy

## Purpose/Implementation Notes

I forgot to populate the Terraform Variable `var.elasticsearch_port` in my last PR that used it.

The script for restarting the API without cycling it's instance was missing a couple env vars as well.


## Types of changes

- Bugfix (non-breaking change which fixes an issue)
