### PR TITLE
warning -> debug in smasher

### DIFF
--- a/workers/data_refinery_workers/processors/smasher.py
+++ b/workers/data_refinery_workers/processors/smasher.py
@@ -560,7 +560,7 @@ def _smash(job_context: Dict, how="inner") -> Dict:
                     num_samples = num_samples + 1
 
                     if (num_samples % 100) == 0:
-                        logger.warning("Loaded " + str(num_samples) + " samples into frames.",
+                        logger.debug("Loaded " + str(num_samples) + " samples into frames.",
                             dataset_id=job_context['dataset'].id,
                             how=how
                         )


### PR DESCRIPTION
This looks like a status message. It also swamps our Sentry interface when folks download large datasets because each message is subtly different. I don't have strong feelings between `info` and `debug` but I do have strong feelings that it shouldn't be `warning` or above.

## Issue Number

N/A

## Purpose/Implementation Notes

Makes our logging less chatty

## Methods

N/A

## Types of changes

What types of changes does your code introduce?

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

None

## Checklist

_Put an `x` in the boxes that apply._

- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots

Please attach any screenshots that illustrate these changes.
