### PR TITLE
Parallelize recreating compendia for all organisms

### DIFF
--- a/README.md
+++ b/README.md
@@ -568,19 +568,19 @@ nomad job dispatch -meta ORGANISM=DANIO_RERIO CREATE_QN_TARGET
 Creating species-wide compendia for a given species can be done in a production environment with the following:
 
 ```bash
-nomad job dispatch -meta ORGANISMs=DANIO_RERIO CREATE_COMPENDIA
+nomad job dispatch -meta ORGANISMS=DANIO_RERIO CREATE_COMPENDIA
 ```
 
 or for a list of organisms:
 
 ```bash
-nomad job dispatch -meta ORGANISM=DANIO_RERIO,HOMO_SAPIENS CREATE_COMPENDIA
+nomad job dispatch -meta ORGANISMS=DANIO_RERIO,HOMO_SAPIENS CREATE_COMPENDIA
 ```
 
 or for all organisms with sufficient data:
 
 ```bash
-nomad job dispatch -meta ORGANISM= CREATE_COMPENDIA
+nomad job dispatch -meta ORGANISMS= CREATE_COMPENDIA
 ```
 
 Compendia jobs run on the smasher instance.

--- a/README.md
+++ b/README.md
@@ -568,7 +568,13 @@ nomad job dispatch -meta ORGANISM=DANIO_RERIO CREATE_QN_TARGET
 Creating species-wide compendia for a given species can be done in a production environment with the following:
 
 ```bash
-nomad job dispatch -meta ORGANISM=DANIO_RERIO CREATE_COMPENDIA
+nomad job dispatch -meta ORGANISMs=DANIO_RERIO CREATE_COMPENDIA
+```
+
+or for a list of organisms:
+
+```bash
+nomad job dispatch -meta ORGANISM=DANIO_RERIO,HOMO_SAPIENS CREATE_COMPENDIA
 ```
 
 or for all organisms with sufficient data:

--- a/workers/data_refinery_workers/processors/management/commands/create_compendia.py
+++ b/workers/data_refinery_workers/processors/management/commands/create_compendia.py
@@ -26,7 +26,7 @@ def create_job_for_organism(organism=Organism):
     Fetch all of the experiments and compile large but normally formated Dataset.
     """
     data = {}
-    experiments = Experiment.objects.filter(id__in=(ExperimentOrganismAssociation.objects.filter(organism=organism)).values('experiment'))
+    experiments = Experiment.objects.filter(organisms=organism).prefetch_related('samples')
     for experiment in experiments:
         data[experiment.accession_code] = list(experiment.samples.filter(organism=organism).values_list('accession_code', flat=True))
 

--- a/workers/data_refinery_workers/processors/management/commands/create_compendia.py
+++ b/workers/data_refinery_workers/processors/management/commands/create_compendia.py
@@ -13,12 +13,40 @@ from data_refinery_common.models import (
     Dataset,
     ProcessorJobDatasetAssociation,
     ExperimentOrganismAssociation,
-    OrganismIndex,
     ExperimentSampleAssociation
 )
 from data_refinery_workers.processors import create_compendia
 
 logger = get_and_configure_logger(__name__)
+
+
+def create_job_for_organism(organism=Organism):
+    """Returns a compendia job for the provided organism.
+
+    Fetch all of the experiments and compile large but normally formated Dataset.
+    """
+    data = {}
+    experiments = Experiment.objects.filter(id__in=(ExperimentOrganismAssociation.objects.filter(organism=organism)).values('experiment'))
+    for experiment in experiments:
+        data[experiment.accession_code] = list(experiment.samples.filter(organism=organism).values_list('accession_code', flat=True))
+
+    job = ProcessorJob()
+    job.pipeline_applied = "COMPENDIA"
+    job.save()
+
+    dset = Dataset()
+    dset.data = data
+    dset.scale_by = 'NONE'
+    dset.aggregate_by = 'SPECIES'
+    dset.quantile_normalize = False
+    dset.save()
+
+    pjda = ProcessorJobDatasetAssociation()
+    pjda.processor_job = job
+    pjda.dataset = dset
+    pjda.save()
+
+    return job
 
 
 class Command(BaseCommand):
@@ -30,40 +58,22 @@ class Command(BaseCommand):
             help=("Name of organism"))
 
     def handle(self, *args, **options):
-        """ For every (or a supplied) organism, fetch all of the experiments and compile large but normally formated Dataset.
+        """Create a compendium for one or more organisms.
 
-        Send all of them to the Smasher. Smash them. Retrieve manually as desired.
+        If --organism is supplied will immediately create a compedium
+        for it. If not a new job will be dispatched for each organism
+        with enough microarray samples.
         """
-
-        dataset_ids = []
-
         if options["organism"] is None:
             all_organisms = Organism.objects.all()
+
+            for organism in all_organisms:
+                job = create_job_for_organism(organism)
+                logger.info("Sending CREATE_COMPENDIA for Organism", job_id=str(job.pk), organism=str(organism))
+                send_job(ProcessorPipeline.CREATE_COMPENDIA, job)
         else:
-            all_organisms = [Organism.get_object_for_name(options["organism"].upper())]
-
-        for organism in all_organisms:
-            data = {}
-            experiments = Experiment.objects.filter(id__in=(ExperimentOrganismAssociation.objects.filter(organism=organism)).values('experiment'))
-            for experiment in experiments:
-                data[experiment.accession_code] = list(experiment.samples.filter(organism=organism).values_list('accession_code', flat=True))
-
-            job = ProcessorJob()
-            job.pipeline_applied = "COMPENDIA"
-            job.save()
-
-            dset = Dataset()
-            dset.data = data
-            dset.scale_by = 'NONE'
-            dset.aggregate_by = 'SPECIES'
-            dset.quantile_normalize = False
-            dset.save()
-
-            pjda = ProcessorJobDatasetAssociation()
-            pjda.processor_job = job
-            pjda.dataset = dset
-            pjda.save()
-
-            final_context = create_compendia.create_compendia(job.id)
+            organism = Organism.get_object_for_name(options["organism"].upper())
+            job = create_job_for_organism(organism)
+            create_compendia.create_compendia(job.id)
 
         sys.exit(0)

--- a/workers/data_refinery_workers/processors/management/commands/create_compendia.py
+++ b/workers/data_refinery_workers/processors/management/commands/create_compendia.py
@@ -70,13 +70,16 @@ class Command(BaseCommand):
             organisms = options["organisms"].upper().replace(" ", "_").split(",")
             all_organisms = Organism.objects.filter(name__in=organisms)
 
+        logger.error(all_organisms)
+
         if all_organisms.count() > 1:
             for organism in all_organisms:
+                logger.error(organism)
                 job = create_job_for_organism(organism)
                 logger.info("Sending CREATE_COMPENDIA for Organism", job_id=str(job.pk), organism=str(organism))
                 send_job(ProcessorPipeline.CREATE_COMPENDIA, job)
         else:
-            job = create_job_for_organism(organisms[0])
+            job = create_job_for_organism(all_organisms[0])
             create_compendia.create_compendia(job.id)
 
         sys.exit(0)

--- a/workers/nomad-job-specs/create_compendia.nomad.tpl
+++ b/workers/nomad-job-specs/create_compendia.nomad.tpl
@@ -9,7 +9,7 @@ job "CREATE_COMPENDIA" {
 
   parameterized {
     payload       = "forbidden"
-    meta_required = ["ORGANISM"]
+    meta_required = ["ORGANISMS"]
   }
 
   group "jobs" {
@@ -88,7 +88,7 @@ job "CREATE_COMPENDIA" {
           "python3",
           "manage.py",
           "create_compendia",
-          "--organism", "${NOMAD_META_ORGANISM}",
+          "--organisms", "${NOMAD_META_ORGANISMS}",
         ]
         ${{EXTRA_HOSTS}}
         volumes = ["${{VOLUME_DIR}}:/home/user/data_store"]


### PR DESCRIPTION
## Issue Number

#1485 

## Purpose/Implementation Notes

Makes create_compendia dispatch jobs if requested to create more than one. This also makes create_compendia accept a list of comma separated organism names and dispatch jobs for each of them.

## Types of changes

- New feature (non-breaking change which adds functionality)

## Functional tests

 I've passed a list of organisms to a compendia job through nomad.

## Checklist

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules
