### PR TITLE
Makes Surveyors Lower Priority Than Downloaders

### DIFF
--- a/foreman/nomad-job-specs/surveyor.nomad.tpl
+++ b/foreman/nomad-job-specs/surveyor.nomad.tpl
@@ -2,6 +2,7 @@ job "SURVEYOR_${{RAM}}" {
   datacenters = ["dc1"]
 
   type = "batch"
+  priority = 30
 
   parameterized {
     payload       = "forbidden"

--- a/foreman/nomad-job-specs/surveyor_dispatcher.nomad.tpl
+++ b/foreman/nomad-job-specs/surveyor_dispatcher.nomad.tpl
@@ -2,6 +2,7 @@ job "SURVEYOR_DISPATCHER" {
   datacenters = ["dc1"]
 
   type = "batch"
+  priority = 90
 
   parameterized {
     payload       = "forbidden"


### PR DESCRIPTION
From IRL discussion during testing.

This allows us to start downloading and processing sooner without having to wait for long running surveyors to continue. Surveyors will be added when there is nothing important left to do.