### PR TITLE
adds tfvar for slack engagementbot webhook

### DIFF
--- a/infrastructure/variables.tf
+++ b/infrastructure/variables.tf
@@ -177,6 +177,9 @@ variable "elasticsearch_port" {
   default = "80"
 }
 
+variable "engagementbot_webhook" {
+}
+
 # Output our production environment variables.
 output "environment_variables" {
   value = [
@@ -265,6 +268,8 @@ output "environment_variables" {
     {name = "MAX_CLIENTS"
       value = "${var.max_clients}"},
     {name = "MAX_DOWNLOADER_JOBS_PER_NODE"
-      value = "${var.max_downloader_jobs_per_node}"}
+      value = "${var.max_downloader_jobs_per_node}"},
+    {name = "ENGAGEMENTBOT_WEBHOOK"
+      value = "${var.engagementbot_webhook}"}
   ]
 }


### PR DESCRIPTION
## Issue Number

#1514 

## Purpose/Implementation Notes

The bot is still broken despite updating the webhook urls etc.

From the logs:
```Invalid URL '${{ENGAGEMENTBOT_WEBHOOK}}': No schema supplied. Perhaps you meant http://${{ENGAGEMENTBOT_WEBHOOK}}?```

Hopefully this will cause it to be parsed.

## Methods

Infrastructure edit... adds the tfvar to the environment variables for engagment bot webhook

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

Didn't test locally yet.

## Checklist

- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

