### PR TITLE
Fix foreman test that broke because I fixed the download job cap.

### DIFF
--- a/foreman/data_refinery_foreman/foreman/test_main.py
+++ b/foreman/data_refinery_foreman/foreman/test_main.py
@@ -137,11 +137,11 @@ class ForemanTestCase(TestCase):
     def test_retrying_many_failed_downloader_jobs(self, mock_send_job, mock_breakdown, mock_active_volumes):
         mock_send_job.return_value = True
         mock_breakdown.return_value = {"nomad_pending_jobs_by_volume": {"0": 7, "1": 9},
-                                       "nomad_running_jobs_by_volume": {"0": 60, "1": 90}}
+                                       "nomad_running_jobs_by_volume": {"0": 600, "1": 900}}
         mock_active_volumes.return_value = ['0', '1']
 
         main.update_volume_work_depth(datetime.timedelta(0))
-        self.assertEqual(main.VOLUME_WORK_DEPTH, {"0": 67, "1": 99})
+        self.assertEqual(main.VOLUME_WORK_DEPTH, {"0": 607, "1": 909})
 
         # Ensure that there are at least enough jobs to saturate the desired work depth
         # for both mocked volumes
@@ -156,7 +156,7 @@ class ForemanTestCase(TestCase):
         # depth plus any new queued jobs, so this should only queue up enough jobs to fill the
         # DESIRED_WORK_DEPTH for every node
         # ((DESIRED_WORK_DEPTH - 67) + (DESIRED_WORK_DEPTH - 99) jobs in total)
-        self.assertEqual(len(mock_send_job.mock_calls), 2 * main.DESIRED_WORK_DEPTH - 67 - 99)
+        self.assertEqual(len(mock_send_job.mock_calls), 2 * main.DESIRED_WORK_DEPTH - 607 - 909)
         self.assertEqual(main.VOLUME_WORK_DEPTH,
                          {"0": main.DESIRED_WORK_DEPTH, "1": main.DESIRED_WORK_DEPTH})
 


### PR DESCRIPTION
## Issue Number

Caused by https://github.com/AlexsLemonade/refinebio/pull/1508

## Purpose/Implementation Notes

In #1508 I fixed the fact that we weren't keeping track of downloader job counts properly. However once I fixed this limit it started being imposed on this test, which made the test unable to queue as many jobs as it was expecting.

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

N/A this is a unit test fix

## Checklist

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules
