### PR TITLE
Add downloadable samples filter

### DIFF
--- a/api/data_refinery_api/views.py
+++ b/api/data_refinery_api/views.py
@@ -309,7 +309,7 @@ class ExperimentDocumentView(DocumentViewSet):
             'facet': TermsFacet,
             'enabled': True # These are enabled by default, which is more expensive but more simple.
         },
-        'organism_names': {
+        'organism': {
             'field': 'organism_names',
             'facet': TermsFacet,
             'enabled': True,
@@ -317,7 +317,7 @@ class ExperimentDocumentView(DocumentViewSet):
                 'size': 999999
             }
         },
-        'platform_accession_codes': {
+        'platform': {
             'field': 'platform_accession_codes',
             'facet': TermsFacet,
             'enabled': True,
@@ -331,16 +331,6 @@ class ExperimentDocumentView(DocumentViewSet):
             'facet': TermsFacet,
             'enabled': True,
             'global': False,
-        },
-        'num_downloadable_samples__gt': {
-            'field': 'num_downloadable_samples',
-            'facet': RangeFacet,
-            'options': {
-                'ranges': [
-                    ("0", (1, None)),
-                ]
-            },
-            'enabled': True,
         },
         # We don't actually need any "globals" to drive our web frontend,
         # but we'll leave them available but not enabled by default, as they're

--- a/api/data_refinery_api/views.py
+++ b/api/data_refinery_api/views.py
@@ -333,7 +333,7 @@ class ExperimentDocumentView(DocumentViewSet):
             'global': False,
         },
         'num_downloadable_samples__gt': {
-            'field': 'num_total_samples',
+            'field': 'num_downloadable_samples',
             'facet': RangeFacet,
             'options': {
                 'ranges': [

--- a/api/data_refinery_api/views.py
+++ b/api/data_refinery_api/views.py
@@ -36,7 +36,7 @@ from django_elasticsearch_dsl_drf.filter_backends import (
 )
 from django_filters.rest_framework import DjangoFilterBackend
 import django_filters
-from elasticsearch_dsl import TermsFacet, DateHistogramFacet
+from elasticsearch_dsl import TermsFacet, RangeFacet
 from rest_framework import status, filters, generics, mixins
 from rest_framework.exceptions import APIException, NotFound
 from rest_framework.exceptions import ValidationError
@@ -326,6 +326,16 @@ class ExperimentDocumentView(DocumentViewSet):
             'facet': TermsFacet,
             'enabled': True,
             'global': False,
+        },
+        'num_downloadable_samples__gt': {
+            'field': 'num_total_samples',
+            'facet': RangeFacet,
+            'options': {
+                'ranges': [
+                    ("0", (0, None)),
+                ]
+            },
+            'enabled': True,
         },
         # We don't actually need any "globals" to drive our web frontend,
         # but we'll leave them available but not enabled by default, as they're

--- a/api/data_refinery_api/views.py
+++ b/api/data_refinery_api/views.py
@@ -201,6 +201,11 @@ manual_parameters=[
         type=openapi.TYPE_NUMBER,
         description="Use ElasticSearch queries to specify the number of processed samples of the results",
     ),
+    openapi.Parameter(
+        name='num_downloadable_samples', in_=openapi.IN_QUERY,
+        type=openapi.TYPE_NUMBER,
+        description="Use ElasticSearch queries to specify the number of downloadable samples of the results. Eg: `/?num_downloadable_samples__gt=0`",
+    ),
 ],
 operation_description="""
 Use this endpoint to search among the experiments. 

--- a/api/data_refinery_api/views.py
+++ b/api/data_refinery_api/views.py
@@ -337,7 +337,7 @@ class ExperimentDocumentView(DocumentViewSet):
             'facet': RangeFacet,
             'options': {
                 'ranges': [
-                    ("0", (0, None)),
+                    ("0", (1, None)),
                 ]
             },
             'enabled': True,

--- a/api/data_refinery_api/views.py
+++ b/api/data_refinery_api/views.py
@@ -399,7 +399,7 @@ class ExperimentDocumentView(DocumentViewSet):
                 if field == 'has_publication':
                     filter_group[bucket['key_as_string']] = bucket['total_samples']['value']
                 else:
-                    filter_group[bucket['key']] = bucket['total_samples']['value']
+                    filter_group[bucket['key']] = bucket['total_samples']['value'] if 'total_samples' in bucket else 0
             result[field] = filter_group
         return result
 


### PR DESCRIPTION
## Issue Number

https://github.com/alexslemonade/refinebio-frontend/issues/639

## Purpose/Implementation Notes

Adds a new filter on the search api that counts the number of results that have downloadable samples.

![image](https://user-images.githubusercontent.com/1882507/60836637-1d47fe80-a194-11e9-8751-ead36d285545.png)


## Types of changes

- New feature (non-breaking change which adds functionality)

## Functional tests

Tested locally

## Checklist

- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules
