### PR TITLE
Set PG engine version in TF to match engine version in production

### DIFF
--- a/infrastructure/instances.tf
+++ b/infrastructure/instances.tf
@@ -549,6 +549,7 @@ resource "aws_db_instance" "postgres_db" {
   storage_type = "gp2"
   engine = "postgres"
   engine_version = "9.6.11"
+  auto_minor_version_upgrade = false
   instance_class = "db.${var.database_instance_type}"
   name = "data_refinery"
   port = "${var.database_hidden_port}"

--- a/infrastructure/instances.tf
+++ b/infrastructure/instances.tf
@@ -548,7 +548,7 @@ resource "aws_db_instance" "postgres_db" {
   allocated_storage = 100
   storage_type = "gp2"
   engine = "postgres"
-  engine_version = "9.6.6"
+  engine_version = "9.6.11"
   instance_class = "db.${var.database_instance_type}"
   name = "data_refinery"
   port = "${var.database_hidden_port}"


### PR DESCRIPTION
Welp, this one is terrifying.

For some reason, all of of our PG servers are at 9.6.11. Our terraform value sets it to 9.6.6. 

It has been 9.6.6 for a year:

![Screen Shot 2019-03-08 at 4 25 00 PM](https://user-images.githubusercontent.com/139987/54056706-e7cbde00-41be-11e9-923c-bbc618347acf.png)

And yet the prod instances are now at 9.6.11:
![Screen Shot 2019-03-08 at 4 23 45 PM](https://user-images.githubusercontent.com/139987/54056733-f87c5400-41be-11e9-9494-4968ed626a7e.png)

So updating a stack with TF now causes a downgrade error:
![Screen Shot 2019-03-08 at 4 27 36 PM](https://user-images.githubusercontent.com/139987/54056785-206bb780-41bf-11e9-8efd-328678592ee6.png)

This updates the TF stack, but doesn't explain what the heck actually happened.

My guess is that AWS upgraded us and didn't tell us? I have no idea how that's possible. That seems like dangerous behavior.

## Types of changes

What types of changes does your code introduce?

<!-- Remove any which your PR isn't -->
- Bugfix (non-breaking change which fixes an issue)
- Spooky ghosts (ghosts have made changes that can't be explaiend)
