### PR TITLE
Lower downloader RAM requirement

### DIFF
--- a/workers/nomad-job-specs/downloader.nomad.tpl
+++ b/workers/nomad-job-specs/downloader.nomad.tpl
@@ -72,7 +72,7 @@ job "DOWNLOADER" {
         # CPU is in AWS's CPU units.
         cpu = 512
         # Memory is in MB of RAM.
-        memory = 4096
+        memory = 1024 
       }
 
       logs {


### PR DESCRIPTION
4096 seems way more than needed for a single downloader.