### PR TITLE
Reset the is_downloaded field to false if we detect that a file isn't downloaded

### DIFF
--- a/workers/data_refinery_workers/downloaders/geo.py
+++ b/workers/data_refinery_workers/downloaders/geo.py
@@ -297,6 +297,13 @@ def download_geo(job_id: int) -> None:
 
     file_assocs = DownloaderJobOriginalFileAssociation.objects.filter(downloader_job=job)
 
+    if file_assocs.count() == 0:
+        job.failure_reason = "No files associated with the job."
+        logger.error(
+            "Error occured while extracting tar file.", downloader_job=job_id)
+        utils.end_downloader_job(job, success=False)
+        return
+
     original_file = file_assocs[0].original_file
     url = original_file.source_url
     accession_code = job.accession_code

--- a/workers/data_refinery_workers/processors/utils.py
+++ b/workers/data_refinery_workers/processors/utils.py
@@ -145,6 +145,13 @@ def create_downloader_job(undownloaded_files: OriginalFile) -> bool:
         # another file that came out of it could have already
         # recreated the DownloaderJob.
         if archive_file.needs_downloading():
+            if archive_file.is_downloaded:
+                # If it needs to be downloaded then it's not
+                # downloaded and the is_downloaded field should stop
+                # lying about that.
+                archive_file.is_downloaded = False
+                archive_file.save()
+
             DownloaderJobOriginalFileAssociation.objects.get_or_create(
                 downloader_job=new_job,
                 original_file=archive_file
@@ -178,6 +185,13 @@ def prepare_original_files(job_context):
     undownloaded_files = set()
     for original_file in original_files:
         if original_file.needs_downloading():
+            if original_file.is_downloaded:
+                # If it needs to be downloaded then it's not
+                # downloaded and the is_downloaded field should stop
+                # lying about that.
+                original_file.is_downloaded = False
+                original_file.save()
+
             undownloaded_files.add(original_file)
 
     if undownloaded_files:


### PR DESCRIPTION
## Issue Number

#227 

## Purpose/Implementation Notes

SRA downloader jobs were finishing instantly because they thought the file wasn't downloaded.

## Types of changes

- Bugfix (non-breaking change which fixes an issue)
