### PR TITLE
Fix at least some of the surveyor jobs.

### DIFF
--- a/foreman/data_refinery_foreman/surveyor/sra.py
+++ b/foreman/data_refinery_foreman/surveyor/sra.py
@@ -369,8 +369,15 @@ class SraSurveyor(ExternalSourceSurveyor):
 
         # Rare, but it happens.
         if not experiment.protocol_description:
-            experiment.protocol_description = metadata.get("library_construction_protocol",
-                                                           "Protocol was never provided.")
+            # metadata.get() doesn't work here because sometimes the
+            # key is present but its value is None, in which case None
+            # is returned, causing our database constraint to be
+            # violated.
+            if "library_construction_protocol" in metadata and metadata["library_construction_protocol"]:
+                experiment.protocol_description = metadata["library_construction_protocol"]
+            else:
+                experiment.protocol_description = "Protocol was never provided."
+
         # Scrape publication title and authorship from Pubmed
         if experiment.pubmed_id:
             pubmed_metadata = utils.get_title_and_authors_for_pubmed_id(experiment.pubmed_id)

--- a/foreman/data_refinery_foreman/surveyor/surveyor.py
+++ b/foreman/data_refinery_foreman/surveyor/surveyor.py
@@ -86,6 +86,7 @@ def run_job(survey_job: SurveyJob) -> SurveyJob:
     except Exception as e:
         logger.exception("Exception caught while running Survey Job.",
                          survey_job=survey_job.id)
+        survey_job.failure_reason = str(e)
         job_success = False
 
     survey_job = _end_job(survey_job, job_success)


### PR DESCRIPTION
## Issue Number

#1491 

## Purpose/Implementation Notes

We got bit by get!

`a.get("x", "y")` can return `None` if `a["x"] == None`, which I think is what was happening. That's why we were violating our database constraint.

This also set failure reasons for surveyor jobs.

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

I ran a surveyor job for DRP003656 and it failed without these changes. With these changes it worked!
