### PR TITLE
Kurtwheeler/fastq dump split 3

### DIFF
--- a/foreman/data_refinery_foreman/surveyor/test_end_to_end.py
+++ b/foreman/data_refinery_foreman/surveyor/test_end_to_end.py
@@ -575,7 +575,10 @@ class SraRedownloadingTestCase(TransactionTestCase):
             organism = Organism(name="HOMO_SAPIENS", taxonomy_id=9606, is_scientific_name=True)
             organism.save()
 
-            survey_job = surveyor.survey_experiment("SRP040623", "SRA")
+            # survey_job = surveyor.survey_experiment("SRP040623", "SRA")
+            # survey_job = surveyor.survey_experiment("ERP022060", "SRA")
+            # OK so I think this will be best because this has unmated reads and is only 15GB big.
+            survey_job = surveyor.survey_experiment("SRP015332", "SRA")
 
             self.assertTrue(survey_job.success)
 

--- a/foreman/data_refinery_foreman/surveyor/test_end_to_end.py
+++ b/foreman/data_refinery_foreman/surveyor/test_end_to_end.py
@@ -561,7 +561,6 @@ class GeoCelgzRedownloadingTestCase(TransactionTestCase):
 class SraRedownloadingTestCase(TransactionTestCase):
     @tag("slow")
     @tag("salmon")
-    @skip("We're doing a staging test to see if the new salmon version works.")
     def test_sra_redownloading(self):
         """Survey, download, then process an experiment we know is SRA."""
         # Clear out pre-existing work dirs so there's no conflicts:

--- a/run_nomad.sh
+++ b/run_nomad.sh
@@ -99,10 +99,10 @@ fi
 
 # Start Nomad in both server and client mode locally
 nomad agent -bind "$HOST_IP" \
-      -data-dir "$nomad_dir" "$TEST_NOMAD_CONFIG" \
+      -data-dir "$nomad_dir" $TEST_NOMAD_CONFIG \
       -config nomad_client.config \
       -dev \
-    &> nomad.logs"$TEST_POSTFIX" &
+    &> nomad.logs$TEST_POSTFIX &
 
 export NOMAD_ADDR="http://$HOST_IP:$NOMAD_PORT"
 

--- a/workers/data_refinery_workers/processors/salmon.py
+++ b/workers/data_refinery_workers/processors/salmon.py
@@ -729,32 +729,49 @@ def _run_salmon(job_context: Dict) -> Dict:
                                                    output_directory=job_context["output_directory"])
         # Paired are trickier
         else:
+            # fastq-dump does not allow you to choose the names of its
+            # output files. With the --split-3 option it will output
+            # paired reads to:
+            #   * <ACCESSION_CODE>_1.fastq
+            #   * <ACCESSION_CODE>_2.fastq
+            # and if there are unmated reads they will be output to:
+            #   * <ACCESSION_CODE>.fastq
+            # We don't care about unmated reads, so we'll just forward
+            # that to /dev/null. We'll still use a named pipe so that
+            # we don't have to use any I/O to write it to disk,
+            # however we do need to read it out because otherwise
+            # fastq-dump will hang until the data is read out of the
+            # pipe.
+            alpha_fifo = job_context["work_dir"] + job_context["sample_accession_code"] + "_1.fastq"
+            os.mkfifo(alpha_fifo)
+            beta_fifo = job_context["work_dir"] + job_context["sample_accession_code"] + "_2.fastq"
+            os.mkfifo(beta_fifo)
+            unmated_fifo = job_context["work_dir"] + job_context["sample_accession_code"] + ".fastq"
+            os.mkfifo(unmated_fifo)
 
-            # Okay, for some reason I can't explain, this only works in the temp directory,
-            # otherwise the `tee` part will only output to one or the other of the streams (non-deterministically),
-            # but not both. This doesn't appear to happen if the fifos are in tmp.
-            alpha = "/tmp/alpha"
-            os.mkfifo(alpha)
-            beta = "/tmp/beta"
-            os.mkfifo(beta)
+            unmated_process = subprocess.Popen(["cat", unmated_fifo, ">", "/dev/null", "&"],
+                                               shell=True,
+                                               executable='/bin/bash',
+                                               stdout=subprocess.PIPE,
+                                               stderr=subprocess.STDOUT)
 
-            dump_str = "fastq-dump --stdout --split-files -I {input_sra_file} | tee >(grep '@.*\.1\s' -A3 --no-group-separator > {fifo_alpha}) >(grep '@.*\.2\s' -A3 --no-group-separator > {fifo_beta}) > /dev/null &"
-            formatted_dump_command = dump_str.format(input_sra_file=job_context["sra_input_file_path"],
-                                                   fifo_alpha=alpha,
-                                                   fifo_beta=beta)
-            dump_po = subprocess.Popen(formatted_dump_command,
-                                        shell=True,
-                                        executable='/bin/bash',
-                                        stdout=subprocess.PIPE,
-                                        stderr=subprocess.STDOUT)
+            # Call `cd` so we know where fastq-dump will be dumping files to.
+            dump_str = "cd {work_dir} && fastq-dump --stdout --split-3 -I {input_sra_file} &"
+            formatted_dump_command = dump_str.format(work_dir=job_context["work_dir"],
+                                                     input_sra_file=job_context["sra_input_file_path"])
+            subprocess.Popen(formatted_dump_command,
+                             shell=True,
+                             executable='/bin/bash',
+                             stdout=subprocess.PIPE,
+                             stderr=subprocess.STDOUT)
 
             command_str = ( "salmon --no-version-check quant -l A -i {index} "
-                            "-1 {fifo_alpha} -2 {fifo_beta} -p 16 -o {output_directory} --seqBias --dumpEq --writeUnmappedNames"
+                            "-1 {alpha_fifo} -2 {beta_fifo} -p 16 -o {output_directory} --seqBias --dumpEq --writeUnmappedNames"
                          )
             formatted_command = command_str.format(index=job_context["index_directory"],
                                                    input_sra_file=job_context["sra_input_file_path"],
-                                                   fifo_alpha=alpha,
-                                                   fifo_beta=beta,
+                                                   alpha_fifo=alpha_fifo,
+                                                   beta_fifo=beta_fifo,
                                                    output_directory=job_context["output_directory"])
 
     else:

--- a/workers/data_refinery_workers/processors/test_salmon.py
+++ b/workers/data_refinery_workers/processors/test_salmon.py
@@ -322,7 +322,7 @@ class SalmonTestCase(TestCase):
 
         og_read_2 = OriginalFile()
         og_read_2.absolute_file_path = os.path.join(experiment_dir, "raw/reads_2.fastq")
-        og_read_2.filename = "reads_1.fastq"
+        og_read_2.filename = "reads_2.fastq"
         og_read_2.save()
 
         OriginalFileSampleAssociation.objects.create(original_file=og_read_2, sample=test_sample).save()

--- a/workers/dockerfiles/Dockerfile.salmon
+++ b/workers/dockerfiles/Dockerfile.salmon
@@ -40,7 +40,7 @@ RUN groupadd user && useradd --create-home --home-dir /home/user -g user user
 WORKDIR /home/user
 
 # Install Salmon
-ENV SALMON_VERSION 0.13.1
+ENV SALMON_VERSION 0.9.1
 RUN wget https://github.com/COMBINE-lab/salmon/releases/download/v${SALMON_VERSION}/Salmon-${SALMON_VERSION}_linux_x86_64.tar.gz
 RUN mkdir Salmon-${SALMON_VERSION}_linux_x86_64
 # On version 0.13.1 salmon was being extracted to a folder with an all lowercase name

--- a/workers/run_tests.sh
+++ b/workers/run_tests.sh
@@ -461,9 +461,6 @@ for image in ${worker_images[*]}; do
         elif [[ $tag == "janitor" ]]; then
             ./prepare_image.sh -i smasher -s workers
             image_name=ccdlstaging/dr_smasher
-        elif [[ $tag == "salmon" ]]; then
-            # ignore salmon tests temporarily
-            continue
         else
             ./prepare_image.sh -i $image -s workers
             image_name=ccdlstaging/dr_$image

--- a/workers/run_tests.sh
+++ b/workers/run_tests.sh
@@ -82,28 +82,41 @@ if [[ -z $tag || $tag == "salmon" ]]; then
     git clone https://github.com/dongbohu/tximport_test.git $volume_directory/tximport_test
 
     # Make sure data for Salmon test is downloaded from S3.
-    rna_seq_test_raw_dir="$volume_directory/raw/TEST/SALMON"
+    ERR1562482_dir="$volume_directory/TEST/ERR1562482"
     read_1_name="ERR1562482_1.fastq.gz"
     read_2_name="ERR1562482_2.fastq.gz"
-    dotsra_name="ERR1562482.sra"
-    rna_seq_test_data_1="$rna_seq_test_raw_dir/$read_1_name"
-    rna_seq_test_data_2="$rna_seq_test_raw_dir/$read_2_name"
-    dotsra="$rna_seq_test_raw_dir/$dotsra_name"
-    if [ ! -e "$rna_seq_test_data_1" ]; then
-        mkdir -p $rna_seq_test_raw_dir
+    fastq_test_data_1="$ERR1562482_dir/$read_1_name"
+    fastq_test_data_2="$ERR1562482_dir/$read_2_name"
+    if [ ! -e "$fastq_test_data_1" ]; then
+        mkdir -p $ERR1562482_dir
         echo "Downloading $read_1_name for Salmon tests."
-        wget -q -O $rna_seq_test_data_1 \
+        wget -q -O $fastq_test_data_1 \
              "$test_data_repo/$read_1_name"
         echo "Downloading $read_2_name for Salmon tests."
-        wget -q -O $rna_seq_test_data_2 \
+        wget -q -O $fastq_test_data_2 \
              "$test_data_repo/$read_2_name"
     fi
-    if [ ! -e "$dotsra" ]; then
-        mkdir -p $rna_seq_test_raw_dir
-        echo "Downloading $dotsra_name for Salmon tests."
-        wget -q -O $dotsra \
-             "$test_data_repo/$dotsra_name"
+
+    SRR1944916_dir="$volume_directory/TEST/SRR1944916"
+    SRR1944916_name="SRR1944916.sra"
+    SRR1944916_data="$SRR1944916_dir/$SRR1944916_name"
+    if [ ! -e "$SRR1944916_data" ]; then
+        mkdir -p $SRR1944916_dir
+        echo "Downloading $SRR1944916_name for Salmon tests."
+        wget -q -O $SRR1944916_data \
+             "$test_data_repo/$SRR1944916_name"
     fi
+
+    SRR548309_dir="$volume_directory/TEST/SRR548309"
+    SRR548309_name="SRR548309.sra"
+    SRR548309_data="$SRR548309_dir/$SRR548309_name"
+    if [ ! -e "$SRR548309_data" ]; then
+        mkdir -p $SRR548309_dir
+        echo "Downloading $SRR548309_name for Salmon tests."
+        wget -q -O $SRR548309_data \
+             "$test_data_repo/$SRR548309_name"
+    fi
+
 fi
 
 if [[ -z $tag || $tag == "affymetrix" ]]; then


### PR DESCRIPTION
## Issue Number

#1317 

## Purpose/Implementation Notes

This PR attempts to use the `--split-3` option of fastq-dump to filter out unmated reads so that salmon doesn't hang. I think it does it fairly well, however there is an issue in that sometimes one pipe fills up, causing fastq-dump and then accordingly salmon to hang. One of the samples used in the salmon tests triggers this error. I think the thing that needs to happen to make this work generally is to have much larger buffers in between fastq-dump and salmon.

I tried to use `fcntl` to do this but examples such as https://www.golinuxhub.com/2018/05/how-to-view-and-increase-default-pipe-size-buffer.html ended up hanging because opening a named pipe causes the program to hang until something is doing the opposite (for example if you open it for reading the program will hang until something starts writing to it). I'm not sure if this is a python issue or not, trying to do this in C is probably a decent next step.

Other next steps that could be pursued would be to use a message queue or an in-memory database like rabbitmq or redis. Additionally there could be a hack that would be simpler where we link a whole bunch of smaller pipes together to combine the size of their buffers together.

## Methods

The scientific implications of this PR are that for samples with unmated reads, we will throw those unmated reads away.

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

I've chosen samples for the unit tests that cover the cases that we need to: a sample with unmated reads and one without.

## Checklist

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules
