### PR TITLE
Don't run the compendia generation on the smasher instance

### DIFF
--- a/workers/nomad-job-specs/create_compendia.nomad.tpl
+++ b/workers/nomad-job-specs/create_compendia.nomad.tpl
@@ -77,7 +77,12 @@ job "CREATE_COMPENDIA" {
         max_file_size = 1
       }
 
-      ${{SMASHER_CONSTRAINT}}
+      # Don't run on the smasher instance, it's too small
+      constraint {
+        attribute = "${meta.is_smasher}"
+        operator = "!="
+        value = "true"
+      }
 
       config {
         image = "${{DOCKERHUB_REPO}}/${{COMPENDIA_DOCKER_IMAGE}}"


### PR DESCRIPTION
## Issue Number

Closes #1385 

## Purpose/Implementation Notes

Don't run the compendia generation on the smasher. The compendia job specification requires more ram than is available on smasher instances, so the jobs hang indefinitely.

## Types of changes

- Tuning
- Bugfix

## Functional tests

N/A

## Checklist

_Put an `x` in the boxes that apply._

- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots

Please attach any screenshots that illustrate these changes.
