### PR TITLE
Dashboard - Adds pending jobs back to job stats

### DIFF
--- a/api/data_refinery_api/views.py
+++ b/api/data_refinery_api/views.py
@@ -999,7 +999,7 @@ class Stats(APIView):
                 'month': current_date - timedelta(days=30),
                 'year': current_date - timedelta(days=365)
             }.get(range_param)
-            start_filter = start_filter | Q(start_time__gte=start_date)
+            start_filter = start_filter | Q(start_time__gte=start_date) | Q(start_time__isnull=True)
 
         result = jobs.filter(start_filter).aggregate(
             total=Count('id'),


### PR DESCRIPTION
## Issue Number

@kurtwheeler noticed that after deploy the downloader jobs stats were missing the values for jobs in a pending state. This remedies that by including queried jobs whose start_time is null.

## Purpose/Implementation Notes

Adds Q(start_time__isnull=True) to jobs query filter.

## Methods

API/stats
## Types of changes

- Bugfix (non-breaking change which fixes an issue)
