### PR TITLE
Reduce the size of compendia jobs so a smasher job can run alongside them.

### DIFF
--- a/infrastructure/variables.tf
+++ b/infrastructure/variables.tf
@@ -120,7 +120,7 @@ variable "client_instance_type" {
 }
 
 variable "smasher_instance_type" {
-  # 256 GiB Memory, compendia jobs needs 250
+  # 256 GiB Memory, compendia jobs needs 220 and smasher jobs need 28.
   default = "m5.16xlarge"
 }
 

--- a/workers/nomad-job-specs/create_compendia.nomad.tpl
+++ b/workers/nomad-job-specs/create_compendia.nomad.tpl
@@ -69,7 +69,7 @@ job "CREATE_COMPENDIA" {
         # CPU is in AWS's CPU units.
         cpu =   4000
         # Memory is in MB of RAM.
-        memory = 250000
+        memory = 220000
       }
 
       logs {


### PR DESCRIPTION
## Issue Number

N/A noticed that there's some smasher jobs stuck on pending cause a compendia job is running.

## Purpose/Implementation Notes

This should make it so that one compendia job and one smasher job can both fit on the smasher instance at the same time. If we end up needing more RAM for compendia jobs then we can up that and up the instance size, but we should still leave 30GB so smasher jobs can get in there.

## Methods

## Types of changes

What types of changes does your code introduce?

- Infrastructure

## Functional tests

N/A infra only
