### PR TITLE
Fix incorrect dashboard statistics

### DIFF
--- a/api/data_refinery_api/views.py
+++ b/api/data_refinery_api/views.py
@@ -1043,7 +1043,7 @@ class Stats(APIView):
         return result
 
     @classmethod
-    def _get_intervals(cls, objects, range_param, field='created_at'):
+    def _get_intervals(cls, objects, range_param, field='last_modified'):
         range_to_trunc = {
             'day': 'hour',
             'week': 'day',
@@ -1058,7 +1058,7 @@ class Stats(APIView):
             'year': current_date - timedelta(days=365)
         }
 
-        # trucate the `created_at` field by hour, day or month depending on the `range` param
+        # trucate the `last_modified` field by hour, day or month depending on the `range` param
         # and annotate each object with that. This will allow us to count the number of objects
         # on each interval with a single query
         # ref https://stackoverflow.com/a/38359913/763705

--- a/api/data_refinery_api/views.py
+++ b/api/data_refinery_api/views.py
@@ -1058,7 +1058,7 @@ class Stats(APIView):
             'year': current_date - timedelta(days=365)
         }
 
-        # trucate the `last_modified` field by hour, day or month depending on the `range` param
+        # truncate the `last_modified` field by hour, day or month depending on the `range` param
         # and annotate each object with that. This will allow us to count the number of objects
         # on each interval with a single query
         # ref https://stackoverflow.com/a/38359913/763705


### PR DESCRIPTION
## Issue Number

Closes #1461

## Purpose/Implementation Notes

We should not be grouping based off of `created_at` for job statistics, because we want to see when jobs succeeded/failed. If we instead group based on `last_modified`, we will see jobs on the graph when they were last modified, either because they were created or because they succeeded or failed.

```
data_refinery=> select count(id) from downloader_jobs where success = True and date_trunc('hour', created_at) = timestamp '2019-08-08T09:00:00Z';
 count
-------
     7
(1 row)

data_refinery=> select count(id) from downloader_jobs where success = True and date_trunc('hour', last_modified) = timestamp '2019-08-08T09:00:00Z';
 count
-------
  1281
(1 row)
```

## Types of changes

What types of changes does your code introduce?

<!-- Remove any which your PR isn't -->
- Bugfix (non-breaking change which fixes an issue)

## Functional tests

I ran SQL queries to make sure that they matched what we expected.

## Checklist

_Put an `x` in the boxes that apply._

- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots

Please attach any screenshots that illustrate these changes.
