### PR TITLE
Delete failed processor data

### DIFF
--- a/common/data_refinery_common/models/jobs.py
+++ b/common/data_refinery_common/models/jobs.py
@@ -148,6 +148,13 @@ class ProcessorJob(models.Model):
         self.last_modified = current_time
         return super(ProcessorJob, self).save(*args, **kwargs)
 
+    def clean_up_original_files(self):
+        """ If a processor job fails too many times, we want to clean up the downloaded files to
+        save hard drive space.
+        """
+        for original_file in self.original_files:
+            original_file.delete_local_file()
+
     def __str__(self):
         return "ProcessorJob " + str(self.pk) + ": " + str(self.pipeline_applied)
 

--- a/common/data_refinery_common/models/jobs.py
+++ b/common/data_refinery_common/models/jobs.py
@@ -152,7 +152,7 @@ class ProcessorJob(models.Model):
         """ If a processor job fails too many times, we want to clean up the downloaded files to
         save hard drive space.
         """
-        for original_file in self.original_files:
+        for original_file in self.original_files.all():
             original_file.delete_local_file()
 
     def __str__(self):

--- a/foreman/data_refinery_foreman/foreman/main.py
+++ b/foreman/data_refinery_foreman/foreman/main.py
@@ -121,6 +121,11 @@ def handle_repeated_failure(job) -> None:
     job.success = False
     job.save()
 
+    # If the job is a processor job and we want to stop retrying it,
+    # delete the original files to conserve disk space.
+    if isinstance(job, ProcessorJob):
+        job.clean_up_original_files()
+
     # At some point this should become more noisy/attention
     # grabbing. However for the time being just logging should be
     # sufficient because all log messages will be closely monitored

--- a/foreman/data_refinery_foreman/foreman/test_main.py
+++ b/foreman/data_refinery_foreman/foreman/test_main.py
@@ -82,7 +82,8 @@ class ForemanTestCase(TestCase):
         self.assertEqual(retried_job.original_files.count(), 2)
 
     @patch('data_refinery_foreman.foreman.main.send_job')
-    def test_repeated_download_failures(self, mock_send_job):
+    @patch('os.remove')
+    def test_repeated_download_failures(self, mock_send_job, mock_os_remove):
         """Jobs will be repeatedly retried."""
         mock_send_job.return_value = True
 
@@ -109,6 +110,7 @@ class ForemanTestCase(TestCase):
         self.assertTrue(last_job.retried)
         self.assertEqual(last_job.num_retries, main.MAX_NUM_RETRIES)
         self.assertFalse(last_job.success)
+        mock_os_remove.assert_called()
 
     @patch('data_refinery_foreman.foreman.main.send_job')
     def test_retrying_failed_downloader_jobs(self, mock_send_job):

--- a/foreman/data_refinery_foreman/foreman/test_main.py
+++ b/foreman/data_refinery_foreman/foreman/test_main.py
@@ -81,9 +81,8 @@ class ForemanTestCase(TestCase):
 
         self.assertEqual(retried_job.original_files.count(), 2)
 
-    @patch('os.remove')
     @patch('data_refinery_foreman.foreman.main.send_job')
-    def test_repeated_download_failures(self, mock_send_job, mock_os_remove):
+    def test_repeated_download_failures(self, mock_send_job):
         """Jobs will be repeatedly retried."""
         mock_send_job.return_value = True
 
@@ -110,7 +109,6 @@ class ForemanTestCase(TestCase):
         self.assertTrue(last_job.retried)
         self.assertEqual(last_job.num_retries, main.MAX_NUM_RETRIES)
         self.assertFalse(last_job.success)
-        mock_os_remove.assert_called()
 
     @patch('data_refinery_foreman.foreman.main.send_job')
     def test_retrying_failed_downloader_jobs(self, mock_send_job):
@@ -397,9 +395,10 @@ class ForemanTestCase(TestCase):
         self.assertEqual(original_job.ram_amount, 16384)
         self.assertEqual(retried_job.ram_amount, 32768)
 
+    @patch('os.remove')
     @patch('data_refinery_foreman.foreman.main.get_active_volumes')
     @patch('data_refinery_foreman.foreman.main.send_job')
-    def test_repeated_processor_failures(self, mock_send_job, mock_get_active_volumes):
+    def test_repeated_processor_failures(self, mock_send_job, mock_get_active_volumes, mock_os_remove):
         mock_send_job.return_value = True
         mock_get_active_volumes.return_value = {"1", "2", "3"}
 
@@ -427,6 +426,8 @@ class ForemanTestCase(TestCase):
         self.assertTrue(last_job.retried)
         self.assertEqual(last_job.num_retries, main.MAX_NUM_RETRIES)
         self.assertFalse(last_job.success)
+
+        mock_os_remove.assert_called_with("nor this")
 
     @patch('data_refinery_foreman.foreman.main.get_active_volumes')
     @patch('data_refinery_foreman.foreman.main.send_job')

--- a/foreman/data_refinery_foreman/foreman/test_main.py
+++ b/foreman/data_refinery_foreman/foreman/test_main.py
@@ -81,8 +81,8 @@ class ForemanTestCase(TestCase):
 
         self.assertEqual(retried_job.original_files.count(), 2)
 
-    @patch('data_refinery_foreman.foreman.main.send_job')
     @patch('os.remove')
+    @patch('data_refinery_foreman.foreman.main.send_job')
     def test_repeated_download_failures(self, mock_send_job, mock_os_remove):
         """Jobs will be repeatedly retried."""
         mock_send_job.return_value = True


### PR DESCRIPTION
## Issue Number

Closes #1380 

## Purpose/Implementation Notes

I put a method on the ProcessorJob model that will delete all the local copies of its original files, which is then called by the foreman after a job fails for the maximum number of times.

## Types of changes

What types of changes does your code introduce?

<!-- Remove any which your PR isn't -->
- Bugfix (non-breaking change which fixes an issue)

## Functional tests

I modified one of the unit tests to make sure that the file deletion was attempted after the maximum number of tries for a processor job.

## Checklist

_Put an `x` in the boxes that apply._

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules

## Screenshots

Please attach any screenshots that illustrate these changes.
