### PR TITLE
Move KS failure to KS warning

### DIFF
--- a/workers/data_refinery_workers/processors/smasher.py
+++ b/workers/data_refinery_workers/processors/smasher.py
@@ -744,7 +744,6 @@ def _smash(job_context: Dict, how="inner") -> Dict:
         # https://github.com/AlexsLemonade/refinebio/pull/421#discussion_r203799646
         metadata['non_aggregated_files'] = unsmashable_files
         metadata['ks_statistic'] = job_context.get("ks_statistic", None)
-        metadata['ks_statistic'] = job_context.get("ks_statistic", None)
         metadata['ks_pvalue'] = job_context.get("ks_pvalue", None)
         metadata['ks_warning'] = job_context.get("ks_warning", None)
 

--- a/workers/data_refinery_workers/processors/smasher.py
+++ b/workers/data_refinery_workers/processors/smasher.py
@@ -427,7 +427,7 @@ def _quantile_normalize(job_context: Dict, ks_check=True, ks_stat=0.001) -> Dict
                 # rather than failing tons of tests. This may need tuning.
                 if ks_check:
                     if statistic > ks_stat or pvalue < 0.8:
-                        raise Exception("Failed Kolmogorov Smirnov test! Stat: " +
+                        job_context['ks_warning'] = ("Failed Kolmogorov Smirnov test! Stat: " +
                                         str(statistic) + ", PVal: " + str(pvalue))
         else:
             logger.warning("Not enough columns to perform KS test - either bad smash or single saple smash.",
@@ -743,6 +743,10 @@ def _smash(job_context: Dict, how="inner") -> Dict:
         metadata['scale_by'] = job_context["dataset"].scale_by
         # https://github.com/AlexsLemonade/refinebio/pull/421#discussion_r203799646
         metadata['non_aggregated_files'] = unsmashable_files
+        metadata['ks_statistic'] = job_context.get("ks_statistic", None)
+        metadata['ks_statistic'] = job_context.get("ks_statistic", None)
+        metadata['ks_pvalue'] = job_context.get("ks_pvalue", None)
+        metadata['ks_warning'] = job_context.get("ks_warning", None)
 
         samples = {}
         for sample in job_context["dataset"].get_samples():


### PR DESCRIPTION
## Issue Number
I failed a large smash because of just barely failing a Kolmogorov Smirnov test, it'd be a much better experience to at least give users something rather than a self-imposed error message and no data. Moves the test result into the metadata rather than a job failure. We can revert this but I kind of need it for debugging anyway.