### PR TITLE
Make cluster connect work for both linux and mac.

### DIFF
--- a/infrastructure/cluster_connect.sh
+++ b/infrastructure/cluster_connect.sh
@@ -1,2 +1,14 @@
 #! /bin/bash
-csshX --ssh_args "-i /Users/rjones/Projects/data-refinery/infrastructure/data-refinery-key.pem" --login ubuntu --hosts hosts
+
+# Connects to each host in the file 'hosts'
+# 'hosts' can be populated with 'lists_hosts.sh' which contains usage instructions.
+
+if [ $(cssh -v > /dev/null 2>&1; echo $?) == 0 ]; then
+    cssh --options "-i data-refinery-key.pem" --username ubuntu $(<hosts)
+elif [ $(csshX -v  > /dev/null 2>&1; echo $?) == 2 ]; then # MacOS, csshX has an exit code of 2 for -v...
+    csshX --ssh_args "-i data-refinery-key.pem" --login ubuntu --hosts hosts
+else
+    echo "You must have either cssh (linux) or csshX (MacOSX) installed."
+    echo 'cssh can be installed with: `sudo apt install clusterssh`'
+    echo 'csshX can be installed with: `brew install csshX`'
+fi

--- a/infrastructure/list_hosts.sh
+++ b/infrastructure/list_hosts.sh
@@ -1,10 +1,10 @@
 #! /bin/bash
 # Use like:
-# ./list_hosts rjones > hosts
+# ./list_hosts.sh data-refinery-key-circleci-prod > hosts
 # ./connect_cluster.sh
 
 if [[ $# -eq 0 ]] ; then
-    echo "Hey, you need to supply a user!" 
+    echo "Hey, you need to supply a user!"
     exit 0
 fi
 if [[ $# -eq 1 ]] ; then
@@ -14,4 +14,4 @@ else
 fi
 
 # /Users/rjones/Library/Python/2.7/bin/aws ec2 describe-instances --region=$REGION --filters "Name=tag:User,Values=$1" | grep PublicDnsName | tr -d '"' | sed "s/PublicDnsName: //g" | tr -d "," | awk '{$1=$1};1' | uniq
-aws ec2 describe-instances --region=$REGION --filters "Name=tag:User,Values=$1" | grep PublicDnsName | tr -d '"' | sed "s/PublicDnsName: //g" | tr -d "," | awk '{$1=$1};1' | uniq
+aws ec2 describe-instances --region=$REGION --filter "Name=key-name,Values=$1" | grep PublicDnsName | tr -d '"' | sed "s/PublicDnsName: //g" | tr -d "," | awk '{$1=$1};1' | uniq


### PR DESCRIPTION
## Issue Number

N/A I wanted teh POWAH

## Purpose/Implementation Notes

This makes lists_hosts.sh and cluster_connect.sh work on both linux and mac.

## Types of changes

- New feature (non-breaking change which adds functionality)

## Functional tests

I've tested these scripts on linux. I had Rich test an early version of the script to make sure the branching worked, but it'd be good to run the full thing and make sure it works.

## Checklist

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules
