### PR TITLE
Run compendia jobs on the smasher instance

### DIFF
--- a/README.md
+++ b/README.md
@@ -545,6 +545,13 @@ or for all organisms with sufficient data:
 nomad job dispatch -meta ORGANISM= CREATE_COMPENDIA
 ```
 
+Compendia jobs run on the smasher instance.
+However they require a very large amount of RAM to be able to complete.
+Our smasher instance does not generally have enough RAM to be able to run them, so if you need to run a smasher job you should temporarily increase the size of the smasher instance.
+This can be done by changing the terraform variable `smasher_instance_type` which can be found in qinfrastructure/variables.tf`.
+Select an AWS instance type that has enough RAM to run the compendia jobs.
+At the time of writing, compendia jobs require 180GB of RAM and m5.12xlarge has 192GM of RAM so it is sufficiently large to run the jobs.
+
 
 ### Running Tximport Early
 

--- a/README.md
+++ b/README.md
@@ -548,7 +548,7 @@ nomad job dispatch -meta ORGANISM= CREATE_COMPENDIA
 Compendia jobs run on the smasher instance.
 However they require a very large amount of RAM to be able to complete.
 Our smasher instance does not generally have enough RAM to be able to run them, so if you need to run a smasher job you should temporarily increase the size of the smasher instance.
-This can be done by changing the terraform variable `smasher_instance_type` which can be found in qinfrastructure/variables.tf`.
+This can be done by changing the terraform variable `smasher_instance_type` which can be found in infrastructure/variables.tf`.
 Select an AWS instance type that has enough RAM to run the compendia jobs.
 At the time of writing, compendia jobs require 180GB of RAM and m5.12xlarge has 192GM of RAM so it is sufficiently large to run the jobs.
 

--- a/README.md
+++ b/README.md
@@ -548,7 +548,7 @@ nomad job dispatch -meta ORGANISM= CREATE_COMPENDIA
 Compendia jobs run on the smasher instance.
 However they require a very large amount of RAM to be able to complete.
 Our smasher instance does not generally have enough RAM to be able to run them, so if you need to run a smasher job you should temporarily increase the size of the smasher instance.
-This can be done by changing the terraform variable `smasher_instance_type` which can be found in infrastructure/variables.tf`.
+This can be done by changing the terraform variable `smasher_instance_type` which can be found in `infrastructure/variables.tf`.
 Select an AWS instance type that has enough RAM to run the compendia jobs.
 At the time of writing, compendia jobs require 180GB of RAM and m5.12xlarge has 192GM of RAM so it is sufficiently large to run the jobs.
 

--- a/infrastructure/variables.tf
+++ b/infrastructure/variables.tf
@@ -120,7 +120,8 @@ variable "client_instance_type" {
 }
 
 variable "smasher_instance_type" {
-  default = "m5.2xlarge"
+  # 192 GiB Memory, compendia jobs needs 180!
+  default = "m5.12xlarge"
 }
 
 variable "spot_price" {

--- a/workers/nomad-job-specs/create_compendia.nomad.tpl
+++ b/workers/nomad-job-specs/create_compendia.nomad.tpl
@@ -77,12 +77,7 @@ job "CREATE_COMPENDIA" {
         max_file_size = 1
       }
 
-      # Don't run on the smasher instance, it's too small
-      constraint {
-        attribute = "${meta.is_smasher}"
-        operator = "!="
-        value = "true"
-      }
+      ${{SMASHER_CONSTRAINT}}
 
       config {
         image = "${{DOCKERHUB_REPO}}/${{COMPENDIA_DOCKER_IMAGE}}"


### PR DESCRIPTION
## Issue Number

Reverts https://github.com/AlexsLemonade/refinebio/pull/1386

## Purpose/Implementation Notes

It's best to run compendia jobs on the smasher instance because it won't get cycled by AWS and we don't have to worry about enough capacity being available to run the job. It does mean we have to scale our smasher instance up and then back down to run compendia, but it's better than running these jobs on spot instances.

## Types of changes

- New feature (non-breaking change which adds functionality)
