### PR TITLE
Fix typo that broke all of circleci.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -289,7 +289,7 @@ workflows:
               # From CirlceCI Docs:
               # If both only and ignore are specified the only is considered before ignore.
               only: /v.*/
-              igore: /v.*-hotfix/
+              ignore: /v.*-hotfix/
 
   hotfix-deploy:
     jobs:


### PR DESCRIPTION
## Issue Number

#1048 

## Purpose/Implementation Notes

I misspelled this word, so it broke the config and made all jobs not run.

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

Look they're actually running: https://circleci.com/workflow-run/5205632b-2b17-44ca-8502-327b0e09423d

## Checklist

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules
