### PR TITLE
Use a single serializer for the dataset endpoint

### DIFF
--- a/api/data_refinery_api/views.py
+++ b/api/data_refinery_api/views.py
@@ -72,7 +72,6 @@ from data_refinery_api.serializers import (
     APITokenSerializer,
     CreateDatasetSerializer,
     DatasetSerializer,
-    DatasetWithUrlSerializer,
 )
 from data_refinery_common.job_lookup import ProcessorPipeline
 from data_refinery_common.message_queue import send_job
@@ -578,18 +577,17 @@ class DatasetView(generics.RetrieveUpdateAPIView):
     serializer_class = DatasetSerializer
     lookup_field = 'id'
 
-    def get(self, request, id=None, format=None):
-        dataset = get_object_or_404(Dataset, id=id)
-
+    def get_serializer_context(self):
+        """
+        Extra context provided to the serializer class.
+        """
+        serializer_context = super(DatasetView, self).get_serializer_context()
         token_id = self.request.META.get('HTTP_API_KEY', None)
-
         try:
             token = APIToken.objects.get(id=token_id, is_activated=True)
-            serializer = DatasetWithUrlSerializer(dataset)
-        except Exception: # General APIToken.DoesNotExist or django.core.exceptions.ValidationError
-            serializer = DatasetSerializer(dataset)
-
-        return Response(serializer.data)
+            return {**serializer_context, 'token': token}
+        except Exception:  # General APIToken.DoesNotExist or django.core.exceptions.ValidationError
+            return serializer_context
 
     def perform_update(self, serializer):
         """ If `start` is set, fire off the job. Disables dataset data updates after that. """


### PR DESCRIPTION
## Issue Number

fixes https://github.com/AlexsLemonade/refinebio-frontend/issues/611
fixes https://github.com/AlexsLemonade/refinebio-frontend/issues/610
fixes https://github.com/AlexsLemonade/refinebio-frontend/issues/600

## Purpose/Implementation Notes

https://github.com/AlexsLemonade/refinebio/pull/1109 added a new serializer for the datasets that included the `download_url` when an `API-KEY` header was provided. However also changed how the serializers were initialized, the one we had required information about the request params in order to decide what fields to return.

This PR goes back to using a single serializer, and moves all the logic that decides which fields to return to it's constructor.

The bugs mentioned before were caused because the FE got fields that wasn't expecting when getting details for the dataset.

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

Tested locally.

## Checklist

- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules