### PR TITLE
Increase smasher size

### DIFF
--- a/infrastructure/instances.tf
+++ b/infrastructure/instances.tf
@@ -274,7 +274,7 @@ resource "aws_instance" "smasher_instance" {
   # Should be more than enough to store 2 jobs worth of data at a time.
   root_block_device = {
     volume_type = "gp2"
-    volume_size = 100
+    volume_size = 3000
   }
 }
 

--- a/infrastructure/instances.tf
+++ b/infrastructure/instances.tf
@@ -274,7 +274,7 @@ resource "aws_instance" "smasher_instance" {
   # Should be more than enough to store 2 jobs worth of data at a time.
   root_block_device = {
     volume_type = "gp2"
-    volume_size = 3000
+    volume_size = 6000
   }
 }
 


### PR DESCRIPTION
## Issue Number

#1587 

## Purpose/Implementation Notes

Describe the big picture of your changes.

One of the jobs to generate the quantcompendia failed with 50k human samples because it ran out of space.

The total size of the quantfiles that we have is `5000GB`. This increases the smasher to `3000GB` to be prepared for when we generate the datasets in parallel. 

```sql
data_refinery=> select sum(size_in_bytes) from computed_files where filename='quant.sf';
      sum      
---------------
 5603241992755
(1 row)
```

## Types of changes

- Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Functional tests

None

## Checklist

- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules
