### PR TITLE
Revert Nomad from 0.9.0-beta3 to 0.8.3 

### DIFF
--- a/README.md
+++ b/README.md
@@ -698,12 +698,6 @@ or to start a job with a file located in S3:
 nomad job dispatch -meta FILE=s3://data-refinery-test-assets/NEUROBLASTOMA.txt SURVEYOR_DISPATCHER
 ```
 
-or just by a single accession:
-
-```
-nomad job dispatch -meta ACCESSION=E-MTAB-3050 SURVEYOR
-```
-
 ### Log Consumption
 
 All of the different Refine.bio subservices log to the same AWS CloudWatch Log

--- a/install_nomad.sh
+++ b/install_nomad.sh
@@ -10,12 +10,11 @@
 curl https://keybase.io/hashicorp/pgp_keys.asc | gpg --import
 
 # Download the binary and signature files.
-export RELEASE_VERSION=0.9.0-beta3
+export RELEASE_VERSION=0.8.3
 export RELEASE_PLATFORM=`uname | tr '[:upper:]' '[:lower:]'`
 if [[ "$RELEASE_PLATFORM" = "darwin" ]]; then
 	function sha256sum() { shasum -a 256 "$@" ; } && export -f sha256sum
 fi
-
 
 curl -0s https://releases.hashicorp.com/nomad/${RELEASE_VERSION}/nomad_${RELEASE_VERSION}_${RELEASE_PLATFORM}_amd64.zip > nomad_${RELEASE_VERSION}_${RELEASE_PLATFORM}_amd64.zip
 curl -0s https://releases.hashicorp.com/nomad/${RELEASE_VERSION}/nomad_${RELEASE_VERSION}_SHA256SUMS > nomad_${RELEASE_VERSION}_SHA256SUMS


### PR DESCRIPTION
## Issue Number

Nomad 0.9.0-beta3 is a dud: https://github.com/hashicorp/nomad/issues/5367

Reverts back to last known "good" version.

Also removes a documentation example that doesn't work anymore.