### PR TITLE
Lower Smasher Instance Class, Raise Smasher RAM Usage

### DIFF
--- a/infrastructure/variables.tf
+++ b/infrastructure/variables.tf
@@ -120,7 +120,7 @@ variable "client_instance_type" {
 }
 
 variable "smasher_instance_type" {
-  default = "m5.12xlarge"
+  default = "m5.2xlarge"
 }
 
 variable "spot_price" {

--- a/workers/nomad-job-specs/smasher.nomad.tpl
+++ b/workers/nomad-job-specs/smasher.nomad.tpl
@@ -65,9 +65,9 @@ job "SMASHER" {
       # The resources the job will require.
       resources {
         # CPU is in AWS's CPU units.
-        cpu = 1024
+        cpu = 2048
         # Memory is in MB of RAM.
-        memory = 12288
+        memory = 24576
       }
 
       logs {

--- a/workers/nomad-job-specs/smasher.nomad.tpl
+++ b/workers/nomad-job-specs/smasher.nomad.tpl
@@ -67,7 +67,7 @@ job "SMASHER" {
         # CPU is in AWS's CPU units.
         cpu = 2048
         # Memory is in MB of RAM.
-        memory = 24576
+        memory = 28000
       }
 
       logs {


### PR DESCRIPTION
## Issue Number
https://github.com/AlexsLemonade/refinebio/issues/944

## Purpose/Implementation Notes
@cansav09 got a smasher OOM yesterday, 944 wasn't fully resolved for very large datasets.

I'm not sure how it happened (must have been during compendia processing time), but the smasher instance was way way too powerful, this lowers it down to something more sane but raises the RAM usage of each individual job.
