### PR TITLE
Avoid searching in sample metadata

### DIFF
--- a/api/data_refinery_api/views.py
+++ b/api/data_refinery_api/views.py
@@ -688,7 +688,6 @@ class SampleList(generics.ListAPIView):
         ref https://www.django-rest-framework.org/api-guide/filtering/#filtering-against-query-parameters
         """
         queryset = Sample.public_objects \
-            .prefetch_related('sampleannotation_set') \
             .prefetch_related('organism') \
             .prefetch_related('results') \
             .prefetch_related('results__processor') \
@@ -697,7 +696,7 @@ class SampleList(generics.ListAPIView):
             .filter(**self.get_query_params_filters())
 
         # case insensitive search https://docs.djangoproject.com/en/2.1/ref/models/querysets/#icontains
-        filter_by = self.request.query_params.get('filter_by', None)        
+        filter_by = self.request.query_params.get('filter_by', None)
         if filter_by:
             queryset = queryset.filter(Q(title__icontains=filter_by) |
                                        Q(sex__icontains=filter_by) |
@@ -711,8 +710,7 @@ class SampleList(generics.ListAPIView):
                                        Q(race__icontains=filter_by) |
                                        Q(subject__icontains=filter_by) |
                                        Q(compound__icontains=filter_by) |
-                                       Q(time__icontains=filter_by) |
-                                       Q(sampleannotation__data__icontains=filter_by))
+                                       Q(time__icontains=filter_by))
 
         return queryset
 

--- a/common/data_refinery_common/models/documents.py
+++ b/common/data_refinery_common/models/documents.py
@@ -121,6 +121,7 @@ class ExperimentDocument(DocType):
 
     def get_queryset(self):
         return super(ExperimentDocument, self).get_queryset()\
+            .order_by('id')\
             .prefetch_related('samples')\
             .prefetch_related('samples__organism')
 


### PR DESCRIPTION
## Issue Number

close https://github.com/alexslemonade/refinebio-frontend/issues/705

## Purpose/Implementation Notes

We had a discussion on close https://github.com/alexslemonade/refinebio-frontend/issues/705 and decided to remove the sample additional metadata from the search fields. 

This will only affect people trying to filter on the `/samples` endpoint

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

Tested locally.

## Checklist

- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules
