### PR TITLE
Hacks/optimizations to try to get fasterq-dump to actually succeed for Zebrafish

### DIFF
--- a/infrastructure/instances.tf
+++ b/infrastructure/instances.tf
@@ -315,151 +315,151 @@ resource "aws_spot_fleet_request" "cheap_ram" {
   ##
   # x1.16xlarge
   ##
-  launch_specification {
+  # launch_specification {
 
-    # Client Specific
-    instance_type             = "x1.16xlarge"
-    weighted_capacity         = 10 # via https://aws.amazon.com/ec2/instance-types/
-    spot_price                = "${var.spot_price}"
-    ami                       = "${data.aws_ami.ubuntu.id}"
-    iam_instance_profile_arn  = "${aws_iam_instance_profile.data_refinery_instance_profile.arn}"
-    user_data                 = "${data.template_file.nomad_client_script_smusher.rendered}"
-    vpc_security_group_ids    = ["${aws_security_group.data_refinery_worker.id}"]
-    subnet_id                 = "${aws_subnet.data_refinery_1a.id}"
-    availability_zone         = "${var.region}a"
-    key_name = "${aws_key_pair.data_refinery.key_name}"
+  #   # Client Specific
+  #   instance_type             = "x1.16xlarge"
+  #   weighted_capacity         = 10 # via https://aws.amazon.com/ec2/instance-types/
+  #   spot_price                = "${var.spot_price}"
+  #   ami                       = "${data.aws_ami.ubuntu.id}"
+  #   iam_instance_profile_arn  = "${aws_iam_instance_profile.data_refinery_instance_profile.arn}"
+  #   user_data                 = "${data.template_file.nomad_client_script_smusher.rendered}"
+  #   vpc_security_group_ids    = ["${aws_security_group.data_refinery_worker.id}"]
+  #   subnet_id                 = "${aws_subnet.data_refinery_1a.id}"
+  #   availability_zone         = "${var.region}a"
+  #   key_name = "${aws_key_pair.data_refinery.key_name}"
 
-    root_block_device {
-      volume_size = 100
-      volume_type = "gp2"
-    }
+  #   root_block_device {
+  #     volume_size = 100
+  #     volume_type = "gp2"
+  #   }
 
-    tags {
-        Name = "Spot Fleet Launch Specification x1.16xlarge ${var.user}-${var.stage}"
-        User = "${var.user}"
-        Stage = "${var.stage}"
-    }
+  #   tags {
+  #       Name = "Spot Fleet Launch Specification x1.16xlarge ${var.user}-${var.stage}"
+  #       User = "${var.user}"
+  #       Stage = "${var.stage}"
+  #   }
 
-  }
-  ##
-  # x1.32xlarge
-  ##
-  launch_specification {
+  # }
+  # ##
+  # # x1.32xlarge
+  # ##
+  # launch_specification {
 
-    # Client Specific
-    instance_type             = "x1.32xlarge"
-    weighted_capacity         = 20 # via https://aws.amazon.com/ec2/instance-types/
-    spot_price                = "${var.spot_price}"
-    ami                       = "${data.aws_ami.ubuntu.id}"
-    iam_instance_profile_arn  = "${aws_iam_instance_profile.data_refinery_instance_profile.arn}"
-    user_data                 = "${data.template_file.nomad_client_script_smusher.rendered}"
-    vpc_security_group_ids    = ["${aws_security_group.data_refinery_worker.id}"]
-    subnet_id                 = "${aws_subnet.data_refinery_1a.id}"
-    availability_zone         = "${var.region}a"
-    key_name = "${aws_key_pair.data_refinery.key_name}"
+  #   # Client Specific
+  #   instance_type             = "x1.32xlarge"
+  #   weighted_capacity         = 20 # via https://aws.amazon.com/ec2/instance-types/
+  #   spot_price                = "${var.spot_price}"
+  #   ami                       = "${data.aws_ami.ubuntu.id}"
+  #   iam_instance_profile_arn  = "${aws_iam_instance_profile.data_refinery_instance_profile.arn}"
+  #   user_data                 = "${data.template_file.nomad_client_script_smusher.rendered}"
+  #   vpc_security_group_ids    = ["${aws_security_group.data_refinery_worker.id}"]
+  #   subnet_id                 = "${aws_subnet.data_refinery_1a.id}"
+  #   availability_zone         = "${var.region}a"
+  #   key_name = "${aws_key_pair.data_refinery.key_name}"
 
-    root_block_device {
-      volume_size = 100 
-      volume_type = "gp2"
-    }
+  #   root_block_device {
+  #     volume_size = 100
+  #     volume_type = "gp2"
+  #   }
 
-    tags {
-        Name = "Spot Fleet Launch Specification x1.32xlarge ${var.user}-${var.stage}"
-        User = "${var.user}"
-        Stage = "${var.stage}"
-    }
+  #   tags {
+  #       Name = "Spot Fleet Launch Specification x1.32xlarge ${var.user}-${var.stage}"
+  #       User = "${var.user}"
+  #       Stage = "${var.stage}"
+  #   }
 
-  }
+  # }
 
-  ##
-  # x1e.8xlarge
-  ##
-  launch_specification {
+  # ##
+  # # x1e.8xlarge
+  # ##
+  # launch_specification {
 
-    # Client Specific
-    instance_type             = "x1e.8xlarge"
-    weighted_capacity         = 10 # via https://aws.amazon.com/ec2/instance-types/
-    spot_price                = "${var.spot_price}"
-    ami                       = "${data.aws_ami.ubuntu.id}"
-    iam_instance_profile_arn  = "${aws_iam_instance_profile.data_refinery_instance_profile.arn}"
-    user_data                 = "${data.template_file.nomad_client_script_smusher.rendered}"
-    vpc_security_group_ids    = ["${aws_security_group.data_refinery_worker.id}"]
-    subnet_id                 = "${aws_subnet.data_refinery_1a.id}"
-    availability_zone         = "${var.region}a"
-    key_name = "${aws_key_pair.data_refinery.key_name}"
+  #   # Client Specific
+  #   instance_type             = "x1e.8xlarge"
+  #   weighted_capacity         = 10 # via https://aws.amazon.com/ec2/instance-types/
+  #   spot_price                = "${var.spot_price}"
+  #   ami                       = "${data.aws_ami.ubuntu.id}"
+  #   iam_instance_profile_arn  = "${aws_iam_instance_profile.data_refinery_instance_profile.arn}"
+  #   user_data                 = "${data.template_file.nomad_client_script_smusher.rendered}"
+  #   vpc_security_group_ids    = ["${aws_security_group.data_refinery_worker.id}"]
+  #   subnet_id                 = "${aws_subnet.data_refinery_1a.id}"
+  #   availability_zone         = "${var.region}a"
+  #   key_name = "${aws_key_pair.data_refinery.key_name}"
 
-    root_block_device {
-      volume_size = 100 
-      volume_type = "gp2"
-    }
+  #   root_block_device {
+  #     volume_size = 100
+  #     volume_type = "gp2"
+  #   }
 
-    tags {
-        Name = "Spot Fleet Launch Specification x1e.8xlarge ${var.user}-${var.stage}"
-        User = "${var.user}"
-        Stage = "${var.stage}"
-    }
+  #   tags {
+  #       Name = "Spot Fleet Launch Specification x1e.8xlarge ${var.user}-${var.stage}"
+  #       User = "${var.user}"
+  #       Stage = "${var.stage}"
+  #   }
 
-  }
+  # }
 
-  ##
-  # r5d.24xlarge
-  ##
-  launch_specification {
+  # ##
+  # # r5d.24xlarge
+  # ##
+  # launch_specification {
 
-    # Client Specific
-    instance_type             = "r5d.24xlarge"
-    weighted_capacity         = 8 # Really, more like 1.4 # via https://aws.amazon.com/ec2/instance-types/
-    spot_price                = "${var.spot_price}"
-    ami                       = "${data.aws_ami.ubuntu.id}"
-    iam_instance_profile_arn  = "${aws_iam_instance_profile.data_refinery_instance_profile.arn}"
-    user_data                 = "${data.template_file.nomad_client_script_smusher.rendered}"
-    vpc_security_group_ids    = ["${aws_security_group.data_refinery_worker.id}"]
-    subnet_id                 = "${aws_subnet.data_refinery_1a.id}"
-    availability_zone         = "${var.region}a"
-    key_name = "${aws_key_pair.data_refinery.key_name}"
+  #   # Client Specific
+  #   instance_type             = "r5d.24xlarge"
+  #   weighted_capacity         = 8 # Really, more like 1.4 # via https://aws.amazon.com/ec2/instance-types/
+  #   spot_price                = "${var.spot_price}"
+  #   ami                       = "${data.aws_ami.ubuntu.id}"
+  #   iam_instance_profile_arn  = "${aws_iam_instance_profile.data_refinery_instance_profile.arn}"
+  #   user_data                 = "${data.template_file.nomad_client_script_smusher.rendered}"
+  #   vpc_security_group_ids    = ["${aws_security_group.data_refinery_worker.id}"]
+  #   subnet_id                 = "${aws_subnet.data_refinery_1a.id}"
+  #   availability_zone         = "${var.region}a"
+  #   key_name = "${aws_key_pair.data_refinery.key_name}"
 
-    root_block_device {
-      volume_size = 100 
-      volume_type = "gp2"
-    }
+  #   root_block_device {
+  #     volume_size = 100
+  #     volume_type = "gp2"
+  #   }
 
-    tags {
-        Name = "Spot Fleet Launch Specification r5d.24xlarge ${var.user}-${var.stage}"
-        User = "${var.user}"
-        Stage = "${var.stage}"
-    }
+  #   tags {
+  #       Name = "Spot Fleet Launch Specification r5d.24xlarge ${var.user}-${var.stage}"
+  #       User = "${var.user}"
+  #       Stage = "${var.stage}"
+  #   }
 
-  }
+  # }
 
-  ##
-  # r5a.24xlarge
-  ##
-  launch_specification {
+  # ##
+  # # r5a.24xlarge
+  # ##
+  # launch_specification {
 
-    # Client Specific
-    instance_type             = "r5a.24xlarge"
-    weighted_capacity         = 8 # Really, more like 1.4 # via https://aws.amazon.com/ec2/instance-types/
-    spot_price                = "${var.spot_price}"
-    ami                       = "${data.aws_ami.ubuntu.id}"
-    iam_instance_profile_arn  = "${aws_iam_instance_profile.data_refinery_instance_profile.arn}"
-    user_data                 = "${data.template_file.nomad_client_script_smusher.rendered}"
-    vpc_security_group_ids    = ["${aws_security_group.data_refinery_worker.id}"]
-    subnet_id                 = "${aws_subnet.data_refinery_1a.id}"
-    availability_zone         = "${var.region}a"
-    key_name = "${aws_key_pair.data_refinery.key_name}"
+  #   # Client Specific
+  #   instance_type             = "r5a.24xlarge"
+  #   weighted_capacity         = 8 # Really, more like 1.4 # via https://aws.amazon.com/ec2/instance-types/
+  #   spot_price                = "${var.spot_price}"
+  #   ami                       = "${data.aws_ami.ubuntu.id}"
+  #   iam_instance_profile_arn  = "${aws_iam_instance_profile.data_refinery_instance_profile.arn}"
+  #   user_data                 = "${data.template_file.nomad_client_script_smusher.rendered}"
+  #   vpc_security_group_ids    = ["${aws_security_group.data_refinery_worker.id}"]
+  #   subnet_id                 = "${aws_subnet.data_refinery_1a.id}"
+  #   availability_zone         = "${var.region}a"
+  #   key_name = "${aws_key_pair.data_refinery.key_name}"
 
-    root_block_device {
-      volume_size = 100 
-      volume_type = "gp2"
-    }
+  #   root_block_device {
+  #     volume_size = 100
+  #     volume_type = "gp2"
+  #   }
 
-    tags {
-        Name = "Spot Fleet Launch Specification r5a.24xlarge ${var.user}-${var.stage}"
-        User = "${var.user}"
-        Stage = "${var.stage}"
-    }
+  #   tags {
+  #       Name = "Spot Fleet Launch Specification r5a.24xlarge ${var.user}-${var.stage}"
+  #       User = "${var.user}"
+  #       Stage = "${var.stage}"
+  #   }
 
-  }
+  # }
 
   ##
   # r4.16xlarge

--- a/infrastructure/nomad-configuration/client-instance-user-data.tpl.sh
+++ b/infrastructure/nomad-configuration/client-instance-user-data.tpl.sh
@@ -115,12 +115,12 @@ EOF
 # Make the client.meta.volume_id is set to waht we just mounted
 sed -i "s/REPLACE_ME/$EBS_VOLUME_INDEX/" client.hcl
 
-# We want to leave enough RAM to run 4 SALMON jobs at once but not
-# enough to run 5.  Each SALMON job takes 32768MB of RAM, 32768 * 4 =
-# 131072, but that doesn't leave much margin for error. Therefore just
+# We want to leave enough RAM to run 3 SALMON jobs at once but not
+# enough to run 4.  Each SALMON job takes 32768MB of RAM, 32768 * 3 =
+# 98304, but that doesn't leave much margin for error. Therefore just
 # give it an extra 10GB of RAM since that won't be enough for an
 # entire other job to be queued, but keeps things from being so tight.
-TARGET_RAM=141072
+TARGET_RAM=108304
 # Make the client.meta.volume_id is set to waht we just mounted
 TOTAL_RAM=$(free -m | grep Mem | tr -s ' ' | cut -d\  -f2)
 RESERVED_RAM=$((TOTAL_RAM - TARGET_RAM))

--- a/workers/data_refinery_workers/processors/salmon.py
+++ b/workers/data_refinery_workers/processors/salmon.py
@@ -167,7 +167,7 @@ def _extract_sra(job_context: Dict) -> Dict:
         completed_command = subprocess.run(formatted_command.split(),
                                            stdout=subprocess.PIPE,
                                            stderr=subprocess.PIPE,
-                                           timeout=1200)
+                                           timeout=2400)
     except subprocess.TimeoutExpired as e:
         logger.exception("Shell call to fasterq-dump failed with timeout",
                      processor_job=job_context["job_id"],


### PR DESCRIPTION
## Issue Number

#227 

## Purpose/Implementation Notes

I want to run 3 of the smallest instance type, so if we get a bigger one it throws that off, so therefore I've temporarily disabled them.

Also fasterq-dump is still failing ~80% of the time. I'm trying to address this two ways:
  1. Decreaase the number of concurrent Salmon jobs from 4 to 3
  2. Increase the fasterq-dump timeout to allow it to complete.

I think 2 is justifiable based on the average file sizes for successful Salmon jobs

```
data_refinery=> select AVG(size_in_bytes) from original_files where id in (select original_file_id from processorjob_originalfile_associations where processor_job_id in (select id from processor_jobs where pipeline_applied='SALMON' and success ='t' order by last_modified desc limit 20));
         avg         
---------------------
 4902683849.50000000
```

 vs. Salmon jobs that fail because of this timeout:
```
data_refinery=> select AVG(size_in_bytes) from original_files where id in (select original_file_id from processorjob_originalfile_associations where processor_job_id in (select id from processor_jobs where failure_reason like '%timed out after %' and success ='f' order by last_modified desc limit 20));
         avg         
---------------------
 8265004603.15000000
```

As you can see the average file size for jobs that timeout is almost more than 1.5x as big as those that succeed.

## Types of changes

- Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Functional tests

N/A, this is mostly configuration/infrastructure.

## Checklist

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules
