### PR TITLE
Fix API stats refresh scheduler

### DIFF
--- a/infrastructure/deploy.sh
+++ b/infrastructure/deploy.sh
@@ -375,6 +375,26 @@ if [[ ! -z $container_running ]]; then
        --name=dr_api \
        -it -d $DOCKERHUB_REPO/$API_DOCKER_IMAGE /bin/sh -c /home/user/collect_and_run_uwsgi.sh"
 
+    ssh -o StrictHostKeyChecking=no \
+        -o ServerAliveInterval=15 \
+        -o ConnectTimeout=5 \
+        -i data-refinery-key.pem \
+        ubuntu@$API_IP_ADDRESS "docker run \
+       --env-file environment \
+       -e DATABASE_HOST=$DATABASE_HOST \
+       -e DATABASE_NAME=$DATABASE_NAME \
+       -e DATABASE_USER=$DATABASE_USER \
+       -e DATABASE_PASSWORD=$DATABASE_PASSWORD \
+       -e ELASTICSEARCH_HOST=$ELASTICSEARCH_HOST \
+       -e ELASTICSEARCH_PORT=$ELASTICSEARCH_PORT \
+       -v /tmp/volumes_static:/tmp/www/static \
+       --log-driver=awslogs \
+       --log-opt awslogs-region=$REGION \
+       --log-opt awslogs-group=data-refinery-log-group-$USER-$STAGE \
+       --log-opt awslogs-stream=log-stream-api-$USER-$STAGE \
+       --name=dr_api_stats_refresh \
+       -it -d $DOCKERHUB_REPO/$API_DOCKER_IMAGE python3 manage.py start_stats_refresh"
+
     # Don't leave secrets lying around.
     ssh -o StrictHostKeyChecking=no \
         -o ServerAliveInterval=15 \


### PR DESCRIPTION
## Issue Number

#1468 

## Purpose/Implementation Notes

I changed it so that a background job refreshes the stat cache rather than a scheduler instance in the views, since it seemed that Django replicated those schedulers. Also, only cache None and 'day' for range parameters, since those are the default and that should reduce the load on our database.

## Types of changes

What types of changes does your code introduce?

<!-- Remove any which your PR isn't -->
- Bugfix (non-breaking change which fixes an issue)

## Functional tests

I ran the new management command inside one container and the API inside another and tested the cache using `time curl` and debugging print statements.

## Checklist

_Put an `x` in the boxes that apply._

- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots

Please attach any screenshots that illustrate these changes.
