### PR TITLE
Apply platform `contained_by` filtering when creating ES index

### DIFF
--- a/common/data_refinery_common/models/documents.py
+++ b/common/data_refinery_common/models/documents.py
@@ -89,7 +89,7 @@ class ExperimentDocument(DocType):
     platform_accession_codes = fields.TextField(
         analyzer=standard_keyword,
         fielddata=True,
-        fields={'raw': fields.TextField(analyzer='keyword')}
+        fields={'raw': fields.TextField()}
     )
     
     # Basic Fields


### PR DESCRIPTION
## Issue Number
https://github.com/AlexsLemonade/refinebio/issues/1022

## Purpose/Implementation Notes
Prevents experiments with completely unsupported platforms from entering the search results. We can use this method to purge data in the future if we want to, but I've never been a fan of that, so this just removes it from the search results.