### PR TITLE
Zero Default Target Capacity

### DIFF
--- a/infrastructure/variables.tf
+++ b/infrastructure/variables.tf
@@ -128,7 +128,7 @@ variable "spot_price" {
 }
 
 variable "spot_fleet_capacity" {
-  default = "100"
+  default = "0"
 }
 
 variable "max_clients" {


### PR DESCRIPTION
Since we keep manipulating this value as needed via the web console, let's get rid of this expensive default value.