### PR TITLE
extend excluded list and add ALSF email addrs

### DIFF
--- a/api/data_refinery_api/views.py
+++ b/api/data_refinery_api/views.py
@@ -939,7 +939,19 @@ class Stats(APIView):
 
         return data
 
-    EMAIL_USERNAME_BLACKLIST = ['arielsvn', 'miserlou', 'kurt.wheeler91', 'd.prasad']
+
+    EMAIL_USERNAME_BLACKLIST = [
+        'arielsvn',
+        'cansav09',
+        'd.prasad',
+        'daniel.himmelstein',
+        'dv.prasad991',
+        'greenescientist',
+        'jaclyn.n.taroni',
+        'kurt.wheeler91',
+        'michael.zietz',
+        'miserlou'
+    ]
 
     @classmethod
     def _get_dataset_stats(cls, range_param):
@@ -947,6 +959,7 @@ class Stats(APIView):
         filter_query = Q()
         for username in Stats.EMAIL_USERNAME_BLACKLIST:
             filter_query = filter_query | Q(email_address__startswith=username)
+        filter_query = filter_query | Q(email_address__endswith='@alexslemonade.org')
         processed_datasets = Dataset.objects.filter(is_processed=True, email_address__isnull=False).exclude(filter_query)
         result = processed_datasets.aggregate(
             total=Count('id'),


### PR DESCRIPTION
## Issue Number

Front End Issue:
[##714](https://github.com/AlexsLemonade/refinebio-frontend/issues/714)

## Purpose/Implementation Notes

This is addresses a front end issue where the dashboard dataset downloads appears to be too high, so we are trying to filter out more known emails for the statistics on downloaded datasets.

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

Ran locally fine but without data to verify this will bring the current numbers to within ideal range.

## Checklist

- [ x ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots

Please attach any screenshots that illustrate these changes.