### PR TITLE
Make the foreman check nomad more often

### DIFF
--- a/foreman/data_refinery_foreman/foreman/main.py
+++ b/foreman/data_refinery_foreman/foreman/main.py
@@ -131,7 +131,7 @@ def handle_repeated_failure(job) -> None:
                 failure_reason=job.failure_reason)
 
 
-def update_volume_work_depth(window=datetime.timedelta(minutes=5)):
+def update_volume_work_depth(window=datetime.timedelta(minutes=2)):
     """When a new job is created our local idea of the work depth is updated, but every so often
     we refresh from Nomad how many jobs were stopped or killed"""
     global VOLUME_WORK_DEPTH
@@ -397,7 +397,7 @@ def requeue_downloader_job(last_job: DownloaderJob) -> (bool, str):
     return True, new_job.volume_index
 
 
-def count_downloader_jobs_in_queue(window=datetime.timedelta(minutes=5)) -> int:
+def count_downloader_jobs_in_queue(window=datetime.timedelta(minutes=2)) -> int:
     """Counts how many downloader jobs in the Nomad queue do not have status of 'dead'."""
 
     nomad_host = get_env_variable("NOMAD_HOST")
@@ -455,6 +455,7 @@ def handle_downloader_jobs(jobs: List[DownloaderJob]) -> None:
 
     No more than queue_capacity jobs will be retried.
     """
+    global VOLUME_WORK_DEPTH
 
     queue_capacity = get_capacity_for_downloader_jobs()
 


### PR DESCRIPTION
## Issue Number

N/A I've been thinking this has been an issue

## Purpose/Implementation Notes

Also use a global variable correctly so it gets updated in between checks.

Basically the graph of instance CPU utilization makes it seem like only the instance with the least utilization gets assigned downloader jobs, and then it gets so many that it ends up being high utilization for a long time. However I'd like the foreman to distribute jobs between all the instances better so that we get more even and consistent CPU utilization.

## Types of changes

- New feature (non-breaking change which adds functionality)

## Functional tests

I have not tested this, but these are minor tweaks that I'm not worried about.

## Checklist

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules
