### PR TITLE
Use dynamodb for terraform state locking.

### DIFF
--- a/infrastructure/deploy.sh
+++ b/infrastructure/deploy.sh
@@ -18,7 +18,7 @@ print_options() {
     echo '   "-e dev" will deploy a dev stack which is appropriate for a single developer to use to test.'
     echo '-d May be used to override the Dockerhub repo where the images will be pulled from.'
     echo '   This may also be specified by setting the TF_VAR_dockerhub_repo environment variable.'
-    echo '   If unset, defaults to the value in `infrastructure/environments/$env`, which is "ccdlstaging"'
+    echo '   If unset, defaults to "ccdlstaging" if the version contains "-dev" and "ccdl" otherwise.'
     echo '   for dev and staging environments and "ccdl" for prod.'
     echo '   This option is useful for testing code changes. Images with the code to be tested can be pushed'
     echo '   to your private Dockerhub repo and then the system will find them.'
@@ -78,6 +78,14 @@ fi
 if [[ -z $SYSTEM_VERSION ]]; then
     echo 'Error: must specify the system version with -v.'
     exit 1
+fi
+
+if [[ -z $TF_VAR_dockerhub_repo ]]; then
+    if [[ $SYSTEM_VERSION == *"-dev" ]]; then
+        export TF_VAR_dockerhub_repo=ccdlstaging
+    else
+        export TF_VAR_dockerhub_repo=ccdl
+    fi
 fi
 
 if [[ -z $TF_VAR_region ]]; then

--- a/infrastructure/init_terraform.sh
+++ b/infrastructure/init_terraform.sh
@@ -21,4 +21,5 @@ rm -rf .terraform
 terraform init \
     -force-copy \
     -backend-config="bucket=refinebio-tfstate-deploy-$STAGE" \
-    -backend-config="key=terraform-${TF_VAR_user}.tfstate"
+    -backend-config="key=terraform-${TF_VAR_user}.tfstate" \
+    -backend-config="dynamodb_table=refinebio-terraform-lock"


### PR DESCRIPTION
## Issue Number

#461 

## Purpose/Implementation Notes

There's a couple things about this which aren't obvious. The first is the dynamodb table. Since this is being used by terraform to manage our infrastructure's state, I am not managing this with terraform. This is similar to what we did for the S3 buckets which store the state files.

The second thing is that it seems enabling state locking on a terraform stack that already exists causes the following error:
```
Error refreshing state: state data in S3 does not have the expected content.

This may be caused by unusually long delays in S3 processing a previous state
update.  Please wait for a minute or two and try again. If this problem
persists, and neither S3 nor DynamoDB are experiencing an outage, you may need
to manually verify the remote state and update the Digest value stored in the
DynamoDB table to the following value: 607b05b86830c4676a6a84a7abea8cb5
```

However I found that going into dynamodb and manually changing that as instructed worked and enabled the deploy. Therefore I expect that I will have to take this manual step for staging and prod, and I don't know how to get that value other than letting the deploys fail.

So in short the plan is:
  * Deploy to staging
  * Let that deploy fail
  * Go on deploy box and get the value needed for dynamodb.
  * Update that value
  * Deploy to staging, which should work

And then the same for prod after that.

## Types of changes

- New feature (non-breaking change which adds functionality)

## Functional tests

I tested this with a dev stack from scratch.
I also tested this with a dev stack that already existed, which is how I know about the error I pointed out above.

## Checklist

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules
