### PR TITLE
No more direct policy attachments

### DIFF
--- a/infrastructure/nomad-configuration/client-instance-user-data.tpl.sh
+++ b/infrastructure/nomad-configuration/client-instance-user-data.tpl.sh
@@ -23,22 +23,24 @@ ulimit -n 65536
 # Find, configure and mount a free EBS volume
 mkdir -p /var/ebs/
 
+# Takes USER, STAGE
 fetch_and_mount_volume () {
     INSTANCE_ID=$(curl http://169.254.169.254/latest/meta-data/instance-id)
 
     # Try to mount volume 0 first, so we have one volume we know is always mounted!
-    if aws ec2 describe-volumes --filters "Name=tag:User,Values=circleci" "Name=tag:Stage,Values=$1" "Name=tag:IsBig,Values=True" "Name=tag:Index,Values=0" "Name=status,Values=available" "Name=availability-zone,Values=us-east-1a" --region us-east-1 | grep 'VolumeID'; then
-        EBS_VOLUME_ID=`aws ec2 describe-volumes --filters "Name=tag:User,Values=circleci" "Name=tag:Stage,Values=$1" "Name=tag:IsBig,Values=True" "Name=tag:Index,Values=0" "Name=status,Values=available" "Name=availability-zone,Values=us-east-1a" --region us-east-1 | jq '.Volumes[0].VolumeId' | tr -d '"'`
+    if aws ec2 describe-volumes --filters "Name=tag:User,Values=$1" "Name=tag:Stage,Values=$2" "Name=tag:IsBig,Values=True" "Name=tag:Index,Values=0" "Name=status,Values=available" "Name=availability-zone,Values=us-east-1a" --region us-east-1 | grep 'VolumeID'; then
+        EBS_VOLUME_ID=`aws ec2 describe-volumes --filters "Name=tag:User,Values=$1" "Name=tag:Stage,Values=$2" "Name=tag:IsBig,Values=True" "Name=tag:Index,Values=0" "Name=status,Values=available" "Name=availability-zone,Values=us-east-1a" --region us-east-1 | jq '.Volumes[0].VolumeId' | tr -d '"'`
     else
-        EBS_VOLUME_ID=`aws ec2 describe-volumes --filters "Name=tag:User,Values=circleci" "Name=tag:Stage,Values=$1" "Name=tag:IsBig,Values=True" "Name=status,Values=available" "Name=availability-zone,Values=us-east-1a" --region us-east-1 | jq '.Volumes[0].VolumeId' | tr -d '"'`
+        EBS_VOLUME_ID=`aws ec2 describe-volumes --filters "Name=tag:User,Values=$1" "Name=tag:Stage,Values=$2" "Name=tag:IsBig,Values=True" "Name=status,Values=available" "Name=availability-zone,Values=us-east-1a" --region us-east-1 | jq '.Volumes[0].VolumeId' | tr -d '"'`
     fi
 
     aws ec2 attach-volume --volume-id $EBS_VOLUME_ID --instance-id $INSTANCE_ID --device "/dev/sdf" --region ${region}
 }
 
 export STAGE=${stage}
+export USER=${user}
 
-until fetch_and_mount_volume "$STAGE"; do
+until fetch_and_mount_volume "$USER" "$STAGE"; do
     sleep 10
 done
 

--- a/infrastructure/permissions.tf
+++ b/infrastructure/permissions.tf
@@ -107,6 +107,8 @@ resource "aws_iam_policy" "ec2_access_policy" {
   name = "data-refinery-ec2-access-policy-${var.user}-${var.stage}"
   description = "Allows EC2 Permissions."
 
+  # We can't iterate instances from the fleet, so allow attaching to any instance,
+  # but restrict which volumes can be attached.
   policy = <<EOF
 {
    "Version":"2012-10-17",
@@ -123,7 +125,8 @@ resource "aws_iam_policy" "ec2_access_policy" {
       {
          "Effect":"Allow",
          "Action": [
-            "ec2:AttachVolume"
+            "ec2:AttachVolume",
+            "ec2:CreateTags"
           ],
           "Resource": [
             "arn:aws:ec2:${var.region}:${data.aws_caller_identity.current.account_id}:volume/${element(aws_ebs_volume.data_refinery_ebs.*.id, 0)}",
@@ -137,8 +140,18 @@ resource "aws_iam_policy" "ec2_access_policy" {
             "arn:aws:ec2:${var.region}:${data.aws_caller_identity.current.account_id}:volume/${element(aws_ebs_volume.data_refinery_ebs.*.id, 8)}",
             "arn:aws:ec2:${var.region}:${data.aws_caller_identity.current.account_id}:volume/${element(aws_ebs_volume.data_refinery_ebs.*.id, 9)}",
             "arn:aws:ec2:${var.region}:${data.aws_caller_identity.current.account_id}:volume/${element(aws_ebs_volume.data_refinery_ebs.*.id, 10)}",
-            "arn:aws:ec2:${var.region}:${data.aws_caller_identity.current.account_id}:volume/${element(aws_ebs_volume.data_refinery_ebs.*.id, 11)}"
+            "arn:aws:ec2:${var.region}:${data.aws_caller_identity.current.account_id}:volume/${element(aws_ebs_volume.data_refinery_ebs.*.id, 11)}",
+            "arn:aws:ec2:${var.region}:${data.aws_caller_identity.current.account_id}:instance/*"
           ]
+      },
+      {
+        "Effect": "Allow",
+        "Action": [
+          "sts:DecodeAuthorizationMessage"
+        ],
+        "Resource": [
+          "*"
+        ]
       }
    ]
 }

--- a/infrastructure/permissions.tf
+++ b/infrastructure/permissions.tf
@@ -170,6 +170,8 @@ resource "aws_iam_policy" "cloudwatch_policy" {
 
   # Policy text found at:
   # http://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/iam-identity-based-access-control-cwl.html
+
+  # Log streams are created dynamically by Nomad, so we give permission to the entire group
   policy = <<EOF
 {
     "Version": "2012-10-17",
@@ -188,13 +190,7 @@ resource "aws_iam_policy" "cloudwatch_policy" {
                 "cloudwatch:SetAlarmState"
             ],
             "Resource": [
-              "arn:aws:logs:${var.region}:${aws_cloudwatch_log_group.data_refinery_log_group.name}:${aws_cloudwatch_log_stream.log_stream_surveyor.name}",
-              "arn:aws:logs:${var.region}:${aws_cloudwatch_log_group.data_refinery_log_group.name}:${aws_cloudwatch_log_stream.log_stream_processor.name}",
-              "arn:aws:logs:${var.region}:${aws_cloudwatch_log_group.data_refinery_log_group.name}:${aws_cloudwatch_log_stream.log_stream_downloader.name}",
-              "arn:aws:logs:${var.region}:${aws_cloudwatch_log_group.data_refinery_log_group.name}:${aws_cloudwatch_log_stream.log_stream_foreman.name}",
-              "arn:aws:logs:${var.region}:${aws_cloudwatch_log_group.data_refinery_log_group.name}:${aws_cloudwatch_log_stream.log_stream_api.name}",
-              "arn:aws:logs:${var.region}:${aws_cloudwatch_log_group.data_refinery_log_group.name}:${aws_cloudwatch_log_stream.log_stream_api_nginx_access.name}",
-              "arn:aws:logs:${var.region}:${aws_cloudwatch_log_group.data_refinery_log_group.name}:${aws_cloudwatch_log_stream.log_stream_api_nginx_error.name}"
+              "arn:aws:logs:${var.region}:${aws_cloudwatch_log_group.data_refinery_log_group.name}:*"
             ]
         }
     ]

--- a/infrastructure/permissions.tf
+++ b/infrastructure/permissions.tf
@@ -190,7 +190,7 @@ resource "aws_iam_policy" "cloudwatch_policy" {
                 "cloudwatch:SetAlarmState"
             ],
             "Resource": [
-              "arn:aws:logs:${var.region}:${aws_cloudwatch_log_group.data_refinery_log_group.name}:*"
+              "arn:aws:logs:${var.region}:${data.aws_caller_identity.current.account_id}:log-group:${aws_cloudwatch_log_group.data_refinery_log_group.name}:*"
             ]
         }
     ]

--- a/infrastructure/permissions.tf
+++ b/infrastructure/permissions.tf
@@ -114,7 +114,15 @@ resource "aws_iam_policy" "ec2_access_policy" {
       {
          "Effect":"Allow",
          "Action": [
-            "ec2:DescribeVolumes",
+            "ec2:DescribeVolumes"
+          ],
+          "Resource": [
+            "*"
+          ]
+      },
+      {
+         "Effect":"Allow",
+         "Action": [
             "ec2:AttachVolume"
           ],
           "Resource": [

--- a/infrastructure/users.tf
+++ b/infrastructure/users.tf
@@ -23,6 +23,26 @@ resource "aws_iam_user" "data-refinery-deployer" {
 }
 
 ##
+# Groups
+##
+
+resource "aws_iam_group" "data_refinery_group" {
+  name = "data-refinery-user-client-group-${var.user}-${var.stage}"
+}
+
+resource "aws_iam_group_membership" "data_refinery_group_membership" {
+  name = "tf-testing-group-membership"
+
+  users = [
+    "${aws_iam_user.data_refinery_user_client.name}",
+    "${aws_iam_user.data-refinery-deployer.name}",
+  ]
+
+  group = "${aws_iam_group.data_refinery_group.name}"
+}
+
+
+##
 # Roles
 ##
 
@@ -87,6 +107,11 @@ resource "aws_iam_policy_attachment" "data_refinery_user_policy_attachment_logs"
   policy_arn = "${aws_iam_policy.data_refinery_client_policy_logs.arn}"
 }
 
+resource "aws_iam_group_policy_attachment" "data_refinery_group_policy_attachment_logs" {
+  group      = "${aws_iam_group.data_refinery_group.name}"
+  policy_arn = "${aws_iam_policy.data_refinery_client_policy_logs.arn}"
+}
+
 # S3
 resource "aws_iam_policy" "data_refinery_client_policy_s3" {
   name = "data-refinery-user-client-s3-${var.user}-${var.stage}"
@@ -129,6 +154,11 @@ resource "aws_iam_policy_attachment" "data_refinery_user_policy_attachment_s3" {
   policy_arn = "${aws_iam_policy.data_refinery_client_policy_s3.arn}"
 }
 
+resource "aws_iam_group_policy_attachment" "data_refinery_group_policy_attachment_s3" {
+  group      = "${aws_iam_group.data_refinery_group.name}"
+  policy_arn = "${aws_iam_policy.data_refinery_client_policy_s3.arn}"
+}
+
 # SES
 resource "aws_iam_policy" "data_refinery_client_policy_ses" {
   name = "data-refinery-user-client-ses-${var.user}-${var.stage}"
@@ -153,6 +183,11 @@ EOF
 resource "aws_iam_policy_attachment" "data_refinery_user_policy_attachment_ses" {
   name       = "data-refinery-user-policy-attachment-${var.user}-${var.stage}"
   roles      = ["${aws_iam_role.data_refinery_user_role.name}"]
+  policy_arn = "${aws_iam_policy.data_refinery_client_policy_ses.arn}"
+}
+
+resource "aws_iam_group_policy_attachment" "data_refinery_group_policy_attachment_ses" {
+  group      = "${aws_iam_group.data_refinery_group.name}"
   policy_arn = "${aws_iam_policy.data_refinery_client_policy_ses.arn}"
 }
 
@@ -185,6 +220,11 @@ EOF
 resource "aws_iam_policy_attachment" "data_refinery_user_policy_attachment_ec2" {
   name       = "data-refinery-user-policy-attachment-${var.user}-${var.stage}"
   roles      = ["${aws_iam_role.data_refinery_user_role.name}"]
+  policy_arn = "${aws_iam_policy.data_refinery_client_policy_ec2.arn}"
+}
+
+resource "aws_iam_group_policy_attachment" "data_refinery_group_policy_attachment_ec2" {
+  group      = "${aws_iam_group.data_refinery_group.name}"
   policy_arn = "${aws_iam_policy.data_refinery_client_policy_ec2.arn}"
 }
 
@@ -224,6 +264,11 @@ EOF
 resource "aws_iam_policy_attachment" "data_refinery_user_policy_attachment_es" {
   name       = "data-refinery-user-policy-attachment-${var.user}-${var.stage}"
   roles      = ["${aws_iam_role.data_refinery_user_role.name}"]
+  policy_arn = "${aws_iam_policy.data_refinery_client_policy_es.arn}"
+}
+
+resource "aws_iam_group_policy_attachment" "data_refinery_group_policy_attachment_es" {
+  group      = "${aws_iam_group.data_refinery_group.name}"
   policy_arn = "${aws_iam_policy.data_refinery_client_policy_es.arn}"
 }
 

--- a/infrastructure/users.tf
+++ b/infrastructure/users.tf
@@ -76,6 +76,8 @@ EOF
 resource "aws_iam_policy" "data_refinery_client_policy_logs" {
   name = "data-refinery-user-client-logs-${var.user}-${var.stage}"
 
+
+  # Streams are dynamically created, allow anything in the group.
   policy = <<EOF
 {
     "Version": "2012-10-17",
@@ -87,13 +89,7 @@ resource "aws_iam_policy" "data_refinery_client_policy_logs" {
                 "logs:DescribeLogStreams"
             ],
             "Resource": [
-              "arn:aws:logs:${var.region}:${aws_cloudwatch_log_group.data_refinery_log_group.name}:${aws_cloudwatch_log_stream.log_stream_surveyor.name}",
-              "arn:aws:logs:${var.region}:${aws_cloudwatch_log_group.data_refinery_log_group.name}:${aws_cloudwatch_log_stream.log_stream_processor.name}",
-              "arn:aws:logs:${var.region}:${aws_cloudwatch_log_group.data_refinery_log_group.name}:${aws_cloudwatch_log_stream.log_stream_downloader.name}",
-              "arn:aws:logs:${var.region}:${aws_cloudwatch_log_group.data_refinery_log_group.name}:${aws_cloudwatch_log_stream.log_stream_foreman.name}",
-              "arn:aws:logs:${var.region}:${aws_cloudwatch_log_group.data_refinery_log_group.name}:${aws_cloudwatch_log_stream.log_stream_api.name}",
-              "arn:aws:logs:${var.region}:${aws_cloudwatch_log_group.data_refinery_log_group.name}:${aws_cloudwatch_log_stream.log_stream_api_nginx_access.name}",
-              "arn:aws:logs:${var.region}:${aws_cloudwatch_log_group.data_refinery_log_group.name}:${aws_cloudwatch_log_stream.log_stream_api_nginx_error.name}"
+              "arn:aws:logs:${var.region}:${aws_cloudwatch_log_group.data_refinery_log_group.name}:*"
             ]
         }
     ]

--- a/infrastructure/users.tf
+++ b/infrastructure/users.tf
@@ -31,7 +31,7 @@ resource "aws_iam_group" "data_refinery_group" {
 }
 
 resource "aws_iam_group_membership" "data_refinery_group_membership" {
-  name = "tf-testing-group-membership"
+  name = "data-refinery-user-group-membership-${var.user}-${var.stage}"
 
   users = [
     "${aws_iam_user.data_refinery_user_client.name}",


### PR DESCRIPTION
The IAM role policy limit is not any individual policy, but the _total_ bytes. Annoying!

The limit is higher for attached policies, so let's try it that way.