### PR TITLE
Fix R by iinstalling geoquery

### DIFF
--- a/workers/affymetrix_dependencies.R
+++ b/workers/affymetrix_dependencies.R
@@ -28,6 +28,7 @@ bioc_url <- 'https://bioconductor.org/packages/3.6/bioc/src/contrib/'
 bioc_pkgs <- c(
   'oligo_1.42.0.tar.gz',
   'Biobase_2.38.0.tar.gz',
+  'GEOquery_2.46.15.tar.gz',
   'SCAN.UPC_2.20.0.tar.gz',
   'affy_1.56.0.tar.gz',
   'affyio_1.48.0.tar.gz',

--- a/workers/affymetrix_dependencies.R
+++ b/workers/affymetrix_dependencies.R
@@ -12,6 +12,8 @@ devtools::install_version('RSQLite', version='2.0')
 devtools::install_version('tibble', version='1.4.2')
 devtools::install_version('xtable', version='1.8-2')
 devtools::install_version('pkgconfig', version='2.0.1')
+devtools::install_version('dplyr', version='0.7.8')
+devtools::install_version('tidyr', version='0.8.2')
 
 # Bioconductor packages, installed by devtools::install_url()
 

--- a/workers/install_affy_only.R
+++ b/workers/install_affy_only.R
@@ -19,6 +19,7 @@ bioc_url <- 'https://bioconductor.org/packages/3.6/bioc/src/contrib/'
 bioc_pkgs <- c(
   'oligo_1.42.0.tar.gz',
   'Biobase_2.38.0.tar.gz',
+  'GEOquery_2.46.15.tar.gz',
   'SCAN.UPC_2.20.0.tar.gz',
   'affy_1.56.0.tar.gz',
   'affyio_1.48.0.tar.gz',

--- a/workers/install_affy_only.R
+++ b/workers/install_affy_only.R
@@ -4,6 +4,10 @@ options(warn=2)
 options(repos=structure(c(CRAN="https://cran.microsoft.com/snapshot/2019-07-03")))
 options(Ncpus=parallel::detectCores())
 
+# Use devtools::install_version() to install packages in cran.
+devtools::install_version('dplyr', version='0.7.8')
+devtools::install_version('tidyr', version='0.8.2')
+
 # Bioconductor packages, installed by devtools::install_url()
 
 # devtools::install_url() requires BiocInstaller


### PR DESCRIPTION
## Issue Number

Builds are still failing because of R stuff

## Purpose/Implementation Notes

This installs GEOQuery and it's two dependencies: tidyr and dplyr.

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

I was able to get past these dependencies and it said SCAN.UPC was successfully installed, also I didn't see any errors in the logs like `ERROR: dependency 'dplyr' is not available for package 'tidyr'` which is what has failed most recently.

## Checklist

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules
