### PR TITLE
fix pagination ordering warning

### DIFF
--- a/common/data_refinery_common/migrations/0017_auto_20190312_2011.py
+++ b/common/data_refinery_common/migrations/0017_auto_20190312_2011.py
@@ -25,7 +25,7 @@ def make_sample_platform_names_readable(apps, schema_editor):
     for platform in get_supported_rnaseq_platforms():
         platform_mapping[platform.replace(' ', '').upper()] = platform
 
-    paginator = Paginator(Sample.objects.all(), 200)
+    paginator = Paginator(Sample.objects.all().order_by('id'), 200)
 
     for page_idx in range(1, paginator.num_pages):
         for sample in paginator.page(page_idx).object_list:

--- a/common/data_refinery_common/migrations/0019_sample_is_blacklisted.py
+++ b/common/data_refinery_common/migrations/0019_sample_is_blacklisted.py
@@ -14,7 +14,7 @@ def update_blacklisted_samples(apps, schema_editor):
 
     blacklist = load_blacklist()
 
-    paginator = Paginator(Sample.objects.all(), 1000)
+    paginator = Paginator(Sample.objects.all().order_by('id'), 1000)
     for page_idx in range(1, paginator.num_pages):
         blacklisted = []
         for sample in paginator.page(page_idx).object_list:


### PR DESCRIPTION
## Issue Number

N/A

## Purpose/Implementation Notes

Running django unit tests would throw this warning when it created the testing DB

``` Pagination may yield inconsistent results with an unordered object_list:```

```Running tests with the following command:
coverage run --source="." manage.py test --no-input --tag=smasher data_refinery_workers.processors.test_smasher.SmasherTestCase.test_smasher; exit_code=$?; coverage report -m; exit $exit_code
Creating test database for alias 'default'... 
/usr/local/lib/python3.5/dist-packages/data_refinery_common/migrations/0017_auto_20190312_2011.py:28: UnorderedObjectListWarning: Pagination may yield inconsistent results with an unordered object_list: <class '__fake__.Sample'> QuerySet.                                                                                                                                                                                         
  paginator = Paginator(Sample.objects.all(), 200) 
usr/local/lib/python3.5/dist-packages/data_refinery_common/migrations/0019_sample_is_blacklisted.py:17: UnorderedObjectListWarning: Pagination may yield inconsistent results with an unordered object_list: <class '__fake__.Sample'> QuerySet.
  paginator = Paginatorå(Sample.objects.all(), 1000)
Updating platform name from 'IlluminaGenomeAnalyzer' to 'Illumina Genome Analyzer'
```

## Methods

This PR really only adds the order_by clause to the query selector in order to remove that warning.

## Types of changes


- Bugfix (non-breaking change which fixes an issue)

## Functional tests

Tests perform with fewer warnings now.

## Checklist

- [X] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules
