### PR TITLE
[WIP] Switch the SRA downloader over to use HTTPS instead of aspera.

### DIFF
--- a/common/data_refinery_common/utils.py
+++ b/common/data_refinery_common/utils.py
@@ -306,7 +306,7 @@ def get_fasp_sra_download(run_accession: str):
 
     These URLs should not actually include the protcol."""
     full_url = get_sra_download_url(run_accession, 'fasp')
-    sra_url = resp.text.split('\n')[1].split('|')[6].split('fasp://')[1]
+    sra_url = full_url.text.split('\n')[1].split('|')[6].split('fasp://')[1]
     return sra_url
 
 def get_https_sra_download(run_accession: str):

--- a/common/data_refinery_common/utils.py
+++ b/common/data_refinery_common/utils.py
@@ -306,8 +306,11 @@ def get_fasp_sra_download(run_accession: str):
 
     These URLs should not actually include the protcol."""
     full_url = get_sra_download_url(run_accession, 'fasp')
-    sra_url = full_url.text.split('\n')[1].split('|')[6].split('fasp://')[1]
-    return sra_url
+    if full_url:
+        sra_url = full_url.split('fasp://')[1]
+        return sra_url
+    else:
+        return None
 
 def get_https_sra_download(run_accession: str):
     """Get an HTTPS URL for SRA."""

--- a/workers/data_refinery_workers/downloaders/sra.py
+++ b/workers/data_refinery_workers/downloaders/sra.py
@@ -13,7 +13,7 @@ from data_refinery_common.models import (
     DownloaderJobOriginalFileAssociation,
     OriginalFile,
 )
-from data_refinery_common.utils import get_env_variable, get_fasp_sra_download
+from data_refinery_common.utils import get_env_variable, get_https_sra_download
 from data_refinery_workers.downloaders import utils
 
 logger = get_and_configure_logger(__name__)
@@ -38,14 +38,14 @@ def _download_file(download_url: str,
     elif "ncbi.nlm.nih.gov" in download_url and not force_ftp:
         # Try to convert old-style endpoints into new-style endpoints if possible
         try:
-            if 'anonftp' in download_url:
+            if 'anonftp' in download_url or 'dbtest' in download_url:
                 accession = download_url.split('/')[-1].split('.sra')[0]
-                new_url = get_fasp_sra_download(accession)
+                new_url = get_https_sra_download(accession)
                 if new_url:
                     download_url = new_url
         except Exception:
             pass
-        return _download_file_aspera(download_url, downloader_job, target_file_path, source="NCBI")
+        return _download_file_http(download_url, downloader_job, target_file_path)
     else:
         return _download_file_ftp(download_url, downloader_job, target_file_path)
 
@@ -73,6 +73,29 @@ def _download_file_ftp(download_url: str, downloader_job: DownloaderJob, target_
         downloader_job.failure_reason = ("Exception caught while downloading "
                                          "file from the URL via FTP: {}").format(download_url)
         return False
+
+    return True
+
+
+def _download_file_http(download_url: str,
+                        downloader_job: DownloaderJob,
+                        target_file_path: str
+                          ) -> bool:
+    try:
+        logger.debug("Downloading file from %s to %s using HTTP.",
+                     download_url,
+                     target_file_path,
+                     downloader_job=downloader_job.id)
+        target_file = open(target_file_path, "wb")
+        with closing(urllib.request.urlopen(download_url, timeout=60)) as request:
+            shutil.copyfileobj(request, target_file, CHUNK_SIZE)
+    except Exception:
+        logger.exception("Exception caught while downloading file.",
+                         downloader_job=downloader_job.id)
+        downloader_job.failure_reason = "Exception caught while downloading file"
+        return False
+    finally:
+        target_file.close()
 
     return True
 

--- a/workers/data_refinery_workers/downloaders/sra.py
+++ b/workers/data_refinery_workers/downloaders/sra.py
@@ -82,11 +82,12 @@ def _download_file_http(download_url: str,
                         target_file_path: str
                           ) -> bool:
     try:
+        target_file = open(target_file_path, "wb")
         logger.debug("Downloading file from %s to %s using HTTP.",
                      download_url,
                      target_file_path,
                      downloader_job=downloader_job.id)
-        target_file = open(target_file_path, "wb")
+
         with closing(urllib.request.urlopen(download_url, timeout=60)) as request:
             shutil.copyfileobj(request, target_file, CHUNK_SIZE)
     except Exception:

--- a/workers/data_refinery_workers/downloaders/test_sra.py
+++ b/workers/data_refinery_workers/downloaders/test_sra.py
@@ -30,7 +30,7 @@ class DownloadSraTestCase(TestCase):
     # @patch('data_refinery_workers.downloaders.utils.send_job')
     # def test_download_file(self, mock_send_job):
     #     mock_send_job.return_value = None
-        
+
     #     dlj = DownloaderJob()
     #     dlj.accession_code = "ERR036"
     #     dlj.save()
@@ -62,17 +62,17 @@ class DownloadSraTestCase(TestCase):
     @patch('data_refinery_workers.downloaders.utils.send_job')
     def test_download_file_ncbi(self, mock_send_job):
         mock_send_job.return_value = None
-        
+
         dlj = DownloaderJob()
-        dlj.accession_code = "DRR002116"
+        dlj.accession_code = "SRR9117853"
         dlj.save()
         og = OriginalFile()
-        og.source_filename = "DRR002116.sra"
-        og.source_url = "anonftp@ftp.ncbi.nlm.nih.gov:/sra/sra-instant/reads/ByRun/sra/DRR/DRR002/DRR002116/DRR002116.sra"
+        og.source_filename = "SRR9117853.sra"
+        og.source_url = "anonftp@ftp.ncbi.nlm.nih.gov:/sra/sra-instant/reads/ByRun/sra/SRR/SRR9117/SRR9117853/SRR9117853.sra"
         og.is_archive = True
         og.save()
         sample = Sample()
-        sample.accession_code = 'DRR002116'
+        sample.accession_code = 'SRR9117853'
         sample.save()
         assoc = OriginalFileSampleAssociation()
         assoc.sample = sample
@@ -85,7 +85,7 @@ class DownloadSraTestCase(TestCase):
         result, downloaded_files = sra.download_sra(dlj.pk)
         utils.end_downloader_job(dlj, result)
         self.assertTrue(result)
-        self.assertEqual(downloaded_files[0].sha1, 'd5374e7fe047d4f76b165c3f5148ab2df9d42cea')
+        self.assertEqual(downloaded_files[0].sha1, 'e7ad484fe6f134ba7d1b2664e58cc15ae5a958cc')
         self.assertTrue(os.path.exists(downloaded_files[0].absolute_file_path))
 
     @tag('downloaders')
@@ -93,17 +93,17 @@ class DownloadSraTestCase(TestCase):
     @patch('data_refinery_workers.downloaders.utils.send_job')
     def test_download_file_swapper(self, mock_send_job):
         mock_send_job.return_value = None
-        
+
         dlj = DownloaderJob()
-        dlj.accession_code = "DRR002116"
+        dlj.accession_code = "SRR9117853"
         dlj.save()
         og = OriginalFile()
-        og.source_filename = "DRR002116.sra"
-        og.source_url = "anonftp@ftp.ncbi.nlm.nih.gov:/sra/sra-instant/reads/ByRun/sra/DRR/DRR002/DRR002116/DRR002116.sra"
+        og.source_filename = "SRR9117853.sra"
+        og.source_url = "anonftp@ftp.ncbi.nlm.nih.gov:/sra/sra-instant/reads/ByRun/sra/SRR/SRR9117/SRR9117853/SRR9117853.sra"
         og.is_archive = True
         og.save()
         sample = Sample()
-        sample.accession_code = 'DRR002116'
+        sample.accession_code = 'SRR9117853'
         sample.save()
         assoc = OriginalFileSampleAssociation()
         assoc.sample = sample
@@ -113,5 +113,5 @@ class DownloadSraTestCase(TestCase):
         assoc.downloader_job = dlj
         assoc.original_file = og
         assoc.save()
-        result = sra._download_file(og.source_url, dlj, "/tmp", force_ftp=False)
+        result = sra._download_file(og.source_url, dlj, "/tmp/doomed", force_ftp=False)
         self.assertTrue(result)

--- a/workers/data_refinery_workers/downloaders/utils.py
+++ b/workers/data_refinery_workers/downloaders/utils.py
@@ -64,7 +64,7 @@ def signal_handler(sig, frame):
     else:
         CURRENT_JOB.start_time = None
         CURRENT_JOB.num_retries = CURRENT_JOB.num_retries - 1
-        CURRENT_JOB.failure_reason = "Interruped by SIGTERM/SIGINT"
+        CURRENT_JOB.failure_reason = "Interruped by SIGTERM/SIGINT: " + str(sig)
         CURRENT_JOB.save()
         sys.exit(0)
 


### PR DESCRIPTION
## Issue Number

N/A came out of a discussion with SRA Chris

## Purpose/Implementation Notes

This is likely to not pass tests because I haven't touched the tests yet :(

However this does in fact use HTTP to download from SRA instead of Aspera. This is because Chris said that they had to tweak their aspera servers a lot to get the uploads to Google Cloud and AWS and so those servers are not currently working.

## Types of changes

- New feature (non-breaking change which adds functionality)

## Functional tests

I downloaded some data with this switch.

## Checklist

- [] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules
