### PR TITLE
Remove blacklisting code

### DIFF
--- a/foreman/data_refinery_foreman/foreman/main.py
+++ b/foreman/data_refinery_foreman/foreman/main.py
@@ -353,13 +353,6 @@ def requeue_downloader_job(last_job: DownloaderJob) -> bool:
         return False
 
     first_sample = original_file.samples.first()
-    if first_sample and first_sample.is_blacklisted:
-        last_job.no_retry = True
-        last_job.success = False
-        last_job.failure_reason = "Sample run accession has been blacklisted by SRA."
-        last_job.save()
-        logger.info("Avoiding requeuing for DownloaderJob for blacklisted run accession: " + str(first_sample.accession_code))
-        return False
 
     # This is a magic string that all the dbGaP studies appear to have
     if first_sample and ("in the dbGaP study" in first_sample.title):


### PR DESCRIPTION
## Issue Number

#1220 

## Purpose/Implementation Notes

The SRA blacklist has been lifted! We don't need this any more!

Unfortunately since we used the blacklist config file in a migration we cannot remove it, or running migrations against a fresh DB would fail.

## Types of changes

- New feature (non-breaking change which adds functionality)

## Functional tests

N/A it's just taking out code.
