### PR TITLE
Filter un-uploaded quant files from tximport. Fix QN bucket perms.

### DIFF
--- a/common/data_refinery_common/rna_seq.py
+++ b/common/data_refinery_common/rna_seq.py
@@ -89,6 +89,12 @@ def get_quant_results_for_experiment(experiment: Experiment, filter_old_versions
     else:
         eligible_results = ComputationalResult.objects.all()
 
+    # A result is only eligible to be used if it actually got uploaded.
+    eligible_results = eligible_results.select_related('computedfile').filter(
+        computedfile__s3_bucket__isnull=False,
+        computedfile__s3_key__isnull=False
+    )
+
     # Calculate the computational results sorted that are associated with a given sample (
     # referenced from the top query)
     newest_computational_results = eligible_results.filter(

--- a/infrastructure/users.tf
+++ b/infrastructure/users.tf
@@ -130,6 +130,7 @@ resource "aws_iam_policy" "data_refinery_client_policy_s3" {
               "arn:aws:s3:::${aws_s3_bucket.data_refinery_bucket.bucket}/*",
               "arn:aws:s3:::${aws_s3_bucket.data_refinery_results_bucket.bucket}/*",
               "arn:aws:s3:::${aws_s3_bucket.data_refinery_transcriptome_index_bucket.bucket}/*",
+              "arn:aws:s3:::${aws_s3_bucket.data_refinery_qn_target_bucket.bucket}/*",
               "arn:aws:s3:::${aws_s3_bucket.data_refinery_compendia_bucket.bucket}/*"
             ]
         }

--- a/workers/data_refinery_workers/downloaders/sra.py
+++ b/workers/data_refinery_workers/downloaders/sra.py
@@ -95,7 +95,7 @@ def _download_file_http(download_url: str,
 
         with closing(urllib.request.urlopen(download_url, timeout=60)) as request:
             shutil.copyfileobj(request, target_file, CHUNK_SIZE)
-    except Exception:
+    except Exception as e:
         logger.exception("Exception caught while downloading file.",
                          downloader_job=downloader_job.id)
         downloader_job.failure_reason = "Exception caught while downloading file\\n " \

--- a/workers/data_refinery_workers/processors/salmon.py
+++ b/workers/data_refinery_workers/processors/salmon.py
@@ -806,7 +806,8 @@ def _run_salmon(job_context: Dict) -> Dict:
 
         quant_file = ComputedFile()
         quant_file.s3_bucket = S3_BUCKET_NAME
-        quant_file.s3_key = "quant_files/sample_" + str(job_context["sample"].id) + "_quant.sf"
+        timestamp = str(timezone.now().timestamp()).split('.')[0]
+        quant_file.s3_key = "quant_files/sample_{0}_{1}_quant.sf".format(job_context["sample"].id, timestamp)
         quant_file.filename = "quant.sf"
         quant_file.absolute_file_path = job_context["output_directory"] + "quant.sf"
         quant_file.is_public = False


### PR DESCRIPTION
## Issue Number

N/A came up while running #1630 

## Purpose/Implementation Notes

QN jobs were still failing because of bucket permissions. This should address that.

Additionally we had problems because `needs_processing` and `get_quant_results_for_experiment` weren't disregarding computed files that hadn't been uploaded. This makes those functions filter out computed files that weren't uploaded so we either can reprocess them or realize that we aren't ready for tximport.

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

The unit tests are actually really good for this, especially since I don't have the test data for it.

## Checklist

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules
