### PR TITLE
Pin ryp2 in all dockerfiles that install it.

### DIFF
--- a/common/dockerfiles/Dockerfile.common_tests
+++ b/common/dockerfiles/Dockerfile.common_tests
@@ -57,7 +57,7 @@ RUN pip3 install -r requirements.txt
 
 # Install this rpy2 here instead of via requirements.txt because
 # pip-compile throws an error for it.
-RUN pip3 install rpy2
+RUN pip3 install rpy2==2.9.5
 
 COPY common/ .
 

--- a/workers/dockerfiles/Dockerfile.affymetrix
+++ b/workers/dockerfiles/Dockerfile.affymetrix
@@ -70,7 +70,7 @@ RUN pip3 install -r requirements.txt
 
 # Install this one here instead of via requirements.txt because not
 # all processors need it.
-RUN pip3 install rpy2
+RUN pip3 install rpy2==2.9.5
 
 ARG SYSTEM_VERSION
 

--- a/workers/dockerfiles/Dockerfile.compendia
+++ b/workers/dockerfiles/Dockerfile.compendia
@@ -67,7 +67,7 @@ RUN Rscript qn_dependencies.R
 RUN pip3 install --upgrade pip
 
 # Smasher-specific requirements
-RUN pip3 install numpy scipy matplotlib pandas==0.23.1 scikit-learn sympy nose rpy2 tzlocal
+RUN pip3 install numpy scipy matplotlib pandas==0.23.1 scikit-learn sympy nose rpy2===2.9.5 tzlocal
 # End smasher-specific
 
 # Impute-specific requirements

--- a/workers/dockerfiles/Dockerfile.downloaders
+++ b/workers/dockerfiles/Dockerfile.downloaders
@@ -69,7 +69,7 @@ RUN  pip3 install -r requirements.txt
 
 # Install this rpy2 here instead of via requirements.txt because
 # pip-compile throws an error for it.
-RUN pip3 install rpy2
+RUN pip3 install rpy2==2.9.5
 COPY common/dist/data-refinery-common-* common/
 
 # Get the latest version from the dist directory.

--- a/workers/dockerfiles/Dockerfile.smasher
+++ b/workers/dockerfiles/Dockerfile.smasher
@@ -52,7 +52,7 @@ RUN Rscript qn_dependencies.R
 RUN pip3 install --upgrade pip
 
 # Smasher-specific requirements
-RUN pip3 install numpy scipy matplotlib pandas==0.23.1 scikit-learn sympy nose rpy2 tzlocal
+RUN pip3 install numpy scipy matplotlib pandas==0.23.1 scikit-learn sympy nose rpy2==2.9.5 tzlocal
 # End smasher-specific
 
 COPY config/ config/


### PR DESCRIPTION
## Issue Number

N/A Github alerted about vulnerable dependencies.

## Purpose/Implementation Notes

Just bumped django versions. Also fixed requirements.txt files that had been manually modified instead of just adding the deps to requirements.in.

Making these changes somehow made pip3 want bump the version of rpy2 to something that needed an additional apt-package. Rather than figure out why it wouldn't install I just pinned rpy2's version.

## Types of changes

- New feature (non-breaking change which adds functionality)
