### PR TITLE
Allow API-KEY header

### DIFF
--- a/api/data_refinery_api/settings.py
+++ b/api/data_refinery_api/settings.py
@@ -16,6 +16,8 @@ from django.core.exceptions import ImproperlyConfigured
 
 from data_refinery_common.utils import get_env_variable, get_env_variable_gracefully
 
+from corsheaders.defaults import default_headers
+
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
@@ -32,6 +34,9 @@ DEBUG = get_env_variable('DJANGO_DEBUG') == "True"
 # XXX: Should be closed down when we figure out domain endpoints
 ALLOWED_HOSTS = ['*']
 CORS_ORIGIN_ALLOW_ALL = True
+CORS_ALLOW_HEADERS = default_headers + (
+    'API-KEY',
+)
 
 # Application definition
 


### PR DESCRIPTION
## Issue Number

https://github.com/AlexsLemonade/refinebio-frontend/issues/560

## Purpose/Implementation Notes

Adds `API-KEY` to the list of `Access-Control-Allow-Headers`, otherwise we'll get a CORS error:

```
Access to fetch at 'https://api.refine.bio/dataset/b5331a10-aa12-4f3f-b056-c11a28ce120d/' from origin 'http://localhost:3000' has been blocked by CORS policy: Request header field api-key is not allowed by Access-Control-Allow-Headers in preflight response.
```

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

Not sure how to test this.

## Checklist

- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules

