### PR TITLE
Fix which bucket we upload QN targets to again

### DIFF
--- a/workers/data_refinery_workers/processors/qn_reference.py
+++ b/workers/data_refinery_workers/processors/qn_reference.py
@@ -204,8 +204,6 @@ def _create_result_objects(job_context: Dict) -> Dict:
     }
     annotation.save()
 
-    # TODO: upload this to a public read bucket.
-    # https://github.com/AlexsLemonade/refinebio/issues/586
     job_context['result'] = result
     job_context['computed_files'] = [computed_file]
     job_context['annotation'] = annotation

--- a/workers/data_refinery_workers/processors/utils.py
+++ b/workers/data_refinery_workers/processors/utils.py
@@ -430,7 +430,7 @@ def end_job(job_context: Dict, abort=False):
         for computed_file in job_context.get('computed_files', []):
             # Ensure even distribution across S3 servers
             nonce = ''.join(random.choice(string.ascii_lowercase + string.digits) for _ in range(24))
-            result = computed_file.sync_to_s3(S3_BUCKET_NAME, nonce + "_" + computed_file.filename)
+            result = computed_file.sync_to_s3(s3_bucket, nonce + "_" + computed_file.filename)
             if result:
                 computed_file.delete_local_file()
     else:


### PR DESCRIPTION
## Issue Number

#1325 

## Purpose/Implementation Notes

In #1325 I made a variable that I forgot to use, this actually uses it. This will make it so that QN targets actually go to the a different bucket so they can be publicly available.

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

I can't really functionally test this without standing up a dev stack and it doesn't really seem worth the time or money for something so easily testable and so low priority.
