### PR TITLE
Don't fail downloader jobs for being unable to queue nomad jobs

### DIFF
--- a/workers/data_refinery_workers/downloaders/utils.py
+++ b/workers/data_refinery_workers/downloaders/utils.py
@@ -243,7 +243,12 @@ def create_processor_jobs_for_original_files(original_files: List[OriginalFile],
                              processor_job=processor_job.id,
                              original_file=original_file.id)
 
-            send_job(pipeline_to_apply, processor_job)
+            try:
+                send_job(pipeline_to_apply, processor_job)
+            except:
+                # If we cannot queue the job now the Foreman will do
+                # it later.
+                pass
 
 
 def create_processor_job_for_original_files(original_files: List[OriginalFile],
@@ -283,4 +288,9 @@ def create_processor_job_for_original_files(original_files: List[OriginalFile],
         logger.debug("Queuing processor job.",
                      processor_job=processor_job.id)
 
-        send_job(pipeline_to_apply, processor_job)
+        try:
+            send_job(pipeline_to_apply, processor_job)
+        except:
+            # If we cannot queue the job now the Foreman will do
+            # it later.
+            pass


### PR DESCRIPTION
## Issue Number

N/A Found it while looking into #1068 

## Purpose/Implementation Notes

Before this change:
When a downloader job finishes and tries to queue a processor job, if Nomad is down then the processor job will still be created but the downloader job will fail, causing it to be retried and thereby creating another processor job for the same data.

This fixes that, if Nomad is unreachable then downloader jobs now let the foreman worry about queuing the Nomad job for them.

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

N/A, this is pretty obvious (although I've tested that nothing obvious breaks)

## Checklist

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules
