### PR TITLE
Strip whitespaces when reading columns in illumina files

### DIFF
--- a/workers/data_refinery_workers/processors/illumina.py
+++ b/workers/data_refinery_workers/processors/illumina.py
@@ -103,7 +103,7 @@ def _detect_columns(job_context: Dict) -> Dict:
         with open(input_file, 'r') as tsv_in:
             tsv_in = csv.reader(tsv_in, delimiter='\t')
             for row in tsv_in:
-                headers = row
+                headers = [column.strip() for column in row]
                 break
 
         # Ex GSE45331_non-normalized.txt


### PR DESCRIPTION
## Issue Number

#1560 

## Purpose/Implementation Notes

Strips whitespaces when parsing tsv columns in ilumina files.

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

None

## Checklist

- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules
