### PR TITLE
Kurtwheeler/better expected failures

### DIFF
--- a/common/data_refinery_common/message_queue.py
+++ b/common/data_refinery_common/message_queue.py
@@ -79,10 +79,10 @@ def send_job(job_type: Enum, job, is_dispatch=False) -> bool:
     else:
         raise ValueError("Invalid job_type: {}".format(job_type.value))
 
-    logger.info("Queuing %s nomad job to run job %s with id %d.",
-                nomad_job,
-                job_type.value,
-                job.id)
+    logger.debug("Queuing %s nomad job to run job %s with id %d.",
+                 nomad_job,
+                 job_type.value,
+                 job.id)
 
     # Smasher doesn't need to be on a specific instance since it will
     # download all the data to its instance anyway.

--- a/workers/data_refinery_workers/downloaders/utils.py
+++ b/workers/data_refinery_workers/downloaders/utils.py
@@ -61,6 +61,7 @@ def signal_handler(sig, frame):
     else:
         CURRENT_JOB.start_time = None
         CURRENT_JOB.num_retries = CURRENT_JOB.num_retries - 1
+        CURRENT_JOB.failure_reason = "Caught either a SIGTERM or SIGINT signal."
         CURRENT_JOB.save()
         sys.exit(0)
 
@@ -96,6 +97,8 @@ def start_job(job_id: int, max_downloader_jobs_per_node=MAX_DOWNLOADER_JOBS_PER_
                 if seconds % 15 == 0:
                     job.start_time = None
                     job.num_retries = job.num_retries - 1
+                    job.success = False
+                    job.failure_reason = "There were too many downloader jobs already running on this node."
                     job.save()
 
                     # What is dead may never die!

--- a/workers/data_refinery_workers/processors/utils.py
+++ b/workers/data_refinery_workers/processors/utils.py
@@ -48,6 +48,7 @@ def signal_handler(sig, frame):
     else:
         CURRENT_JOB.start_time = None
         CURRENT_JOB.num_retries = CURRENT_JOB.num_retries - 1
+        CURRENT_JOB.failure_reason = "Caught either a SIGTERM or SIGINT signal."
         CURRENT_JOB.save()
         sys.exit(0)
 


### PR DESCRIPTION
## Issue Number

N/A Came up based on running in prod

## Purpose/Implementation Notes

There's a couple places that we purposefully fail jobs:
  1. When there's too many downloader jobs and the only way we have to reduce that number is by having them kill themselves.
  2. When a job gets a signal from Nomad or Docker.

When this happens we should set a failure reason so we can tell the difference between these expected failures and failures that don't have a failure reason for an unexpected reason.

Also this stops us logging about queuing jobs in prod because we have 100's of thousands of jobs and that's just a lot of logging.

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

WIP.

## Checklist

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules
