### PR TITLE
Add a check for if a processor job is a tximport job before failing

### DIFF
--- a/workers/data_refinery_workers/processors/utils.py
+++ b/workers/data_refinery_workers/processors/utils.py
@@ -197,7 +197,7 @@ def start_job(job_context: Dict):
         raise Exception("processors.start_job called on job %s that has already been started!" % str(job.id))
 
     original_file = job.original_files.first()
-    if not job.pipeline_applied == ProcessorPipeline.TXIMPORT and original_file\
+    if not job.pipeline_applied == ProcessorPipeline.TXIMPORT.value and original_file\
        and not original_file.needs_processing(job_context["job_id"]):
         failure_reason = ("Sample has a good computed file, it must have been processed, "
                           "so it doesn't need to be downloaded! Aborting!")

--- a/workers/data_refinery_workers/processors/utils.py
+++ b/workers/data_refinery_workers/processors/utils.py
@@ -11,7 +11,7 @@ from django.conf import settings
 from django.utils import timezone
 from typing import List, Dict, Callable
 
-from data_refinery_common.job_lookup import ProcessorEnum
+from data_refinery_common.job_lookup import ProcessorEnum, ProcessorPipeline
 from data_refinery_common.job_management import create_downloader_job
 from data_refinery_common.logging import get_and_configure_logger
 from data_refinery_common.models import (
@@ -197,7 +197,8 @@ def start_job(job_context: Dict):
         raise Exception("processors.start_job called on job %s that has already been started!" % str(job.id))
 
     original_file = job.original_files.first()
-    if original_file and not original_file.needs_processing(job_context["job_id"]):
+    if not job.pipeline_applied == ProcessorPipeline.TXIMPORT and original_file\
+       and not original_file.needs_processing(job_context["job_id"]):
         failure_reason = ("Sample has a good computed file, it must have been processed, "
                           "so it doesn't need to be downloaded! Aborting!")
         logger.error(failure_reason,


### PR DESCRIPTION
## Issue Number

N/A came up while testing the tximport management command

## Purpose/Implementation Notes

Tximport jobs fail because their original files were already processed. They should have been processed already by Salmon, so it doesn't make sense to fail for that reason.

## Types of changes

What types of changes does your code introduce?

<!-- Remove any which your PR isn't -->
- Bugfix (non-breaking change which fixes an issue)

## Functional tests

List out the functional tests you've completed to verify your changes work locally.

## Checklist

_Put an `x` in the boxes that apply._

- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots

Please attach any screenshots that illustrate these changes.
