### PR TITLE
preallocate the all_frames list

### DIFF
--- a/workers/data_refinery_workers/processors/smasher.py
+++ b/workers/data_refinery_workers/processors/smasher.py
@@ -593,7 +593,7 @@ def _smash(job_context: Dict, how="inner") -> Dict:
                     if computed_file_path:
                         os.remove(computed_file_path)
 
-            job_context['all_frames'] = all_frames
+            job_context['all_frames'] = all_frames[0:all_frames_index]
 
             if len(all_frames) < 1:
                 logger.warning("Was told to smash a frame with no frames!",

--- a/workers/data_refinery_workers/processors/smasher.py
+++ b/workers/data_refinery_workers/processors/smasher.py
@@ -496,7 +496,8 @@ def _smash(job_context: Dict, how="inner") -> Dict:
         for key, input_files in job_context['input_files'].items():
 
             # Merge all the frames into one
-            all_frames = []
+            all_frames = [None] * len(input_files)
+            all_frames_index = 0;
 
             for computed_file in input_files:
 
@@ -571,7 +572,8 @@ def _smash(job_context: Dict, how="inner") -> Dict:
                     else:
                         job_context['technologies']['microarray'].append(data.columns)
 
-                    all_frames.append(data)
+                    all_frames[all_frames_index] = data
+                    all_frames_index = all_frames_index + 1
                     num_samples = num_samples + 1
 
                     if (num_samples % 100) == 0:

--- a/workers/data_refinery_workers/processors/smasher.py
+++ b/workers/data_refinery_workers/processors/smasher.py
@@ -573,7 +573,7 @@ def _smash(job_context: Dict, how="inner") -> Dict:
                         job_context['technologies']['microarray'].append(data.columns)
 
                     all_frames[all_frames_index] = data
-                    all_frames_index = all_frames_index + 1
+                    all_frames_index += 1
                     num_samples = num_samples + 1
 
                     if (num_samples % 100) == 0:
@@ -593,7 +593,8 @@ def _smash(job_context: Dict, how="inner") -> Dict:
                     if computed_file_path:
                         os.remove(computed_file_path)
 
-            job_context['all_frames'] = all_frames[0:all_frames_index]
+            all_frames = all_frames[0:all_frames_index]
+            job_context['all_frames'] = all_frames
 
             if len(all_frames) < 1:
                 logger.warning("Was told to smash a frame with no frames!",

--- a/workers/data_refinery_workers/processors/smasher.py
+++ b/workers/data_refinery_workers/processors/smasher.py
@@ -496,7 +496,7 @@ def _smash(job_context: Dict, how="inner") -> Dict:
         for key, input_files in job_context['input_files'].items():
 
             # Merge all the frames into one
-            all_frames = [None] * len(input_files)
+            all_frames = [None] * len(input_files) if input_files else []
             all_frames_index = 0;
 
             for computed_file in input_files:

--- a/workers/data_refinery_workers/processors/test_compendia.py
+++ b/workers/data_refinery_workers/processors/test_compendia.py
@@ -127,6 +127,7 @@ class CompendiaTestCase(TestCase):
         pjda.save()
 
         final_context = create_compendia.create_compendia(job.id)
+        self.assertFalse(final_context['success'])
 
     @tag('compendia')
     def test_create_compendia_danio(self):

--- a/workers/run_tests.sh
+++ b/workers/run_tests.sh
@@ -239,7 +239,7 @@ if [ -z "$tag" ] || [ "$tag" = "no_op" ]; then
     fi
 fi
 
-if [ -z "$tag" ] || [ "$tag" = "smasher" ]; then
+if [ -z "$tag" ] || [ "$tag" = "smasher" || "$tag" = "compendia" ]; then
     # Make sure PCL for test is downloaded from S3
     pcl_name="GSM1237810_T09-1084.PCL"
     pcl_name2="GSM1237812_S97-PURE.PCL"

--- a/workers/run_tests.sh
+++ b/workers/run_tests.sh
@@ -239,7 +239,7 @@ if [ -z "$tag" ] || [ "$tag" = "no_op" ]; then
     fi
 fi
 
-if [ -z "$tag" ] || [ "$tag" = "smasher" || "$tag" = "compendia" ]; then
+if [ -z "$tag" ] || [ "$tag" = "smasher" ] || [ "$tag" = "compendia" ]; then
     # Make sure PCL for test is downloaded from S3
     pcl_name="GSM1237810_T09-1084.PCL"
     pcl_name2="GSM1237812_S97-PURE.PCL"


### PR DESCRIPTION
## Issue Number

#1537 

## Purpose/Implementation Notes

Removes code that appends each frame and instead assigns it to the list with an incremented index.

## Methods

This is the initial part of the improving compendia speed. 

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

Smasher and compendia tests run locally

## Checklist

- [X] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules
