### PR TITLE
Count lost jobs that get requeued towards the Volume depth

### DIFF
--- a/foreman/data_refinery_foreman/foreman/main.py
+++ b/foreman/data_refinery_foreman/foreman/main.py
@@ -587,6 +587,9 @@ def retry_lost_downloader_jobs() -> None:
     during which the price of spot instance is higher than our bid
     price.
     """
+    global VOLUME_WORK_DEPTH
+    global DOWNLOADER_JOBS_IN_QUEUE
+
     potentially_lost_jobs = DownloaderJob.objects.filter(
         success=None,
         retried=False,
@@ -636,6 +639,7 @@ def retry_lost_downloader_jobs() -> None:
                     job.save()
                     send_job(Downloaders[job.downloader_task], job=job, is_dispatch=True)
                     jobs_queued_from_this_page += 1
+                    VOLUME_WORK_DEPTH[dispatched_volume] += 1
             except socket.timeout:
                 logger.info("Timeout connecting to Nomad - is Nomad down?", job_id=job.id)
             except URLNotFoundNomadException:


### PR DESCRIPTION
## Issue Number

N/A I've noticed one volume getting too many jobs and starving the other instances

## Purpose/Implementation Notes

I don't like `global`. I shouldn't have approved the first PR that made use of it, but now switching away from it would be a bigger refactor than I want to tackle right now.

This should fix our usage of a global variable and actually increment it so that when we requeue lost downloader jobs we don't just put them all on whichever instance had the lowest job count at some point.

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

The unit tests cover this code.

## Checklist

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules
