### PR TITLE
Refocus the organism shepherd

### DIFF
--- a/foreman/data_refinery_foreman/foreman/management/commands/test_organism_shepherd.py
+++ b/foreman/data_refinery_foreman/foreman/management/commands/test_organism_shepherd.py
@@ -205,11 +205,13 @@ class OrganismShepherdTestCase(TransactionTestCase):
         fifty_percent_processor_job.refresh_from_db()
         self.assertEqual(first_call_job_object, fifty_percent_processor_job.retried_job)
 
-        second_call_job_type = mock_calls[1][1][0]
-        second_call_job_object = mock_calls[1][2]["job"]
-        self.assertEqual(second_call_job_type, Downloaders.SRA)
-        self.assertEqual(second_call_job_object.accession_code, zero_percent_dl_job.accession_code)
-        self.assertEqual(second_call_job_object.downloader_task, zero_percent_dl_job.downloader_task)
+        # For now we aren't queuing experiments that haven't been processed at all.
+        self.assertEqual(len(mock_calls), 1)
+        # second_call_job_type = mock_calls[1][1][0]
+        # second_call_job_object = mock_calls[1][2]["job"]
+        # self.assertEqual(second_call_job_type, Downloaders.SRA)
+        # self.assertEqual(second_call_job_object.accession_code, zero_percent_dl_job.accession_code)
+        # self.assertEqual(second_call_job_object.downloader_task, zero_percent_dl_job.downloader_task)
 
-        zero_percent_dl_job.refresh_from_db()
-        self.assertEqual(second_call_job_object, zero_percent_dl_job.retried_job)
+        # zero_percent_dl_job.refresh_from_db()
+        # self.assertEqual(second_call_job_object, zero_percent_dl_job.retried_job)

--- a/workers/data_refinery_workers/processors/salmon.py
+++ b/workers/data_refinery_workers/processors/salmon.py
@@ -796,7 +796,7 @@ def _run_salmon(job_context: Dict) -> Dict:
                                            stdout=subprocess.PIPE,
                                            stderr=subprocess.PIPE,
                                            timeout=timeout)
-    except subprocess.TimeoutError:
+    except subprocess.TimeoutExpired:
         failure_reason = "Salmon timed out because it failed to complete within 3 hours."
         logger.error(failure_reason,
                      sample_accesion_code=job_context["sample"].accession_code,

--- a/workers/data_refinery_workers/processors/utils.py
+++ b/workers/data_refinery_workers/processors/utils.py
@@ -92,7 +92,12 @@ def prepare_original_files(job_context):
             missing_files=list(undownloaded_files)
         )
 
-        if not create_downloader_job(undownloaded_files, processor_job_id=job_context["job_id"]):
+        was_job_created = create_downloader_job(
+            undownloaded_files,
+            processor_job_id=job_context["job_id"],
+            force=True
+        )
+        if not was_job_created:
             failure_reason = "Missing file for processor job but unable to recreate downloader jobs!"
             logger.error(failure_reason, processor_job=job.id)
             job_context["success"] = False


### PR DESCRIPTION
## Issue Number

#1321 

## Purpose/Implementation Notes

Unmated reads are still causing salmon to hang. Until we can address this, we can't process these and we can't even detect them until we hang for an hour.

This changes the organism shepherd so that it will only requeue samples for whom we've processed at least one other sample in the experiment.

## Types of changes

- New feature (non-breaking change which adds functionality)

## Functional tests

These are small tweaks and there's existing tests.

## Checklist

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules
