### PR TITLE
Remove `files` from the sample details serializer

### DIFF
--- a/api/data_refinery_api/serializers.py
+++ b/api/data_refinery_api/serializers.py
@@ -95,25 +95,8 @@ class ComputationalResultAnnotationSerializer(serializers.ModelSerializer):
                     'last_modified'
                 )
 
-class ComputedFileSerializer(serializers.ModelSerializer):
-    class Meta:
-        model = ComputedFile
-        fields = (
-                    'id',
-                    'filename',
-                    'size_in_bytes',
-                    'is_smashable',
-                    'is_qc',
-                    'sha1',
-                    's3_bucket',
-                    's3_key',
-                    'created_at',
-                    'last_modified'
-                )
-
 class ComputationalResultSerializer(serializers.ModelSerializer):
     annotations = ComputationalResultAnnotationSerializer(many=True, source='computationalresultannotation_set')
-    files = ComputedFileSerializer(many=True, source='computedfile_set')
     processor = ProcessorSerializer(many=False)
     organism_index = OrganismIndexSerializer(many=False)
 
@@ -125,7 +108,6 @@ class ComputationalResultSerializer(serializers.ModelSerializer):
                     'processor',
                     'is_ccdl',
                     'annotations',
-                    'files',
                     'organism_index',
                     'time_start',
                     'time_end',

--- a/api/data_refinery_api/serializers.py
+++ b/api/data_refinery_api/serializers.py
@@ -95,8 +95,25 @@ class ComputationalResultAnnotationSerializer(serializers.ModelSerializer):
                     'last_modified'
                 )
 
+class ComputedFileSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = ComputedFile
+        fields = (
+                    'id',
+                    'filename',
+                    'size_in_bytes',
+                    'is_smashable',
+                    'is_qc',
+                    'sha1',
+                    's3_bucket',
+                    's3_key',
+                    'created_at',
+                    'last_modified'
+                )
+
 class ComputationalResultSerializer(serializers.ModelSerializer):
     annotations = ComputationalResultAnnotationSerializer(many=True, source='computationalresultannotation_set')
+    files = ComputedFileSerializer(many=True, source='computedfile_set')
     processor = ProcessorSerializer(many=False)
     organism_index = OrganismIndexSerializer(many=False)
 
@@ -108,6 +125,7 @@ class ComputationalResultSerializer(serializers.ModelSerializer):
                     'processor',
                     'is_ccdl',
                     'annotations',
+                    'files',
                     'organism_index',
                     'time_start',
                     'time_end',
@@ -216,10 +234,21 @@ class SampleAnnotationSerializer(serializers.ModelSerializer):
                     'last_modified',
                 )
 
+class DetailedSamplesComputationalResultSerializer(serializers.ModelSerializer):
+    processor = ProcessorSerializer(many=False)
+    organism_index = OrganismIndexSerializer(many=False)
+
+    class Meta:
+        model = ComputationalResult
+        fields = (
+                    'processor',
+                    'organism_index',
+                )
+
 class DetailedSampleSerializer(serializers.ModelSerializer):
     annotations = SampleAnnotationSerializer(many=True, source='sampleannotation_set')
     organism = OrganismSerializer(many=False)
-    results = ComputationalResultSerializer(many=True)
+    results = DetailedSamplesComputationalResultSerializer(many=True)
 
     class Meta:
         model = Sample


### PR DESCRIPTION
## Issue Number

#1071 

## Purpose/Implementation Notes

Remove `files` from the response of the API, on the detailed samples endpoint (`/samples`).
