### PR TITLE
Make SRA `ascp` settings match `prefetch`

### DIFF
--- a/foreman/data_refinery_foreman/foreman/main.py
+++ b/foreman/data_refinery_foreman/foreman/main.py
@@ -48,7 +48,8 @@ MAX_NUM_RETRIES = 2
 # This can be overritten by the env var "MAX_TOTAL_JOBS"
 DEFAULT_MAX_JOBS = 20000
 
-DOWNLOADER_JOBS_PER_NODE = 40
+DOWNLOADER_JOBS_PER_NODE = 65
+PAGE_SIZE=500
 
 # This is the maximum number of non-dead nomad jobs that can be in the
 # queue. Set the default to one node's worth so we never are unable
@@ -397,7 +398,7 @@ def retry_failed_downloader_jobs() -> None:
     nomad_client = Nomad(nomad_host, port=int(nomad_port), timeout=30)
     queue_capacity = get_capacity_for_downloader_jobs(nomad_client)
 
-    paginator = Paginator(failed_jobs, 200)
+    paginator = Paginator(failed_jobs, PAGE_SIZE)
     page = paginator.page()
     page_count = 0
     while queue_capacity > 0:
@@ -436,7 +437,7 @@ def retry_hung_downloader_jobs() -> None:
     nomad_client = Nomad(nomad_host, port=int(nomad_port), timeout=30)
     queue_capacity = get_capacity_for_downloader_jobs(nomad_client)
 
-    paginator = Paginator(potentially_hung_jobs, 200)
+    paginator = Paginator(potentially_hung_jobs, PAGE_SIZE)
     page = paginator.page()
     page_count = 0
     while queue_capacity > 0:
@@ -499,7 +500,7 @@ def retry_lost_downloader_jobs() -> None:
     nomad_client = Nomad(nomad_host, port=int(nomad_port), timeout=30)
     queue_capacity = get_capacity_for_downloader_jobs(nomad_client)
 
-    paginator = Paginator(potentially_lost_jobs, 200)
+    paginator = Paginator(potentially_lost_jobs, PAGE_SIZE)
     page = paginator.page()
     page_count = 0
     while queue_capacity > 0:

--- a/foreman/data_refinery_foreman/foreman/main.py
+++ b/foreman/data_refinery_foreman/foreman/main.py
@@ -49,7 +49,7 @@ MAX_NUM_RETRIES = 2
 DEFAULT_MAX_JOBS = 20000
 
 DOWNLOADER_JOBS_PER_NODE = 65
-PAGE_SIZE=500
+PAGE_SIZE=2000
 
 # This is the maximum number of non-dead nomad jobs that can be in the
 # queue. Set the default to one node's worth so we never are unable

--- a/workers/data_refinery_workers/downloaders/sra.py
+++ b/workers/data_refinery_workers/downloaders/sra.py
@@ -102,8 +102,8 @@ def _download_file_aspera(download_url: str,
                                                stdout=subprocess.PIPE,
                                                stderr=subprocess.PIPE)
         else:
-            # NCBI requires encryption and recommends -k1 resume.
-            command_str = ".aspera/cli/bin/ascp -T -k1 -i .aspera/cli/etc/asperaweb_id_dsa.openssh {src} {dest}"
+            # NCBI requires encryption and recommends -k1 resume, as well as the 450m limit and -Q (play fair).
+            command_str = ".aspera/cli/bin/ascp -p -Q -T -k1 -l 450m -i .aspera/cli/etc/asperaweb_id_dsa.openssh {src} {dest}"
             formatted_command = command_str.format(src=download_url,
                                                    dest=target_file_path)
             logger.info("Starting NCBI ascp", time=str(timezone.now()))

--- a/workers/data_refinery_workers/downloaders/sra.py
+++ b/workers/data_refinery_workers/downloaders/sra.py
@@ -103,6 +103,7 @@ def _download_file_aspera(download_url: str,
                                                stderr=subprocess.PIPE)
         else:
             # NCBI requires encryption and recommends -k1 resume, as well as the 450m limit and -Q (play fair).
+            # ex: https://github.com/AlexsLemonade/refinebio/pull/1189#issuecomment-478018580
             command_str = ".aspera/cli/bin/ascp -p -Q -T -k1 -l 450m -i .aspera/cli/etc/asperaweb_id_dsa.openssh {src} {dest}"
             formatted_command = command_str.format(src=download_url,
                                                    dest=target_file_path)


### PR DESCRIPTION
I don't think this will have a huge impact (if anything, it'll have a slight negative impact), but it's possible that adding `-Q -450m` to our ascp calls will make them less likely to knock out the servers.