### PR TITLE
Arielsvn/1391 recreate downloader job

### DIFF
--- a/foreman/data_refinery_foreman/foreman/management/commands/create_missing_downloader_jobs.py
+++ b/foreman/data_refinery_foreman/foreman/management/commands/create_missing_downloader_jobs.py
@@ -38,8 +38,6 @@ class Command(BaseCommand):
 
       logger.info("Found %d samples without downloader jobs, starting to create them now.", samples_without_downloader.count())
 
-      import pdb; pdb.set_trace()
-      
       paginator = Paginator(samples_without_downloader, PAGE_SIZE)
       page = paginator.page()
       page_count = 0

--- a/foreman/data_refinery_foreman/foreman/management/commands/create_missing_downloader_jobs.py
+++ b/foreman/data_refinery_foreman/foreman/management/commands/create_missing_downloader_jobs.py
@@ -1,0 +1,59 @@
+"""
+This command finds Samples that were created and didn't spawned any downloader jobs.
+We tried to debug the reasons why this happened on
+https://github.com/alexslemonade/refinebio/issues/1391
+without any luck. 
+"""
+
+from django.core.management.base import BaseCommand
+
+from data_refinery_common.models import (
+  Sample,
+  DownloaderJob,
+  ProcessorJob,
+  OriginalFile,
+  DownloaderJobOriginalFileAssociation,
+  ProcessorJobOriginalFileAssociation
+)
+from data_refinery_common.logging import get_and_configure_logger
+from data_refinery_common.job_management import create_downloader_job
+from data_refinery_foreman.foreman.performant_pagination.pagination import PerformantPaginator as Paginator
+
+logger = get_and_configure_logger(__name__)
+
+PAGE_SIZE=2000
+
+class Command(BaseCommand):
+    def handle(self, *args, **options):
+      """ Requeues downloader jobs for samples that haven't been processed and their original files 
+      have no no downloader jobs associated with them
+      """
+      samples_without_downloader = Sample.objects.all()\
+          .annotate(original_files_count=Count('original_files'), downloader_job_count=Count('original_files__downloader_jobs'))\
+          .filter(is_processed=False, original_files_count__gt=0, downloader_job_count=0)\
+          .prefetch_related(
+            "original_files"
+          )
+
+      logger.info("Found %d samples without downloader jobs, starting to create them now.", samples_without_downloader.count())
+      
+      paginator = Paginator(samples_without_downloader, PAGE_SIZE)
+      page = paginator.page()
+      page_count = 0
+
+      while True:
+          for sample in page.object_list:
+            logger.debug("Creating downloader job for a sample.", sample=sample.accession_code)
+            create_downloader_job(sample.original_files.all())
+
+          logger.info("Created %d new downloader jobs because their samples didn't have any.", PAGE_SIZE)
+
+          if not page.has_next():
+              break
+              
+          page = paginator.page(page.next_page_number())
+
+          # 2000 samples queued up every five minutes should be fast
+          # enough and also not thrash the DB.
+          time.sleep(60 * 5)
+

--- a/foreman/data_refinery_foreman/foreman/management/commands/create_missing_downloader_jobs.py
+++ b/foreman/data_refinery_foreman/foreman/management/commands/create_missing_downloader_jobs.py
@@ -6,6 +6,7 @@ without any luck.
 """
 
 from django.core.management.base import BaseCommand
+from django.db.models import Count
 
 from data_refinery_common.models import (
   Sample,
@@ -36,6 +37,8 @@ class Command(BaseCommand):
           )
 
       logger.info("Found %d samples without downloader jobs, starting to create them now.", samples_without_downloader.count())
+
+      import pdb; pdb.set_trace()
       
       paginator = Paginator(samples_without_downloader, PAGE_SIZE)
       page = paginator.page()

--- a/foreman/data_refinery_foreman/foreman/management/commands/test_create_missing_downloader_jobs.py
+++ b/foreman/data_refinery_foreman/foreman/management/commands/test_create_missing_downloader_jobs.py
@@ -35,7 +35,8 @@ class SurveyTestCase(TransactionTestCase):
         sample_with_downloader = Sample()
         sample_with_downloader.accession_code = "MA_doesnt_need_processor"
         sample_with_downloader.technology = "MICROARRAY"
-        sample_with_downloader.source_database = "ARRAY_EXPRESS"
+        sample_with_downloader.source_database = "GEO"
+        sample_with_downloader.platform_accession_code = "bovine"
         sample_with_downloader.save()
 
         OriginalFileSampleAssociation.objects.get_or_create(
@@ -65,7 +66,8 @@ class SurveyTestCase(TransactionTestCase):
         sample_no_downloader = Sample()
         sample_no_downloader.accession_code = "sample_no_downloader"
         sample_no_downloader.technology = "MICROARRAY"
-        sample_no_downloader.source_database = "ARRAY_EXPRESS"
+        sample_no_downloader.source_database = "GEO"
+        sample_no_downloader.platform_accession_code = "bovine" # must be a supported platform
         sample_no_downloader.save()
 
         OriginalFileSampleAssociation.objects.get_or_create(

--- a/foreman/data_refinery_foreman/foreman/management/commands/test_create_missing_downloader_jobs.py
+++ b/foreman/data_refinery_foreman/foreman/management/commands/test_create_missing_downloader_jobs.py
@@ -1,6 +1,7 @@
 
 from django.test import TransactionTestCase
 from unittest.mock import Mock, patch, call
+from django.test import tag
 
 from data_refinery_common.models import (
     DownloaderJob,
@@ -15,10 +16,11 @@ from data_refinery_common.models import (
     SurveyJob,
     SurveyJobKeyValue,
 )
-from data_refinery_foreman.foreman.management.commands.create_missing_processor_jobs import Command
+from data_refinery_foreman.foreman.management.commands.create_missing_downloader_jobs import Command
 from data_refinery_foreman.surveyor.geo import GeoSurveyor
 
 class SurveyTestCase(TransactionTestCase):
+    @tag('missing_jobs')
     def test_create_missing_jobs(self):
         """Tests that files which should have downloader jobs get them created."""
 
@@ -70,7 +72,6 @@ class SurveyTestCase(TransactionTestCase):
             sample=sample_no_downloader,
             original_file=original_file
         )
-
 
         # 3. Setup is done, actually run the command.
         command = Command()

--- a/foreman/data_refinery_foreman/foreman/management/commands/test_create_missing_downloader_jobs.py
+++ b/foreman/data_refinery_foreman/foreman/management/commands/test_create_missing_downloader_jobs.py
@@ -1,0 +1,95 @@
+
+from django.test import TransactionTestCase
+from unittest.mock import Mock, patch, call
+
+from data_refinery_common.models import (
+    DownloaderJob,
+    DownloaderJobOriginalFileAssociation,
+    Experiment,
+    ExperimentSampleAssociation,
+    Organism,
+    OriginalFile,
+    OriginalFileSampleAssociation,
+    ProcessorJob,
+    Sample,
+    SurveyJob,
+    SurveyJobKeyValue,
+)
+from data_refinery_foreman.foreman.management.commands.create_missing_processor_jobs import Command
+from data_refinery_foreman.surveyor.geo import GeoSurveyor
+
+class SurveyTestCase(TransactionTestCase):
+    def test_create_missing_jobs(self):
+        """Tests that files which should have downloader jobs get them created."""
+
+        # 1. create a sample with an original file and a downloader job
+        original_file_with_downloader = OriginalFile()
+        original_file_with_downloader.filename = "processed.CEL"
+        original_file_with_downloader.source_filename = "processed.CEL"
+        original_file_with_downloader.is_downloaded = True
+        original_file_with_downloader.is_archive = False
+        original_file_with_downloader.save()
+
+        sample_with_downloader = Sample()
+        sample_with_downloader.accession_code = "MA_doesnt_need_processor"
+        sample_with_downloader.technology = "MICROARRAY"
+        sample_with_downloader.source_database = "ARRAY_EXPRESS"
+        sample_with_downloader.save()
+
+        OriginalFileSampleAssociation.objects.get_or_create(
+            sample=sample_with_downloader,
+            original_file=original_file_with_downloader
+        )
+
+        downloader_job = DownloaderJob()
+        downloader_job.success = True
+        downloader_job.worker_id = "worker_1"
+        downloader_job.volume_index = "1"
+        downloader_job.save()
+
+        DownloaderJobOriginalFileAssociation.objects.get_or_create(
+            downloader_job=downloader_job,
+            original_file=original_file_with_downloader
+        )
+
+        # 2. create a sample with an original file and no downloader job
+        original_file = OriginalFile()
+        original_file.filename = "tarball.gz"
+        original_file.source_filename = "tarball.gz"
+        original_file.is_downloaded = True
+        original_file.is_archive = True
+        original_file.save()
+
+        sample_no_downloader = Sample()
+        sample_no_downloader.accession_code = "sample_no_downloader"
+        sample_no_downloader.technology = "MICROARRAY"
+        sample_no_downloader.source_database = "ARRAY_EXPRESS"
+        sample_no_downloader.save()
+
+        OriginalFileSampleAssociation.objects.get_or_create(
+            sample=sample_no_downloader,
+            original_file=original_file
+        )
+
+
+        # 3. Setup is done, actually run the command.
+        command = Command()
+        command.handle()
+
+        ## Test that a missing downloader job was created.
+        self.assertEqual(
+            1,
+            DownloaderJobOriginalFileAssociation.objects.filter(
+                original_file=original_file
+            ).count()
+        )
+
+        ## Test that a downloader job that wasn't missing wasn't created.
+        ## Of course, we created one in test setup, so we're really
+        ## checking that it's still only 1.
+        self.assertEqual(
+            1,
+            DownloaderJobOriginalFileAssociation.objects.filter(
+                original_file=original_file_with_downloader
+            ).count()
+        )


### PR DESCRIPTION
## Issue Number

#1391 

## Purpose/Implementation Notes

Adds a new management command that search for samples that don't have any downloader jobs associated and creates them.

Creates 2000 new downloader jobs every 5mins. Not sure if this is too conservative or aggressive, we need to test it.

## Types of changes

- New feature (non-breaking change which adds functionality)

## Functional tests

Tested queries locally and added tests.

## Checklist

- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules
