### PR TITLE
Exposes the field `quantile_normalize` in the dataset endpoint.

### DIFF
--- a/api/data_refinery_api/serializers.py
+++ b/api/data_refinery_api/serializers.py
@@ -569,16 +569,14 @@ class DatasetDetailsExperimentSerializer(serializers.ModelSerializer):
     """ This serializer contains all of the information about an experiment needed for the download
     page
     """
-    organisms = serializers.StringRelatedField(many=True)
+    organisms = serializers.ReadOnlyField(source='organism_names')
     sample_metadata = serializers.ReadOnlyField(source='sample_metadata_fields')
-    pretty_platforms = serializers.ReadOnlyField()
 
     class Meta:
         model = Experiment
         fields = (
                     'title',
                     'accession_code',
-                    'pretty_platforms',
                     'organisms',
                     'sample_metadata',
                     'technology'
@@ -705,7 +703,7 @@ class DatasetSerializer(serializers.ModelSerializer):
 
     def get_experiments(self, obj):
         """ Call `get_experiments` in the model but add some `prefetch_related` calls """
-        experiments = obj.get_experiments().prefetch_related('organisms')
+        experiments = obj.get_experiments()
         return DatasetDetailsExperimentSerializer(experiments, many=True).data
 
 

--- a/api/data_refinery_api/serializers.py
+++ b/api/data_refinery_api/serializers.py
@@ -584,7 +584,7 @@ class DatasetDetailsExperimentSerializer(serializers.ModelSerializer):
 
 class DatasetSerializer(serializers.ModelSerializer):
     start = serializers.NullBooleanField(required=False)
-    experiments = serializers.SerializerMethodField(read_only=True)
+    experiments = DatasetDetailsExperimentSerializer(source='get_experiments', many=True, read_only=True)
     organism_samples = serializers.SerializerMethodField(read_only=True)
 
     def __init__(self, *args, **kwargs):
@@ -700,12 +700,6 @@ class DatasetSerializer(serializers.ModelSerializer):
             result[sample['organism__name']].append(sample['accession_code'])
 
         return result
-
-    def get_experiments(self, obj):
-        """ Call `get_experiments` in the model but add some `prefetch_related` calls """
-        experiments = obj.get_experiments()
-        return DatasetDetailsExperimentSerializer(experiments, many=True).data
-
 
 class APITokenSerializer(serializers.ModelSerializer):
 

--- a/api/data_refinery_api/serializers.py
+++ b/api/data_refinery_api/serializers.py
@@ -570,7 +570,7 @@ class DatasetDetailsExperimentSerializer(serializers.ModelSerializer):
     page
     """
     organisms = serializers.StringRelatedField(many=True)
-    sample_metadata = serializers.ReadOnlyField(source='get_sample_metadata_fields')
+    sample_metadata = serializers.ReadOnlyField(source='sample_metadata_fields')
     pretty_platforms = serializers.ReadOnlyField()
 
     class Meta:
@@ -581,6 +581,7 @@ class DatasetDetailsExperimentSerializer(serializers.ModelSerializer):
                     'pretty_platforms',
                     'organisms',
                     'sample_metadata',
+                    'technology'
                 )
 
 class DatasetSerializer(serializers.ModelSerializer):
@@ -628,7 +629,8 @@ class DatasetSerializer(serializers.ModelSerializer):
                     'sha1',
                     'experiments',
                     'organism_samples',
-                    'download_url'
+                    'download_url',
+                    'quantile_normalize'
             )
         extra_kwargs = {
                         'id': {
@@ -703,7 +705,7 @@ class DatasetSerializer(serializers.ModelSerializer):
 
     def get_experiments(self, obj):
         """ Call `get_experiments` in the model but add some `prefetch_related` calls """
-        experiments = obj.get_experiments().prefetch_related('samples').prefetch_related('organisms')
+        experiments = obj.get_experiments().prefetch_related('organisms')
         return DatasetDetailsExperimentSerializer(experiments, many=True).data
 
 


### PR DESCRIPTION
## Issue Number

https://github.com/AlexsLemonade/refinebio-frontend/issues/629

## Purpose/Implementation Notes

Exposes the field `quantile_normalize` in the dataset endpoint.

Adds small optimizations on the dataset serializers to use cached experiment fields.

## Types of changes

- New feature (non-breaking change which adds functionality)

## Functional tests

Tested locally.

## Checklist

- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules

## Screenshots

![2019-05-17 14 50 01](https://user-images.githubusercontent.com/1882507/57949705-25ca3a00-78b3-11e9-81be-869c0ab9d1c5.gif)