### PR TITLE
Enable cloudfront compression by default

### DIFF
--- a/infrastructure/networking.tf
+++ b/infrastructure/networking.tf
@@ -265,6 +265,9 @@ resource "aws_cloudfront_distribution" "static-distribution" {
     min_ttl = 0
     default_ttl = 0
     max_ttl = 0
+
+    # https://www.terraform.io/docs/providers/aws/r/cloudfront_distribution.html#compress
+    compress = true
   }
 
   restrictions {


### PR DESCRIPTION
I enabled it manually on aws. But adding it here so that it gets activated on the next deploy.

https://github.com/AlexsLemonade/refinebio-frontend/issues/543