### PR TITLE
Our string comparison was broken :(

### DIFF
--- a/infrastructure/deploy.sh
+++ b/infrastructure/deploy.sh
@@ -181,7 +181,7 @@ echo "Confirming Nomad cluster.."
 start_time=$(date +%s)
 diff=0
 nomad_status=$(check_nomad_status)
-while [[ $diff < 900 && $nomad_status != "200" ]]; do
+while [ "$diff" -lt "900" -a $nomad_status != "200" ]]; do
     sleep 1
     nomad_status=$(check_nomad_status)
     let "diff = $(date +%s) - $start_time"

--- a/infrastructure/deploy.sh
+++ b/infrastructure/deploy.sh
@@ -181,7 +181,7 @@ echo "Confirming Nomad cluster.."
 start_time=$(date +%s)
 diff=0
 nomad_status=$(check_nomad_status)
-while [ "$diff" -lt "900" -a $nomad_status != "200" ]]; do
+while [ "$diff" -lt "900" -a $nomad_status != "200" ]; do
     sleep 1
     nomad_status=$(check_nomad_status)
     let "diff = $(date +%s) - $start_time"


### PR DESCRIPTION
## Issue Number

We failed to have Nomad start up in production in ~12 minutes.

## Purpose/Implementation Notes

We thought we were giving Nomad up to 15 minutes, but it turns out our time comparison code was buggy. This fixes that.

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

```
diff=0
(dr_env) kurt@kurtputer:~/Development/refinebio-collab$ start_time=$(date +%s)
(dr_env) kurt@kurtputer:~/Development/refinebio-collab$ while [ "$diff" -lt "15" -a $nomad_status != "200" ]; do sleep 1; let "diff = $(date +%s) - $start_time"; echo $diff; done
5
6
7
8
9
10
11
12
13
14
15
```

## Checklist

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules
