### PR TITLE
Increase visibility for organism shepherd

### DIFF
--- a/foreman/data_refinery_foreman/foreman/management/commands/organism_shepherd.py
+++ b/foreman/data_refinery_foreman/foreman/management/commands/organism_shepherd.py
@@ -106,7 +106,7 @@ def build_prioritized_jobs_list(organism: Organism) -> List:
             "Experiment %s has %d / %d samples processed.",
             experiment_stats_dict["experiment"],
             len(unprocessed_samples),
-            len(experiment_stats_dict["processed"])
+            (len(unprocessed_samples) + len(experiment_stats_dict["processed"]))
         )
 
         for sample in unprocessed_samples:

--- a/foreman/data_refinery_foreman/foreman/management/commands/organism_shepherd.py
+++ b/foreman/data_refinery_foreman/foreman/management/commands/organism_shepherd.py
@@ -33,7 +33,7 @@ from data_refinery_common.utils import get_env_variable
 logger = get_and_configure_logger(__name__)
 
 
-MAX_JOBS_FOR_THIS_MODE = 2000
+MAX_JOBS_FOR_THIS_MODE = 3000
 
 
 def build_completion_list(organism: Organism) -> List[Dict]:
@@ -44,7 +44,7 @@ def build_completion_list(organism: Organism) -> List[Dict]:
     samples, and the number of unprocessed samples under the keys:
     experiment, processed, and unprocessed respectively.
     """
-    experiments = organism.experiments.all()
+    experiments = organism.experiments.filter(technology='RNA-SEQ')
 
     completion_list = []
     for experiment in experiments:
@@ -102,6 +102,12 @@ def build_prioritized_jobs_list(organism: Organism) -> List:
     prioritized_job_list = []
     for experiment_stats_dict in completion_list:
         unprocessed_samples = experiment_stats_dict["unprocessed"]
+        logger.info(
+            "Experiment %s has %d / %d samples processed.",
+            experiment_stats_dict["experiment"],
+            len(unprocessed_samples),
+            len(experiment_stats_dict["processed"])
+        )
 
         for sample in unprocessed_samples:
             processor_jobs = list(sample.get_processor_jobs())
@@ -181,15 +187,26 @@ def requeue_job(job):
             job.retried_job = new_job
             job.save()
         else:
+            logger.error(
+                ("Failed to requeue %s which had ID %d with a new %s "
+                 "with ID %d because send_job returned false."),
+                type(job).__name__,
+                job.id,
+                type(job).__name__,
+                new_job.id
+            )
             # Can't communicate with nomad just now, leave the job for a later loop.
             new_job.delete()
             return False
     except:
-        logger.error("Failed to requeue %s which had ID %d with a new %s with ID %d.",
-                     type(job).__name__,
-                     job.id,
-                     type(job).__name__,
-                     new_job.id)
+        logger.exception(
+            ("Failed to requeue %s which had ID %d with a new %s "
+             "with ID %d because send_job raised an exception."),
+            type(job).__name__,
+            job.id,
+            type(job).__name__,
+            new_job.id
+        )
         # Can't communicate with nomad just now, leave the job for a later loop.
         new_job.delete()
         return False
@@ -239,12 +256,13 @@ class Command(BaseCommand):
             num_short_from_max = MAX_JOBS_FOR_THIS_MODE - len_all_jobs
             if num_short_from_max > 0:
                 for i in range(num_short_from_max):
-                    if len(prioritized_job_list) > 0 and requeue_job(prioritized_job_list[0]):
-                        prioritized_job_list.pop(0)
+                    if len(prioritized_job_list) > 0:
+                        requeue_job(prioritized_job_list.pop(0))
 
             # Wait 10 minutes in between queuing additional work to
             # give it time to actually get done.
             if len(prioritized_job_list) > 0:
+                logger.info("Sleeping for 5 minutes while jobs get done.")
                 time.sleep(600)
 
         logger.info("Successfully requeued all jobs for unprocessed %s samples.", organism_name)

--- a/foreman/data_refinery_foreman/foreman/management/commands/organism_shepherd.py
+++ b/foreman/data_refinery_foreman/foreman/management/commands/organism_shepherd.py
@@ -151,7 +151,7 @@ def requeue_job(job):
             num_retries=num_retries,
             pipeline_applied=job.pipeline_applied,
             ram_amount=job.ram_amount,
-            volume_index=0
+            volume_index="0"
         )
         new_job.save()
 

--- a/foreman/data_refinery_foreman/foreman/management/commands/test_organism_shepherd.py
+++ b/foreman/data_refinery_foreman/foreman/management/commands/test_organism_shepherd.py
@@ -56,6 +56,7 @@ class OrganismShepherdTestCase(TransactionTestCase):
 
         # Experiment that is 0% complete.
         zero_percent_experiment = Experiment(accession_code='ERP037000')
+        zero_percent_experiment.technology = 'RNA-SEQ'
         zero_percent_experiment.save()
 
         organism_assoc = ExperimentOrganismAssociation.objects.create(
@@ -101,6 +102,7 @@ class OrganismShepherdTestCase(TransactionTestCase):
 
         # Experiment that is 50% complete.
         fify_percent_experiment = Experiment(accession_code='ERP036000')
+        fify_percent_experiment.technology = 'RNA-SEQ'
         fify_percent_experiment.save()
 
         organism_assoc = ExperimentOrganismAssociation.objects.create(


### PR DESCRIPTION
## Issue Number

#227 

## Purpose/Implementation Notes

I think the organism spun while failing to requeue a particular job for a while. I'm not sure why it couldn't queue it, so I've added some additional logging. I also removed the looping bug that made the shepherd get stuck on it.

Additionally I added some logging so I can see the prioritized list of experiments that the organism is going to queue.

Also, for the time being we only care about finishing RNA-SEQ experiments so I've added an RNA-SEQ filter that I should have had before.

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

I ran the command locally and saw it requeue only the expected jobs successfully.

## Checklist

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules
