### PR TITLE
Correct Affy samples mislabelled as RNA-Seq

### DIFF
--- a/common/data_refinery_common/models/models.py
+++ b/common/data_refinery_common/models/models.py
@@ -749,8 +749,8 @@ class OriginalFile(models.Model):
         # has been processed and doesn't need to be processed again.
         return successful_processor_jobs.count() == 0
 
-    def is_CEL_file(self) -> bool:
-        """Return true if original_file is a CEL file."""
+    def is_affy_data(self) -> bool:
+        """Return true if original_file is a CEL file or a gzipped CEL file."""
         upper_name = self.source_filename.upper()
         return (len(upper_name) > 4 and upper_name[-4:] == ".CEL") \
             or (len(upper_name) > 7 and upper_name[-7:] == ".CEL.GZ")

--- a/common/data_refinery_common/models/models.py
+++ b/common/data_refinery_common/models/models.py
@@ -749,6 +749,12 @@ class OriginalFile(models.Model):
         # has been processed and doesn't need to be processed again.
         return successful_processor_jobs.count() == 0
 
+    def is_CEL_file(self) -> bool:
+        """Return true if original_file is a CEL file."""
+        upper_name = self.source_filename.upper()
+        return (len(upper_name) > 4 and upper_name[-4:] == ".CEL") \
+            or (len(upper_name) > 7 and upper_name[-7:] == ".CEL.GZ")
+
 
 class ComputedFile(models.Model):
     """ A representation of a file created by a data-refinery process """

--- a/workers/data_refinery_workers/processors/management/commands/correct_affy_samples.py
+++ b/workers/data_refinery_workers/processors/management/commands/correct_affy_samples.py
@@ -1,0 +1,201 @@
+"""
+"""
+
+from django.core.management.base import BaseCommand
+from data_refinery_common.models import *
+
+
+# There's no image with both aspera and the R deps needed to detect
+# package, so just don't use aspera.
+# def _download_file_aspera(download_url: str,
+#                           target_file_path: str,
+#                           attempt=0) -> bool:
+#     """ Download a file to a location using Aspera by shelling out to the `ascp` client. """
+
+#     try:
+#         logger.debug("Downloading file from %s to %s via Aspera.",
+#                      download_url,
+#                      target_file_path)
+
+#         ascp = ".aspera/cli/bin/ascp"
+#         key = ".aspera/cli/etc/asperaweb_id_dsa.openssh"
+#         url = download_url
+#         user = "anonftp"
+#         ftp = "ftp-trace.ncbi.nlm.nih.gov"
+#         if url.startswith("ftp://"):
+#             url = url.replace("ftp://", "")
+#         url = url.replace(ftp, "").replace('ftp.ncbi.nlm.nih.gov', '')
+
+#         # Resume level 1, use encryption, unlimited speed
+#         command_str = "{} -i {} -k1 -T {}@{}:{} {}".format(ascp, key, user, ftp, url, target_file_path)
+#         formatted_command = command_str.format(src=download_url,
+#                                                dest=target_file_path)
+#         completed_command = subprocess.run(formatted_command.split(),
+#                                            stdout=subprocess.PIPE,
+#                                            stderr=subprocess.PIPE)
+
+#         # Something went wrong! Else, just fall through to returning True.
+#         if completed_command.returncode != 0:
+
+#             stderr = completed_command.stderr.decode().strip()
+#             logger.debug("Shell call of `%s` to ascp failed with error message: %s",
+#                          formatted_command,
+#                          stderr)
+
+#             # Sometimes, GEO fails mysteriously.
+#             # Wait a few minutes and try again.
+#             if attempt >= 5:
+#                 logger.error("All attempts to download accession via ascp failed: %s\nCommand was: %s",
+#                              stderr,
+#                              formatted_command)
+#                 return False
+#             else:
+#                 time.sleep(30)
+#                 return _download_file_aspera(download_url,
+#                                              target_file_path,
+#                                              attempt + 1
+#                                              )
+#     except Exception:
+#         logger.exception("Exception caught while downloading file from the URL via Aspera: %s",
+#                          download_url)
+#         return False
+
+#     # If Aspera has given a zero-byte file for some reason, let's back off and retry.
+#     if os.path.getsize(target_file_path) < 1:
+#         os.remove(target_file_path)
+#         if attempt > 5:
+#             return False
+
+#         logger.error("Got zero byte ascp download for target, retrying.",
+#                      target_url=download_url)
+#         time.sleep(10)
+#         return _download_file_aspera(download_url,
+#                                      target_file_path,
+#                                      attempt + 1
+#                                      )
+#     return True
+
+
+def _download_file(download_url: str, file_path: str) -> None:
+    """ Download a file from GEO.
+    """
+
+    # Ensure directory exists
+    os.makedirs(file_path.rsplit('/', 1)[0], exist_ok=True)
+
+    try:
+        logger.debug("Downloading file from %s to %s.",
+                     download_url,
+                     file_path)
+
+        # Ancient unresolved bug. WTF python: https://bugs.python.org/issue27973
+        urllib.request.urlcleanup()
+
+        target_file = open(file_path, "wb")
+        with closing(urllib.request.urlopen(download_url)) as request:
+            shutil.copyfileobj(request, target_file, CHUNK_SIZE)
+
+        urllib.request.urlcleanup()
+    except Exception:
+        logger.exception("Exception caught while downloading file %s from %s",
+                         file_path, download_url)
+        raise
+    finally:
+        target_file.close()
+
+    return True
+
+
+def _create_ensg_pkg_map() -> Dict:
+    """Reads the text file that was generated when installing ensg R
+    packages, and returns a map whose keys are chip names and values are
+    the corresponding BrainArray ensg package name.
+    """
+    ensg_pkg_filename = "/home/user/r_ensg_probe_pkgs.txt"
+    chip2pkg = dict()
+    with open(ensg_pkg_filename) as file_handler:
+        for line in file_handler:
+            tokens = line.strip("\n").split("\t")
+            # tokens[0] is (normalized) chip name,
+            # tokens[1] is the package's URL in this format:
+            # http://mbni.org/customcdf/<version>/ensg.download/<pkg>_22.0.0.tar.gz
+            pkg_name = tokens[1].split("/")[-1].split("_")[0]
+            chip2pkg[tokens[0]] = pkg_name
+
+    return chip2pkg
+
+
+def _determine_brainarray_package(input_file: str) -> Dict:
+    """
+    """
+    try:
+        header = ro.r['::']('affyio', 'read.celfile.header')(input_file)
+    except RRuntimeError as e:
+        error_template = ("Unable to read Affy header in input file {0}"
+                          " while running AFFY_TO_PCL due to error: {1}")
+        error_message = error_template.format(input_file, str(e))
+        logger.info(error_message)
+        return None
+
+    # header is a list of vectors. [0][0] contains the package name.
+    punctuation_table = str.maketrans(dict.fromkeys(string.punctuation))
+    # Normalize header[0][0]
+    package_name = header[0][0].translate(punctuation_table).lower()
+
+    # Headers can contain the version "v1" or "v2", which doesn't
+    # appear in the brainarray package name. This replacement is
+    # brittle, but the list of brainarray packages is relatively short
+    # and we can monitor what packages are added to it and modify
+    # accordingly. So far "v1" and "v2" are the only known versions
+    # which must be accomodated in this way.
+    # Related: https://github.com/data-refinery/data-refinery/issues/141
+    package_name_without_version = package_name.replace("v1", "").replace("v2", "")
+    chip_pkg_map = _create_ensg_pkg_map()
+    return chip_pkg_map.get(package_name_without_version, None)
+
+
+class Command(BaseCommand):
+    def handle(self, *args, **options):
+        """"""
+        for sample in Sample.objects.filter(technology='RNA-SEQ', source_database='GEO'):
+            for original_file in sample.original_files.all():
+                if original_file.is_CEL_file() :
+                    input_file_path = original_file.source_filename
+                    download_success = False
+                    try:
+                        download_success = _download_file(original_file.source_url,
+                                                          input_file_path)
+                    except:
+                        logger.info("Failed to download %s from %s",
+                                    original_file.source_url,
+                                    original_file.source_filename)
+
+                    if download_success:
+                        brainarray_package = None
+                        try:
+                            brainarray_package = _determine_brainarray_package(input_file_path)
+                        except:
+                            logger.info("Failed to detect platform from downloaded file %s.",
+                                        input_file_path)
+
+                        if brainarray_package:
+                            # If we've detected the platform using affy, then this
+                            # is the best source of truth we'll be able to get, so
+                            # update the sample to match it.
+                            platform_name = get_readable_affymetrix_names()[brainarray_package]
+
+                            sample.platform_accession_code = brainarray_package
+                            sample_object.platform_name = platform_name
+
+                    # Regardless of whether we could detect the
+                    # platform successfully or not, we definitely know
+                    # it's an Affymetrix Microarray because that's the
+                    # only one that makes .CEL files.
+                    sample.technology = 'MICROARRAY'
+                    sample.manufacturer = 'AFFYMETRTIX'
+                    sample.save()
+
+                    # If there's other original files associated with
+                    # this sample, we don't need them because we
+                    # already corrected the platform.
+                    break

--- a/workers/data_refinery_workers/processors/management/commands/correct_affy_samples.py
+++ b/workers/data_refinery_workers/processors/management/commands/correct_affy_samples.py
@@ -52,7 +52,7 @@ def _download_file(download_url: str, file_path: str) -> None:
     except Exception:
         logger.exception("Exception caught while downloading file %s from %s",
                          file_path, download_url)
-        raise
+        return False
     finally:
         target_file.close()
 
@@ -99,16 +99,10 @@ class Command(BaseCommand):
         os.makedirs(work_dir, exist_ok=True)
         for sample in Sample.objects.filter(technology='RNA-SEQ', source_database='GEO'):
             for original_file in sample.original_files.all():
-                if original_file.is_CEL_file() :
+                if original_file.is_affy_data() :
                     input_file_path = work_dir + original_file.source_filename
-                    download_success = False
-                    try:
-                        download_success = _download_file(original_file.source_url,
-                                                          input_file_path)
-                    except:
-                        logger.exception("Failed to download %s from %s",
-                                    input_file_path,
-                                    original_file.source_url)
+                    download_success = _download_file(original_file.source_url,
+                                                      input_file_path)
 
                     if download_success:
                         try:

--- a/workers/data_refinery_workers/processors/management/commands/correct_affy_samples.py
+++ b/workers/data_refinery_workers/processors/management/commands/correct_affy_samples.py
@@ -21,7 +21,7 @@ logger = get_and_configure_logger(__name__)
 
 
 def _download_file(download_url: str, file_path: str) -> None:
-    """ Download a file from GEO.
+    """Download a file from GEO.
     """
     # Ensure directory exists
     os.makedirs(file_path.rsplit('/', 1)[0], exist_ok=True)
@@ -69,7 +69,7 @@ def _create_ensg_pkg_map() -> Dict:
 
 
 def _determine_brainarray_package(input_file: str) -> Dict:
-    """
+    """Uses the R package affy.io to read the .CEL file and determine its platform.
     """
     try:
         header = ro.r['::']('affyio', 'read.celfile.header')(input_file)
@@ -99,7 +99,10 @@ def _determine_brainarray_package(input_file: str) -> Dict:
 
 class Command(BaseCommand):
     def handle(self, *args, **options):
-        """"""
+        """Main function for this command.
+
+        Basically does what is described at the top of this file.
+        """
         for sample in Sample.objects.filter(technology='RNA-SEQ', source_database='GEO'):
             for original_file in sample.original_files.all():
                 if original_file.is_CEL_file() :


### PR DESCRIPTION
## Issue Number

https://github.com/AlexsLemonade/refinebio/issues/968
https://github.com/AlexsLemonade/refinebio/issues/963#issuecomment-451249805
https://github.com/AlexsLemonade/refinebio/issues/967

## Purpose/Implementation Notes

This is related to #1091 which corrects the way we survey GEO. That PR prevents us from mislabelling more Microarray data as RNA-Seq. This PR corrects the data that was already mislabelled.

## Types of changes

- Data migration

## Functional tests

I surveyed GSE69111 to get all of its samples mislabelled as RNA-Seq. I then ran this command and it corrected ONLY the microarray samples back to microarray.

I've retested this since fixing the platform detection stuff:
```
10 | GSM1692995     | postnatal day 1 (p1), biological rep3                    | GEO             |                    |                 |                           | t       | Illumina Genome Analyzer II | Illumina Genome Analyzer II | RNA-SEQ    | ILLUMINA     |
```
got corrected to:
```
10 | GSM1692995     | postnatal day 1 (p1), biological rep3                    | GEO             |                    |                 |                           | t       | mogene10st                  | [MoGene-1_0-st] Affymetrix Mouse Gene 1.0 ST Array | MICROARRAY | AFFYMETRTIX  |
```

(Sorry for the dump of partial rows straight from the DB, but I think it's good enough to show the technology, manufacturer, platform_name, and platform_accession_codes are changing correctly.)

## Checklist

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules
