### PR TITLE
Give monit a 4 minute timeout

### DIFF
--- a/infrastructure/nomad-configuration/client-smasher-instance-user-data.tpl.sh
+++ b/infrastructure/nomad-configuration/client-smasher-instance-user-data.tpl.sh
@@ -94,7 +94,7 @@ chmod +x /home/ubuntu/kill_restart_nomad.sh
 
 echo '
 check program nomad with path "/bin/bash /home/ubuntu/nomad_status.sh" as uid 0 and with gid 0
-    start program = "/home/ubuntu/kill_restart_nomad.sh" as uid 0 and with gid 0
+    start program = "/home/ubuntu/kill_restart_nomad.sh" as uid 0 and with gid 0 with timeout 240 seconds
     if status != 0
         then restart
 set daemon 300


### PR DESCRIPTION
## Issue Number

N/A

## Purpose/Implementation Notes

Our startup script has a 2 minute sleep, so let's have monit wait 4 minutes.

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

N/A it's monit

## Checklist

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules
