### PR TITLE
Remove the tmpfs config for Nomad 

### DIFF
--- a/workers/nomad-job-specs/salmon.nomad.tpl
+++ b/workers/nomad-job-specs/salmon.nomad.tpl
@@ -95,17 +95,6 @@ job "SALMON_${{INDEX}}_${{RAM}}" {
         ${{EXTRA_HOSTS}}
         volumes = ["${{VOLUME_DIR}}:/home/user/data_store"]
         ${{LOGGING_CONFIG}}
-
-        mounts = [
-          {
-            type = "tmpfs"
-            target = "/home/user/data_store_tmpfs"
-            readonly = false
-            tmpfs_options {
-              size = 17179869184 # size in bytes (17GB)
-            }
-          }
-        ]
       }
     }
   }

--- a/workers/tester.sh
+++ b/workers/tester.sh
@@ -99,6 +99,5 @@ docker run \
        --env AWS_SECRET_ACCESS_KEY \
        --entrypoint ./manage.py \
        --volume "$volume_directory":/home/user/data_store \
-       --mount type=tmpfs,destination=/home/user/data_store_tmpfs \
        --link drdb:postgres \
        "$image_name" "${@: -3}" "${@: -2}" "${@: -1}"


### PR DESCRIPTION
## Issue Number

#1574 

## Purpose/Implementation Notes

We upgraded Nomad and now the tmpfs config we had lying around in the Salmon job spec is actually being used and is thus causing problems.
