### PR TITLE
Try bumping Nomad up to 0.9.5

### DIFF
--- a/.circleci/run_terraform.sh
+++ b/.circleci/run_terraform.sh
@@ -32,7 +32,7 @@ sudo mv terraform /usr/local/bin/
 sudo apt-get update
 sudo apt-get install lxc -y  # Install lxc, which is required by nomad
 
-NOMAD_VERSION=0.8.7
+NOMAD_VERSION=0.9.5
 wget -N https://releases.hashicorp.com/nomad/$NOMAD_VERSION/nomad_${NOMAD_VERSION}_linux_amd64.zip
 wget -N https://releases.hashicorp.com/nomad/$NOMAD_VERSION/nomad_${NOMAD_VERSION}_SHA256SUMS
 wget -N https://releases.hashicorp.com/nomad/$NOMAD_VERSION/nomad_${NOMAD_VERSION}_SHA256SUMS.sig

--- a/scripts/install_nomad.sh
+++ b/scripts/install_nomad.sh
@@ -10,7 +10,7 @@
 curl https://keybase.io/hashicorp/pgp_keys.asc | gpg --import
 
 # Download the binary and signature files.
-RELEASE_VERSION=0.8.7
+RELEASE_VERSION=0.9.5
 export RELEASE_VERSION
 RELEASE_PLATFORM="$(uname | tr '[:upper:]' '[:lower:]')"
 export RELEASE_PLATFORM


### PR DESCRIPTION
## Issue Number

#1574 

## Purpose/Implementation Notes

Nomad jobs are failing with: `Exit Code: 137, Exit Message: "Docker container exited with non-zero exit code: 137"`

We've seen this on 0.8.7 and 0.9.0 I think. Maybe it's been fixed in 0.9.5

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

I'm running a test locally now
