### PR TITLE
Fix creation counter for the run_tximport command.

### DIFF
--- a/foreman/data_refinery_foreman/foreman/management/commands/run_tximport.py
+++ b/foreman/data_refinery_foreman/foreman/management/commands/run_tximport.py
@@ -57,10 +57,10 @@ def run_tximport():
     tximport_pipeline = ProcessorPipeline.TXIMPORT
 
     while True:
+        creation_count = 0
+
         for experiment in page.object_list:
             quant_results = get_quant_results_for_experiment(experiment)
-
-            creation_count = 0
 
             if should_run_tximport(experiment, quant_results, True):
                 processor_job = ProcessorJob()


### PR DESCRIPTION
## Issue Number

#1544 

## Purpose/Implementation Notes

I put this in the wrong place. It doesn't affect anything, but the counter is always 0 or 1.
