### PR TITLE
Removed Eutils API calls from tests

### DIFF
--- a/foreman/data_refinery_foreman/surveyor/test_sra.py
+++ b/foreman/data_refinery_foreman/surveyor/test_sra.py
@@ -86,7 +86,6 @@ class SraSurveyorTestCase(TestCase):
         sra_surveyor.discover_experiment_and_samples()
 
         samples = Sample.objects.all()
-        # downloader_jobs = DownloaderJob.objects.all()
 
         # We are expecting this to discover 1 sample.
         self.assertEqual(samples.count(), 1)

--- a/foreman/data_refinery_foreman/surveyor/test_sra.py
+++ b/foreman/data_refinery_foreman/surveyor/test_sra.py
@@ -63,6 +63,16 @@ class SraSurveyorTestCase(TestCase):
                             is_scientific_name=True)
         organism.save()
 
+        organism1 = Organism(name="GALLUS_GALLUS",
+                             taxonomy_id=9031,
+                             is_scientific_name=True)
+        organism1.save()
+
+        organism2 = Organism(name="DANIO_RERIO",
+                             taxonomy_id=7955,
+                             is_scientific_name=True)
+        organism2.save()
+
     def tearDown(self):
         DownloaderJob.objects.all().delete()
         SurveyJobKeyValue.objects.all().delete()
@@ -76,22 +86,19 @@ class SraSurveyorTestCase(TestCase):
         sra_surveyor.discover_experiment_and_samples()
 
         samples = Sample.objects.all()
-        downloader_jobs = DownloaderJob.objects.all()
+        # downloader_jobs = DownloaderJob.objects.all()
 
         # We are expecting this to discover 1 sample.
         self.assertEqual(samples.count(), 1)
         # Confirm the sample's protocol_info
         experiment = Experiment.objects.all().first()
         self.assertEqual(samples.first().protocol_info[0]['Description'],
-                         experiment.protocol_description
-        )
-
+                         experiment.protocol_description)
 
     @patch('data_refinery_foreman.surveyor.external_source.message_queue.send_job')
     def test_srp_survey(self, mock_send_task):
         """A slightly harder test of the SRA surveyor.
         """
-
         survey_job = SurveyJob(source_type="SRA")
         survey_job.save()
         key_value_pair = SurveyJobKeyValue(survey_job=survey_job,
@@ -115,7 +122,7 @@ class SraSurveyorTestCase(TestCase):
         experiment, samples = sra_surveyor.discover_experiment_and_samples()
 
         self.assertEqual(experiment.accession_code, "SRP111553")
-        self.assertEqual(len(samples), 16) # 8 samples with 2 runs each
+        self.assertEqual(len(samples), 16)  # 8 samples with 2 runs each
 
         survey_job = SurveyJob(source_type="SRA")
         survey_job.save()

--- a/workers/data_refinery_workers/processors/test_salmon.py
+++ b/workers/data_refinery_workers/processors/test_salmon.py
@@ -175,6 +175,14 @@ def strong_quant_correlation(ref_filename, output_filename):
 
 
 class SalmonTestCase(TestCase):
+    def setUp(self):
+        # Insert the organism into the database so the model doesn't call the
+        # taxonomy API to populate it.
+        organism = Organism(name="CAENORHABDITIS_ELEGANS",
+                            taxonomy_id=6239,
+                            is_scientific_name=True)
+        organism.save()
+
     @tag('salmon')
     def test_salmon(self):
         """Test the whole pipeline."""
@@ -517,6 +525,12 @@ class SalmonToolsTestCase(TestCase):
 
     def setUp(self):
         self.test_dir = '/home/user/data_store/salmontools/'
+        # Insert the organism into the database so the model doesn't call the
+        # taxonomy API to populate it.
+        organism = Organism(name="CAENORHABDITIS_ELEGANS",
+                            taxonomy_id=6239,
+                            is_scientific_name=True)
+        organism.save()
 
     @tag('salmon')
     def test_double_reads(self):
@@ -595,6 +609,13 @@ class DetermineIndexLengthTestCase(TestCase):
     """Test salmon._determine_index_length function, which gets the salmon index length of a sample.
     For now, these tests only ensure that the output of the new faster salmon index function match
     that of the old one for the test data."""
+    def setUp(self):
+        # Insert the organism into the database so the model doesn't call the
+        # taxonomy API to populate it.
+        organism = Organism(name="CAENORHABDITIS_ELEGANS",
+                            taxonomy_id=6239,
+                            is_scientific_name=True)
+        organism.save()
 
     @tag('salmon')
     def test_salmon_determine_index_length_single_read(self):


### PR DESCRIPTION
## Issue Number

Fixes #1390

## Purpose/Implementation Notes

Manually create Organisms in our database in all our tests so that we don't have to call the Esearch API for taxon ids.

## Types of changes

What types of changes does your code introduce?

<!-- Remove any which your PR isn't -->
- Bugfix (non-breaking change which fixes an issue)

## Functional tests

I ran the tests locally to make sure that my changes didn't break the tests, then these tests will run on CircleCI which will verify that we don't have any Esearch errors.

## Checklist

_Put an `x` in the boxes that apply._

- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots

Please attach any screenshots that illustrate these changes.
