### PR TITLE
Make Those QN Tests Match Reality

### DIFF
--- a/api/data_refinery_api/tests.py
+++ b/api/data_refinery_api/tests.py
@@ -614,7 +614,7 @@ class APITestCases(APITestCase):
 
         cra = ComputationalResultAnnotation()
         cra.result = cr
-        cra.data = {"organism": "Ailuropoda melanoleuca", "organism_id": 9646, "is_qn": True}
+        cra.data = {"organism": "Ailuropoda melanoleuca", "organism_id": Organism.get_object_for_name("Ailuropoda melanoleuca").id, "is_qn": True}
         cra.save()
 
         qni = ComputedFile()

--- a/api/data_refinery_api/views.py
+++ b/api/data_refinery_api/views.py
@@ -1434,7 +1434,7 @@ class QNTargetsDetail(APIView):
 
         organism = organism.upper().replace(" ", "_")
         try:
-            organism_id = Organism.get_id_for_name(organism)
+            organism_id = Organism.get_object_for_name(organism).id
             annotation = ComputationalResultAnnotation.objects.filter(
                 data__organism_id=organism_id,
                 data__is_qn=True


### PR DESCRIPTION
The organism_id being stored in the result annotations is the object ID, not the taxonomy ID.