### PR TITLE
Access quant files through computational results

### DIFF
--- a/common/data_refinery_common/models/models.py
+++ b/common/data_refinery_common/models/models.py
@@ -201,6 +201,15 @@ class Sample(models.Model):
             # This sample has no smashable files yet.
             return None
 
+    def get_most_recent_quant_sf_file(self):
+        """ Returns the latest quant.sf file that was generated for this sample.
+        Note: We don't associate that file to the computed_files of this sample, that's
+        why we have to go through the computational results. """
+        return ComputedFile.objects\
+            .filter(result__in=self.results.all(), filename='quant.sf')\
+            .order_by('-created_at')\
+            .first()
+
     @property
     def pretty_platform(self):
         """ Turns

--- a/workers/data_refinery_workers/processors/smasher.py
+++ b/workers/data_refinery_workers/processors/smasher.py
@@ -50,7 +50,6 @@ def log_state(message):
     cpu = psutil.cpu_percent()
     logger.debug("cpu:%s - ram:%s -  %s", cpu, ram, message)
 
-
 def _prepare_files(job_context: Dict) -> Dict:
     """
     Fetches and prepares the files to smash.
@@ -467,15 +466,15 @@ def sync_quant_files(output_path, files_sample_tuple, job_context: Dict):
     """ Takes a list of ComputedFiles and copies the ones that are quant files to the provided directory.
         Returns the total number of samples that were included """
     num_samples = 0
-    for (computed_file, sample) in files_sample_tuple:
+    for (_, sample) in files_sample_tuple:
+        latest_computed_file = sample.get_most_recent_quant_sf_file()
         # we just want to output the quant.sf files
-        if computed_file.filename != 'quant.sf': continue
-        if not sample: continue # check that the computed file is associated with a sample
+        if not latest_computed_file: continue
         accession_code = sample.accession_code
         # copy file to the output path
         output_file_path = output_path + accession_code + "_quant.sf"
         num_samples += 1
-        computed_file.get_synced_file_path(path=output_file_path)
+        latest_computed_file.get_synced_file_path(path=output_file_path)
     return num_samples
 
 def _smash(job_context: Dict, how="inner") -> Dict:

--- a/workers/data_refinery_workers/processors/test_smasher.py
+++ b/workers/data_refinery_workers/processors/test_smasher.py
@@ -570,6 +570,13 @@ class SmasherTestCase(TestCase):
         computed_file.sha1 = "08c7ea90b66b52f7cd9d9a569717a1f5f3874967" # this matches with the downloaded file
         computed_file.save()
 
+        computed_file = ComputedFile()
+        computed_file.filename = "logquant.tsv"
+        computed_file.is_smashable = True
+        computed_file.size_in_bytes = 123123
+        computed_file.result = result        
+        computed_file.save()
+
         assoc = SampleComputedFileAssociation()
         assoc.sample = sample
         assoc.computed_file = computed_file
@@ -589,7 +596,7 @@ class SmasherTestCase(TestCase):
         pjda.save()
 
         final_context = smasher.smash(job.pk, upload=False)
-        
+
         # Check that the sample was really generated
         self.assertTrue(os.path.exists(final_context['output_dir'] + '/HOMO_SAPIENS/GSM1237818_quant.sf'))
         self.assertTrue(final_context['metadata']['quant_sf_only'])


### PR DESCRIPTION
## Issue Number

#1602 

## Purpose/Implementation Notes

Seems that we don't associate `ComputedFiles` with `quant.sf` results with the samples, instead this changes the code to fetch them through the `ComputationalResults` relations.

## Types of changes

- Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Functional tests

Tested locally

## Checklist

- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules
