### PR TITLE
Normalize Smashed Header Format

### DIFF
--- a/workers/data_refinery_workers/processors/smasher.py
+++ b/workers/data_refinery_workers/processors/smasher.py
@@ -724,6 +724,9 @@ def _smash(job_context: Dict, how="inner") -> Dict:
             elif job_context['dataset'].aggregate_by == "ALL":
                 subdir = "ALL"
 
+            # Normalize the Header format
+            untransposed.index.rename('Gene', inplace=True)
+
             outfile_dir = smash_path + key + "/"
             os.makedirs(outfile_dir, exist_ok=True)
             outfile = outfile_dir + key + ".tsv"


### PR DESCRIPTION
The Smashed gene column should always be labeled "Gene".