### PR TITLE
Reserve RAM on client instances so not more than 4 SALMON jobs can run at once.

### DIFF
--- a/infrastructure/nomad-configuration/client-instance-user-data.tpl.sh
+++ b/infrastructure/nomad-configuration/client-instance-user-data.tpl.sh
@@ -115,6 +115,17 @@ EOF
 # Make the client.meta.volume_id is set to waht we just mounted
 sed -i "s/REPLACE_ME/$EBS_VOLUME_INDEX/" client.hcl
 
+# We want to leave enough RAM to run 4 SALMON jobs at once but not
+# enough to run 5.  Each SALMON job takes 32768MB of RAM, 32768 * 4 =
+# 131072, but that doesn't leave much margin for error. Therefore just
+# give it an extra 10GB of RAM since that won't be enough for an
+# entire other job to be queued, but keeps things from being so tight.
+TARGET_RAM=141072
+# Make the client.meta.volume_id is set to waht we just mounted
+TOTAL_RAM=$(free -m | grep Mem | tr -s ' ' | cut -d\  -f2)
+RESERVED_RAM=$((TOTAL_RAM - TARGET_RAM))
+sed -i "s/CHANGE_ME/$RESERVED_RAM/" client.hcl
+
 # Create a directory for docker to use as a volume.
 mkdir /home/ubuntu/docker_volume
 chmod a+rwx /home/ubuntu/docker_volume

--- a/infrastructure/nomad-configuration/client.tpl.hcl
+++ b/infrastructure/nomad-configuration/client.tpl.hcl
@@ -8,13 +8,17 @@ data_dir = "/tmp/nomad_client1"
 
 # Enable the client
 client {
-    enabled = true
-    servers = ["${nomad_lead_server_ip}:4647"]
+  enabled = true
+  servers = ["${nomad_lead_server_ip}:4647"]
 
-    meta {
-      volume_index = "REPLACE_ME"
-      is_smasher = "false"
-    }
+  meta {
+    volume_index = "REPLACE_ME"
+    is_smasher = "false"
+  }
+
+  reserved {
+    memory = "CHANGE_ME"
+  }
 }
 
 consul {


### PR DESCRIPTION
## Issue Number

#227 

## Purpose/Implementation Notes

I've observed 5 concurrent SALMON jobs as being enough to make fasterq-dump timeout. Therefore this uses Nomad's RAM reservation to make it so that 4 SALMON jobs will fit on a single instance, but not 5.

This can be undone once Nomad releases its tmpfs feature.

## Types of changes

- New feature (non-breaking change which adds functionality)

## Functional tests

From one of our client instances:
```
ubuntu@ip-10-0-81-222:~$ TARGET_RAM=141072
ubuntu@ip-10-0-81-222:~$ TOTAL_RAM=$(free -m | grep Mem | tr -s ' ' | cut -d\  -f2)
ubuntu@ip-10-0-81-222:~$ RESERVED_RAM=$((TOTAL_RAM - TARGET_RAM))
ubuntu@ip-10-0-81-222:~$ echo $RESERVED_RAM
350733
ubuntu@ip-10-0-81-222:~$ echo $TOTAL_RAM
491805
```

I also tested the `sed` command by running it against client.tpl.hcl and making sure it replaced `CHANGE_ME` properly.

## Checklist

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules
