### PR TITLE
Search filters return platform accession codes instead of platform name

### DIFF
--- a/api/data_refinery_api/views.py
+++ b/api/data_refinery_api/views.py
@@ -269,8 +269,8 @@ class ExperimentDocumentView(DocumentViewSet):
                 'size': 999999
             }
         },
-        'platform_names': {
-            'field': 'platform_names',
+        'platform_accession_codes': {
+            'field': 'platform_accession_codes',
             'facet': TermsFacet,
             'enabled': True,
             'global': False,
@@ -284,7 +284,6 @@ class ExperimentDocumentView(DocumentViewSet):
             'enabled': True,
             'global': False,
         },
-
         # We don't actually need any "globals" to drive our web frontend,
         # but we'll leave them available but not enabled by default, as they're
         # expensive.


### PR DESCRIPTION
## Issue Number

https://github.com/AlexsLemonade/refinebio/issues/1181

## Purpose/Implementation Notes

Send the platform accession codes in the search filters instead of the platform names. The FE can query the `/platforms` endpoint to get each platform's formatted name.

## Types of changes

- Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Functional tests

I wasn't able to test this locally.

## Checklist

- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules