### PR TITLE
Add the code to enforce a timeout on salmon

### DIFF
--- a/workers/data_refinery_workers/processors/salmon.py
+++ b/workers/data_refinery_workers/processors/salmon.py
@@ -785,11 +785,11 @@ def _run_salmon(job_context: Dict) -> Dict:
                  formatted_command,
                  processor_job=job_context["job_id"])
 
-    # 3 hours seems like a reasonable timeout for salmon. This is
+    # 1 hour seems like a reasonable timeout for salmon. This is
     # necessary because some samples make salmon hang forever and this
     # ties up our computing resources forever. Until this bug is
     # fixed, we'll just have to do it like this.
-    timeout = 60 * 60 * 3
+    timeout = 60 * 60
     job_context['time_start'] = timezone.now()
     try:
         completed_command = subprocess.run(formatted_command.split(),

--- a/workers/data_refinery_workers/processors/salmon.py
+++ b/workers/data_refinery_workers/processors/salmon.py
@@ -785,10 +785,27 @@ def _run_salmon(job_context: Dict) -> Dict:
                  formatted_command,
                  processor_job=job_context["job_id"])
 
+    # 3 hours seems like a reasonable timeout for salmon. This is
+    # necessary because some samples make salmon hang forever and this
+    # ties up our computing resources forever. Until this bug is
+    # fixed, we'll just have to do it like this.
+    timeout = 60 * 60 * 3
     job_context['time_start'] = timezone.now()
-    completed_command = subprocess.run(formatted_command.split(),
-                                       stdout=subprocess.PIPE,
-                                       stderr=subprocess.PIPE)
+    try:
+        completed_command = subprocess.run(formatted_command.split(),
+                                           stdout=subprocess.PIPE,
+                                           stderr=subprocess.PIPE,
+                                           timeout=timeout)
+    except subprocess.TimeoutError:
+        failure_reason = "Salmon timed out because it failed to complete within 3 hours."
+        logger.error(failure_reason,
+                     sample_accesion_code=job_context["sample"].accession_code,
+                     processor_job=job_context["job_id"]
+        )
+        job_context["job"].failure_reason = failure_reason
+        job_context["success"] = False
+        return job_context
+
     job_context['time_end'] = timezone.now()
 
     ## To me, this looks broken: error codes are anything non-zero.


### PR DESCRIPTION
## Issue Number

#1321 

## Purpose/Implementation Notes

We're back up and running, but we haven't cracked the --split-3/unmated reads nut yet. So these jobs are going to hang forever. Therefore we need a timeout. Here it is!

## Types of changes

- New feature (non-breaking change which adds functionality)

## Functional tests

I think I did some back when I wrote this but I forget.