### PR TITLE
[HOTFIX] Updating docker images wasn't allowed for hotfixes -- fixed!

### DIFF
--- a/.circleci/update_docker_img.sh
+++ b/.circleci/update_docker_img.sh
@@ -7,7 +7,9 @@ source ~/refinebio/common.sh
 # Circle won't set the branch name for us, so do it ourselves.
 branch=$(get_master_or_dev $CIRCLE_TAG)
 
-if [[ $branch == "master" ]]; then
+if [[ "$CIRCLE_TAG" == *"-hotfix" && $branch == "dev" ]]; then
+    DOCKERHUB_REPO=ccdl
+elif [[ $branch == "master" ]]; then
     DOCKERHUB_REPO=ccdl
 elif [[ $branch == "dev" ]]; then
     DOCKERHUB_REPO=ccdlstaging


### PR DESCRIPTION
## Issue Number

N/A Came up during hotfix deploy

## Purpose/Implementation Notes

We added checks for hotfix tags, but missed one spot. This remedies that.

## Types of changes

- Bugfix (non-breaking change which fixes an issue)
