### PR TITLE
Arielsvn/1487 start time isnull false

### DIFF
--- a/foreman/data_refinery_foreman/foreman/management/commands/retry_samples.py
+++ b/foreman/data_refinery_foreman/foreman/management/commands/retry_samples.py
@@ -75,7 +75,7 @@ def retry_by_regex(pattern):
     https://docs.djangoproject.com/en/dev/ref/models/querysets/#regex
     """
     latest_processor_job_for_sample = ProcessorJob.objects\
-        .filter(original_files__samples=OuterRef('id'))\
+        .filter(start_time__isnull=False, original_files__samples=OuterRef('id'))\
         .order_by('-start_time')
 
     eligible_samples = Sample.objects\

--- a/foreman/data_refinery_foreman/foreman/management/commands/test_retry_samples.py
+++ b/foreman/data_refinery_foreman/foreman/management/commands/test_retry_samples.py
@@ -82,6 +82,8 @@ def setup_experiment() -> Dict:
 
     # add a failed processor job for the second sample
     processor_job = ProcessorJob()
+    processor_job.start_time = timezone.now()
+    processor_job.end_time = timezone.now()
     processor_job.no_retry=True
     processor_job.success=False
     processor_job.failure_reason = 'ProcessorJob has already completed with a fail - why are we here again? Bad Nomad!'


### PR DESCRIPTION
## Issue Number

#1487 

## Purpose/Implementation Notes

On the `retry_samples` command we want to get the latest job that was applied to a sample. We were sorting by `start_time` which puts the jobs where `start_time=NULL` first. This filters out those jobs to only get the ones that actually started.

## Types of changes


- New feature (non-breaking change which adds functionality)

## Functional tests

Ran tests locally

## Checklist

- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules
