### PR TITLE
Force salmon rerun jobs to get created. 

### DIFF
--- a/foreman/data_refinery_foreman/foreman/management/commands/rerun_salmon_old_samples.py
+++ b/foreman/data_refinery_foreman/foreman/management/commands/rerun_salmon_old_samples.py
@@ -56,7 +56,7 @@ def update_salmon_versions(experiment: Experiment):
                 if (has_open_processor_job):
                     continue
 
-                create_downloader_job(original_files)
+                create_downloader_job(original_files, force=True)
                 total_samples_queued += 1
 
     logger.info("Re-ran Salmon for %d samples in experiment %s.",

--- a/infrastructure/foreman-configuration/foreman-server-instance-user-data.tpl.sh
+++ b/infrastructure/foreman-configuration/foreman-server-instance-user-data.tpl.sh
@@ -63,7 +63,7 @@ docker run \\
        --add-host=nomad:${nomad_lead_server_ip} \\
        -it -d ${dockerhub_repo}/${foreman_docker_image} python3 manage.py \$@
 " >> /home/ubuntu/run_management_command.sh
-chmod +x /home/ubuntu/run_foreman_command.sh
+chmod +x /home/ubuntu/run_management_command.sh
 
 # Start the Nomad agent in server mode via Monit
 apt-get -y update


### PR DESCRIPTION
## Issue Number

#1523 

## Purpose/Implementation Notes

I've seen 3 errors from the salmon rerun jobs like:
```
2019-08-28 14:25:10,276 i-03c3479626488d617 [volume: -1] data_refinery_common.job_management WARNING [original_downloader_job: DownloaderJob 5307576: SRA] [undownloaded_files: [<OriginalFile: OriginalFile: SRR534304.sra>]]: Downloader job has already been recreated once, not doing it again.
```

Not too bad considering we've already created 21k jobs with it. Still should be fixed so we get all of salmon on the same version.

Also fix typo in foreman startup script.

## Types of changes

- Bugfix (non-breaking change which fixes an issue)
