### PR TITLE
Remove mailchimp from terraform output variables.

### DIFF
--- a/infrastructure/variables.tf
+++ b/infrastructure/variables.tf
@@ -262,12 +262,6 @@ output "environment_variables" {
       value = "${aws_instance.nomad_server_1.public_ip}"},
     {name = "NOMAD_PORT"
       value = "4646"},
-    {name = "MAILCHIMP_USER"
-      value = "${var.mailchimp_user}"},
-    {name = "MAILCHIMP_API_KEY"
-      value = "${var.mailchimp_api_key}"},
-    {name = "MAILCHIMP_LIST_ID"
-      value = "${var.mailchimp_list_id}"},
     {name = "MAX_CLIENTS"
       value = "${var.max_clients}"},
     {name = "MAX_DOWNLOADER_JOBS_PER_NODE"


### PR DESCRIPTION
## Issue Number

#1547 

## Purpose/Implementation Notes

These were missed before, easy enough to fix.
