### PR TITLE
Filter Wrong Organism Samples from Compendia // Guard Against Unicode Metadata

### DIFF
--- a/workers/data_refinery_workers/processors/create_compendia.py
+++ b/workers/data_refinery_workers/processors/create_compendia.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*- 
+
 import os
 import random
 import shutil

--- a/workers/data_refinery_workers/processors/create_compendia.py
+++ b/workers/data_refinery_workers/processors/create_compendia.py
@@ -8,6 +8,7 @@ import warnings
 
 import numpy as np
 import pandas as pd
+pd.set_option('mode.chained_assignment', None)
 from fancyimpute import KNN, BiScaler, SoftImpute, IterativeSVD
 
 from django.utils import timezone

--- a/workers/data_refinery_workers/processors/create_compendia.py
+++ b/workers/data_refinery_workers/processors/create_compendia.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*- 
-
 import os
 import random
 import shutil

--- a/workers/data_refinery_workers/processors/management/commands/create_compendia.py
+++ b/workers/data_refinery_workers/processors/management/commands/create_compendia.py
@@ -46,7 +46,7 @@ class Command(BaseCommand):
             data = {}
             experiments = Experiment.objects.filter(id__in=(ExperimentOrganismAssociation.objects.filter(organism=organism)).values('experiment'))
             for experiment in experiments:
-                data[experiment.accession_code] = list(experiment.samples.values_list('accession_code', flat=True))
+                data[experiment.accession_code] = list(experiment.samples.filter(organism=organism).values_list('accession_code', flat=True))
 
             job = ProcessorJob()
             job.pipeline_applied = "COMPENDIA"

--- a/workers/data_refinery_workers/processors/smasher.py
+++ b/workers/data_refinery_workers/processors/smasher.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*- 
+
 import boto3
 import csv
 import os
@@ -264,7 +266,7 @@ def _write_tsv_json(job_context, metadata, smash_path):
             os.makedirs(experiment_dir, exist_ok=True)
             tsv_path = experiment_dir + 'metadata_' + experiment_title + '.tsv'
             tsv_paths.append(tsv_path)
-            with open(tsv_path, 'w') as tsv_file:
+            with open(tsv_path, 'w', encoding='utf-8-sig') as tsv_file:
                 dw = csv.DictWriter(tsv_file, columns, delimiter='\t')
                 dw.writeheader()
                 for sample_title, sample_metadata in metadata['samples'].items():
@@ -281,8 +283,8 @@ def _write_tsv_json(job_context, metadata, smash_path):
             samples_in_species = []
             tsv_path = species_dir + "metadata_" + species + '.tsv'
             tsv_paths.append(tsv_path)
-            with open(tsv_path, 'w') as tsv_file:
-                dw = csv.DictWriter(tsv_file, columns, delimiter='\t')
+            with open(tsv_path, 'w', encoding='utf-8-sig') as tsv_file:
+                dw = csv.DictWriter(tsv_file, columns, delimiter='\t', encoding='utf8')
                 dw.writeheader()
                 for sample_metadata in metadata['samples'].values():
                     if sample_metadata.get('refinebio_organism', '') == species:
@@ -297,7 +299,7 @@ def _write_tsv_json(job_context, metadata, smash_path):
                     'samples': samples_in_species
                 }
                 json_path = species_dir + "metadata_" + species + '.json'
-                with open(json_path, 'w') as json_file:
+                with open(json_path, 'w', encoding='utf-8-sig') as json_file:
                     json.dump(species_metadata, json_file, indent=4, sort_keys=True)
         return tsv_paths
     # All Metadata
@@ -305,7 +307,7 @@ def _write_tsv_json(job_context, metadata, smash_path):
         all_dir = smash_path + "ALL/"
         os.makedirs(all_dir, exist_ok=True)
         tsv_path = all_dir + 'metadata_ALL.tsv' 
-        with open(tsv_path, 'w') as tsv_file:
+        with open(tsv_path, 'w', encoding='utf-8-sig') as tsv_file:
             dw = csv.DictWriter(tsv_file, columns, delimiter='\t')
             dw.writeheader()
             for sample_metadata in metadata['samples'].values():
@@ -748,7 +750,7 @@ def _smash(job_context: Dict, how="inner") -> Dict:
 
         # Metadata to JSON
         metadata['created_at'] = datetime.utcnow().strftime('%Y-%m-%dT%H:%M:%S')
-        with open(smash_path + 'aggregated_metadata.json', 'w') as metadata_file:
+        with open(smash_path + 'aggregated_metadata.json', 'w', encoding='utf-8-sig') as metadata_file:
             json.dump(metadata, metadata_file, indent=4, sort_keys=True)
 
         # Finally, compress all files into a zip

--- a/workers/data_refinery_workers/processors/smasher.py
+++ b/workers/data_refinery_workers/processors/smasher.py
@@ -547,7 +547,7 @@ def _smash(job_context: Dict, how="inner") -> Dict:
                     num_samples = num_samples + 1
 
                     if (num_samples % 100) == 0:
-                        logger.warn("Loaded " + str(num_samples) + " samples into frames.",
+                        logger.warning("Loaded " + str(num_samples) + " samples into frames.",
                             dataset_id=job_context['dataset'].id,
                             how=how
                         )
@@ -636,7 +636,7 @@ def _smash(job_context: Dict, how="inner") -> Dict:
                     old_len_merged = len(merged)
                     merged_backup = merged
             else:
-                merged = pd.concat(all_frames, axis=1, keys=None, join='outer', copy=False)
+                merged = pd.concat(all_frames, axis=1, keys=None, join='outer', copy=False, sort=True)
 
             job_context['original_merged'] = merged
 

--- a/workers/data_refinery_workers/processors/smasher.py
+++ b/workers/data_refinery_workers/processors/smasher.py
@@ -251,8 +251,6 @@ def _write_tsv_json(job_context, metadata, smash_path):
     """Writes tsv files on disk.
     If the dataset is aggregated by species, also write species-level
     JSON file.
-
-
     """
 
     # Uniform TSV header per dataset
@@ -266,7 +264,7 @@ def _write_tsv_json(job_context, metadata, smash_path):
             os.makedirs(experiment_dir, exist_ok=True)
             tsv_path = experiment_dir + 'metadata_' + experiment_title + '.tsv'
             tsv_paths.append(tsv_path)
-            with open(tsv_path, 'w', encoding='utf-8-sig') as tsv_file:
+            with open(tsv_path, 'w') as tsv_file:
                 dw = csv.DictWriter(tsv_file, columns, delimiter='\t')
                 dw.writeheader()
                 for sample_title, sample_metadata in metadata['samples'].items():
@@ -283,8 +281,8 @@ def _write_tsv_json(job_context, metadata, smash_path):
             samples_in_species = []
             tsv_path = species_dir + "metadata_" + species + '.tsv'
             tsv_paths.append(tsv_path)
-            with open(tsv_path, 'w', encoding='utf-8-sig') as tsv_file:
-                dw = csv.DictWriter(tsv_file, columns, delimiter='\t', encoding='utf8')
+            with open(tsv_path, 'w', encoding='utf-8') as tsv_file:
+                dw = csv.DictWriter(tsv_file, columns, delimiter='\t')
                 dw.writeheader()
                 for sample_metadata in metadata['samples'].values():
                     if sample_metadata.get('refinebio_organism', '') == species:
@@ -299,7 +297,7 @@ def _write_tsv_json(job_context, metadata, smash_path):
                     'samples': samples_in_species
                 }
                 json_path = species_dir + "metadata_" + species + '.json'
-                with open(json_path, 'w', encoding='utf-8-sig') as json_file:
+                with open(json_path, 'w', encoding='utf-8') as json_file:
                     json.dump(species_metadata, json_file, indent=4, sort_keys=True)
         return tsv_paths
     # All Metadata
@@ -307,7 +305,7 @@ def _write_tsv_json(job_context, metadata, smash_path):
         all_dir = smash_path + "ALL/"
         os.makedirs(all_dir, exist_ok=True)
         tsv_path = all_dir + 'metadata_ALL.tsv' 
-        with open(tsv_path, 'w', encoding='utf-8-sig') as tsv_file:
+        with open(tsv_path, 'w', encoding='utf-8') as tsv_file:
             dw = csv.DictWriter(tsv_file, columns, delimiter='\t')
             dw.writeheader()
             for sample_metadata in metadata['samples'].values():
@@ -750,7 +748,7 @@ def _smash(job_context: Dict, how="inner") -> Dict:
 
         # Metadata to JSON
         metadata['created_at'] = datetime.utcnow().strftime('%Y-%m-%dT%H:%M:%S')
-        with open(smash_path + 'aggregated_metadata.json', 'w', encoding='utf-8-sig') as metadata_file:
+        with open(smash_path + 'aggregated_metadata.json', 'w', encoding='utf-8') as metadata_file:
             json.dump(metadata, metadata_file, indent=4, sort_keys=True)
 
         # Finally, compress all files into a zip

--- a/workers/data_refinery_workers/processors/smasher.py
+++ b/workers/data_refinery_workers/processors/smasher.py
@@ -547,7 +547,7 @@ def _smash(job_context: Dict, how="inner") -> Dict:
                     num_samples = num_samples + 1
 
                     if (num_samples % 100) == 0:
-                        logger.info("Loaded " + str(num_samples) + " samples into frames.",
+                        logger.warn("Loaded " + str(num_samples) + " samples into frames.",
                             dataset_id=job_context['dataset'].id,
                             how=how
                         )

--- a/workers/data_refinery_workers/processors/test_compendia.py
+++ b/workers/data_refinery_workers/processors/test_compendia.py
@@ -265,5 +265,5 @@ class CompendiaTestCase(TestCase):
         for file in final_context['computed_files']:
             self.assertTrue(os.path.exists(file.absolute_file_path))
 
-        # It's not worth asserting this until we're sure the behavior is correct
-        # self.assertEqual(final_context['merged_qn'].shape, (9045, 830))
+        # It's maybe not worth asserting this until we're sure the behavior is correct
+        self.assertEqual(final_context['merged_qn'].shape, (9045, 830))

--- a/workers/data_refinery_workers/processors/test_compendia.py
+++ b/workers/data_refinery_workers/processors/test_compendia.py
@@ -266,4 +266,4 @@ class CompendiaTestCase(TestCase):
             self.assertTrue(os.path.exists(file.absolute_file_path))
 
         # It's maybe not worth asserting this until we're sure the behavior is correct
-        self.assertEqual(final_context['merged_qn'].shape, (9045, 830))
+        # self.assertEqual(final_context['merged_qn'].shape, (9045, 830))

--- a/workers/data_refinery_workers/processors/test_smasher.py
+++ b/workers/data_refinery_workers/processors/test_smasher.py
@@ -1254,8 +1254,7 @@ class AggregationTestCase(TestCase):
         # Test json file of "homo_sapiens"
         json_filename = self.smash_path + "homo_sapiens/metadata_homo_sapiens.json"
         self.assertTrue(os.path.isfile(json_filename))
-
-        with open(json_filename) as json_fp:
+        with open(json_filename, encoding='utf-8') as json_fp:
             species_metadada = json.load(json_fp)
         self.assertEqual(species_metadada['species'], 'homo_sapiens')
         self.assertEqual(len(species_metadada['samples']), 1)

--- a/workers/data_refinery_workers/processors/test_smasher.py
+++ b/workers/data_refinery_workers/processors/test_smasher.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*- 
+
 import csv
 import json
 import os
@@ -1224,6 +1226,70 @@ class AggregationTestCase(TestCase):
         os.remove(tsv_filename)
 
     @tag("smasher")
+    def test_unicode_writer(self):
+        self.unicode_metadata = {
+            'experiments': {
+                "E-GEOD-😎": {
+                    "accession_code": "E-GEOD-😎",
+                    "sample_titles": [ "😎", "undefined_sample" ]
+                }
+            },
+            'samples': {
+                "😎": {  # Sample #1 is an ArrayExpress sample
+                    "refinebio_😎": "😎",
+                    "refinebio_accession_code": "eyy",
+                    "refinebio_annotations": [
+                        # annotation #1
+                        {
+                            "😎😎": "😎😎",
+                            "detection_percentage": 98.44078,
+                            "mapped_percentage": 100.0
+                        }
+                    ]  # end of annotations
+                },  # end of sample #1
+            }  # end of "samples"
+        }
+        self.smash_path = "/tmp/"
+
+        job_context = {
+            'dataset': Dataset.objects.create(aggregate_by='ALL'),
+            'input_files': {
+            }
+        }
+        final_context = smasher._write_tsv_json(job_context, self.unicode_metadata, self.smash_path)
+        reso = final_context[0]
+        with open(reso, encoding='utf-8') as tsv_file: 
+            reader = csv.DictReader(tsv_file, delimiter='\t')
+            for row_num, row in enumerate(reader):
+                print(str(row).encode('utf-8'))
+
+        job_context = {
+            'dataset': Dataset.objects.create(aggregate_by='EXPERIMENT'),
+            'input_files': {
+            }
+        }
+        final_context = smasher._write_tsv_json(job_context, self.unicode_metadata, self.smash_path)
+        reso = final_context[0]
+        with open(reso, encoding='utf-8') as tsv_file: 
+            reader = csv.DictReader(tsv_file, delimiter='\t')
+            for row_num, row in enumerate(reader):
+                print(str(row).encode('utf-8'))
+
+        job_context = {
+            'dataset': Dataset.objects.create(aggregate_by='SPECIES'),
+            'input_files': {
+                'homo_sapiens': [], # only the key matters in this test
+                'fake_species': []  # only the key matters in this test
+            }
+        }
+        final_context = smasher._write_tsv_json(job_context, self.unicode_metadata, self.smash_path)
+        reso = final_context[0]
+        with open(reso, encoding='utf-8') as tsv_file: 
+            reader = csv.DictReader(tsv_file, delimiter='\t')
+            for row_num, row in enumerate(reader):
+                print(str(row).encode('utf-8'))
+
+    @tag("smasher")
     def test_species(self):
         """Check tsv file that is aggregated by species."""
 
@@ -1254,7 +1320,7 @@ class AggregationTestCase(TestCase):
         # Test json file of "homo_sapiens"
         json_filename = self.smash_path + "homo_sapiens/metadata_homo_sapiens.json"
         self.assertTrue(os.path.isfile(json_filename))
-        with open(json_filename, encoding='utf-8') as json_fp:
+        with open(json_filename) as json_fp:
             species_metadada = json.load(json_fp)
         self.assertEqual(species_metadada['species'], 'homo_sapiens')
         self.assertEqual(len(species_metadada['samples']), 1)

--- a/workers/nomad-job-specs/create_compendia.nomad.tpl
+++ b/workers/nomad-job-specs/create_compendia.nomad.tpl
@@ -27,7 +27,7 @@ job "CREATE_COMPENDIA" {
       size = "10"
     }
 
-    task "create_qn_target" {
+    task "create_compendia" {
       driver = "docker"
 
       kill_timeout = "30s"


### PR DESCRIPTION
Two bugfixes in here: 

 - explicitly out an experiment's samples that are of the wrong organism type,
 - Properly handle unicode metadata, guard against against TSV writing fail
