### PR TITLE
Revert "Delete failed processor data"

### DIFF
--- a/common/data_refinery_common/models/jobs.py
+++ b/common/data_refinery_common/models/jobs.py
@@ -148,13 +148,6 @@ class ProcessorJob(models.Model):
         self.last_modified = current_time
         return super(ProcessorJob, self).save(*args, **kwargs)
 
-    def clean_up_original_files(self):
-        """ If a processor job fails too many times, we want to clean up the downloaded files to
-        save hard drive space.
-        """
-        for original_file in self.original_files.all():
-            original_file.delete_local_file()
-
     def __str__(self):
         return "ProcessorJob " + str(self.pk) + ": " + str(self.pipeline_applied)
 

--- a/foreman/data_refinery_foreman/foreman/main.py
+++ b/foreman/data_refinery_foreman/foreman/main.py
@@ -121,11 +121,6 @@ def handle_repeated_failure(job) -> None:
     job.success = False
     job.save()
 
-    # If the job is a processor job and we want to stop retrying it,
-    # delete the original files to conserve disk space.
-    if isinstance(job, ProcessorJob):
-        job.clean_up_original_files()
-
     # At some point this should become more noisy/attention
     # grabbing. However for the time being just logging should be
     # sufficient because all log messages will be closely monitored

--- a/foreman/data_refinery_foreman/foreman/test_main.py
+++ b/foreman/data_refinery_foreman/foreman/test_main.py
@@ -395,10 +395,9 @@ class ForemanTestCase(TestCase):
         self.assertEqual(original_job.ram_amount, 16384)
         self.assertEqual(retried_job.ram_amount, 32768)
 
-    @patch('os.remove')
     @patch('data_refinery_foreman.foreman.main.get_active_volumes')
     @patch('data_refinery_foreman.foreman.main.send_job')
-    def test_repeated_processor_failures(self, mock_send_job, mock_get_active_volumes, mock_os_remove):
+    def test_repeated_processor_failures(self, mock_send_job, mock_get_active_volumes):
         mock_send_job.return_value = True
         mock_get_active_volumes.return_value = {"1", "2", "3"}
 
@@ -426,8 +425,6 @@ class ForemanTestCase(TestCase):
         self.assertTrue(last_job.retried)
         self.assertEqual(last_job.num_retries, main.MAX_NUM_RETRIES)
         self.assertFalse(last_job.success)
-
-        mock_os_remove.assert_called_with("nor this")
 
     @patch('data_refinery_foreman.foreman.main.get_active_volumes')
     @patch('data_refinery_foreman.foreman.main.send_job')


### PR DESCRIPTION
Reverts AlexsLemonade/refinebio#1387

I just realized this isn't the right way to do this because the foreman cannot delete data off of a worker instance's EBS. This should instead be done by the jobs themselves (which would require them to know what the job limit was) or by the janitor jobs (probably the better option).