### PR TITLE
Prevent hotfix deploys from running the deploy step twice.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -286,7 +286,10 @@ workflows:
             branches:
               ignore: /.*/
             tags:
+              # From CirlceCI Docs:
+              # If both only and ignore are specified the only is considered before ignore.
               only: /v.*/
+              igore: /v.*-hotfix/
 
   hotfix-deploy:
     jobs:


### PR DESCRIPTION
## Issue Number

N/A came up because I saw a deploy happen twice for one tag.

## Purpose/Implementation Notes

We made the hotfix deploy job run for tags that match /v.*-hotfix/, but we didn't stop it from running for tags that match /v.*/, which includes all the tags that would match /v.*-hotfix/. This makes it so the normal deploy ignores hotfix tags.

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

N/A this needs a hotfix tag to be tested.

## Checklist

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules
