### PR TITLE
Try setting the repos using a data structure instead of what the docs say

### DIFF
--- a/workers/affymetrix_dependencies.R
+++ b/workers/affymetrix_dependencies.R
@@ -1,7 +1,7 @@
 # Turn warnings into errors because biocLite throws warnings instead
 # of error if it fails to install something.
 options(warn=2)
-options(repos="https://cran.microsoft.com/snapshot/2019-07-03")
+options(repos=structure(c(CRAN="https://cran.microsoft.com/snapshot/2019-07-03")))
 options(Ncpus=parallel::detectCores())
 
 # Use devtools::install_version() to install packages in cran.

--- a/workers/illumina_dependencies.R
+++ b/workers/illumina_dependencies.R
@@ -1,5 +1,5 @@
 options(warn=2)
-options(repos="https://cran.microsoft.com/snapshot/2019-07-03")
+options(repos=structure(c(CRAN="https://cran.microsoft.com/snapshot/2019-07-03")))
 options(Ncpus=parallel::detectCores())
 
 devtools::install_version('doParallel', version='1.0.11')

--- a/workers/install_affy_only.R
+++ b/workers/install_affy_only.R
@@ -1,7 +1,7 @@
 # Turn warnings into errors because biocLite throws warnings instead
 # of error if it fails to install something.
 options(warn=2)
-options(repos="https://cran.microsoft.com/snapshot/2019-07-03")
+options(repos=structure(c(CRAN="https://cran.microsoft.com/snapshot/2019-07-03")))
 options(Ncpus=parallel::detectCores())
 
 # Bioconductor packages, installed by devtools::install_url()

--- a/workers/install_downloader_R_only.R
+++ b/workers/install_downloader_R_only.R
@@ -1,7 +1,7 @@
 # Turn warnings into errors because biocLite throws warnings instead
 # of error if it fails to install something.
 options(warn=2)
-options(repos="https://cran.microsoft.com/snapshot/2019-07-03")
+options(repos=structure(c(CRAN="https://cran.microsoft.com/snapshot/2019-07-03")))
 options(Ncpus=parallel::detectCores())
 
 # Bioconductor packages, installed by devtools::install_url()

--- a/workers/install_gene_convert.R
+++ b/workers/install_gene_convert.R
@@ -1,7 +1,7 @@
 # Turn warnings into errors because biocLite throws warnings instead
 # of error if it fails to install something.
 options(warn=2)
-options(repos="https://cran.microsoft.com/snapshot/2019-07-03")
+options(repos=structure(c(CRAN="https://cran.microsoft.com/snapshot/2019-07-03")))
 
 devtools::install_version('data.table', version='1.11.0')
 devtools::install_version('optparse', version='1.4.4')

--- a/workers/install_tximport.R
+++ b/workers/install_tximport.R
@@ -2,7 +2,7 @@
 # of error if it fails to install something.
 options(warn=2)
 options(Ncpus=parallel::detectCores())
-options(repos="https://cran.microsoft.com/snapshot/2019-07-03")
+options(repos=structure(c(CRAN="https://cran.microsoft.com/snapshot/2019-07-03")))
 
 devtools::install_version('optparse', version='1.4.4')
 devtools::install_version('rjson', version='0.2.19')

--- a/workers/qn_dependencies.R
+++ b/workers/qn_dependencies.R
@@ -1,5 +1,5 @@
 options(warn=2)
-options(repos="https://cran.microsoft.com/snapshot/2019-07-03")
+options(repos=structure(c(CRAN="https://cran.microsoft.com/snapshot/2019-07-03")))
 options(Ncpus=parallel::detectCores())
 
 devtools::install_version('doParallel', version='1.0.11')


### PR DESCRIPTION
## Issue Number

#1403

## Purpose/Implementation Notes

In #1403 we changed the way we specified repos from `options(repos=structure(c(CRAN="https://cran.revolutionanalytics.com")))` to `options(repos="https://cran.microsoft.com/snapshot/2019-07-03")`. I think that despite the docs saying:

> character vector, the base URL(s) of the repositories to use, e.g., the URL of a CRAN mirror such as "https://cloud.r-project.org"

that it does indeed need to have the special data structure to be used by devtools. I dunno why, but I built it on my local machine and it worked.

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

I built the image on my local machine and got a nice:

```
Successfully built 308e96f1abd8
Successfully tagged dr_affymetrix:test
```

## Checklist

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules
