### PR TITLE
Changes our calculations for max number of downloader jobs

### DIFF
--- a/workers/data_refinery_workers/downloaders/test_array_express.py
+++ b/workers/data_refinery_workers/downloaders/test_array_express.py
@@ -106,66 +106,66 @@ class DownloadArrayExpressTestCase(TestCase):
 
         self.assertEqual(ProcessorJob.objects.all().count(), 2)
 
-    # @tag('downloaders')
-    # def test_dharma(self):
+    @tag('downloaders')
+    def test_dharma(self):
 
-    #     dlj1 = DownloaderJob()
-    #     dlj1.accession_code = 'D1'
-    #     dlj1.worker_id = get_instance_id()
-    #     dlj1.start_time = datetime.datetime.now()
-    #     dlj1.save()
+        dlj1 = DownloaderJob()
+        dlj1.accession_code = 'D1'
+        dlj1.worker_id = get_instance_id()
+        dlj1.start_time = datetime.datetime.now()
+        dlj1.save()
 
-    #     dlj2 = DownloaderJob()
-    #     dlj2.accession_code = 'D2'
-    #     dlj2.worker_id = get_instance_id()
-    #     dlj2.start_time = datetime.datetime.now()
-    #     dlj2.save()
+        dlj2 = DownloaderJob()
+        dlj2.accession_code = 'D2'
+        dlj2.worker_id = get_instance_id()
+        dlj2.start_time = datetime.datetime.now()
+        dlj2.save()
 
-    #     dlj3 = DownloaderJob()
-    #     dlj3.accession_code = 'D3'
-    #     dlj3.worker_id = get_instance_id()
-    #     dlj3.save()
+        dlj3 = DownloaderJob()
+        dlj3.accession_code = 'D3'
+        dlj3.worker_id = get_instance_id()
+        dlj3.save()
 
-    #     original_file = OriginalFile()
-    #     original_file.source_url = "ftp://ftp.ebi.ac.uk/pub/databases/microarray/data/experiment/MEXP/E-MEXP-433/E-MEXP-433.raw.1.zip"
-    #     original_file.source_filename = "Waldhof_020604_R30_01-2753_U133A.CEL"
-    #     original_file.save()
+        original_file = OriginalFile()
+        original_file.source_url = "ftp://ftp.ebi.ac.uk/pub/databases/microarray/data/experiment/MEXP/E-MEXP-433/E-MEXP-433.raw.1.zip"
+        original_file.source_filename = "Waldhof_020604_R30_01-2753_U133A.CEL"
+        original_file.save()
 
-    #     assoc = DownloaderJobOriginalFileAssociation()
-    #     assoc.original_file = original_file
-    #     assoc.downloader_job = dlj3
-    #     assoc.save()
+        assoc = DownloaderJobOriginalFileAssociation()
+        assoc.original_file = original_file
+        assoc.downloader_job = dlj3
+        assoc.save()
 
-    #     sample = Sample()
-    #     sample.accession_code = 'Blahblahblah'
-    #     sample.technology = "MICROARRAY"
-    #     sample.manufacturer = "AFFYMETRIX"
-    #     sample.has_raw = True
-    #     sample.platform_accession_code = "hgu133a"
-    #     sample.save()
+        sample = Sample()
+        sample.accession_code = 'Blahblahblah'
+        sample.technology = "MICROARRAY"
+        sample.manufacturer = "AFFYMETRIX"
+        sample.has_raw = True
+        sample.platform_accession_code = "hgu133a"
+        sample.save()
 
-    #     OriginalFileSampleAssociation.objects.get_or_create(sample=sample, original_file=original_file)
+        OriginalFileSampleAssociation.objects.get_or_create(sample=sample, original_file=original_file)
 
-    #     exited = False
-    #     try:
-    #         utils.start_job(dlj3.id, max_downloader_jobs_per_node=2, force_harakiri=True)
-    #     except SystemExit as e:
-    #         # This is supposed to happen!
-    #         self.assertTrue(True)
-    #         exited = True
-    #     except Exception as e:
-    #         # This isn't!
-    #         self.assertTrue(False)
-    #     self.assertTrue(exited)
+        exited = False
+        try:
+            utils.start_job(dlj3.id, max_downloader_jobs_per_node=2, force_harakiri=True)
+        except SystemExit as e:
+            # This is supposed to happen!
+            self.assertTrue(True)
+            exited = True
+        except Exception as e:
+            # This isn't!
+            self.assertTrue(False)
+        self.assertTrue(exited)
 
-    #     exited = False
-    #     try:
-    #         utils.start_job(dlj3.id, max_downloader_jobs_per_node=15, force_harakiri=True)
-    #     except SystemExit as e:
-    #         # This is not supposed to happen!
-    #         self.assertTrue(False)
-    #         exited = True
-    #     except Exception as e:
-    #         # This is!
-    #         self.assertTrue(True)
-    #     self.assertFalse(exited)
+        exited = False
+        try:
+            utils.start_job(dlj3.id, max_downloader_jobs_per_node=15, force_harakiri=True)
+        except SystemExit as e:
+            # This is not supposed to happen!
+            self.assertTrue(False)
+            exited = True
+        except Exception as e:
+            # This is!
+            self.assertTrue(True)
+        self.assertFalse(exited)

--- a/workers/data_refinery_workers/downloaders/utils.py
+++ b/workers/data_refinery_workers/downloaders/utils.py
@@ -78,28 +78,28 @@ def start_job(job_id: int, max_downloader_jobs_per_node=MAX_DOWNLOADER_JOBS_PER_
         raise
 
     worker_id = get_instance_id()
-    # num_downloader_jobs_currently_running = DownloaderJob.objects.filter(
-    #                             worker_id=worker_id,
-    #                             start_time__isnull=False,
-    #                             end_time__isnull=True,
-    #                             success__isnull=True,
-    #                             retried=False
-    #                         ).count()
+    num_downloader_jobs_currently_running = DownloaderJob.objects.filter(
+                                worker_id=worker_id,
+                                start_time__isnull=False,
+                                end_time__isnull=True,
+                                success__isnull=True,
+                                retried=False
+                            ).count()
 
-    # # Death and rebirth.
-    # if settings.RUNNING_IN_CLOUD or force_harakiri:
-    #     if num_downloader_jobs_currently_running >= int(max_downloader_jobs_per_node):
-    #         # Wait for the death window
-    #         while True:
-    #             seconds = datetime.datetime.now().second
-    #             # Mass harakiri happens every 15 seconds.
-    #             if seconds % 15 == 0:
-    #                 job.start_time = None
-    #                 job.num_retries = job.num_retries - 1
-    #                 job.save()
+    # Death and rebirth.
+    if settings.RUNNING_IN_CLOUD or force_harakiri:
+        if num_downloader_jobs_currently_running >= int(max_downloader_jobs_per_node):
+            # Wait for the death window
+            while True:
+                seconds = datetime.datetime.now().second
+                # Mass harakiri happens every 15 seconds.
+                if seconds % 15 == 0:
+                    job.start_time = None
+                    job.num_retries = job.num_retries - 1
+                    job.save()
 
-    #                 # What is dead may never die!
-    #                 sys.exit(0)
+                    # What is dead may never die!
+                    sys.exit(0)
 
     # This job should not have been started.
     if job.start_time is not None:

--- a/workers/data_refinery_workers/downloaders/utils.py
+++ b/workers/data_refinery_workers/downloaders/utils.py
@@ -34,16 +34,16 @@ CURRENT_JOB = None
 
 def get_max_jobs_for_current_node():
     """ Determine the maximum number of Downloader jobs that this node should sustain,
-    based on total system RAM made available to this container """
+    based on total system RAM."""
 
     total_vm = psutil.virtual_memory().total
     gb = int(total_vm / 1000000000)
     logger.info("Detected " + str(gb) + "GB of RAM.")
 
-    # We basically want to hit 2GB/s total across 10 x1.32larges. Each job hits 18MB/s.
-    # So it'd take 111 jobs across 10 boxes to hit our limit, so let's set our GB per to 12,
-    # which should pack well enough and give us a slight buffer.
-    max_jobs = (gb/12)
+    # We basically want to hit 2GB/s total across our entire cluster. Each job hits ~20MB/s,
+    # so it'd take 100 jobs to hit our limit. Our cluster has 10TB of RAM, which is ~10000 GB.
+    # 100 jobs per 10000 GB = 1 job per 100 GB
+    max_jobs = (gb/100)
 
     # However this will make sure we can still run a few jobs in local environments and in CI.
     if max_jobs < 5:


### PR DESCRIPTION
## Issue Number

N/A  came up during prod tuning

## Purpose/Implementation Notes

We're hitting different NCBI servers than we were before. This changes the number of downloader jobs that we'll run in parallel to reflect the speed and of those servers and the size of our cluster.

This also reenables harakari for downloader jobs so that these limits actually do something.

## Types of changes

- New feature (non-breaking change which adds functionality)

## Functional tests

Unit tests cover it.

## Checklist

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules
