### PR TITLE
Added an option to create missing downloader jobs created after date

### DIFF
--- a/foreman/data_refinery_foreman/foreman/management/commands/create_missing_downloader_jobs.py
+++ b/foreman/data_refinery_foreman/foreman/management/commands/create_missing_downloader_jobs.py
@@ -2,59 +2,60 @@
 This command finds Samples that were created and didn't spawned any downloader jobs.
 We tried to debug the reasons why this happened on
 https://github.com/alexslemonade/refinebio/issues/1391
-without any luck. 
+without any luck.
 """
 
 from django.core.management.base import BaseCommand
 from django.db.models import Count
+from dateutil.parser import parse as parse_date
+import time
 
-from data_refinery_common.models import (
-  Sample,
-  DownloaderJob,
-  ProcessorJob,
-  OriginalFile,
-  DownloaderJobOriginalFileAssociation,
-  ProcessorJobOriginalFileAssociation
-)
+from data_refinery_common.models import Sample
 from data_refinery_common.logging import get_and_configure_logger
 from data_refinery_common.job_management import create_downloader_job
 from data_refinery_foreman.foreman.performant_pagination.pagination import PerformantPaginator as Paginator
 
 logger = get_and_configure_logger(__name__)
 
-PAGE_SIZE=2000
+PAGE_SIZE = 2000
+
 
 class Command(BaseCommand):
+    def add_arguments(self, parser):
+        parser.add_argument('--created-after',
+                            type=parse_date,
+                            help='Only recreate jobs created after this date')
+
     def handle(self, *args, **options):
-      """ Requeues downloader jobs for samples that haven't been processed and their original files 
-      have no no downloader jobs associated with them
-      """
-      samples_without_downloader = Sample.objects.all()\
-          .annotate(original_files_count=Count('original_files'), downloader_job_count=Count('original_files__downloader_jobs'))\
-          .filter(is_processed=False, original_files_count__gt=0, downloader_job_count=0)\
-          .prefetch_related(
-            "original_files"
-          )
+        """ Requeues downloader jobs for samples that haven't been processed and their original files
+        have no no downloader jobs associated with them
+        """
+        samples_without_downloader = Sample.objects.all()\
+                                                   .annotate(original_files_count=Count('original_files'), downloader_job_count=Count('original_files__downloader_jobs'))\
+                                                   .filter(is_processed=False, original_files_count__gt=0, downloader_job_count=0)\
 
-      logger.info("Found %d samples without downloader jobs, starting to create them now.", samples_without_downloader.count())
+        if options.get('created_after', None):
+            samples_without_downloader = samples_without_downloader.filter(created_at__gt=options['created_after'])
 
-      paginator = Paginator(samples_without_downloader, PAGE_SIZE)
-      page = paginator.page()
-      page_count = 0
+        samples_without_downloader = samples_without_downloader.prefetch_related("original_files")
 
-      while True:
-          for sample in page.object_list:
-            logger.debug("Creating downloader job for a sample.", sample=sample.accession_code)
-            create_downloader_job(sample.original_files.all())
+        logger.info("Found %d samples without downloader jobs, starting to create them now.", samples_without_downloader.count())
 
-          logger.info("Created %d new downloader jobs because their samples didn't have any.", PAGE_SIZE)
+        paginator = Paginator(samples_without_downloader, PAGE_SIZE)
+        page = paginator.page()
 
-          if not page.has_next():
-              break
-              
-          page = paginator.page(page.next_page_number())
+        while True:
+            for sample in page.object_list:
+                logger.debug("Creating downloader job for a sample.", sample=sample.accession_code)
+                create_downloader_job(sample.original_files.all())
 
-          # 2000 samples queued up every five minutes should be fast
-          # enough and also not thrash the DB.
-          time.sleep(60 * 5)
+            logger.info("Created %d new downloader jobs because their samples didn't have any.", PAGE_SIZE)
 
+            if not page.has_next():
+                break
+
+            page = paginator.page(page.next_page_number())
+
+            # 2000 samples queued up every five minutes should be fast
+            # enough and also not thrash the DB.
+            time.sleep(60 * 5)


### PR DESCRIPTION
## Issue Number

N/A, I need it for testing tximport.

## Purpose/Implementation Notes

Add an option to the management command that creates missing downloader jobs which only creates samples made after a certain datetime, so that we can queue up only the jobs we're interested in retrying.

## Types of changes

What types of changes does your code introduce?

<!-- Remove any which your PR isn't -->
- New feature (non-breaking change which adds functionality)

## Functional tests
I created a sample management command locally to make sure that the `datetime` was parsed correctly.

## Checklist

_Put an `x` in the boxes that apply._

- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots

Please attach any screenshots that illustrate these changes.
