### PR TITLE
Detect SRA based on source, not file extention

### DIFF
--- a/README.md
+++ b/README.md
@@ -500,6 +500,18 @@ or
 ./workers/tester.sh -i no_op run_processor_job --job-name=NO_OP --job-id=1
 ```
 
+or
+
+```bash
+./workers/tester.sh -i salmon run_processor_job --job-name=SALMON --job-id=1
+```
+
+or
+
+```bash
+./workers/tester.sh -i transcriptome run_processor_job --job-name=TRANSCRIPTOME_INDEX_LONG --job-id=1
+```
+
 Or for more information run:
 ```bash
 ./workers/tester.sh -h

--- a/workers/data_refinery_workers/processors/salmon.py
+++ b/workers/data_refinery_workers/processors/salmon.py
@@ -133,7 +133,7 @@ def _prepare_files(job_context: Dict) -> Dict:
         return job_context
 
     # Detect that this is an SRA file from the source URL
-    if 'ncbi.nlm.nih.gov' in job_context['original_files'][0].source_url:
+    if ('ncbi.nlm.nih.gov' in job_context['original_files'][0].source_url) or (job_context["input_file_path"][-4:].upper() == ".SRA"):
         new_input_file_path = os.path.join(job_context["work_dir"], original_files[0].filename)
         shutil.copyfile(job_context["input_file_path"], new_input_file_path)
         job_context['input_file_path'] = new_input_file_path

--- a/workers/data_refinery_workers/processors/salmon.py
+++ b/workers/data_refinery_workers/processors/salmon.py
@@ -132,8 +132,8 @@ def _prepare_files(job_context: Dict) -> Dict:
         job_context["job"].no_retry = True
         return job_context
 
-    # Copy the .sra file so fasterq-dump can't corrupt it.
-    if job_context["input_file_path"][-4:].upper() == ".SRA":
+    # Detect that this is an SRA file from the source URL
+    if 'ncbi.nlm.nih.gov' in job_context['original_files'][0].source_url:
         new_input_file_path = os.path.join(job_context["work_dir"], original_files[0].filename)
         shutil.copyfile(job_context["input_file_path"], new_input_file_path)
         job_context['input_file_path'] = new_input_file_path


### PR DESCRIPTION
Sometimes files downloaded have a '.sra' extension, but apparently they don't.

This uses the source url rather than the file extension.