### PR TITLE
Adds RUN_QN_JOB to Pipeline Enum

### DIFF
--- a/common/data_refinery_common/job_lookup.py
+++ b/common/data_refinery_common/job_lookup.py
@@ -36,6 +36,7 @@ class ProcessorPipeline(PipelineEnums):
     SMASHER = "SMASHER"
     NO_OP = "NO_OP"
     QN_REFERENCE = "RUN_QN_JOB"
+    RUN_QN_JOB = "RUN_QN_JOB"
     JANITOR = "JANITOR"
     NONE = "NONE"
 

--- a/workers/data_refinery_workers/processors/management/commands/run_processor_job.py
+++ b/workers/data_refinery_workers/processors/management/commands/run_processor_job.py
@@ -21,13 +21,18 @@ class Command(BaseCommand):
 
     def handle(self, *args, **options):
         if options["job_id"] is None:
-            logger.error("You must specify a job ID.")
+            logger.error("You must specify a job ID.",
+                job_id=options["job_id"]
+            )
             sys.exit(1)
 
         try:
             job_type = ProcessorPipeline[options["job_name"]]
         except KeyError:
-            logger.error("You must specify a valid job name.")
+            logger.error("You must specify a valid job name.",
+                job_name=options["job_name"],
+                job_id=options["job_id"]
+            )
             sys.exit(1)
 
         if job_type is ProcessorPipeline.AFFY_TO_PCL:


### PR DESCRIPTION
Dispatched jobs were failing an early check because this wasn't enumerated. Also improves accompanying logging.