### PR TITLE
Calculate number of samples per experiment in a single query

### DIFF
--- a/common/data_refinery_common/models/models.py
+++ b/common/data_refinery_common/models/models.py
@@ -331,8 +331,7 @@ class Experiment(models.Model):
         """ Update our cache values """
         self.num_total_samples = self.samples.count()
         self.num_processed_samples = self.samples.filter(is_processed=True).count()
-        qn_organisms = Organism.get_objects_with_qn_targets()
-        self.num_downloadable_samples = self.samples.filter(is_processed=True, organism__in=qn_organisms).count()
+        self.num_downloadable_samples = self.samples.filter(is_processed=True, organism__qn_target__isnull=False).count()
         self.save()
 
     def to_metadata_dict(self):


### PR DESCRIPTION
## Issue Number

#1378 

## Purpose/Implementation Notes

Calculate the number of processed/downloadable samples for experiments in a single query. This was one of the queries that impacted the surveyor negatively.

## Types of changes

- Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Functional tests

Tested locally.

## Checklist

- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules
