### PR TITLE
Use count instead of len when calculating number of elements in a query

### DIFF
--- a/foreman/data_refinery_foreman/surveyor/external_source.py
+++ b/foreman/data_refinery_foreman/surveyor/external_source.py
@@ -61,9 +61,9 @@ class ExternalSourceSurveyor:
                 continue
 
             # There is already a downloader job associated with this file.
-            old_assocs = DownloaderJobOriginalFileAssociation.objects.filter(
-                original_file__source_url=original_file.source_url)
-            if len(old_assocs) > 0:
+            old_assocs_count = DownloaderJobOriginalFileAssociation.objects.filter(
+                original_file__source_url=original_file.source_url).count()
+            if old_assocs_count > 0:
                 logger.debug("We found an existing DownloaderJob for this file/url.",
                              original_file_id=original_file.id)
                 continue
@@ -118,9 +118,9 @@ class ExternalSourceSurveyor:
         else:
             source_urls = [original_file.source_url for original_file in original_files]        
             # There is already a downloader job associated with this file.
-            old_assocs = DownloaderJobOriginalFileAssociation.objects.filter(
-                original_file__source_url__in=source_urls)
-            if len(old_assocs) > 0:
+            old_assocs_count = DownloaderJobOriginalFileAssociation.objects.filter(
+                original_file__source_url__in=source_urls).count()
+            if old_assocs_count > 0:
                 logger.debug("We found an existing DownloaderJob for these urls.",
                             source_urls=source_urls)
                 return False


### PR DESCRIPTION
## Issue Number

#1378 

## Purpose/Implementation Notes

We were loading the whole query just to count the number of results.

This should remove queries like this one:

```sql
SELECT "downloaderjob_originalfile_associations"."id", "downloaderjob_originalfile_associations"."downloader_job_id", "downloaderjob_originalfile_associations"."original_file_id" FROM "downloaderjob_originalfile_associations" INNER JOIN "original_files" ON ("downloaderjob_originalfile_associations"."original_file_id" = "original_files"."id") WHERE "original_files"."source_url" IN ('dbtest@sra-download.ncbi.nlm.nih.gov:data/sracloud/traces/sra76/SRR/008287/SRR8486235')
```

ref https://docs.djangoproject.com/en/2.2/ref/models/querysets/#django.db.models.query.QuerySet.count

## Types of changes

- Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Functional tests

Didn't tested it. Changes should be equivalent.

## Checklist

- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules
