### PR TITLE
Provide access to resources that should still be accessible even once we lock down our buckets

### DIFF
--- a/api/data_refinery_api/serializers.py
+++ b/api/data_refinery_api/serializers.py
@@ -124,20 +124,6 @@ class ComputedFileSerializer(serializers.ModelSerializer):
 
 class ComputedFileWithUrlSerializer(serializers.ModelSerializer):
 
-    download_url = serializers.SerializerMethodField()
-
-    def get_download_url(self, computed_file):
-        if settings.RUNNING_IN_CLOUD and computed_file.s3_bucket and computed_file.s3_key:
-            return s3.generate_presigned_url(
-                ClientMethod='get_object',
-                Params={
-                    'Bucket': computed_file.s3_bucket,
-                    'Key': computed_file.s3_key
-                }
-            )
-        else:
-            return None
-
     class Meta:
         model = ComputedFile
         fields = (
@@ -732,6 +718,7 @@ class APITokenSerializer(serializers.ModelSerializer):
                         }
                     }
 
+
 class CompendiaSerializer(serializers.ModelSerializer):
     organism_name = serializers.CharField(source='compendia_organism.name', read_only=True)
 
@@ -751,6 +738,29 @@ class CompendiaSerializer(serializers.ModelSerializer):
                     'created_at',
                     'last_modified'
                 )
+
+
+class CompendiaWithUrlSerializer(serializers.ModelSerializer):
+    organism_name = serializers.CharField(source='compendia_organism.name', read_only=True)
+
+    class Meta:
+        model = ComputedFile
+        fields = (
+                    'id',
+                    'filename',
+                    'size_in_bytes',
+                    'is_compendia',
+                    'compendia_version',
+                    'organism_name',
+                    'sha1',
+                    's3_bucket',
+                    's3_key',
+                    's3_url',
+                    'download_url',
+                    'created_at',
+                    'last_modified'
+                )
+
 
 ##
 # ElasticSearch Document Serializers

--- a/api/data_refinery_api/serializers.py
+++ b/api/data_refinery_api/serializers.py
@@ -697,6 +697,35 @@ class DatasetSerializer(serializers.ModelSerializer):
         experiments = obj.get_experiments().prefetch_related('samples').prefetch_related('organisms')
         return DatasetDetailsExperimentSerializer(experiments, many=True).data
 
+
+class DatasetWithUrlSerializer(DatasetSerializer):
+
+    class Meta:
+        model = Dataset
+        fields = (
+                    'id',
+                    'data',
+                    'aggregate_by',
+                    'scale_by',
+                    'is_processing',
+                    'is_processed',
+                    'is_available',
+                    'has_email',
+                    'expires_on',
+                    's3_bucket',
+                    's3_key',
+                    'download_url',
+                    'success',
+                    'failure_reason',
+                    'created_at',
+                    'last_modified',
+                    'start',
+                    'size_in_bytes',
+                    'sha1',
+                    'experiments',
+                    'organism_samples'
+            )
+
 class APITokenSerializer(serializers.ModelSerializer):
 
     class Meta:

--- a/api/data_refinery_api/tests.py
+++ b/api/data_refinery_api/tests.py
@@ -716,6 +716,23 @@ class APITestCases(APITestCase):
         self.assertEqual(ds.email_address, 'trust@verify.com')
         self.assertTrue(ds.email_ccdl_ok)
 
+        # Reset the dataset so we can test providing an API token via
+        # HTTP Header.
+        dataset = Dataset.objects.get(id=good_id)
+        dataset.is_processing = False
+        dataset.email_address = None
+        dataset.email_ccdl_ok = False
+        dataset.save()
+
+        jdata = json.dumps({'data': {"A": ["D"]}, 'start': True, 'no_send_job': True, 'email_address': 'trust@verify.com', 'email_ccdl_ok': True } )
+        response = self.client.put(reverse('dataset', kwargs={'id': good_id}), jdata, content_type="application/json", HTTP_API_KEY=token_id)
+
+        self.assertEqual(response.json()["is_processing"], True)
+
+        ds = Dataset.objects.get(id=response.json()['id'])
+        self.assertEqual(ds.email_address, 'trust@verify.com')
+        self.assertTrue(ds.email_ccdl_ok)
+
     def test_processed_samples_only(self):
         """ Don't return unprocessed samples """
         experiment = Experiment()

--- a/api/data_refinery_api/views.py
+++ b/api/data_refinery_api/views.py
@@ -58,6 +58,7 @@ from data_refinery_api.serializers import (
     ProcessorSerializer,
     SampleSerializer,
     CompendiaSerializer,
+    CompendiaWithUrlSerializer,
     QNTargetSerializer,
     ComputedFileListSerializer,
 

--- a/common/data_refinery_common/models/models.py
+++ b/common/data_refinery_common/models/models.py
@@ -956,7 +956,7 @@ class ComputedFile(models.Model):
 
     def create_download_url(self):
         """ Create a temporary URL from which the file can be downloaded."""
-        if self.s3_bucket and self.s3_key:
+        if settings.RUNNING_IN_CLOUD and self.s3_bucket and self.s3_key:
             return S3.generate_presigned_url(
                 ClientMethod='get_object',
                 Params={

--- a/common/data_refinery_common/models/models.py
+++ b/common/data_refinery_common/models/models.py
@@ -956,13 +956,14 @@ class ComputedFile(models.Model):
 
     def create_download_url(self):
         """ Create a temporary URL from which the file can be downloaded."""
-        if settings.RUNNING_IN_CLOUD and self.s3_bucket and self.s3_key:
-            return s3.generate_presigned_url(
+        if self.s3_bucket and self.s3_key:
+            return S3.generate_presigned_url(
                 ClientMethod='get_object',
                 Params={
                     'Bucket': self.s3_bucket,
                     'Key': self.s3_key
-                }
+                },
+                ExpiresIn=(60 * 60 * 24) # 1 day in seconds.
             )
         else:
             return None

--- a/common/data_refinery_common/models/models.py
+++ b/common/data_refinery_common/models/models.py
@@ -1085,6 +1085,25 @@ class Dataset(models.Model):
         else:
             return False
 
+    @property
+    def download_url(self):
+        """ A temporary URL from which the file can be downloaded. """
+        return self.create_download_url()
+
+    def create_download_url(self):
+        """ Create a temporary URL from which the file can be downloaded."""
+        if settings.RUNNING_IN_CLOUD and self.s3_bucket and self.s3_key:
+            return S3.generate_presigned_url(
+                ClientMethod='get_object',
+                Params={
+                    'Bucket': self.s3_bucket,
+                    'Key': self.s3_key
+                },
+                ExpiresIn=(60 * 60 * 24) # 1 day in seconds.
+            )
+        else:
+            return None
+
     def s3_url(self):
         """ Render the resulting S3 URL """
         if (self.s3_key) and (self.s3_bucket):

--- a/common/data_refinery_common/models/models.py
+++ b/common/data_refinery_common/models/models.py
@@ -939,13 +939,31 @@ class ComputedFile(models.Model):
 
     @property
     def s3_url(self):
-        """ Render the resulting S3 URL """
+        """ Render the resulting HTTPS URL for the S3 object."""
         return self.get_s3_url()
 
     def get_s3_url(self):
-        """ Render the resulting S3 URL """
+        """ Render the resulting HTTPS URL for the S3 object."""
         if (self.s3_key) and (self.s3_bucket):
             return "https://s3.amazonaws.com/" + self.s3_bucket + "/" + self.s3_key
+        else:
+            return None
+
+    @property
+    def download_url(self):
+        """ A temporary URL from which the file can be downloaded. """
+        return self.create_download_url()
+
+    def create_download_url(self):
+        """ Create a temporary URL from which the file can be downloaded."""
+        if settings.RUNNING_IN_CLOUD and self.s3_bucket and self.s3_key:
+            return s3.generate_presigned_url(
+                ClientMethod='get_object',
+                Params={
+                    'Bucket': self.s3_bucket,
+                    'Key': self.s3_key
+                }
+            )
         else:
             return None
 

--- a/foreman/data_refinery_foreman/foreman/main.py
+++ b/foreman/data_refinery_foreman/foreman/main.py
@@ -1067,4 +1067,5 @@ def monitor_jobs():
         loop_time = timezone.now() - start_time
         if loop_time < MIN_LOOP_TIME:
             remaining_time = MIN_LOOP_TIME - loop_time
-            time.sleep(remaining_time.seconds)
+            if remaining_time.seconds > 0:
+                time.sleep(remaining_time.seconds)


### PR DESCRIPTION
## Issue Number

#731 

## Purpose/Implementation Notes

In order to be able to lock down our S3 buckets we need to provide a mechanism by which people can still get the data that they're supposed to. The mechanism this adds is that ComputedFile resources will have a `download_url` field if the request included an `API_KEY` header (or if the key was present in the POST-data for datasets). This `download_url` is a temporary presigned URL from AWS which allows access to the resource using that URL for a few hours.

## Types of changes

- New feature (non-breaking change which adds functionality)

## Functional tests

In addition to the unit tests, I also tested this by making requests against the API using curl/the browser.

## Checklist

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules
