### PR TITLE
Temporarily Disable Illumina Tests on CI'

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -177,7 +177,7 @@ jobs:
       - run: sudo chown -R circleci:circleci workers/test_volume/
 
       # Run Illumina tests.
-      - run: .circleci/filter_tests.sh -t illumina
+      # - run: .circleci/filter_tests.sh -t illumina
 
       # Files created by containers are owned by the user ubuntu, which prevents workers/run_tests.sh
       # from making sure all the files in workers/test_volume have read/write permissions.


### PR DESCRIPTION
These tests are not helping us test anything relevant to our current development, but do fail intermittently due to forces outside of our control. Let's prevent bad builds and broken deploys from them.
