### PR TITLE
Break up retry_samples query into smaller queries

### DIFF
--- a/foreman/data_refinery_foreman/foreman/management/commands/retry_samples.py
+++ b/foreman/data_refinery_foreman/foreman/management/commands/retry_samples.py
@@ -93,9 +93,7 @@ def retry_by_regex(pattern):
     logger.info("Re-queued %d samples that had failed with the pattern %s.", total_samples_queued, pattern)
 
 def retry_computed_files_not_uploaded():
-    samples_with_results = Sample.objects.filter(
-        Q(computed_files__s3_bucket__isnull=True) | Q(results__computedfile__s3_bucket__isnull=True)
-    ).values('accession_code')
+    samples_with_results = Sample.objects.filter(Q(results__computedfile__s3_bucket__isnull=True)).values('id')
 
     samples_with_computed_files = Sample.objects.filter(Q(computed_files__s3_bucket__isnull=True)).values('id')
 

--- a/foreman/data_refinery_foreman/foreman/management/commands/retry_samples.py
+++ b/foreman/data_refinery_foreman/foreman/management/commands/retry_samples.py
@@ -99,7 +99,7 @@ def retry_computed_files_not_uploaded():
 
     samples_with_computed_files = Sample.objects.filter(Q(computed_files__s3_bucket__isnull=True)).values('id')
 
-    sample_ids {s['id'] for s in samples_with_results} | {s['id'] for s in samples_with_computed_files}
+    sample_ids = {s['id'] for s in samples_with_results} | {s['id'] for s in samples_with_computed_files}
 
     eligible_samples = Sample.objects.filter(id__in=sample_ids)
 

--- a/foreman/data_refinery_foreman/foreman/management/commands/retry_samples.py
+++ b/foreman/data_refinery_foreman/foreman/management/commands/retry_samples.py
@@ -6,7 +6,6 @@ from typing import Dict, List
 
 from django.core.management.base import BaseCommand
 from django.db.models import OuterRef, Subquery, Count
-from django.db.models.expressions import Q
 from data_refinery_common.models import (
     ProcessorJob,
     Sample,
@@ -93,9 +92,9 @@ def retry_by_regex(pattern):
     logger.info("Re-queued %d samples that had failed with the pattern %s.", total_samples_queued, pattern)
 
 def retry_computed_files_not_uploaded():
-    samples_with_results = Sample.objects.filter(Q(results__computedfile__s3_bucket__isnull=True)).values('id')
+    samples_with_results = Sample.objects.filter(results__computedfile__s3_bucket__isnull=True).values('id')
 
-    samples_with_computed_files = Sample.objects.filter(Q(computed_files__s3_bucket__isnull=True)).values('id')
+    samples_with_computed_files = Sample.objects.filter(computed_files__s3_bucket__isnull=True).values('id')
 
     sample_ids = {s['id'] for s in samples_with_results} | {s['id'] for s in samples_with_computed_files}
 

--- a/foreman/data_refinery_foreman/foreman/management/commands/retry_samples.py
+++ b/foreman/data_refinery_foreman/foreman/management/commands/retry_samples.py
@@ -8,7 +8,7 @@ from django.core.management.base import BaseCommand
 from django.db.models import OuterRef, Subquery, Count
 from django.db.models.expressions import Q
 from data_refinery_common.models import (
-    ProcessorJob,    
+    ProcessorJob,
     Sample,
 )
 from data_refinery_common.logging import get_and_configure_logger
@@ -93,9 +93,16 @@ def retry_by_regex(pattern):
     logger.info("Re-queued %d samples that had failed with the pattern %s.", total_samples_queued, pattern)
 
 def retry_computed_files_not_uploaded():
-    eligible_samples = Sample.objects.filter(
+    samples_with_results = Sample.objects.filter(
         Q(computed_files__s3_bucket__isnull=True) | Q(results__computedfile__s3_bucket__isnull=True)
-    ).distinct()
+    ).values('accession_code')
+
+    samples_with_computed_files = Sample.objects.filter(Q(computed_files__s3_bucket__isnull=True)).values('id')
+
+    sample_ids {s['id'] for s in samples_with_results} | {s['id'] for s in samples_with_computed_files}
+
+    eligible_samples = Sample.objects.filter(id__in=sample_ids)
+
     total_samples_queued = requeue_samples(eligible_samples)
     logger.info("Re-queued %d samples that were associated with computed files that were not uploaded to S3", total_samples_queued)
 
@@ -143,4 +150,3 @@ class Command(BaseCommand):
 
         if options['computed_files_not_uploaded']:
             retry_computed_files_not_uploaded()
-        


### PR DESCRIPTION
## Issue Number

#1630 

## Purpose/Implementation Notes

The query was too big so it timed out. This breaks it up into smaller chucks and does the distinct samples in python's memory.

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

I ran the command and it completed without errors, but I don't have data it would affect.

## Checklist

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules
