### PR TITLE
Change the query to calculate the samples with computed files that were not uploaded to S3

### DIFF
--- a/foreman/data_refinery_foreman/foreman/management/commands/retry_samples.py
+++ b/foreman/data_refinery_foreman/foreman/management/commands/retry_samples.py
@@ -9,6 +9,7 @@ from django.db.models import OuterRef, Subquery, Count
 from data_refinery_common.models import (
     ProcessorJob,
     Sample,
+    ComputedFile
 )
 from data_refinery_common.logging import get_and_configure_logger
 from data_refinery_common.job_management import create_downloader_job
@@ -92,11 +93,15 @@ def retry_by_regex(pattern):
     logger.info("Re-queued %d samples that had failed with the pattern %s.", total_samples_queued, pattern)
 
 def retry_computed_files_not_uploaded():
-    samples_with_results = Sample.objects.filter(results__computedfile__s3_bucket__isnull=True).values('id')
+    samples_with_computed_files = ComputedFile.objects\
+        .filter(s3_bucket__isnull=True, samples__isnull=False)\
+        .values_list('samples', flat=True)
 
-    samples_with_computed_files = Sample.objects.filter(computed_files__s3_bucket__isnull=True).values('id')
+    samples_with_results = ComputedFile.objects\
+        .filter(s3_bucket__isnull=True, result__samples__isnull=False)\
+        .values_list('result__samples', flat=True)
 
-    sample_ids = {s['id'] for s in samples_with_results} | {s['id'] for s in samples_with_computed_files}
+    sample_ids = set(samples_with_results) | set(samples_with_computed_files)
 
     eligible_samples = Sample.objects.filter(id__in=sample_ids)
 


### PR DESCRIPTION
## Issue Number

#1627 

## Purpose/Implementation Notes

Current version is timing out. This one uses the `ComputedFiles` to calculate the samples, instead of the other way around.

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

Tested queries on staging and ran the sql in prod to ensure they don't time out.

## Checklist

- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules
