### PR TITLE
Dramatically improve /samples/ load times

### DIFF
--- a/api/data_refinery_api/views.py
+++ b/api/data_refinery_api/views.py
@@ -697,8 +697,7 @@ class SampleList(generics.ListAPIView):
             .prefetch_related('results__processor') \
             .prefetch_related('results__computationalresultannotation_set') \
             .prefetch_related('results__computedfile_set') \
-            .filter(**self.get_query_params_filters()) \
-            .distinct()
+            .filter(**self.get_query_params_filters())
 
         # case insensitive search https://docs.djangoproject.com/en/2.1/ref/models/querysets/#icontains
         filter_by = self.request.query_params.get('filter_by', None)        


### PR DESCRIPTION
## Issue Number

#1378

## Purpose/Implementation Notes

For the samples endpoint, we were calling `distinct()` on the queryset. This made the query take much longer to execute. We think we initially added it to prevent duplication with `prefetch_related`, but I could not find any references online to people having problems with duplication and `prefetch_related`. The Django docs also didn't say that you had to use `distinct()` with prefetch_related`, so it looks like this might be an unnecessary strain on our database.

## Types of changes

What types of changes does your code introduce?

<!-- Remove any which your PR isn't -->
- Bugfix (non-breaking change which fixes an issue)

## Functional tests

I ran the API locally and verified that this made the `/samples` endpoint faster without duplicating samples.

## Checklist

_Put an `x` in the boxes that apply._

- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots

Please attach any screenshots that illustrate these changes.
