### PR TITLE
Log exceptions rather than letting them interrupt the correct affy cdfs command.

### DIFF
--- a/foreman/data_refinery_foreman/foreman/management/commands/correct_affy_cdfs.py
+++ b/foreman/data_refinery_foreman/foreman/management/commands/correct_affy_cdfs.py
@@ -86,6 +86,8 @@ class Command(BaseCommand):
                         accession_code=experiment.accession_code,
                         created_at=current_time
                     ).save()
+                except Exception:
+                    logger.exception("Caught an exception with %s!", experiment.accession_code)
                 finally:
                     # GEOparse downloads files here and never cleans them up! Grrrr!
                     download_path = GEO_TEMP_DIR + experiment.accession_code + '_family.soft.gz'


### PR DESCRIPTION
## Issue Number

#1276 

## Purpose/Implementation Notes

The job was failing for what I think was a GEOParse error. We'll just move on and see how we do.

## Functional tests

I ran it but I don't have much test data for it.
