### PR TITLE
Kurtwheeler/handle missing downloader jobs

### DIFF
--- a/foreman/data_refinery_foreman/foreman/main.py
+++ b/foreman/data_refinery_foreman/foreman/main.py
@@ -63,7 +63,7 @@ JANITOR_DISPATCH_TIME = datetime.timedelta(minutes=30)
 # there's a separate management command being used to pick what work
 # to focus on. So all the foreman needs to do is worry about jobs
 # queued after the beginning of the zebrafish sprint
-JOB_CREATED_AT_CUTOFF = datetime.date(2019, 2, 5)
+JOB_CREATED_AT_CUTOFF = datetime.datetime(2019, 2, 5, tzinfo=timezone.utc)
 
 
 def read_config_list(config_file: str) -> List[str]:


### PR DESCRIPTION
## Issue Number

#227 

## Purpose/Implementation Notes

It turns out some DownloaderJobs have been deleted and every processor job having a corresponding downloader job was an assumption I made in #1032. This is tripping a lot of jobs up, so this adds logic to create a downloader job even if the original downloader job isn't there.

This also uses timezone aware datetime objects for Foreman queries.

I also changed `wait_for_job` to be able to loop faster so we don't get unlucky with a downloader job finishing and queuing a processor job which starts and checks for its file before the tests are able to delete that file.

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

I made a unit test for this stuff.

## Checklist

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules
