### PR TITLE
Make smasher HUGE. Also make it so that human and mouse compendia mus…

### DIFF
--- a/infrastructure/variables.tf
+++ b/infrastructure/variables.tf
@@ -120,8 +120,8 @@ variable "client_instance_type" {
 }
 
 variable "smasher_instance_type" {
-  # 256 GiB Memory, compendia jobs needs 220 and smasher jobs need 28.
-  default = "m5.16xlarge"
+  # 3,904 GiB Memory, compendia jobs needs 220 and smasher jobs need 28.
+  default = "x1e.32xlarge"
 }
 
 variable "spot_price" {

--- a/workers/data_refinery_workers/processors/management/commands/create_compendia.py
+++ b/workers/data_refinery_workers/processors/management/commands/create_compendia.py
@@ -62,7 +62,7 @@ class Command(BaseCommand):
 
         If --organism is supplied will immediately create a compedium
         for it. If not a new job will be dispatched for each organism
-        with enough microarray samples.
+        with enough microarray samples except for human and mouse.
         """
         if options["organisms"] is None:
             all_organisms = Organism.objects.exclude(name__in=["HOMO_SAPIENS", "MUS_MUSCULUS"])

--- a/workers/data_refinery_workers/processors/management/commands/create_compendia.py
+++ b/workers/data_refinery_workers/processors/management/commands/create_compendia.py
@@ -65,7 +65,7 @@ class Command(BaseCommand):
         with enough microarray samples.
         """
         if options["organisms"] is None:
-            all_organisms = Organism.objects.all()
+            all_organisms = Organism.objects.exclude(name__in=["HOMO_SAPIENS", "MUS_MUSCULUS"])
         else:
             organisms = options["organisms"].upper().replace(" ", "_").split(",")
             all_organisms = Organism.objects.filter(name__in=organisms)


### PR DESCRIPTION
…t be queued up separately.

## Issue Number

#1258 

## Purpose/Implementation Notes

This makes the smasher big enough to run multiple compedia jobs on it at the same time. This also makes it so that queuing compendia for all organisms won't queue up human and mouse, so I can kick those off manually first so they get placed and then kick off the rest.
