### PR TITLE
Make the foreman depend on the ES server so it can use its hostname.

### DIFF
--- a/infrastructure/instances.tf
+++ b/infrastructure/instances.tf
@@ -807,7 +807,7 @@ resource "aws_instance" "foreman_server_1" {
   vpc_security_group_ids = ["${aws_security_group.data_refinery_foreman.id}"]
   iam_instance_profile = "${aws_iam_instance_profile.data_refinery_instance_profile.name}"
   subnet_id = "${aws_subnet.data_refinery_1a.id}"
-  depends_on = ["aws_db_instance.postgres_db", "aws_instance.pg_bouncer"]
+  depends_on = ["aws_db_instance.postgres_db", "aws_instance.pg_bouncer", "aws_elasticsearch_domain.es"]
   user_data = "${data.template_file.foreman_server_script_smusher.rendered}"
   key_name = "${aws_key_pair.data_refinery.key_name}"
 


### PR DESCRIPTION
## Issue Number

N/A came up during deploy.

## Purpose/Implementation Notes

We had 
```
data-refinery-log-group-circleci-prod log-stream-foreman-circleci-prod   File "/home/user/data_refinery_foreman/settings.py", line 168, in <module>
data-refinery-log-group-circleci-prod log-stream-foreman-circleci-prod     'hosts': get_env_variable('ELASTICSEARCH_HOST') + ":" + get_env_variable('ELASTICSEARCH_PORT')
data-refinery-log-group-circleci-prod log-stream-foreman-circleci-prod   File "/usr/local/lib/python3.5/dist-packages/data_refinery_common/utils.py", line 32, in get_env_variable
data-refinery-log-group-circleci-prod log-stream-foreman-circleci-prod     raise ImproperlyConfigured(error_msg)
```
Happen during a prod deploy. Seems like the foreman's userdata script was formatted before ES came up enough to have a hostname for it.

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

N/A, it's just infrastructure.
