### PR TITLE
Removed pip.conf recommendation from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,17 +102,6 @@ Instructions for installing Docker, Terraform, and Nomad can be found by
 following the link for each service. git-crypt, jq, and iproute2 can be installed via
 `sudo apt-get install git-crypt jq iproute2`.
 
-When installing pip packages later in the install, you might get an error saying you need sudo permissions.
-In order to fix this you have to edit your `~/.config/pip/pip.conf` to add this:
-
-```
-[install]
-user = yes
-no-binary = :all:
-```
-
-This sets pip to install all packages in your user directory so sudo is not required for pip intalls.
-
 #### Mac
 
 The following services will need to be installed:


### PR DESCRIPTION
## Issue Number

N/A

## Purpose/Implementation Notes

I added this last year because it fixed some issue I was having, but this recommendation actually breaks `create_virtualenv.sh` for me and I can't figure out what issue it was trying to prevent.

## Types of changes

What types of changes does your code introduce?

<!-- Remove any which your PR isn't -->
- Bugfix (non-breaking change which fixes an issue)

## Functional tests

I ran the installation without the `pip.conf` and it worked.

## Checklist

_Put an `x` in the boxes that apply._

- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots

Please attach any screenshots that illustrate these changes.
