### PR TITLE
Adds ?organism filter to qn_targets API endpoint

### DIFF
--- a/api/data_refinery_api/tests.py
+++ b/api/data_refinery_api/tests.py
@@ -640,7 +640,7 @@ class APITestCases(APITestCase):
         qni.save()
 
         response = self.client.get(reverse('qn-targets'), {'organism': 'Ailuropoda melanoleuca'})
-        self.assertEqual(len(response.json()), 1)
+        self.assertEqual(len(response.json().keys()), 11)
         self.assertEqual(response.json()['s3_url'], 'https://s3.amazonaws.com/fake_qni_bucket/zazaza_homo_sapiens_1234.tsv')
 
         response = self.client.get(reverse('computed-files'))

--- a/api/data_refinery_api/tests.py
+++ b/api/data_refinery_api/tests.py
@@ -614,7 +614,7 @@ class APITestCases(APITestCase):
 
         cra = ComputationalResultAnnotation()
         cra.result = cr
-        cra.data = {"organism": "Ailuropoda melanoleuca"}
+        cra.data = {"organism": "Ailuropoda melanoleuca", "organism_id": 9646, "is_qn": True}
         cra.save()
 
         qni = ComputedFile()
@@ -639,9 +639,9 @@ class APITestCases(APITestCase):
         qni.result = cr
         qni.save()
 
-        response = self.client.get(reverse('qn-targets'))
+        response = self.client.get(reverse('qn-targets'), {'organism': 'Ailuropoda melanoleuca'})
         self.assertEqual(len(response.json()), 1)
-        self.assertEqual(response.json()[0]['s3_url'], 'https://s3.amazonaws.com/fake_qni_bucket/zazaza_homo_sapiens_1234.tsv')
+        self.assertEqual(response.json()['s3_url'], 'https://s3.amazonaws.com/fake_qni_bucket/zazaza_homo_sapiens_1234.tsv')
 
         response = self.client.get(reverse('computed-files'))
         self.assertEqual(len(response.json()), 2)

--- a/api/data_refinery_api/views.py
+++ b/api/data_refinery_api/views.py
@@ -1419,13 +1419,36 @@ class QNTargetsAvailable(APIView):
 
 class QNTargetsDetail(APIView):
     """
-    Quantile Normalization Targets
+    Get a detailed view of the Quantile Normalization file for an organism.
+
+    ex: `?organism=DANIO_RERIO&format=json`
+
     """
 
-    """List all processors."""
     def get(self, request, format=None):
-        computed_files = ComputedFile.objects.filter(is_public=True, is_qn_target=True)
-        serializer = QNTargetSerializer(computed_files, many=True)
+
+        filter_dict = request.query_params.dict()
+        organism = filter_dict.pop('organism', None)
+        if not organism:
+            raise APIException("Organism must be supplied!")
+
+        organism = organism.upper().replace(" ", "_")
+        try:
+            organism_id = Organism.get_id_for_name(organism)
+            annotation = ComputationalResultAnnotation.objects.filter(
+                data__organism_id=organism_id,
+                data__is_qn=True
+            ).order_by(
+                '-created_at'
+            ).first()
+            qn_target = annotation.result.computedfile_set.first()
+        except Exception:
+            raise APIException("Don't have a target for that organism!")
+
+        if not qn_target:
+            raise APIException("Don't have a target for that organism!!")
+
+        serializer = QNTargetSerializer(qn_target, many=False)
         return Response(serializer.data)
 
 ##


### PR DESCRIPTION
## Issue Number

https://github.com/AlexsLemonade/refinebio/issues/1224

## Purpose/Implementation Notes

I don't know how it was communicated that this worked already, but this was never implemented. Requires that 'organism' is supplied. Tests updated.
