### PR TITLE
[HOTFIX] Scale OOM-killed downloader jobs

### DIFF
--- a/foreman/data_refinery_foreman/foreman/main.py
+++ b/foreman/data_refinery_foreman/foreman/main.py
@@ -323,7 +323,7 @@ def requeue_downloader_job(last_job: DownloaderJob) -> bool:
     num_retries = last_job.num_retries + 1
 
     ram_amount = last_job.ram_amount
-    if last_job.failure_reason is not None and 'harakiri' not in last_job.failure_reason:
+    if last_job.failure_reason is None or 'harakiri' not in last_job.failure_reason:
         if ram_amount == 1024:
             ram_amount = 4096
         elif ram_amount == 4096:


### PR DESCRIPTION
## Issue Number

N/A I found this while trying 10 experiments.

## Purpose/Implementation Notes

We wanted to make sure that we didn't scale up harakiri killed jobs, but our conditional statement also prevented us from scaling up jobs that don't have a failure reason, which includes all jobs that get OOM-killed because when they get OOM-killed the job is killed before we can even record why.

This meant that the jobs that actually would actually benefit from scaling never got scaled. This fixes that.

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

I tested the logic to make sure it would work as expected now and have no chance of error.

## Checklist

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules
