### PR TITLE
Use rest.ensembl.org api endpoint

### DIFF
--- a/foreman/data_refinery_foreman/surveyor/test_transcriptome_index.py
+++ b/foreman/data_refinery_foreman/surveyor/test_transcriptome_index.py
@@ -27,7 +27,6 @@ class SurveyTestCase(TestCase):
         key_value_pair.save()
 
     @patch('data_refinery_foreman.surveyor.external_source.message_queue.send_job')
-    @skip("We're doing a staging test to see if the new salmon version works.")
     def test_survey(self, mock_send_job):
         surveyor = TranscriptomeIndexSurveyor(self.survey_job)
         surveyor.survey(source_type="TRANSCRIPTOME_INDEX")
@@ -67,7 +66,6 @@ class SurveyTestCase(TestCase):
         for file in files:
             urllib.request.urlopen(file.source_url)
 
-    @skip("We're doing a staging test to see if the new salmon version works.")
     def test_correct_index_location_metazoa(self):
         """ Tests that the files returned actually exist.
 

--- a/foreman/data_refinery_foreman/surveyor/transcriptome_index.py
+++ b/foreman/data_refinery_foreman/surveyor/transcriptome_index.py
@@ -17,13 +17,14 @@ from data_refinery_foreman.surveyor.external_source import ExternalSourceSurveyo
 logger = get_and_configure_logger(__name__)
 
 
-DIVISION_URL_TEMPLATE = ("https://rest.ensemblgenomes.org/info/genomes/division/{division}"
+MAIN_DIVISION_URL_TEMPLATE = "https://rest.ensembl.org/info/species?content-type=application/json"
+DIVISION_URL_TEMPLATE = ("https://rest.ensembl.org/info/genomes/division/{division}"
                          "?content-type=application/json")
+
 TRANSCRIPTOME_URL_TEMPLATE = ("ftp://ftp.{url_root}/fasta/{species_sub_dir}/dna/"
                               "{filename_species}.{assembly}.dna.{schema_type}.fa.gz")
 GTF_URL_TEMPLATE = ("ftp://ftp.{url_root}/gtf/{species_sub_dir}/"
                     "{filename_species}.{assembly}.{assembly_version}.gtf.gz")
-MAIN_DIVISION_URL_TEMPLATE = "https://rest.ensembl.org/info/species?content-type=application/json"
 
 
 # For whatever reason the division in the download URL is shortened in
@@ -41,7 +42,7 @@ DIVISION_LOOKUP = {"EnsemblPlants": "plants",
 # release versions. These urls will return what the most recent
 # release version is.
 MAIN_RELEASE_URL = "https://rest.ensembl.org/info/software?content-type=application/json"
-DIVISION_RELEASE_URL = "https://rest.ensemblgenomes.org/info/eg_version?content-type=application/json"
+DIVISION_RELEASE_URL = "https://rest.ensembl.org/info/eg_version?content-type=application/json"
 
 
 class EnsemblUrlBuilder(ABC):
@@ -59,20 +60,15 @@ class EnsemblUrlBuilder(ABC):
         self.url_root = "ensemblgenomes.org/pub/release-{assembly_version}/{short_division}"
         self.short_division = DIVISION_LOOKUP[species["division"]]
         self.assembly = species["assembly_name"].replace(" ", "_")
-        self.assembly_version = utils.requests_retry_session().get(DIVISION_RELEASE_URL).json()["version"]
 
-        # Some species are nested within a collection directory. If
-        # this is the case, then we need to add that extra directory
-        # to the URL, and for whatever reason the filename is not
-        # capitalized.
-        COLLECTION_REGEX = r"^(.*_collection).*"
-        match_object = re.search(COLLECTION_REGEX, species["dbname"])
-        if match_object:
-            self.species_sub_dir = match_object.group(1) + "/" + species["species"]
-            self.filename_species = species["species"]
-        else:
-            self.species_sub_dir = species["species"]
-            self.filename_species = species["species"].capitalize()
+        # For some reason the API is returning version 44, which doesn't seem to exist
+        # in the FTP servers: ftp://ftp.ensemblgenomes.org/pub/
+        # That's why the version is hardcoded below.
+        # self.assembly_version = utils.requests_retry_session().get(DIVISION_RELEASE_URL).json()["version"]
+        self.assembly_version = '43'
+
+        self.species_sub_dir = species["name"]
+        self.filename_species = species["name"].capitalize()
 
         # These fields aren't needed for the URL, but they vary between
         # the two REST APIs.
@@ -127,7 +123,8 @@ class MainEnsemblUrlBuilder(EnsemblUrlBuilder):
         self.species_sub_dir = species["name"]
         self.filename_species = species["name"].capitalize()
         self.assembly = species["assembly"]
-        self.assembly_version = utils.requests_retry_session().get(MAIN_RELEASE_URL).json()["release"]
+        self.assembly_version = utils.requests_retry_session().get(
+            MAIN_RELEASE_URL).json()["release"]
         self.scientific_name = self.filename_species.replace("_", " ")
         self.taxonomy_id = species["taxon_id"]
 
@@ -205,7 +202,7 @@ class TranscriptomeIndexSurveyor(ExternalSourceSurveyor):
         url_builder = ensembl_url_builder_factory(species)
         fasta_download_url = url_builder.build_transcriptome_url()
         gtf_download_url = url_builder.build_gtf_url()
-
+        
         platform_accession_code = species.pop("division")
         self._clean_metadata(species)
 


### PR DESCRIPTION
## Issue Number

close #1301

## Purpose/Implementation Notes

Remove usages of the ensembl endpoint that was obsolete (https://rest.ensemblgenomes.org). A few fields were also deprecated like `species["dbname"]`, I removed those usages as well.

The branch [arielsvn/1301-ensembl-use-single-ftp](https://github.com/AlexsLemonade/refinebio/blob/arielsvn/1301-ensembl-use-single-ftp/foreman/data_refinery_foreman/surveyor/transcriptome_index.py) contains changes to use a single ftp server as well, but that is not yet correct. Leaving a reference here in case it's helpful in the future.

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

Ran tests locally.

## Checklist

- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules