### PR TITLE
Bump timeout for Nomad and fail deploys if Nomad never comes up.

### DIFF
--- a/infrastructure/deploy.sh
+++ b/infrastructure/deploy.sh
@@ -181,11 +181,17 @@ echo "Confirming Nomad cluster.."
 start_time=$(date +%s)
 diff=0
 nomad_status=$(check_nomad_status)
-while [[ $diff < 300 && $nomad_status != "200" ]]; do
+while [[ $diff < 900 && $nomad_status != "200" ]]; do
     sleep 1
     nomad_status=$(check_nomad_status)
     let "diff = $(date +%s) - $start_time"
 done
+
+if [[ $nomad_status != "200" ]]; do
+    echo "Nomad didn't start, aborting deploy."
+    echo "Either the timeout needs to be raised or there's something else broken."
+    exit 1
+fi
 
 # Kill Base Nomad Jobs so no new jobs can be queued.
 echo "Killing base jobs.. (this takes a while..)"


### PR DESCRIPTION
## Issue Number

N/A came up during staging test because nomad never got started.

## Purpose/Implementation Notes

Seems like EC2 instances take longer to initialize now, so a 5 minute timeout for a nomad server coming up and getting Nomad running on it no longer is enough.

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

N/A infra related
