### PR TITLE
[HOTFIX] For whatever reason we were throwing away the logs from the docker daemon

### DIFF
--- a/infrastructure/nomad-configuration/client-smasher-instance-user-data.tpl.sh
+++ b/infrastructure/nomad-configuration/client-smasher-instance-user-data.tpl.sh
@@ -55,7 +55,7 @@ echo "
 # Cannot specify bip option in config file because it is hardcoded in
 # the startup command because docker is run by clowns.
 service docker stop
-nohup /usr/bin/dockerd -s overlay2 --bip=172.17.77.1/22 --log-driver=json-file --log-opt max-size=100m --log-opt max-file=3 > /dev/null &
+nohup /usr/bin/dockerd -s overlay2 --bip=172.17.77.1/22 --log-driver=json-file --log-opt max-size=100m --log-opt max-file=3 > /var/log/docker_daemon.log &
 
 # Output the files we need to start up Nomad and register jobs:
 # (Note that the lines starting with "$" are where


### PR DESCRIPTION
## Issue Number

N/A came up while recreating the zebrafish compendium

## Purpose/Implementation Notes

I don't know why we were sending these to /dev/null, but that made it very difficult to debug why Nomad won't start my compendium job.

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

N/A

## Checklist

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules
