### PR TITLE
Fix salmon rerun command

### DIFF
--- a/common/data_refinery_common/job_management.py
+++ b/common/data_refinery_common/job_management.py
@@ -164,7 +164,8 @@ def delete_if_blacklisted(original_file: OriginalFile) -> OriginalFile:
     return original_file
 
 def create_processor_jobs_for_original_files(original_files: List[OriginalFile],
-                                             downloader_job: DownloaderJob=None):
+                                             downloader_job: DownloaderJob=None,
+                                             volume_index: str=None):
     """
     Creates one processor job for each original file given.
     """
@@ -197,6 +198,10 @@ def create_processor_jobs_for_original_files(original_files: List[OriginalFile],
             processor_job = ProcessorJob()
             processor_job.pipeline_applied = pipeline_to_apply.value
             processor_job.ram_amount = determine_ram_amount(sample_object, processor_job)
+
+            if volume_index:
+                processor_job.volume_index = volume_index
+
             processor_job.save()
 
             assoc = ProcessorJobOriginalFileAssociation()
@@ -223,7 +228,8 @@ def create_processor_jobs_for_original_files(original_files: List[OriginalFile],
 
 
 def create_processor_job_for_original_files(original_files: List[OriginalFile],
-                                            downloader_job: DownloaderJob=None):
+                                            downloader_job: DownloaderJob=None,
+                                            volume_index: str=None):
     """
     Create a processor job and queue a processor task for sample related to an experiment.
     """
@@ -248,6 +254,10 @@ def create_processor_job_for_original_files(original_files: List[OriginalFile],
         processor_job = ProcessorJob()
         processor_job.pipeline_applied = pipeline_to_apply.value
         processor_job.ram_amount = determine_ram_amount(sample_object, processor_job)
+
+        if volume_index:
+            processor_job.volume_index = volume_index
+
         processor_job.save()
         for original_file in original_files:
             assoc = ProcessorJobOriginalFileAssociation()

--- a/common/data_refinery_common/job_management.py
+++ b/common/data_refinery_common/job_management.py
@@ -259,6 +259,7 @@ def create_processor_job_for_original_files(original_files: List[OriginalFile],
             processor_job.volume_index = volume_index
 
         processor_job.save()
+
         for original_file in original_files:
             assoc = ProcessorJobOriginalFileAssociation()
             assoc.original_file = original_file

--- a/foreman/data_refinery_foreman/foreman/management/commands/rerun_salmon_old_samples.py
+++ b/foreman/data_refinery_foreman/foreman/management/commands/rerun_salmon_old_samples.py
@@ -60,6 +60,10 @@ def update_salmon_versions(experiment: Experiment):
         )\
         .exclude(salmon_version=latest_salmon_version)
 
+    logger.info("Found %d samples for experiment %s that need to be rerun.",
+                samples.count(),
+                experiment.accession_code)
+
     # create new processor jobs for the samples that were run with an older salmon version
     for sample in samples:
         original_files = list(sample.original_files.all())
@@ -80,7 +84,7 @@ def update_salmon_versions(experiment: Experiment):
             continue
 
         volume_index = main.get_emptiest_volume()
-        create_processor_job_for_original_files(original_files, volume_index)
+        create_processor_job_for_original_files(original_files, volume_index=volume_index)
         main.VOLUME_WORK_DEPTH[volume_index] += 1
 
 def update_salmon_all_experiments():

--- a/foreman/data_refinery_foreman/foreman/management/commands/rerun_salmon_old_samples.py
+++ b/foreman/data_refinery_foreman/foreman/management/commands/rerun_salmon_old_samples.py
@@ -36,8 +36,6 @@ from data_refinery_foreman.foreman import main
 logger = get_and_configure_logger(__name__)
 
 def update_salmon_versions(experiment: Experiment):
-    global main.VOLUME_WORK_DEPTH
-
     quant_results = get_quant_results_for_experiment(experiment)
     salmon_versions = list(quant_results.order_by('-organism_index__created_at')\
                                    .values_list('organism_index__salmon_version', flat=True)\

--- a/foreman/data_refinery_foreman/foreman/management/commands/test_rerun_salmon_old_samples.py
+++ b/foreman/data_refinery_foreman/foreman/management/commands/test_rerun_salmon_old_samples.py
@@ -262,6 +262,9 @@ class RerunSalmonTestCase(TestCase):
         first_call_job_type = mock_calls[0][1][0]
         self.assertEqual(first_call_job_type, ProcessorPipeline.SALMON)
 
+        created_job = ProcessorJob.objects.all()[0]
+        self.assertEqual(created_job.volume_index, '0')
+
     @patch('data_refinery_common.job_management.send_job')
     def test_no_job_created_when_failed_job_exists(self, mock_send_job):
         experiment = setup_experiment([], ['GSM001'])

--- a/foreman/data_refinery_foreman/foreman/management/commands/test_rerun_salmon_old_samples.py
+++ b/foreman/data_refinery_foreman/foreman/management/commands/test_rerun_salmon_old_samples.py
@@ -238,7 +238,7 @@ def setup_experiment(complete_accessions: List[str], incomplete_accessions: List
 
 class RerunSalmonTestCase(TestCase):
     """
-    Tests that new processor jobs are created for samples that belong to experiments that were 
+    Tests that new processor jobs are created for samples that belong to experiments that were
     processed with multiple versions of Salmon
     """
     @patch('data_refinery_common.job_management.send_job')
@@ -249,7 +249,7 @@ class RerunSalmonTestCase(TestCase):
         # Verify that no jobs were created, because all samples had been processed with the latest version
         mock_calls = mock_send_job.mock_calls
         self.assertEqual(len(mock_calls), 0)
-        
+
     @patch('data_refinery_common.job_management.send_job')
     def test(self, mock_send_job):
         setup_experiment(['SS001'], ['SS002'])
@@ -285,4 +285,3 @@ class RerunSalmonTestCase(TestCase):
 
         mock_calls = mock_send_job.mock_calls
         self.assertEqual(len(mock_calls), 0)
-


### PR DESCRIPTION
## Issue Number

#1513 

## Purpose/Implementation Notes

When we deployed #1513 we didn't remove the check where we wouldn't start a job if there was already a good computed file. This fixes that.

This also sets the volume index for created jobs because they were defaulting to "-1" and I was having to update that manually.

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

I ran this locally but I didn't have mixed-version experiment to trigger it, but the tests cover it well and I made sure that the volume index got set properly.
