### PR TITLE
Add management command to retry jobs that timed out

### DIFF
--- a/foreman/data_refinery_foreman/foreman/management/commands/retry_timed_out_jobs.py
+++ b/foreman/data_refinery_foreman/foreman/management/commands/retry_timed_out_jobs.py
@@ -1,0 +1,48 @@
+"""This command will slowly retry Salmon jobs that timed out.
+This is now necessary because samples with unmated reads will no longer cause
+us to time out. It will only queue 300 an hour so as to not overload ENA.
+"""
+
+import time
+from typing import List
+
+from django.core.management.base import BaseCommand
+
+from data_refinery_foreman.foreman.performant_pagination.pagination import PerformantPaginator as Paginator
+from data_refinery_common.logging import get_and_configure_logger
+from data_refinery_common.models import  ProcessorJob
+
+
+logger = get_and_configure_logger(__name__)
+
+
+class Command(BaseCommand):
+    def handle(self, *args, **options):
+        timed_out_jobs = ProcessorJob.objects.filter(
+            success='f',
+            failure_reason='Salmon timed out because it failed to complete within 3 hours.',
+            retried_job_id__isnull=True # Only get jobs that weren't retried.
+        )
+
+        total = 0
+        i = 0
+        paginator = Paginator(timed_out_jobs, 1000)
+        for page_idx in range(1, paginator.num_pages):
+            for processor_job in paginator.page(page_idx).object_list:
+                # Reset the job so it'll start at 12288 RAM (since it'll go up from here).
+                processor_job.ram_amount = 8192
+                # And so it'll be retried twice more.
+                processor_job.num_retries = 0
+                processor_job.retried = False
+
+                # We don't actually have to send this off to Nomad ourselves.
+                # The Foreman will find it and requeue it for us!
+                processor_job.save()
+
+                total += 1
+                i += 1
+                # Only queue 300 of these an hour so we don't overload ENA.
+                if i == 300:
+                    logger.info("Requeued 300 more jobs (total %d). Sleeping for 1 hour.", total)
+                    time.sleep(60*60)
+                    i = 0

--- a/workers/data_refinery_workers/processors/salmon.py
+++ b/workers/data_refinery_workers/processors/salmon.py
@@ -722,11 +722,8 @@ def _run_salmon(job_context: Dict) -> Dict:
                  formatted_command,
                  processor_job=job_context["job_id"])
 
-    # 1 hour seems like a reasonable timeout for salmon. This is
-    # necessary because some samples make salmon hang forever and this
-    # ties up our computing resources forever. Until this bug is
-    # fixed, we'll just have to do it like this.
-    timeout = 60 * 60
+    # Salmon probably shouldn't take longer than three hours.
+    timeout = 60 * 60 * 3
     job_context['time_start'] = timezone.now()
     try:
         completed_command = subprocess.run(formatted_command.split(),


### PR DESCRIPTION
## Issue Number

#1494 

## Purpose/Implementation Notes

It looks like we can finally process samples with unmated reads. Now we have to go back and process all the samples that timed out because of that issue or just because they needed more running time.

## Types of changes

- New feature (non-breaking change which adds functionality)

## Functional tests

I haven't functionally tested this. I think I just want to do so on staging.

## Checklist

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules
