### PR TITLE
Adds management command to correct GEO samples with bad metadata

### DIFF
--- a/foreman/data_refinery_foreman/foreman/management/commands/correct_affy_cdfs.py
+++ b/foreman/data_refinery_foreman/foreman/management/commands/correct_affy_cdfs.py
@@ -54,7 +54,6 @@ class Command(BaseCommand):
                         break
 
                 if wrong_platform:
-                    print(type(options["dry_run"]))
                     if options["dry_run"]:
                         logger.info("Would have re-surveyed experiment with accession code %s",
                                     experiment.accession_code)

--- a/foreman/data_refinery_foreman/foreman/management/commands/correct_affy_cdfs.py
+++ b/foreman/data_refinery_foreman/foreman/management/commands/correct_affy_cdfs.py
@@ -1,0 +1,73 @@
+"""
+This command checks if samples from GEO have incorrect platform
+information and re-surveys them.
+
+We used to be worse at surveying from GEO so some samples have bad
+metadata and some of them were even successufully processed. Therefore
+if this command find any with incorrect metadata it will purge the
+experiment and all related data from the database so we can re-survey
+the experiment and reprocess it correctly.
+"""
+
+from django.core.management.base import BaseCommand
+import GEOparse
+
+from data_refinery_common.models import Experiment, Sample
+from data_refinery_common.logging import get_and_configure_logger
+from data_refinery_common.utils import get_internal_microarray_accession
+from data_refinery_foreman.foreman.performant_pagination.pagination import PerformantPaginator as Paginator
+from data_refinery_foreman.surveyor.management.commands.surveyor_dispatcher import queue_surveyor_for_accession
+from data_refinery_foreman.surveyor.management.commands.unsurvey import purge_experiment
+
+logger = get_and_configure_logger(__name__)
+
+PAGE_SIZE = 2000
+
+
+class Command(BaseCommand):
+    def add_arguments(self, parser):
+        parser.add_argument('--dry-run',
+                            help='Prints which experiments would be resurveyed without doing so.',
+                            action='store_true')
+
+    def handle(self, *args, **options):
+        """Re-surveys GEO experiments containing samples with incorrect platform information.
+        """
+        gse_experiments = Experiment.objects.filter(source_database='GEO')
+
+        paginator = Paginator(gse_experiments, PAGE_SIZE)
+        page = paginator.page()
+
+        while True:
+            for experiment in page.object_list:
+                gse = GEOparse.get_GEO(experiment.accession_code, destdir='/tmp/', how="brief", silent=True)
+
+                sample_accessions = list(gse.gsms.keys())
+                samples = Sample.objects.filter(accession_code__in=sample_accessions)
+
+                wrong_platform = False
+                for sample in samples:
+                    gpl = gse.gsms[sample.accession_code].metadata['platform_id'][0]
+                    internal_accession = get_internal_microarray_accession(gpl)
+                    if internal_accession != sample.platform_accession_code:
+                        wrong_platform = True
+                        break
+
+                if wrong_platform:
+                    print(type(options["dry_run"]))
+                    if options["dry_run"]:
+                        logger.info("Would have re-surveyed experiment with accession code %s",
+                                    experiment.accession_code)
+                    else:
+                        logger.info("Re-surveying experiment with accession code %s",
+                                    experiment.accession_code)
+
+                        purge_experiment(experiment.accession_code)
+
+                        queue_surveyor_for_accession(experiment.accession_code)
+
+
+            if not page.has_next():
+                break
+
+            page = paginator.page(page.next_page_number())

--- a/foreman/data_refinery_foreman/foreman/management/commands/test_correct_affy_cdfs.py
+++ b/foreman/data_refinery_foreman/foreman/management/commands/test_correct_affy_cdfs.py
@@ -10,24 +10,12 @@ from unittest.mock import MagicMock, Mock, patch, call
 
 from data_refinery_common.job_lookup import ProcessorPipeline, Downloaders
 from data_refinery_common.models import (
-    ComputationalResult,
-    ComputationalResultAnnotation,
-    ComputedFile,
-    DownloaderJob,
-    DownloaderJobOriginalFileAssociation,
     Experiment,
-    ExperimentOrganismAssociation,
-    ExperimentResultAssociation,
     ExperimentSampleAssociation,
-    OriginalFile,
-    OriginalFileSampleAssociation,
     Organism,
-    OrganismIndex,
-    Processor,
-    ProcessorJob,
-    ProcessorJobOriginalFileAssociation,
     Sample,
-    SampleResultAssociation,
+    SurveyJob,
+    SurveyJobKeyValue,
 )
 from data_refinery_foreman.foreman.management.commands.rerun_salmon_old_samples import update_salmon_all_experiments
 
@@ -155,4 +143,11 @@ class CorrectAffyCdfTestCase(TestCase):
         for experiment in unchanged_experiments:
             self.assertEqual(2, experiment.samples.count())
 
-        self.assertEqual(405, Experiment.objects.get(accession_code="GSE12417").samples.count())
+        # GSE12417 should have been unsurveyed.
+        with self.assertRaises(Experiment.DoesNotExist):
+            Experiment.objects.get(accession_code="GSE12417")
+
+        survey_jobs = SurveyJob.objects.all()
+        self.assertEqual(1, survey_jobs)
+
+        self.assertEqual("GSE12417", SurveyJobKeyValue.objects.first().value)

--- a/foreman/data_refinery_foreman/foreman/management/commands/test_correct_affy_cdfs.py
+++ b/foreman/data_refinery_foreman/foreman/management/commands/test_correct_affy_cdfs.py
@@ -1,0 +1,158 @@
+import datetime
+import json
+import os
+
+from django.core.management import call_command
+from django.test import TestCase
+from django.utils import timezone
+from typing import Dict, List
+from unittest.mock import MagicMock, Mock, patch, call
+
+from data_refinery_common.job_lookup import ProcessorPipeline, Downloaders
+from data_refinery_common.models import (
+    ComputationalResult,
+    ComputationalResultAnnotation,
+    ComputedFile,
+    DownloaderJob,
+    DownloaderJobOriginalFileAssociation,
+    Experiment,
+    ExperimentOrganismAssociation,
+    ExperimentResultAssociation,
+    ExperimentSampleAssociation,
+    OriginalFile,
+    OriginalFileSampleAssociation,
+    Organism,
+    OrganismIndex,
+    Processor,
+    ProcessorJob,
+    ProcessorJobOriginalFileAssociation,
+    Sample,
+    SampleResultAssociation,
+)
+from data_refinery_foreman.foreman.management.commands.rerun_salmon_old_samples import update_salmon_all_experiments
+
+def setup_experiments() -> None:
+    """Creates three experiments for testing purposes.
+
+    One experiment will not have a GSE* accession code.
+    Both experiments with GSE* accession codes will have two
+    samples. One has a sample that has incorrect platform information
+    so the experiment will need to be re-surveyed.
+    """
+    organism = Organism.get_object_for_name("HOMO_SAPIENS")
+
+    # Experiment that needs to be re-surveyed
+    experiment = Experiment.objects.create(
+        accession_code="GSE12417",
+        organism_names=['HOMO_SAPIENS'],
+        technology='MICROARRAY',
+        source_database='GEO'
+    )
+
+    # Correct platform
+    sample = Sample.objects.create(
+        accession_code='GSM311750',
+        source_database='GEO',
+        technology='MICROARRAY',
+        platform_accession_code='hgu133a'
+    )
+    ExperimentSampleAssociation.objects.create(experiment=experiment, sample=sample)
+
+    # Incorrect Platform
+    sample = Sample.objects.create(
+        accession_code='GSM316652',
+        organism=organism,
+        source_database='GEO',
+        technology='MICROARRAY',
+        platform_accession_code='hgu133a'
+    )
+    ExperimentSampleAssociation.objects.create(experiment=experiment, sample=sample)
+
+
+    # Experiment that does not need to be re-surveyed
+    experiment = Experiment.objects.create(
+        accession_code="GSE9890",
+        organism_names=['HOMO_SAPIENS'],
+        technology='MICROARRAY',
+        source_database='GEO'
+    )
+
+    sample = Sample.objects.create(
+        accession_code='GSM249671',
+        source_database='GEO',
+        technology='MICROARRAY',
+        platform_accession_code='hgu133plus2'
+    )
+    ExperimentSampleAssociation.objects.create(experiment=experiment, sample=sample)
+
+    sample = Sample.objects.create(
+        accession_code='GSM249672',
+        organism=organism,
+        source_database='GEO',
+        technology='MICROARRAY',
+        platform_accession_code='hgu133plus2'
+    )
+    ExperimentSampleAssociation.objects.create(experiment=experiment, sample=sample)
+
+
+    # Experiment that isn't even the right source_database.
+    experiment = Experiment.objects.create(
+        accession_code="SRP12345",
+        organism_names=['HOMO_SAPIENS'],
+        technology='RNA-SEQ',
+        source_database='SRA'
+    )
+
+    sample = Sample.objects.create(
+        accession_code='SRR123145',
+        organism=organism,
+        source_database='SRA',
+        technology='RNA-SEQ',
+        platform_accession_code='IlluminaHiSeq1000'
+    )
+    ExperimentSampleAssociation.objects.create(experiment=experiment, sample=sample)
+
+    # This second sample is just to make checking things easy because
+    # all experiments start with 2 samples in these tests.
+    sample = Sample.objects.create(
+        accession_code='SRR123146',
+        organism=organism,
+        source_database='SRA',
+        technology='RNA-SEQ',
+        platform_accession_code='IlluminaHiSeq1000'
+    )
+    ExperimentSampleAssociation.objects.create(experiment=experiment, sample=sample)
+
+
+class CorrectAffyCdfTestCase(TestCase):
+    """
+    Tests that new processor jobs are created for samples that belong to experiments that were
+    processed with multiple versions of Salmon
+    """
+    def test_dry_run(self):
+        setup_experiments()
+        # Setup is done, actually run the command.
+        args = []
+        options = {"dry_run": True}
+        call_command("correct_affy_cdfs", *args, **options)
+
+        # The experiments actually have more than 2 samples each, so
+        # if any of them have more than 2 samples then it got
+        # resurveyed and the dry run did not work.
+        for experiment in Experiment.objects.all():
+            self.assertEqual(2, experiment.samples.count())
+
+    def test_resurveying(self):
+        setup_experiments()
+        # Setup is done, actually run the command.
+        args = []
+        options = {}
+        call_command("correct_affy_cdfs", *args, **options)
+
+        # Verify that the two experiments with correct platform information do not get queued.
+        unchanged_experiments = Experiment.objects.filter(accession_code__in=["GSE9890", "SRP12345"])
+
+        for experiment in unchanged_experiments:
+            self.assertEqual(2, experiment.samples.count())
+
+        self.assertEqual(405, Experiment.objects.get(accession_code="GSE12417").samples.count())

--- a/foreman/data_refinery_foreman/foreman/management/commands/test_correct_affy_cdfs.py
+++ b/foreman/data_refinery_foreman/foreman/management/commands/test_correct_affy_cdfs.py
@@ -148,6 +148,6 @@ class CorrectAffyCdfTestCase(TestCase):
             Experiment.objects.get(accession_code="GSE12417")
 
         survey_jobs = SurveyJob.objects.all()
-        self.assertEqual(1, survey_jobs)
+        self.assertEqual(1, survey_jobs.count())
 
         self.assertEqual("GSE12417", SurveyJobKeyValue.objects.first().value)


### PR DESCRIPTION
## Issue Number

#1276 

## Purpose/Implementation Notes

It's rather impossible to tell by only looking at the database which samples are wrong and which are not since GEO has mixed-platform experiments. So the only way I could think to figure out which samples had the incorrect platform was to check GEO.

As #1276 mentions, some of these mis-labeled samples were successfully processed so in order to retrigger processing and the correction of metadata, I decided to just unsurvey the whole experiment and resurvey it. This may result in a decent number of reprocessing of samples that aren't incorrect, but these are all microarray samples so they'll go quick and I think this will be a cleaner solution than trying to both correct the metadata and then convincing the system to allow these samples to be reprocessed.

## Types of changes

- New feature (non-breaking change which adds functionality)

## Functional tests

I can't really recreate the situation I'm trying to correct except by manually changing stuff in the database which isn't really much different than the unit tests I wrote.

My plan is to do a dry-run in staging, run it without dry-run in staging (assuming there's actually some samples there that have this issue), then do a dry run in prod, then finally assuming that it looks good do the actual run in prod.

## Checklist

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules
