### PR TITLE
Made run_manage.sh take dockerfile as arguments

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,7 +25,7 @@ jobs:
       - run: ./scripts/update_models.sh
 
       # Update ES models
-      - run: ./scripts/run_manage.sh search_index --rebuild -f;
+      - run: ./scripts/rebuild_es_index.sh
 
       # Install Nomad
       - run: sudo ./scripts/install_nomad.sh
@@ -151,7 +151,7 @@ jobs:
       - run: ./scripts/update_models.sh
 
       # Update ES models
-      - run: ./scripts/run_manage.sh search_index --rebuild -f;
+      - run: ./scripts/rebuild_es_index.sh
 
       # Run API Tests.
       - run: ./api/run_tests.sh
@@ -236,7 +236,7 @@ jobs:
       - run: .circleci/filter_tests.sh -t agilent
 
       # Update ES models
-      - run: ./scripts/run_manage.sh search_index --rebuild -f;
+      - run: ./scripts/rebuild_es_index.sh
 
       # Install Nomad
       - run: sudo ./scripts/install_nomad.sh

--- a/README.md
+++ b/README.md
@@ -203,7 +203,7 @@ One of the API endpoints is powered by ElasticSearch. ElasticSearch must be runn
 And then the ES Indexes (akin to Postgres 'databases') can be created with:
 
 ```bash
-./scripts/run_manage.sh search_index --rebuild -f;
+./scripts/rebuild_es_index.sh
 ```
 
 #### Common Dependecies

--- a/scripts/install_all.sh
+++ b/scripts/install_all.sh
@@ -175,7 +175,7 @@ echo "Starting postgres and installing the database..."
 
 echo "Starting elasticsearch and building the ES Indexes..."
 ./run_es.sh > $OUTPUT
-./run_manage.sh search_index --rebuild -f > $OUTPUT
+./rebuild_es_index.sh > $OUTPUT
 
 echo "Creating virtual environment..."
 ./create_virtualenv.sh > $OUTPUT

--- a/scripts/rebuild_es_index.sh
+++ b/scripts/rebuild_es_index.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+# This script should always run as if it were being called from
+# the directory it lives in.
+script_directory="$(perl -e 'use File::Basename;
+ use Cwd "abs_path";
+ print dirname(abs_path(@ARGV[0]));' -- "$0")"
+cd "$script_directory" || exit
+
+./run_manage.sh -i api_local -s api search_index --rebuild -f


### PR DESCRIPTION
## Issue Number

Closes #1356 

## Purpose/Implementation Notes

When testing the compendia import error fix, I had to manually edit `run_manage.sh` to run the compendia management command locally. I changed `run_manage.sh` to instead specify the requested Dockerfile as arguments. This fix also includes a new script: `./scripts/rebuild_es_index.sh`, which wraps the elasticsearch management command.

## Types of changes

What types of changes does your code introduce?

<!-- Remove any which your PR isn't -->
- New feature (non-breaking change which adds functionality)

## Functional tests

I ran the scripts locally to verify the error handling and to verify that they work.

## Checklist

_Put an `x` in the boxes that apply._

- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots

Please attach any screenshots that illustrate these changes.
