### PR TITLE
Gracefully handles the case where an array express SDRF file returns a 404.

### DIFF
--- a/foreman/data_refinery_foreman/surveyor/harmony.py
+++ b/foreman/data_refinery_foreman/surveyor/harmony.py
@@ -668,10 +668,16 @@ def parse_sdrf(sdrf_url: str) -> List:
     """ Given a URL to an SDRF file, download parses it into JSON. """
 
     try:
-        sdrf_text = requests_retry_session().get(sdrf_url, timeout=60).text
+        sdrf_response = requests_retry_session().get(sdrf_url, timeout=60)
     except Exception as e:
-        logger.exception("Unable to fetch URL: " + sdrf_url, exception=str(e))
+        logger.exception("Unable to fetch URL: " + sdrf_url)
         return []
+
+    if sdrf_response.status_code != 200:
+        logger.error("Unable to fetch URL: " + sdrf_url, response_code=sdrf_response.status_code)
+        return []
+
+    sdrf_text = sdrf_response.text
 
     samples = []
 


### PR DESCRIPTION
## Issue Number

https://github.com/AlexsLemonade/refinebio/issues/1174

## Purpose/Implementation Notes

https://www.ebi.ac.uk/arrayexpress/files/accession/E-GEOD-7753.sdrf.txt

now says:

> The resource located at /arrayexpress/files/accession/E-GEOD-7753.sdrf.txt may have been removed, had its name changed, or has restricted access. If you have been granted access, please log in to proceed.

I'm not sure why this disappeared, but it seems like a thing we should be able to handle gracefully and now we can!

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

The unit tests now pass quietly instead of with a massive amount of logging about how parsing these non-files is broken.

## Checklist

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules
