### PR TITLE
Fix the way we queue downloader jobs.

### DIFF
--- a/foreman/data_refinery_foreman/foreman/main.py
+++ b/foreman/data_refinery_foreman/foreman/main.py
@@ -456,6 +456,7 @@ def handle_downloader_jobs(jobs: List[DownloaderJob]) -> None:
     No more than queue_capacity jobs will be retried.
     """
     global VOLUME_WORK_DEPTH
+    global DOWNLOADER_JOBS_IN_QUEUE
 
     queue_capacity = get_capacity_for_downloader_jobs()
 
@@ -470,6 +471,7 @@ def handle_downloader_jobs(jobs: List[DownloaderJob]) -> None:
             if requeue_success:
                 jobs_dispatched = jobs_dispatched + 1
                 VOLUME_WORK_DEPTH[dispatched_volume] += 1
+                DOWNLOADER_JOBS_IN_QUEUE += 1
         else:
             handle_repeated_failure(job)
 


### PR DESCRIPTION
## Issue Number

#1405

## Purpose/Implementation Notes

We aren't keeping all our instances busy well because we aren't queuing downloader jobs well.

Because we've been failing to update `DOWNLOADER_JOBS_IN_QUEUE` as we queue downloader jobs and only refresh that every two minutes, that means that as soon as we drop below 750 downloader jobs we queue downloader jobs for 2 minutes straight before we realize we're past 750. This causes lots of downloaders jobs to get queued so we can't queue more for a long time, at which point one or more instances runs out and starts idling to some degree.

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

I haven't tested this. It's a hard one to test when not running at scale.
