### PR TITLE
Upload QN targets to the correct bucket.

### DIFF
--- a/workers/data_refinery_workers/processors/qn_reference.py
+++ b/workers/data_refinery_workers/processors/qn_reference.py
@@ -25,7 +25,6 @@ from data_refinery_common.utils import get_env_variable
 from data_refinery_workers.processors import utils, smasher
 
 
-S3_BUCKET_NAME = get_env_variable("S3_QN_TARGET_BUCKET_NAME", "data-refinery")
 logger = get_and_configure_logger(__name__)
 
 

--- a/workers/data_refinery_workers/processors/utils.py
+++ b/workers/data_refinery_workers/processors/utils.py
@@ -40,6 +40,7 @@ logger = get_and_configure_logger(__name__)
 # Let this fail if SYSTEM_VERSION is unset.
 SYSTEM_VERSION = get_env_variable("SYSTEM_VERSION")
 S3_BUCKET_NAME = get_env_variable("S3_BUCKET_NAME", "data-refinery")
+S3_QN_TARGET_BUCKET_NAME = get_env_variable("S3_QN_TARGET_BUCKET_NAME", "data-refinery")
 DIRNAME = os.path.dirname(os.path.abspath(__file__))
 CURRENT_JOB = None
 
@@ -418,6 +419,13 @@ def end_job(job_context: Dict, abort=False):
                 original_file.delete_local_file()
 
     if success:
+        # QN reference files go to a special bucket so they can be
+        # publicly available.
+        if job_context["job"].pipeline_applied == "QN_REFERENCE":
+            s3_bucket = S3_QN_TARGET_BUCKET_NAME
+        else:
+            s3_bucket = S3_BUCKET_NAME
+
         # S3-sync Computed Files
         for computed_file in job_context.get('computed_files', []):
             # Ensure even distribution across S3 servers


### PR DESCRIPTION
## Issue Number

#1257 

## Purpose/Implementation Notes

I noticed that after deploying #1115 and created a QN target that the QN target got uploaded to the wrong bucket. This fixes that.

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

N/A. Creating a QN target is a lot so I'm gonna test this in staging again.

## Checklist

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules
