### PR TITLE
Small improvements to be able to queue up lots of work

### DIFF
--- a/api/data_refinery_api/views.py
+++ b/api/data_refinery_api/views.py
@@ -119,6 +119,9 @@ MAILCHIMP_USER = get_env_variable("MAILCHIMP_USER")
 MAILCHIMP_API_KEY = get_env_variable("MAILCHIMP_API_KEY")
 MAILCHIMP_LIST_ID = get_env_variable("MAILCHIMP_LIST_ID")
 
+
+JOB_CREATED_AT_CUTOFF = datetime(2019, 6, 5, tzinfo=timezone.utc)
+
 ##
 # ElasticSearch
 ##
@@ -1015,7 +1018,9 @@ class Stats(APIView):
             total=Count('id'),
             successful=Count('id', filter=Q(success=True)),
             failed=Count('id', filter=Q(success=False)),
-            pending=Count('id', filter=Q(start_time__isnull=True, success__isnull=True)),
+            pending=Count('id', filter=Q(start_time__isnull=True,
+                                         success__isnull=True,
+                                         created_at__gt=JOB_CREATED_AT_CUTOFF)),
             open=Count('id', filter=Q(start_time__isnull=False, success__isnull=True)),
         )
         # via https://stackoverflow.com/questions/32520655/get-average-of-difference-of-datetime-fields-in-django

--- a/common/data_refinery_common/models/models.py
+++ b/common/data_refinery_common/models/models.py
@@ -782,8 +782,8 @@ class OriginalFile(models.Model):
         if sample.source_database == "SRA":
             for computed_file in sample.computed_files.prefetch_related('result__organism_index').all():
                     if computed_file.s3_bucket and computed_file.s3_key \
-                       and (computed_file.result.organism_index == None
-                       or computed_file.result.organism_index.salmon_version == CURRENT_SALMON_VERSION):
+                       and computed_file.result.organism_index != None \
+                       and computed_file.result.organism_index.salmon_version == CURRENT_SALMON_VERSION:
                         # If the file wasn't computed with the latest
                         # version of salmon, then it should be rerun
                         # with the latest version of salmon.

--- a/foreman/data_refinery_foreman/foreman/main.py
+++ b/foreman/data_refinery_foreman/foreman/main.py
@@ -69,7 +69,7 @@ DESIRED_WORK_DEPTH = 500
 # be queued across the whole cluster no matter how many nodes we
 # have. This is important because too many downloader jobs and we take
 # down NCBI.
-HARD_MAX_DOWNLOADER_JOBS = 750
+HARD_MAX_DOWNLOADER_JOBS = 1000
 
 # The minimum amount of time in between each iteration of the main
 # loop. We could loop much less frequently than every two minutes if

--- a/foreman/data_refinery_foreman/foreman/management/commands/feed_the_beast.py
+++ b/foreman/data_refinery_foreman/foreman/management/commands/feed_the_beast.py
@@ -28,7 +28,7 @@ class Command(BaseCommand):
         with open("config/all_rna_seq_accessions.txt") as accession_list_file:
             all_accessions = [line.strip() for line in accession_list_file]
 
-        # We've surveyed up to SRP076491 so far!
+        # We've surveyed up to SRP134965 so far!
         all_accessions = all_accessions[all_accessions.index('SRP134965'):]
 
         BATCH_SIZE = 1000

--- a/foreman/data_refinery_foreman/foreman/management/commands/feed_the_beast.py
+++ b/foreman/data_refinery_foreman/foreman/management/commands/feed_the_beast.py
@@ -29,7 +29,7 @@ class Command(BaseCommand):
             all_accessions = [line.strip() for line in accession_list_file]
 
         # We've surveyed up to SRP076491 so far!
-        all_accessions = all_accessions[all_accessions.index('SRP076491'):]
+        all_accessions = all_accessions[all_accessions.index('SRP134965'):]
 
         BATCH_SIZE = 1000
         batch_index = 0

--- a/workers/data_refinery_workers/processors/salmon.py
+++ b/workers/data_refinery_workers/processors/salmon.py
@@ -636,7 +636,7 @@ def tximport(job_context: Dict) -> Dict:
 
         quantified_experiments += 1
 
-    if quantified_experiments == 0:
+    if quantified_experiments == 0 and job_context["is_tximport_only"]:
         failure_reason = ("Tximport job ran on no experiments... Why?!?!?")
         logger.error(failure_reason, processor_job=job_context["job_id"])
         job_context["job"].failure_reason = failure_reason

--- a/workers/data_refinery_workers/processors/salmon.py
+++ b/workers/data_refinery_workers/processors/salmon.py
@@ -636,7 +636,9 @@ def tximport(job_context: Dict) -> Dict:
 
         quantified_experiments += 1
 
-    if quantified_experiments == 0 and job_context["is_tximport_only"]:
+    if quantified_experiments == 0 \
+       and "is_tximport_job" in job_context \
+       and job_context["is_tximport_only"]:
         failure_reason = ("Tximport job ran on no experiments... Why?!?!?")
         logger.error(failure_reason, processor_job=job_context["job_id"])
         job_context["job"].failure_reason = failure_reason


### PR DESCRIPTION
## Issue Number

N/A 3 small changes that we realized were necessary.

## Purpose/Implementation Notes

This makes the dashboard job stats use the same cutoff date as the Foreman.

This also fixes the logic in needs_downloading that caused the salmon rerun jobs to not get queued.

Finally, this bumps the downloader job max up to 1000 since the external sources seem to be able to handle the volume we're running at and we've been having trouble keeping a queue populated on all 11 instances.

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

I tested the stats endpoint and I made sure that the conditional I changed gave the expected result when run on prod data (I execed onto the foreman docker container and ran it against a sample that didn't get run for this reason).
