### PR TITLE
Fix an issue with tximport getting the index length 

### DIFF
--- a/common/data_refinery_common/models/models.py
+++ b/common/data_refinery_common/models/models.py
@@ -745,7 +745,7 @@ class OriginalFile(models.Model):
 
         # Check if there's any jobs which should block another
         # processing attempt.
-        blocking_jobs = no_retry | incomplete_processor_jobs
+        blocking_jobs = no_retry_processor_jobs | incomplete_processor_jobs
         if blocking_jobs.count() > 0:
             return False
 


### PR DESCRIPTION
## Issue Number

#1074 

## Purpose/Implementation Notes

Also try to prevent no_retry jobs from being recreated by checking for them in the `needs_processing` method of OriginalFile.

Salmon quant computational results have multiple annotations. Tximport was assuming there was  only one. This fixes that.

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

N/A tests cover this well and we're testing these things on staging ATM.
