### PR TITLE
Set the value of an enum on the downloader jobs rather than the enum object itself.

### DIFF
--- a/workers/data_refinery_workers/processors/utils.py
+++ b/workers/data_refinery_workers/processors/utils.py
@@ -108,6 +108,11 @@ def create_downloader_job(undownloaded_files: OriginalFile) -> bool:
                              " because it was able to have a processor job created for it..."),
                             sample=sample_object.id,
                             original_file=original_file.id)
+            else:
+                # determine_downloader_task returns an enum object,
+                # but we wanna set this on the DownloaderJob object so
+                # we want the actual value.
+                downloader_task = downloader_task.value
 
             accession_code = sample_object.accession_code
             original_files = sample_object.original_files.all()


### PR DESCRIPTION
## Issue Number

#227 

## Purpose/Implementation Notes

Trivial

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

N/A

## Checklist

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules
