### PR TITLE
Bump Nomad up to v0.8.7

### DIFF
--- a/.circleci/run_terraform.sh
+++ b/.circleci/run_terraform.sh
@@ -32,7 +32,7 @@ sudo mv terraform /usr/local/bin/
 sudo apt-get update
 sudo apt-get install lxc -y  # Install lxc, which is required by nomad
 
-NOMAD_VERSION=0.8.3
+NOMAD_VERSION=0.8.7
 wget -N https://releases.hashicorp.com/nomad/$NOMAD_VERSION/nomad_${NOMAD_VERSION}_linux_amd64.zip
 wget -N https://releases.hashicorp.com/nomad/$NOMAD_VERSION/nomad_${NOMAD_VERSION}_SHA256SUMS
 wget -N https://releases.hashicorp.com/nomad/$NOMAD_VERSION/nomad_${NOMAD_VERSION}_SHA256SUMS.sig

--- a/scripts/install_nomad.sh
+++ b/scripts/install_nomad.sh
@@ -10,7 +10,7 @@
 curl https://keybase.io/hashicorp/pgp_keys.asc | gpg --import
 
 # Download the binary and signature files.
-RELEASE_VERSION=0.8.3
+RELEASE_VERSION=0.8.7
 export RELEASE_VERSION
 RELEASE_PLATFORM="$(uname | tr '[:upper:]' '[:lower:]')"
 export RELEASE_PLATFORM


### PR DESCRIPTION
## Issue Number

#1352

## Purpose/Implementation Notes

Nomad v0.8.3 sometimes displays negative job counts for summaries. We use these summaries in the Foreman to determine how many jobs to queue on which volumes so this messes us up. This bug has been "fixed" poorly in v0.8.7 so upgrading should make this better for us.