### PR TITLE
Use pretty_platform as MFG source with NextSeq exception, Test

### DIFF
--- a/foreman/data_refinery_foreman/surveyor/geo.py
+++ b/foreman/data_refinery_foreman/surveyor/geo.py
@@ -120,11 +120,12 @@ class GeoSurveyor(ExternalSourceSurveyor):
             else:
                 channel1_protocol = ""
 
-            if ('AGILENT' in channel1_protocol):
+            platform = sample_object.pretty_platform.upper()
+            if ('AGILENT' in platform):
                 sample_object.manufacturer = "AGILENT"
-            elif ('ILLUMINA' in channel1_protocol):
+            elif ('ILLUMINA' in platform or "NEXTSEQ" in platform):
                 sample_object.manufacturer = "ILLUMINA"
-            elif ('AFFYMETRIX' in channel1_protocol):
+            elif ('AFFYMETRIX' in platform):
                 sample_object.manufacturer = "AFFYMETRIX"
             else:
                 sample_object.manufacturer = UNKNOWN

--- a/foreman/data_refinery_foreman/surveyor/test_geo.py
+++ b/foreman/data_refinery_foreman/surveyor/test_geo.py
@@ -69,6 +69,18 @@ class SurveyTestCase(TransactionTestCase):
         self.assertEqual(45, original_files.count())
 
     @patch('data_refinery_foreman.surveyor.external_source.message_queue.send_job')
+    def test_geo_survey_not_agilent(self, mock_send_task):
+        """ Test to make sure we're setting MFG correctly
+        """
+        self.prep_test("GSE34198")
+
+        geo_surveyor = GeoSurveyor(self.survey_job)
+        geo_surveyor.survey()
+
+        sample_object = Sample.objects.first()
+        self.assertEqual(sample_object.manufacturer, "ILLUMINA")
+
+    @patch('data_refinery_foreman.surveyor.external_source.message_queue.send_job')
     def test_geo_survey_agilent(self, mock_send_task):
         """ Run the GEO surveyor and make sure we get some files to DL!
 


### PR DESCRIPTION
## Issue Number

https://github.com/AlexsLemonade/refinebio/issues/1102

## Purpose/Implementation Notes
`channe1_protcol` often had conflicting brands, if we use the pretty_platform instead, it actually works out fine in most cases with the exception of the NextSeq500, so we just have a special case for that.

New test added.
