### PR TITLE
Add migration to update sample platform names

### DIFF
--- a/common/data_refinery_common/migrations/0023_fix_platform_names_spaces.py
+++ b/common/data_refinery_common/migrations/0023_fix_platform_names_spaces.py
@@ -9,7 +9,7 @@ def make_sample_platform_names_readable(apps, schema_editor):
     for platform_name in get_supported_rnaseq_platforms():
         munged_platform = platform_name.replace(' ', '')
         Sample.objects.all().filter(platform_name=munged_platform).update(platform_name=platform_name)
-        print("Updating platform name from \'%s\' to \'%s\' page" % (munged_platform, platform_name))
+        print("Updating platform name from \'%s\' to \'%s\'" % (munged_platform, platform_name))
 
 class Migration(migrations.Migration):
 

--- a/common/data_refinery_common/migrations/0023_fix_platform_names_spaces.py
+++ b/common/data_refinery_common/migrations/0023_fix_platform_names_spaces.py
@@ -1,0 +1,22 @@
+
+from django.db import migrations
+from data_refinery_common.utils import get_supported_rnaseq_platforms
+from django.core.paginator import Paginator
+
+def make_sample_platform_names_readable(apps, schema_editor):
+    Sample = apps.get_model('data_refinery_common', 'Sample')
+
+    for platform_name in get_supported_rnaseq_platforms():
+        munged_platform = platform_name.replace(' ', '')
+        Sample.objects.all().filter(platform_name=munged_platform).update(platform_name=platform_name)
+        print("Updating platform name from \'%s\' to \'%s\' page" % (munged_platform, platform_name))
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('data_refinery_common', '0022_auto_20190607_1505'),
+    ]
+
+    operations = [
+        migrations.RunPython(make_sample_platform_names_readable)
+    ]


### PR DESCRIPTION
## Issue Number

close #1249 

## Purpose/Implementation Notes

Adds a new migration to fix Sample platform names.

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

Tested locally.

## Checklist

- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules

## Screenshots

Logs

```
Updating platform name from 'IlluminaGenomeAnalyzerII' to 'Illumina Genome Analyzer II' page
Updating platform name from 'IlluminaGenomeAnalyzerIIx' to 'Illumina Genome Analyzer IIx' page
Updating platform name from 'IlluminaHiScanSQ' to 'Illumina HiScanSQ' page
Updating platform name from 'IlluminaHiSeq1000' to 'Illumina HiSeq 1000' page
Updating platform name from 'IlluminaHiSeq1500' to 'Illumina HiSeq 1500' page
Updating platform name from 'IlluminaHiSeq2000' to 'Illumina HiSeq 2000' page
Updating platform name from 'IlluminaHiSeq2500' to 'Illumina HiSeq 2500' page
Updating platform name from 'IlluminaHiSeq3000' to 'Illumina HiSeq 3000' page
Updating platform name from 'IlluminaHiSeq4000' to 'Illumina HiSeq 4000' page
Updating platform name from 'NextSeq500' to 'NextSeq 500' page
Updating platform name from 'NextSeq550' to 'NextSeq 550' page
Updating platform name from 'IonTorrentProton' to 'Ion Torrent Proton' page
Updating platform name from 'IonTorrentS5' to 'Ion Torrent S5' page
Updating platform name from 'IonTorrentS5XL' to 'Ion Torrent S5 XL' page
```