### PR TITLE
Up RAM amounts on downloader jobs that have failed two times

### DIFF
--- a/foreman/data_refinery_foreman/foreman/main.py
+++ b/foreman/data_refinery_foreman/foreman/main.py
@@ -332,7 +332,7 @@ def requeue_downloader_job(last_job: DownloaderJob) -> bool:
         if ram_amount == 1024:
             ram_amount = 4096
         elif ram_amount == 4096:
-            ram_amount = 8192
+            ram_amount = 16384
 
 
     original_file = last_job.original_files.first()

--- a/scripts/format_nomad_with_env.sh
+++ b/scripts/format_nomad_with_env.sh
@@ -248,7 +248,7 @@ if [ "$project" = "workers" ]; then
         # Downloader logs go to a separate log stream.
         if [ "$output_file" = "downloader.nomad" ]; then
             export_log_conf "downloader"
-            rams="1024 4096 8192 16384"
+            rams="1024 4096 16384"
             for r in $rams
             do
                 export RAM_POSTFIX="_$r.nomad"

--- a/scripts/format_nomad_with_env.sh
+++ b/scripts/format_nomad_with_env.sh
@@ -248,7 +248,7 @@ if [ "$project" = "workers" ]; then
         # Downloader logs go to a separate log stream.
         if [ "$output_file" = "downloader.nomad" ]; then
             export_log_conf "downloader"
-            rams="1024 4096 8192"
+            rams="1024 4096 8192 16384"
             for r in $rams
             do
                 export RAM_POSTFIX="_$r.nomad"


### PR DESCRIPTION
## Issue Number

N/A, detected while investigating downloader failure reasons for files on staging.

## Purpose/Implementation Notes

It looks like we have ~18,000 downloader jobs that have failed when their RAM amount was 8192 megs for being out of memory.

Example log output:

```
ERROR [downloader_job: 4624979]: Exception caught while downloading file.
Traceback (most recent call last):
  File "/home/user/data_refinery_workers/downloaders/sra.py", line 92, in _download_file_http
    shutil.copyfileobj(request, target_file, CHUNK_SIZE)
  File "/usr/lib/python3.5/shutil.py", line 76, in copyfileobj
    fdst.write(buf)
OSError: [Errno 12] Cannot allocate memory
```

## Types of changes

What types of changes does your code introduce?

<!-- Remove any which your PR isn't -->
- Bugfix (non-breaking change which fixes an issue)

## Functional tests

List out the functional tests you've completed to verify your changes work locally.

## Checklist

_Put an `x` in the boxes that apply._

- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots

Please attach any screenshots that illustrate these changes.
