### PR TITLE
populate es index on deploy

### DIFF
--- a/infrastructure/api-configuration/api-server-instance-user-data.tpl.sh
+++ b/infrastructure/api-configuration/api-server-instance-user-data.tpl.sh
@@ -127,6 +127,7 @@ docker run \
 sleep 30
 docker exec dr_api python3 manage.py search_index --delete -f;
 docker exec dr_api python3 manage.py search_index --rebuild -f;
+docker exec dr_api python3 manage.py search_index --populate -f;
 
 # Let's use this instance to call the populate command every twenty minutes.
 crontab -l > tempcron


### PR DESCRIPTION
## Issue Number

#1555 

## Purpose/Implementation Notes

Only incrementally reindex elastic search for new experiments created after deploy. On deploy we should index all of the existing experiments.

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

api/run_test.sh appears to be satisfied.

## Checklist

- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules
