### PR TITLE
Fixes P2-P3 Error in Imported Project

### DIFF
--- a/foreman/data_refinery_foreman/foreman/performant_pagination/pagination.py
+++ b/foreman/data_refinery_foreman/foreman/performant_pagination/pagination.py
@@ -103,7 +103,8 @@ class PerformantPaginator(object):
             value = obj._meta.get_field(pieces[-1]).value_to_string(obj)
 
         # return our value
-        return b64encode(value)
+        value_bytes = value.encode()
+        return b64encode(value_bytes)
 
     def _token_to_clause(self, token, rev=False):
         # in the forward direction we want things that are greater than our


### PR DESCRIPTION
The imported project was not fully P3 compatible, this should update it enough to be usable.

Pushing this out now, but it'd be good to develop a new test that spans multiple pages so that we would have caught this sooner.