### PR TITLE
Dynamically Calculate Max Downloader Jobs Limit Based On Nomad Cluster Size

### DIFF
--- a/foreman/data_refinery_foreman/foreman/main.py
+++ b/foreman/data_refinery_foreman/foreman/main.py
@@ -50,6 +50,7 @@ DEFAULT_MAX_JOBS = 20000
 
 # This is the maximum number of non-dead nomad jobs that can be in the queue.
 MAX_TOTAL_DOWNLOADER_JOBS = 0
+DOWNLOADER_JOBS_PER_NODE = 40
 TIME_OF_LAST_SIZE_CHECK = timezone.now()
 
 # The minimum amount of time in between each iteration of the main
@@ -126,10 +127,13 @@ def get_max_downloader_jobs(window=datetime.timedelta(minutes=2), nomad_client=N
             nomad_port = get_env_variable("NOMAD_PORT", "4646")
             nomad_client = Nomad(nomad_host, port=int(nomad_port), timeout=30)
 
-        MAX_TOTAL_DOWNLOADER_JOBS = len(nomad_client.nodes) * 50
+        MAX_TOTAL_DOWNLOADER_JOBS = len(nomad_client.nodes) * DOWNLOADER_JOBS_PER_NODE
         TIME_OF_LAST_SIZE_CHECK = timezone.now()
 
-    return MAX_TOTAL_DOWNLOADER_JOBS
+    if MAX_TOTAL_DOWNLOADER_JOBS > 1000:
+        return 1000
+    else:
+        return MAX_TOTAL_DOWNLOADER_JOBS
 
 ##
 # Job Prioritization

--- a/foreman/data_refinery_foreman/foreman/main.py
+++ b/foreman/data_refinery_foreman/foreman/main.py
@@ -127,7 +127,8 @@ def get_max_downloader_jobs(window=datetime.timedelta(minutes=2), nomad_client=N
             nomad_port = get_env_variable("NOMAD_PORT", "4646")
             nomad_client = Nomad(nomad_host, port=int(nomad_port), timeout=30)
 
-        MAX_TOTAL_DOWNLOADER_JOBS = len(nomad_client.nodes) * DOWNLOADER_JOBS_PER_NODE
+        # Minus one because the smasher doesn't run DLs
+        MAX_TOTAL_DOWNLOADER_JOBS = (len(nomad_client.nodes) - 1) * DOWNLOADER_JOBS_PER_NODE
         TIME_OF_LAST_SIZE_CHECK = timezone.now()
 
     if MAX_TOTAL_DOWNLOADER_JOBS > 1000:

--- a/foreman/data_refinery_foreman/foreman/test_main.py
+++ b/foreman/data_refinery_foreman/foreman/test_main.py
@@ -1,5 +1,6 @@
 from unittest.mock import patch, MagicMock
 import datetime
+import time
 from django.utils import timezone
 from django.test import TestCase
 from data_refinery_foreman.foreman import main
@@ -920,6 +921,18 @@ class ForemanTestCase(TestCase):
             self.assertTrue(p.volume_index in ixs)
             ixs.remove(p.volume_index)
 
+    def test_get_max_downloader_jobs(self):
+
+        # Default is at zero since the cluster isn't online when the foreman starts up.
+        jobsnow = main.get_max_downloader_jobs()
+        self.assertEqual(jobsnow, 0)
+
+        # Once the window has elapsed, this should increase beyond 0.
+        time.sleep(2)
+        jobsnow = main.get_max_downloader_jobs(window=datetime.timedelta(seconds=1))
+        self.assertNotEqual(jobsnow, 0)
+        jobsnow = main.get_max_downloader_jobs()
+        self.assertNotEqual(jobsnow, 0)
 
 # class JobPrioritizationTestCase(TestCase):
 #     def setUp(self):

--- a/workers/data_refinery_workers/processors/salmon.py
+++ b/workers/data_refinery_workers/processors/salmon.py
@@ -286,7 +286,11 @@ def _determine_index_length_sra(job_context: Dict) -> Dict:
                                        stdout=subprocess.PIPE,
                                        stderr=subprocess.PIPE)
     respo = completed_command.stdout.decode().strip()
-    stats = untangle.parse(respo)
+
+    try:
+        stats = untangle.parse(respo)
+    except ValueError:
+        logger.error("Unable to parse sra-stat output!", respo=str(respo), command=formatted_command)
 
     # Different SRA files can create different output formats, somehow.
     # This mess tries every output method we can to parse these stats.


### PR DESCRIPTION
## Issue Number

https://github.com/AlexsLemonade/refinebio/issues/1184

## Purpose/Implementation Notes

Replaces a hardcoded value with a value based on the number of nodes in the cluster. For 10 nodes, sets a theoretical 10GiB/s max, though I don't think we'll ever get close to this.

Also includes a guard against a semi-rare `sra-stat` failure.
