### PR TITLE
Use api to get ensembl version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -138,3 +138,5 @@ dr_env/
 
 # emacs backup files
 *~
+
+.vscode

--- a/foreman/data_refinery_foreman/surveyor/transcriptome_index.py
+++ b/foreman/data_refinery_foreman/surveyor/transcriptome_index.py
@@ -60,12 +60,7 @@ class EnsemblUrlBuilder(ABC):
         self.url_root = "ensemblgenomes.org/pub/release-{assembly_version}/{short_division}"
         self.short_division = DIVISION_LOOKUP[species["division"]]
         self.assembly = species["assembly_name"].replace(" ", "_")
-
-        # For some reason the API is returning version 44, which doesn't seem to exist
-        # in the FTP servers: ftp://ftp.ensemblgenomes.org/pub/
-        # That's why the version is hardcoded below.
-        # self.assembly_version = utils.requests_retry_session().get(DIVISION_RELEASE_URL).json()["version"]
-        self.assembly_version = '43'
+        self.assembly_version = utils.requests_retry_session().get(DIVISION_RELEASE_URL).json()["version"]
 
         self.species_sub_dir = species["name"]
         self.filename_species = species["name"].capitalize()


### PR DESCRIPTION
## Issue Number

close #1314 

## Purpose/Implementation Notes

Initially introduced in https://github.com/AlexsLemonade/refinebio/pull/1308, this un-hardcodes ensembl api version and makes a request to the API endpoint.

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

Tested that [api endpoint](https://rest.ensembl.org/info/eg_version?content-type=application/json) worked

## Checklist

- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules
