### PR TITLE
Bump num of max downloader jobs.

### DIFF
--- a/foreman/data_refinery_foreman/foreman/main.py
+++ b/foreman/data_refinery_foreman/foreman/main.py
@@ -50,7 +50,7 @@ DEFAULT_MAX_JOBS = 20000
 
 
 # This is the maximum number of non-dead nomad jobs that can be in the queue.
-MAX_TOTAL_DOWNLOADER_JOBS = 200
+MAX_TOTAL_DOWNLOADER_JOBS = 400
 
 # The minimum amount of time in between each iteration of the main
 # loop. We could loop much less frequently than every two minutes if


### PR DESCRIPTION
## Issue Number

#1179 

## Purpose/Implementation Notes

Having the foreman limit how many downloader jobs are in the queue seems to be fixing our database woes because there's a lot less harakiri going on. However 200 is too low because some instances get greedy and take more than their fair share leaving others without any.
