### PR TITLE
Fix install_gene_convert.R to not have any version issues ever again?

### DIFF
--- a/workers/data_refinery_workers/processors/illumina.yml
+++ b/workers/data_refinery_workers/processors/illumina.yml
@@ -22,6 +22,7 @@ R:
   - Bioconductor
   - limma
   - oligo
+  - dplyr
   - illuminaHumanv1.db
   - illuminaHumanv2.db
   - illuminaHumanv3.db

--- a/workers/data_refinery_workers/processors/no_op.yml
+++ b/workers/data_refinery_workers/processors/no_op.yml
@@ -22,7 +22,7 @@ python:
 R:
   - AnnotationDbi
   - Bioconductor
-  - tidyverse
+  - dplyr
   - rlang
   - illuminaHumanv1.db
   - illuminaHumanv2.db

--- a/workers/illumina_dependencies.R
+++ b/workers/illumina_dependencies.R
@@ -6,8 +6,10 @@ devtools::install_version('doParallel', version='1.0.11')
 devtools::install_version('data.table', version='1.11.0')
 devtools::install_version('optparse', version='1.4.4')
 devtools::install_version('lazyeval', version='0.2.1')
-devtools::install_version('tidyverse', version='1.2.1')
 devtools::install_version('rlang', version='0.3.1')
+devtools::install_version('pillar', version='1.3.1')
+devtools::install_version('tibble', version='2.0.1')
+devtools::install_version('dplyr', version='0.7.8')
 
 # devtools::install_url() requires BiocInstaller
 install.packages('https://bioconductor.org/packages/3.6/bioc/src/contrib/BiocInstaller_1.28.0.tar.gz')

--- a/workers/install_gene_convert.R
+++ b/workers/install_gene_convert.R
@@ -1,10 +1,16 @@
+# Turn warnings into errors because biocLite throws warnings instead
+# of error if it fails to install something.
+options(warn=2)
 options(repos=structure(c(CRAN="https://cran.revolutionanalytics.com")))
 
 devtools::install_version('data.table', version='1.11.0')
 devtools::install_version('optparse', version='1.4.4')
 
-devtools::install_version('tidyverse', version='1.2.1')
 devtools::install_version('rlang', version='0.3.1')
+devtools::install_version('pillar', version='1.3.1')
+devtools::install_version('tibble', version='2.0.1')
+devtools::install_version('lazyeval', version='0.2.1')
+devtools::install_version('dplyr', version='0.7.8')
 
 # devtools::install_url() requires BiocInstaller
 install.packages('https://bioconductor.org/packages/3.6/bioc/src/contrib/BiocInstaller_1.28.0.tar.gz')

--- a/workers/install_gene_convert.R
+++ b/workers/install_gene_convert.R
@@ -11,6 +11,7 @@ devtools::install_version('pillar', version='1.3.1')
 devtools::install_version('tibble', version='2.0.1')
 devtools::install_version('lazyeval', version='0.2.1')
 devtools::install_version('dplyr', version='0.7.8')
+devtools::install_version('reshape2', version='1.4.3')
 
 # devtools::install_url() requires BiocInstaller
 install.packages('https://bioconductor.org/packages/3.6/bioc/src/contrib/BiocInstaller_1.28.0.tar.gz')


### PR DESCRIPTION
## Issue Number

N/A it broke CI today :(

## Purpose/Implementation Notes

The theory is that tidyverse doesn't pin any dependencies, so it was updating dplyr despite tidyverse itself being pinned. This installs everything from tidyverse and their dependencies that we need so the image will build successfully and so we won't have issues in the future with this.

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

The image built successfully locally, here's hoping it's good in CI too!

## Checklist

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules
