### PR TITLE
Better handle og_files without associated samples 

### DIFF
--- a/foreman/data_refinery_foreman/foreman/main.py
+++ b/foreman/data_refinery_foreman/foreman/main.py
@@ -447,6 +447,7 @@ def retry_failed_downloader_jobs() -> None:
     failed_jobs = DownloaderJob.objects.filter(
         success=False,
         retried=False,
+        no_retry=False,
         created_at__gt=JOB_CREATED_AT_CUTOFF
     ).order_by(
         'id'

--- a/foreman/data_refinery_foreman/foreman/main.py
+++ b/foreman/data_refinery_foreman/foreman/main.py
@@ -333,6 +333,7 @@ def requeue_downloader_job(last_job: DownloaderJob) -> bool:
     original_file = last_job.original_files.first()
     if original_file and original_file.has_been_processed():
         last_job.no_retry = True
+        last_job.success = False
         last_job.failure_reason = "Foreman told to redownloaded job with prior succesful processing."
         last_job.save()
         return False
@@ -341,6 +342,7 @@ def requeue_downloader_job(last_job: DownloaderJob) -> bool:
         first_sample = original_file.samples.first()
         if first_sample and first_sample.is_blacklisted:
             last_job.no_retry = True
+            last_job.success = False
             last_job.failure_reason = "Sample run accession has been blacklisted by SRA."
             last_job.save()
             logger.info("Avoiding requeuing for DownloaderJob for blacklisted run accession: " + str(first_sample.accession_code))

--- a/foreman/requirements.txt
+++ b/foreman/requirements.txt
@@ -8,7 +8,7 @@ biopython==1.72           # via geoparse
 certifi==2018.8.24        # via requests
 chardet==3.0.4            # via requests
 coverage==4.5.1
-django==2.1.5
+django==2.1.8
 geoparse==1.1.0
 idna==2.7                 # via requests
 numpy==1.15.2             # via biopython, geoparse, pandas


### PR DESCRIPTION
Suppresses some sporadic nastiness for the requeueing original files without associated samples - but why do we have those? This will help us diagnose.
