### PR TITLE
Dont Break on - for Technology Field in ES

### DIFF
--- a/common/data_refinery_common/models/documents.py
+++ b/common/data_refinery_common/models/documents.py
@@ -32,6 +32,12 @@ html_strip_no_ngram = analyzer(
     filter=["standard", "lowercase", "stop", "snowball"],
     char_filter=["html_strip"]
 )
+html_strip_no_stop = analyzer(
+    'html_strip_no_stop',
+    tokenizer="whitespace",
+    filter=["standard", "lowercase"],
+    char_filter=["html_strip"]
+)
 standard = analyzer(
     'standard',
     tokenizer="keyword",
@@ -65,7 +71,7 @@ class ExperimentDocument(DocType):
         fields={'raw': fields.KeywordField()}
     )
     technology = fields.TextField(
-        analyzer=html_strip_no_ngram,
+        analyzer=html_strip_no_stop,
         fielddata=True,
         fields={'raw': fields.KeywordField()}
     )


### PR DESCRIPTION
## Issue Number

https://github.com/AlexsLemonade/refinebio-frontend/issues/525

`whitespace` tokenizer doesn't break on `-` like the default one does.