### PR TITLE
Allow QN Normalizing Single-Sample Datasets

### DIFF
--- a/workers/data_refinery_workers/processors/smasher.py
+++ b/workers/data_refinery_workers/processors/smasher.py
@@ -372,64 +372,66 @@ def _quantile_normalize(job_context: Dict, ks_check=True, ks_stat=0.001) -> Dict
 
         n = ncol(reso)[0]
         m = 2
-        if n < m:
-            raise Exception("Found fewer columns than required for QN combinatorial - bad smash?")
-        combos = combn(ncol(reso), 2)
+        if n >= m:
+            combos = combn(ncol(reso), 2)
 
-        # Convert to NP, Shuffle, Return to R
-        ar = np.array(combos)
-        np.random.shuffle(np.transpose(ar))
-        nr, nc = ar.shape
-        combos = ro.r.matrix(ar, nrow=nr, ncol=nc)
+            # Convert to NP, Shuffle, Return to R
+            ar = np.array(combos)
+            np.random.shuffle(np.transpose(ar))
+            nr, nc = ar.shape
+            combos = ro.r.matrix(ar, nrow=nr, ncol=nc)
 
-        # adapted from
-        # https://stackoverflow.com/questions/9661469/r-t-test-over-all-columns
-        # apply KS test to randomly selected pairs of columns (samples)
-        for i in range(1, min(ncol(combos)[0], 100)):
-            value1 = combos.rx(1, i)[0]
-            value2 = combos.rx(2, i)[0]
+            # adapted from
+            # https://stackoverflow.com/questions/9661469/r-t-test-over-all-columns
+            # apply KS test to randomly selected pairs of columns (samples)
+            for i in range(1, min(ncol(combos)[0], 100)):
+                value1 = combos.rx(1, i)[0]
+                value2 = combos.rx(2, i)[0]
 
-            test_a = reso.rx(True, value1)
-            test_b = reso.rx(True, value2)
+                test_a = reso.rx(True, value1)
+                test_b = reso.rx(True, value2)
 
-            # RNA-seq has a lot of zeroes in it, which
-            # breaks the ks_test. Therefore we want to
-            # filter them out. To do this we drop the
-            # lowest half of the values. If there's
-            # still zeroes in there, then that's
-            # probably too many zeroes so it's okay to
-            # fail.
-            median_a = np.median(test_a)
-            median_b = np.median(test_b)
+                # RNA-seq has a lot of zeroes in it, which
+                # breaks the ks_test. Therefore we want to
+                # filter them out. To do this we drop the
+                # lowest half of the values. If there's
+                # still zeroes in there, then that's
+                # probably too many zeroes so it's okay to
+                # fail.
+                median_a = np.median(test_a)
+                median_b = np.median(test_b)
 
-            # `which` returns indices which are
-            # 1-indexed. Python accesses lists with
-            # zero-indexes, even if that list is
-            # actually an R vector. Therefore subtract
-            # 1 to account for the difference.
-            test_a = [test_a[i-1] for i in which(test_a > median_a)]
-            test_b = [test_b[i-1] for i in which(test_b > median_b)]
+                # `which` returns indices which are
+                # 1-indexed. Python accesses lists with
+                # zero-indexes, even if that list is
+                # actually an R vector. Therefore subtract
+                # 1 to account for the difference.
+                test_a = [test_a[i-1] for i in which(test_a > median_a)]
+                test_b = [test_b[i-1] for i in which(test_b > median_b)]
 
-            # The python list comprehension gives us a
-            # python list, but ks_test wants an R
-            # vector so let's go back.
-            test_a = as_numeric(test_a)
-            test_b = as_numeric(test_b)
+                # The python list comprehension gives us a
+                # python list, but ks_test wants an R
+                # vector so let's go back.
+                test_a = as_numeric(test_a)
+                test_b = as_numeric(test_b)
 
-            ks_res = ks_test(test_a, test_b)
-            statistic = ks_res.rx('statistic')[0][0]
-            pvalue = ks_res.rx('p.value')[0][0]
+                ks_res = ks_test(test_a, test_b)
+                statistic = ks_res.rx('statistic')[0][0]
+                pvalue = ks_res.rx('p.value')[0][0]
 
-            job_context['ks_statistic'] = statistic
-            job_context['ks_pvalue'] = pvalue
+                job_context['ks_statistic'] = statistic
+                job_context['ks_pvalue'] = pvalue
 
-            # We're unsure of how strigent to be about
-            # the pvalue just yet, so we're extra lax
-            # rather than failing tons of tests. This may need tuning.
-            if ks_check:
-                if statistic > ks_stat or pvalue < 0.8:
-                    raise Exception("Failed Kolmogorov Smirnov test! Stat: " +
-                                    str(statistic) + ", PVal: " + str(pvalue))
+                # We're unsure of how strigent to be about
+                # the pvalue just yet, so we're extra lax
+                # rather than failing tons of tests. This may need tuning.
+                if ks_check:
+                    if statistic > ks_stat or pvalue < 0.8:
+                        raise Exception("Failed Kolmogorov Smirnov test! Stat: " +
+                                        str(statistic) + ", PVal: " + str(pvalue))
+        else:
+            logger.warning("Not enough columns to perform KS test - either bad smash or single saple smash.",
+                dset=job_context['dataset'].id)
 
         # And finally convert back to Pandas
         ar = np.array(reso)

--- a/workers/data_refinery_workers/processors/test_smasher.py
+++ b/workers/data_refinery_workers/processors/test_smasher.py
@@ -313,7 +313,6 @@ class SmasherTestCase(TestCase):
             job.end_time = None
             job.save()
 
-
     @tag("smasher")
     def test_get_results(self):
         """ Test our ability to collect the appropriate samples. """
@@ -728,6 +727,29 @@ class SmasherTestCase(TestCase):
 
         final_context = smasher.smash(job.pk, upload=False)
         self.assertTrue(final_context['success'])
+
+        # Test single file smash
+
+        job = ProcessorJob()
+        job.pipeline_applied = "SMASHER"
+        job.save()
+
+        ds = Dataset()
+        ds.data = {'SRP051449': ['SRR1731761']}
+        ds.aggregate_by = 'EXPERIMENT'
+        ds.scale_by = 'NONE'
+        ds.email_address = "null@derp.com"
+        ds.quantile_normalize = True
+        ds.save()
+
+        pjda = ProcessorJobDatasetAssociation()
+        pjda.processor_job = job
+        pjda.dataset = ds
+        pjda.save()
+
+        final_context = smasher.smash(job.pk, upload=False)
+        self.assertTrue(final_context['success'])
+
 
     @tag("smasher")
     def test_log2(self):


### PR DESCRIPTION
## Issue Number

https://github.com/AlexsLemonade/refinebio/issues/1137

## Methods

The KS test required at least two inputs. Now we skip the KS test and warn if the input only has a single sample.