### PR TITLE
Fix the run nomad script which got broken by the double quote branch.

### DIFF
--- a/run_nomad.sh
+++ b/run_nomad.sh
@@ -99,10 +99,10 @@ fi
 
 # Start Nomad in both server and client mode locally
 nomad agent -bind "$HOST_IP" \
-      -data-dir "$nomad_dir" "$TEST_NOMAD_CONFIG" \
+      -data-dir "$nomad_dir" $TEST_NOMAD_CONFIG \
       -config nomad_client.config \
       -dev \
-    &> nomad.logs"$TEST_POSTFIX" &
+    &> nomad.logs$TEST_POSTFIX &
 
 export NOMAD_ADDR="http://$HOST_IP:$NOMAD_PORT"
 


### PR DESCRIPTION
## Issue Number

#1261 

## Purpose/Implementation Notes

These  variables were supposed to not be in double quotes so they disappear if they aren't set.

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

I couldn't run nomad locally before this change, now I can!

## Checklist

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules
