### PR TITLE
Make the foreman retry QN jobs

### DIFF
--- a/common/data_refinery_common/models/models.py
+++ b/common/data_refinery_common/models/models.py
@@ -902,7 +902,7 @@ class ComputedFile(models.Model):
         """ Syncs a file to AWS S3.
         """
         if not settings.RUNNING_IN_CLOUD:
-            return False
+            return True
 
         self.s3_bucket = s3_bucket
         self.s3_key = s3_key

--- a/foreman/data_refinery_foreman/foreman/main.py
+++ b/foreman/data_refinery_foreman/foreman/main.py
@@ -804,7 +804,7 @@ def retry_failed_processor_jobs() -> None:
           retried=False,
           no_retry=False,
           created_at__gt=JOB_CREATED_AT_CUTOFF) \
-        and (Q(volume_index__isnull=True) | Q(volume_index__in=active_volumes))
+        & (Q(volume_index__isnull=True) | Q(volume_index__in=active_volumes))
     ).exclude(
         pipeline_applied="JANITOR"
     ).order_by(
@@ -853,7 +853,7 @@ def retry_hung_processor_jobs() -> None:
           start_time__isnull=False,
           end_time=None,
           nomad_job_id__isnull=False) \
-        and (Q(volume_index__isnull=True) | Q(volume_index__in=active_volumes))
+        & (Q(volume_index__isnull=True) | Q(volume_index__in=active_volumes))
     ).exclude(
         pipeline_applied="JANITOR"
     ).order_by(
@@ -929,7 +929,7 @@ def retry_lost_processor_jobs() -> None:
           created_at__gt=JOB_CREATED_AT_CUTOFF,
           start_time=None,
           end_time=None) \
-        and (Q(volume_index__isnull=True) | Q(volume_index__in=active_volumes))
+        & (Q(volume_index__isnull=True) | Q(volume_index__in=active_volumes))
     ).exclude(
         pipeline_applied="JANITOR"
     ).order_by(

--- a/foreman/data_refinery_foreman/foreman/main.py
+++ b/foreman/data_refinery_foreman/foreman/main.py
@@ -1253,7 +1253,7 @@ def send_janitor_jobs():
         pass
 
     # Clean up the smasher:
-    active_volumes.append(None)
+    active_volumes.add(None)
 
     for volume_index in active_volumes:
         new_job = ProcessorJob(num_retries=0,

--- a/foreman/data_refinery_foreman/foreman/test_main.py
+++ b/foreman/data_refinery_foreman/foreman/test_main.py
@@ -587,6 +587,9 @@ class ForemanTestCase(TestCase):
     @patch('data_refinery_foreman.foreman.main.send_job')
     @patch('data_refinery_foreman.foreman.main.Nomad')
     def test_retrying_lost_smasher_jobs(self, mock_nomad, mock_send_job, mock_get_active_volumes):
+        """Make sure that the smasher jobs will get retried even though they
+        don't have a volume_index.
+        """
         mock_send_job.return_value = True
         mock_get_active_volumes.return_value = {"1", "2", "3"}
 
@@ -600,10 +603,11 @@ class ForemanTestCase(TestCase):
         mock_nomad.side_effect = mock_init_nomad
 
         job = self.create_processor_job(pipeline="SMASHER")
+        job.volume_index = None # Smasher jobs won't have a volume_index.
         job.created_at = timezone.now()
         job.save()
 
-        main.retry_lost_smasher_jobs()
+        main.retry_lost_processor_jobs()
 
         self.assertEqual(len(mock_send_job.mock_calls), 1)
 

--- a/foreman/data_refinery_foreman/foreman/test_main.py
+++ b/foreman/data_refinery_foreman/foreman/test_main.py
@@ -993,11 +993,11 @@ class ForemanTestCase(TestCase):
 
         main.send_janitor_jobs()
 
-        self.assertEqual(ProcessorJob.objects.all().count(), 6)
-        self.assertEqual(ProcessorJob.objects.filter(pipeline_applied="JANITOR").count(), 3)
+        self.assertEqual(ProcessorJob.objects.all().count(), 7)
+        self.assertEqual(ProcessorJob.objects.filter(pipeline_applied="JANITOR").count(), 4)
 
         # Make sure that the janitors are dispatched to the correct volumes.
-        ixs = ["1", "2", "3"]
+        ixs = ["1", "2", "3", None]
         for p in ProcessorJob.objects.filter(pipeline_applied="JANITOR"):
             self.assertTrue(p.volume_index in ixs)
             ixs.remove(p.volume_index)

--- a/workers/data_refinery_workers/processors/test_array_express.py
+++ b/workers/data_refinery_workers/processors/test_array_express.py
@@ -66,7 +66,6 @@ class AffyToPCLTestCase(TestCase):
         self.assertEqual(ComputedFile.objects.all()[0].filename, 'GSM1426071_CD_colon_active_1.PCL')
 
         os.remove(ComputedFile.objects.all()[0].absolute_file_path)
-        ComputationalResult.objects.all()[0].delete() # ComputedFile deleted by cascade
 
     @tag("affymetrix")
     def test_affy_to_pcl_no_brainarray(self):
@@ -83,4 +82,3 @@ class AffyToPCLTestCase(TestCase):
         self.assertEqual(ComputedFile.objects.all()[0].filename, 'GSM45588.PCL')
 
         os.remove(ComputedFile.objects.all()[0].absolute_file_path)
-        ComputationalResult.objects.all()[0].delete() # ComputedFile deleted by cascade

--- a/workers/data_refinery_workers/processors/utils.py
+++ b/workers/data_refinery_workers/processors/utils.py
@@ -260,11 +260,13 @@ def end_job(job_context: Dict, abort=False):
             # Ensure even distribution across S3 servers
             nonce = ''.join(random.choice(string.ascii_lowercase + string.digits) for _ in range(24))
             result = computed_file.sync_to_s3(s3_bucket, nonce + "_" + computed_file.filename)
+
             if result:
                 computed_file.delete_local_file()
             else:
                 success = False
                 job_context['success'] = False
+                job.failure_reason = "Failed to upload computed file."
                 break
 
     if not success:

--- a/workers/data_refinery_workers/processors/utils.py
+++ b/workers/data_refinery_workers/processors/utils.py
@@ -270,7 +270,8 @@ def end_job(job_context: Dict, abort=False):
     if not success:
         for computed_file in job_context.get('computed_files', []):
             computed_file.delete_local_file()
-            computed_file.delete()
+            if computed_file.id:
+                computed_file.delete()
 
     if not abort:
         if job_context.get("success", False) and not (job_context["job"].pipeline_applied in ["SMASHER", "QN_REFERENCE", "COMPENDIA", "JANITOR"]):

--- a/workers/dockerfiles/Dockerfile.affymetrix_local
+++ b/workers/dockerfiles/Dockerfile.affymetrix_local
@@ -2,6 +2,11 @@ FROM ccdlstaging/dr_affymetrix:latest
 
 USER root
 
+# Remove the version of common already installed.
+RUN rm -r common/
+RUN pip3 uninstall -y data_refinery_common
+
+# Reinstall common.
 COPY common/dist/data-refinery-common-* common/
 # Get the latest version from the dist directory.
 RUN pip3 install common/$(ls common -1 | sort --version-sort | tail -1)

--- a/workers/nomad-job-specs/run_qn_job.nomad.tpl
+++ b/workers/nomad-job-specs/run_qn_job.nomad.tpl
@@ -58,6 +58,7 @@ job "RUN_QN_JOB" {
 
         USE_S3 = "${{USE_S3}}"
         S3_BUCKET_NAME = "${{S3_BUCKET_NAME}}"
+        S3_QN_TARGET_BUCKET_NAME = "${{S3_QN_TARGET_BUCKET_NAME}}"
         LOCAL_ROOT_DIR = "${{LOCAL_ROOT_DIR}}"
 
         LOG_LEVEL = "${{LOG_LEVEL}}"


### PR DESCRIPTION
## Issue Number

#1572 

## Purpose/Implementation Notes

The foreman wasn't retrying QN jobs because they didn't have a volume index. This fixes that by letting the foreman retry jobs without volume indices. To avoid this suddenly retrying lots of jobs that were previously filtered out I've moved the job_cutoff date up.

Also set the QN s3 env var in the other QN job. Yes we should have two because one gets dispatched to with a processor job already created and the other will just go for any supplied organism.

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

The unit tests cover this rather well I think.

## Checklist

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules
