### PR TITLE
Explicit organism filtering on QN target creation

### DIFF
--- a/workers/data_refinery_workers/processors/management/commands/create_qn_target.py
+++ b/workers/data_refinery_workers/processors/management/commands/create_qn_target.py
@@ -87,9 +87,10 @@ class Command(BaseCommand):
                 biggest_platform = options["platform"]
 
             sample_codes_results = Sample.processed_objects.filter(
-                platform_accession_code=biggest_platform, 
-                has_raw=True, 
-                technology="MICROARRAY", 
+                platform_accession_code=biggest_platform,
+                has_raw=True,
+                technology="MICROARRAY",
+                organism=organism,
                 is_processed=True).values('accession_code')
             sample_codes = [res['accession_code'] for res in sample_codes_results]
 


### PR DESCRIPTION
I'm not sure how much of a huge effect this will actually have, but there is a lot of active filtering that happens during QN target creation. 