### PR TITLE
Bumps the max downloader jobs back up

### DIFF
--- a/foreman/data_refinery_foreman/foreman/main.py
+++ b/foreman/data_refinery_foreman/foreman/main.py
@@ -50,7 +50,7 @@ MAX_NUM_RETRIES = 2
 # This can be overritten by the env var "MAX_TOTAL_JOBS"
 DEFAULT_MAX_JOBS = 20000
 
-DOWNLOADER_JOBS_PER_NODE = 4
+DOWNLOADER_JOBS_PER_NODE = 25
 PAGE_SIZE=2000
 
 # This is the maximum number of non-dead nomad jobs that can be in the


### PR DESCRIPTION
## Issue Number

#1233 

## Purpose/Implementation Notes

Reverts #1233.

Chris from SRA said:

> I’m looking for the server policy, but I think connections will be refused if more than 4 simultaneous requests come from the same IP. But I thought that would give a ‘connection refused…’ message

This may have been a new change so reverting this might not help stuff, but in the past we were able to get a lot more throughput with higher job caps, so I'm curious to see if we still can or not. Otherwise we're going to be stuck at a crawl.

## Types of changes

- Tuning
