### PR TITLE
Simple JSON import missing

### DIFF
--- a/workers/data_refinery_workers/processors/requirements.in
+++ b/workers/data_refinery_workers/processors/requirements.in
@@ -13,6 +13,7 @@ requests>=2.20.0
 retrying
 scikit-learn
 scipy
+simplejson
 sympy
 unicodecsv
 untangle>=1.1.1

--- a/workers/data_refinery_workers/processors/requirements.txt
+++ b/workers/data_refinery_workers/processors/requirements.txt
@@ -64,6 +64,7 @@ s3transfer==0.1.13        # via boto3
 scikit-image==0.14.2      # via datashader
 scikit-learn==0.20.0
 scipy==1.1.0
+simplejson==3.16.0
 six==1.11.0               # via bokeh, cycler, distributed, elasticsearch-dsl, multipledispatch, packaging, python-dateutil, retrying, scikit-image
 sortedcontainers==2.1.0   # via distributed
 sympy==1.3


### PR DESCRIPTION
This is a great example of why I do not like our requirements.in/requirements.txt pattern - simplejson was used by multiqc, so it tagged that in the requirements.txt file. When multiqc was removed from the requirements.in, it also removed it from the .txt, even thoug we use it elsewhere in the project. This is a bad pattern.

Also why didn't the smasher tests detect this sooner?