### PR TITLE
[HOTFIX] Disable stats background scheduler

### DIFF
--- a/api/data_refinery_api/views.py
+++ b/api/data_refinery_api/views.py
@@ -176,9 +176,9 @@ manual_parameters=[
     ),
 ],
 operation_description="""
-Use this endpoint to search among the experiments. 
+Use this endpoint to search among the experiments.
 
-This is powered by ElasticSearch, information regarding advanced usages of the 
+This is powered by ElasticSearch, information regarding advanced usages of the
 filters can be found in the [Django-ES-DSL-DRF docs](https://django-elasticsearch-dsl-drf.readthedocs.io/en/0.17.1/filtering_usage_examples.html#filtering)
 
 There's an additional field in the response named `facets` that contain stats on the number of results per filter type.
@@ -558,10 +558,10 @@ class DatasetView(generics.RetrieveUpdateAPIView):
         serializer.save()
 
 class CreateApiTokenView(generics.CreateAPIView):
-    """ 
+    """
     token_create
 
-    There're several endpoints like [/dataset](#tag/dataset) and [/results](#tag/results) that return 
+    There're several endpoints like [/dataset](#tag/dataset) and [/results](#tag/results) that return
     S3 urls where users can download the files we produce, however in order to get those files people
     need to accept our terms of use by creating a token and activating it.
 
@@ -741,7 +741,7 @@ class SampleList(generics.ListAPIView):
             filter_dict['accession_code__in'] = [item for sublist in dataset.data.values() for item in sublist]
 
         # Accept Organism in both name and ID form
-        organism = self.request.query_params.get('organism', None)        
+        organism = self.request.query_params.get('organism', None)
         if organism:
             try:
                 organism_id = int(organism)
@@ -1067,12 +1067,12 @@ class Stats(APIView):
                       .filter(start__gte=range_to_start_date.get(range_param))
 
 
-STAT_CACHE_REFRESH_INTERVAL_MINUTES = 5
-scheduler = BackgroundScheduler()
-for timeframe in ('day', 'week', 'month', 'year', None):
-    scheduler.add_job(Stats.update_cache, 'interval', [timeframe],
-                      minutes=STAT_CACHE_REFRESH_INTERVAL_MINUTES)
-scheduler.start()
+# STAT_CACHE_REFRESH_INTERVAL_MINUTES = 5
+# scheduler = BackgroundScheduler()
+# for timeframe in ('day', 'week', 'month', 'year', None):
+#     scheduler.add_job(Stats.update_cache, 'interval', [timeframe],
+#                       minutes=STAT_CACHE_REFRESH_INTERVAL_MINUTES)
+# scheduler.start()
 
 
 ###
@@ -1128,7 +1128,7 @@ class CompendiaDetail(APIView):
     """
     A very simple modified ComputedFile endpoint which only shows Compendia results.
     """
-    
+
     @swagger_auto_schema(deprecated=True)
     def get(self, request, version, format=None):
 
@@ -1195,7 +1195,7 @@ class QNTargetsDetail(generics.RetrieveAPIView):
 class ComputedFilesList(generics.ListAPIView):
     """
     computed_files_list
-    
+
     ComputedFiles are representation of files created by data-refinery processes.
 
     This can also be used to fetch all the compendia files we have generated with:

--- a/common/data_refinery_common/migrations/0026_fix_typo_in_sample_manufacturer.py
+++ b/common/data_refinery_common/migrations/0026_fix_typo_in_sample_manufacturer.py
@@ -9,14 +9,8 @@ def fix_typo_in_sample_manufacturer(apps, schema_editor):
     https://simpleisbetterthancomplex.com/tutorial/2017/09/26/how-to-create-django-data-migrations.html
     '''
     Sample = apps.get_model('data_refinery_common', 'Sample')
-
-    for sample in Sample.objects.all():
-        if sample.manufacturer == "AFFYMETRTIX":
-            sample.manufacturer = "AFFYMETRIX"
-            sample.save()
-        elif sample.manufacturer == "NEXTSEQ":
-            sample.manufacturer = "ILLUMINA"
-            sample.save()
+    Sample.objects.all().filter(platform_name="AFFYMETRTIX").update(platform_name="AFFYMETRIX")
+    Sample.objects.all().filter(platform_name="NEXTSEQ").update(platform_name="ILLUMINA")
 
 
 class Migration(migrations.Migration):


### PR DESCRIPTION
Our database isn't doing so well, big spikes every 5 minutes and we're seeing:

```
2019-08-08 20:00:17 UTC:10.0.73.172(40800):drpostgresuser@data_refinery:[13249]:LOG:  duration: 6306.040 ms  statement: SELECT COUNT("downloader_jobs"."id") AS "total", COUNT("downloader_jobs"."id") FILTER (WHERE "downloader_jobs"."success" = true) AS "successful", COUNT("downloader_jobs"."id") FILTER (WHERE "downloader_jobs"."success" = false) AS "failed", COUNT("downloader_jobs"."id") FILTER (WHERE ("downloader_jobs"."start_time" IS NULL AND "downloader_jobs"."success" IS NULL)) AS "pending", COUNT("downloader_jobs"."id") FILTER (WHERE ("downloader_jobs"."start_time" IS NOT NULL AND "downloader_jobs"."success" IS NULL)) AS "open" FROM "downloader_jobs"
```

We gotta disable this ASAP