### PR TITLE
Newest salmon version outputs version number to stdout instead of stderr

### DIFF
--- a/workers/data_refinery_workers/processors/transcriptome_index.py
+++ b/workers/data_refinery_workers/processors/transcriptome_index.py
@@ -216,7 +216,7 @@ def _create_index(job_context: Dict) -> Dict:
     # https://github.com/COMBINE-lab/salmon/issues/148
     job_context["salmon_version"] = subprocess.run(['salmon', '--version'],
                                                 stderr=subprocess.PIPE,
-                                                stdout=subprocess.PIPE).stderr.decode().strip()
+                                                stdout=subprocess.PIPE).stdout.decode().strip()
 
     # TODO: is this providing a filename prefix or a directory or both?
     rsem_prefix = os.path.join(job_context["rsem_index_dir"],

--- a/workers/data_refinery_workers/processors/utils.py
+++ b/workers/data_refinery_workers/processors/utils.py
@@ -675,13 +675,13 @@ def get_cmd_lines(cmd_list):
             )
 
         output_bytes = process_done.stdout
-        # Workaround for "salmon --version" and "salmontools --version"
-        # commands, whose outputs are both sent to stderr instead of stdout.
+        # Workaround for the "salmontools --version"
+        # command, whose outputs are sent to stderr instead of stdout.
         # Alternatively, we could have used "stderr=subprocess.STDOUT" when
         # initializing process_done, but it is probably a better idea to
         # keep stdout and stderr separate.
         base_cmd = cmd.strip().split()[0]
-        if base_cmd == 'salmon' or base_cmd == "salmontools":
+        if base_cmd == "salmontools":
             output_bytes = process_done.stderr
 
         cmd_output = output_bytes.decode().strip()


### PR DESCRIPTION
## Issue Number

#1302 

## Purpose/Implementation Notes

I noticed the new organism indices I generated didn't have a salmon version, this is why.

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

Testing locally (well really on Jackie's computer)

## Checklist

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules
