### PR TITLE
Note `quantile_normalized` field in JSON

### DIFF
--- a/workers/README_DATASET.md
+++ b/workers/README_DATASET.md
@@ -9,6 +9,8 @@ This download includes gene expression matrices and experiment and sample metada
 
 * The `aggregated_metadata.json` file contains information about the options you selected for download.
 Specifically, the `aggregate_by` and `scale_by` fields note how the samples are grouped into gene expression matrices and how the gene expression data values were transformed, respectively.
+The `quantile_normalized` fields notes whether or not quantile normalization was performed.
+Currently, we only support skipping quantile normalization for RNA-seq experiments when aggregating by experiment on the web interface.
 
 * Individual gene expression matrices and their corresponding sample metadata files are in their own directories.
 


### PR DESCRIPTION
## Issue Number

Related to: https://github.com/AlexsLemonade/refinebio/pull/1303 and https://github.com/AlexsLemonade/refinebio-docs/issues/95

## Purpose/Implementation Notes

Adds information about the `quantile_normalized` field in `aggregated_metadata.json` in the README.md included in a dataset download.

## Checklist

_Put an `x` in the boxes that apply._

- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules
