### PR TITLE
Break out of foreman pagination early.

### DIFF
--- a/foreman/data_refinery_foreman/foreman/main.py
+++ b/foreman/data_refinery_foreman/foreman/main.py
@@ -314,7 +314,8 @@ def get_capacity_for_downloader_jobs(nomad_client) -> bool:
 
 
 
-def handle_downloader_jobs(jobs: List[DownloaderJob], queue_capacity=MAX_TOTAL_JOBS) -> None:
+def handle_downloader_jobs(jobs: List[DownloaderJob],
+                           queue_capacity: int = MAX_TOTAL_DOWNLOADER_JOBS) -> None:
     """For each job in jobs, either retry it or log it.
 
     No more than queue_capacity jobs will be retried.
@@ -586,11 +587,17 @@ def get_capacity_for_processor_jobs(nomad_client) -> bool:
     return MAX_TOTAL_JOBS - len_all_jobs
 
 
-def handle_processor_jobs(jobs: List[ProcessorJob], queue_capacity: int) -> None:
+def handle_processor_jobs(jobs: List[ProcessorJob],
+                          queue_capacity: int = None) -> None:
     """For each job in jobs, either retry it or log it.
 
     No more than queue_capacity jobs will be retried.
     """
+    # Maximum number of total jobs running at a time.
+    # We do this now rather than import time for testing purposes.
+    if queue_capacity is None:
+        queue_capacity = int(get_env_variable_gracefully("MAX_TOTAL_JOBS", DEFAULT_MAX_JOBS))
+
     # We want zebrafish data first, then hgu133plus2, then data
     # related to pediatric cancer, then to finish salmon experiments
     # that are close to completion.
@@ -886,11 +893,15 @@ def get_capacity_for_survey_jobs(nomad_client) -> bool:
     return MAX_TOTAL_JOBS - len_all_jobs
 
 
-def handle_survey_jobs(jobs: List[SurveyJob], queue_capacity=MAX_TOTAL_JOBS) -> None:
+def handle_survey_jobs(jobs: List[SurveyJob], queue_capacity: int = None) -> None:
     """For each job in jobs, either retry it or log it.
 
     No more than queue_capacity jobs will be retried.
     """
+    # Maximum number of total jobs running at a time.
+    # We do this now rather than import time for testing purposes.
+    if queue_capacity is None:
+        queue_capacity = int(get_env_variable_gracefully("MAX_TOTAL_JOBS", DEFAULT_MAX_JOBS))
     jobs_dispatched = 0
     for count, job in enumerate(jobs):
         if jobs_dispatched >= queue_capacity:

--- a/foreman/data_refinery_foreman/foreman/main.py
+++ b/foreman/data_refinery_foreman/foreman/main.py
@@ -48,9 +48,12 @@ MAX_NUM_RETRIES = 2
 # This can be overritten by the env var "MAX_TOTAL_JOBS"
 DEFAULT_MAX_JOBS = 20000
 
-# This is the maximum number of non-dead nomad jobs that can be in the queue.
-MAX_TOTAL_DOWNLOADER_JOBS = 0
 DOWNLOADER_JOBS_PER_NODE = 40
+
+# This is the maximum number of non-dead nomad jobs that can be in the
+# queue. Set the default to one node's worth so we never are unable
+# to queue downloader jobs.
+MAX_TOTAL_DOWNLOADER_JOBS = DOWNLOADER_JOBS_PER_NODE
 TIME_OF_LAST_SIZE_CHECK = timezone.now()
 
 # The minimum amount of time in between each iteration of the main
@@ -346,7 +349,7 @@ def get_capacity_for_downloader_jobs(nomad_client) -> bool:
 
     current_max_downloader_jobs = get_max_downloader_jobs(nomad_client=nomad_client)
     current_downloader_jobs_in_queue = count_downloader_jobs_in_queue(nomad_client)
-    return current_max_downloader_jobs - current_max_downloader_jobs
+    return current_max_downloader_jobs - current_downloader_jobs_in_queue
 
 
 def handle_downloader_jobs(jobs: List[DownloaderJob],

--- a/foreman/data_refinery_foreman/foreman/main.py
+++ b/foreman/data_refinery_foreman/foreman/main.py
@@ -113,9 +113,17 @@ def handle_repeated_failure(job) -> None:
     logger.warn("%s #%d failed %d times!!!", job.__class__.__name__, job.id, MAX_NUM_RETRIES + 1)
 
 def get_max_downloader_jobs(window=datetime.timedelta(minutes=2), nomad_client=None):
-    """
-    Fetches the desired maximum number of downloader jobs available based on the cluster size.
-    If this has been calculated recently, returns a cached value, else it will calculate it fresh every `window`.
+    """Fetches the desired maximum number of downloader jobs available
+    based on the cluster size.
+
+    If this has been calculated recently, returns a cached value, else
+    it will calculate it fresh every `window`.
+
+    Will never return less than DOWNLOADER_JOBS_PER_NODE because in
+    local and test environments we will never have more than one
+    node. Having DOWNLOADER_JOBS_PER_NODE jobs in the queue when
+    there's no nodes isn't an issue since they'll just get picked up
+    when there is.
     """
     global MAX_TOTAL_DOWNLOADER_JOBS
     global TIME_OF_LAST_SIZE_CHECK
@@ -133,6 +141,8 @@ def get_max_downloader_jobs(window=datetime.timedelta(minutes=2), nomad_client=N
 
     if MAX_TOTAL_DOWNLOADER_JOBS > 1000:
         return 1000
+    elif MAX_TOTAL_DOWNLOADER_JOBS == 0:
+        return DOWNLOADER_JOBS_PER_NODE
     else:
         return MAX_TOTAL_DOWNLOADER_JOBS
 

--- a/foreman/data_refinery_foreman/foreman/test_main.py
+++ b/foreman/data_refinery_foreman/foreman/test_main.py
@@ -922,17 +922,7 @@ class ForemanTestCase(TestCase):
             ixs.remove(p.volume_index)
 
     def test_get_max_downloader_jobs(self):
-
-        # Default is at zero since the cluster isn't online when the foreman starts up.
-        jobsnow = main.get_max_downloader_jobs()
-        self.assertEqual(jobsnow, 0)
-
-        # Once the window has elapsed, this should increase beyond 0.
-        time.sleep(2)
-        jobsnow = main.get_max_downloader_jobs(window=datetime.timedelta(seconds=1))
-        self.assertNotEqual(jobsnow, 0)
-        jobsnow = main.get_max_downloader_jobs()
-        self.assertNotEqual(jobsnow, 0)
+        self.assertNotEqual(main.get_max_downloader_jobs(), 0)
 
 # class JobPrioritizationTestCase(TestCase):
 #     def setUp(self):


### PR DESCRIPTION
## Issue Number

#1179

## Purpose/Implementation Notes

The foreman can pull a lot of pages of jobs to requeue. There can be way more jobs to iterate through than we want to actually queue, so this makes it so that once we hit the queue capacity for each job type we stop looping over the pages of jobs.

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

They're hard to do for this without the volume of data we have in the cloud.

## Checklist

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules
