### PR TITLE
Create separate README files for types of compendia

### DIFF
--- a/workers/README_NORMALIZED.md
+++ b/workers/README_NORMALIZED.md
@@ -1,7 +1,7 @@
-# refine.bio Species Compendium
+# refine.bio Normalized Compendium
 
-This is a refine.bio species compendium comprised of all the samples from a species that we were able to process. 
-Species compendia provide a snapshot of the most complete collection of gene expression that refine.bio can produce for each supported organism.
+This is a refine.bio normalized compendium comprised of all the samples from a species that we were able to process, aggregate, and normalize. 
+Normalized compendia provide a snapshot of the most complete collection of gene expression that refine.bio can produce for each supported organism.
 
 You can read more about how we process species compendia in [our documentation](http://docs.refine.bio/en/latest/main_text.html#species-compendia).
 

--- a/workers/README_NORMALIZED.md
+++ b/workers/README_NORMALIZED.md
@@ -7,13 +7,13 @@ You can read more about how we process species compendia in [our documentation](
 
 ## Contents
 
-This download includes a gene expression matrix and experiment and sample metadata for all samples from a given organism that are fit for inclusion in the species compendium.
+This download includes a gene expression matrix and experiment and sample metadata for all samples from a given organism that are fit for inclusion in the normalized compendium.
 
 * The `aggregated_metadata.json` file contains experiment metadata and information about the transformation applied to the data. 
-Specifically, the `scale_by` field notes any row-wise transformation that was performed on the gene expression data. For species compendia, this value should always be `NONE`.
+Specifically, the `scale_by` field notes any row-wise transformation that was performed on the gene expression data. For normalized compendia, this value should always be `NONE`.
 
 * The gene expression matrix is the tab-separated value (TSV) file that bears the species name. 
-For example, if you have downloaded the zebrafish species compendium, you would find the gene expression matrix in the file `DANIO_RERIO/DANIO_RERIO.tsv`.
+For example, if you have downloaded the zebrafish normalized compendium, you would find the gene expression matrix in the file `DANIO_RERIO/DANIO_RERIO.tsv`.
 Note that samples are _columns_ and rows are _genes_ or _features_. 
 This pattern is consistent with the input for many programs specifically designed for working with high-throughput gene expression data but may be transposed from what other machine learning libraries are expecting.
 
@@ -33,7 +33,7 @@ We strongly encourage you to consider using methods or models that can account f
 
 ### Methods evaluation and exploratory data analysis
 
-To identify appropriate methods for processing the initial releases of species compendia (described [here](http://docs.refine.bio/en/latest/main_text.html#species-compendia)), we performed a series of evaluations in a small zebrafish test compendium. 
+To identify appropriate methods for processing the initial releases of normalized compendia (described [here](http://docs.refine.bio/en/latest/main_text.html#species-compendia)), we performed a series of evaluations in a small zebrafish test compendium. 
 We've made these evaluations available and have documented our rationale on GitHub [here](https://github.com/AlexsLemonade/compendium-processing/tree/94089d2de170f0ca7b87e9e5c32239a8591faaa7/select_imputation_method).
 
 We have also performed exploratory analyses in a larger zebrafish test compendium ([GitHub](https://github.com/AlexsLemonade/compendium-processing/tree/94089d2de170f0ca7b87e9e5c32239a8591faaa7/quality_check)). 

--- a/workers/README_NORMALIZED.md
+++ b/workers/README_NORMALIZED.md
@@ -3,7 +3,7 @@
 This is a refine.bio normalized compendium comprised of all the samples from a species that we were able to process, aggregate, and normalize. 
 Normalized compendia provide a snapshot of the most complete collection of gene expression that refine.bio can produce for each supported organism.
 
-You can read more about how we process species compendia in [our documentation](http://docs.refine.bio/en/latest/main_text.html#species-compendia).
+You can read more about how we process refine.bio compendia in [our documentation](http://docs.refine.bio/en/latest/main_text.html#refine-bio-compendia).
 
 ## Contents
 

--- a/workers/README_QUANT.md
+++ b/workers/README_QUANT.md
@@ -1,7 +1,7 @@
 # refine.bio RNA-Seq Sample Compendium
 
 This is a refine.bio RNA-seq sample compendium.
-It represents the Salmon output for the collection of RNA-seq samples from an organism that can be processed with refine.bio.
+It represents the Salmon output for the collection of RNA-seq samples from an organism that have been processed with refine.bio.
 Each individual sample has its own `quant.sf` file; the samples have not been aggregated and normalized.
 RNA-seq sample compendia are designed to allow users that are comfortable handling these files to generate output that is most useful for their downstream applications.
 

--- a/workers/README_QUANT.md
+++ b/workers/README_QUANT.md
@@ -1,0 +1,41 @@
+# refine.bio RNA-Seq Sample Compendium
+
+This is a refine.bio RNA-seq sample compendium.
+It represents the Salmon output for the collection of RNA-seq samples from an organism that can be processed with refine.bio.
+Each individual sample has its own `quant.sf` file; the samples have not been aggregated and normalized.
+RNA-seq sample compendia are designed to allow users that are comfortable handling these files to generate output that is most useful for their downstream applications.
+
+Please see the [Salmon documentation on the `quant.sf` output format](https://salmon.readthedocs.io/en/latest/file_formats.html#quantification-file) for more information.
+
+## Contents
+
+This download includes individual `quant.sf` files that that are organized into to folders that represent experiments.
+The individual files represent individual runs (e.g., SRR, ERR, DRR) and the folders represent projects (e.g., SRP, ERP, DRP) from Sequence Read Archive.
+We also included any metadata available from refine.bio, which is limited for RNA-seq data at this time.
+
+* The `aggregated_metadata.json` file contains experiment (project) metadata.
+
+* Each folder corresponds to an experiment and contains a metadata TSV file and `quant.sf` files (named following the convention `<sample-accession-id>_quant.sf`) for each sample that refine.bio was able to process with Salmon.
+
+* Sample metadata (e.g. disease vs. control labels) are contained in the TSV file with `metadata` in the filename as well as any JSON files.
+We apply light harmonization to some sample metadata fields, which are denoted by `refinebio_` (`refinebio_annotations` is an exception).
+The contents of a sample's `refinebio_annotations` field in JSON files include the submitter-supplied sample metadata.
+
+* Experiment metadata (e.g., experiment title and description) are contained in JSON files with `metadata` in the filename.
+
+_Note that we use the terms "sample" and "experiment" to be consistent with the rest of refine.bio, but files will use run identifiers and project identifiers, respectively._
+
+Please see [our documentation](http://docs.refine.bio/en/latest/) for more details.
+
+## Contact
+
+If you identify issues with this download, please [file an issue on GitHub](https://github.com/AlexsLemonade/refinebio/issues).
+If you would prefer to report issues via e-mail, you can also email [ccdl@alexslemonade.org](mailto:ccdl@alexslemonade.org).
+
+## Citing refine.bio
+
+Please use the following:
+
+Casey S. Greene, Dongbo Hu, Richard W. W. Jones, Stephanie Liu, David S. Mejia, Rob Patro, Stephen R. Piccolo, Ariel Rodriguez Romero, Hirak Sarkar, Candace L. Savonen, Jaclyn N. Taroni, William E. Vauclain, Deepashree Venkatesh Prasad, Kurt G. Wheeler. **refine.bio: a resource of uniformly processed publicly available gene expression datasets.** URL: https://www.refine.bio 
+
+_Note that the contributor list is in alphabetical order as we prepare a manuscript for submission._

--- a/workers/README_QUANT.md
+++ b/workers/README_QUANT.md
@@ -25,7 +25,7 @@ The contents of a sample's `refinebio_annotations` field in JSON files include t
 
 _Note that we use the terms "sample" and "experiment" to be consistent with the rest of refine.bio, but files will use run identifiers and project identifiers, respectively._
 
-Please see [our documentation](http://docs.refine.bio/en/latest/) for more details.
+Please see [our documentation](http://docs.refine.bio/en/latest/main_text.html#rna-seq-sample-compendia) for more details.
 
 ## Contact
 

--- a/workers/data_refinery_workers/processors/create_compendia.py
+++ b/workers/data_refinery_workers/processors/create_compendia.py
@@ -105,7 +105,7 @@ def _perform_imputation(job_context: Dict) -> Dict:
      - Remove samples (columns) with >50% missing values in combined_matrix
      - "Reset" zero values that were set to NA in RNA-seq samples (i.e., make these zero again) in combined_matrix
      - Transpose combined_matrix; transposed_matrix
-     - Perform imputation of missing values with IterativeSVD (rank=10) on the transposed_matrix; imputed_matrix 
+     - Perform imputation of missing values with IterativeSVD (rank=10) on the transposed_matrix; imputed_matrix
         -- with specified svd algorithm or skip
      - Untranspose imputed_matrix (genes are now rows, samples are now columns)
      - Quantile normalize imputed_matrix where genes are rows and samples are columns
@@ -325,8 +325,13 @@ def _create_result_objects(job_context: Dict) -> Dict:
 
     # Create the resulting archive
     final_zip_base = "/home/user/data_store/smashed/" + str(job_context["dataset"].pk) + "_compendia"
-    # Copy LICENSE.txt and README.md files
-    shutil.copy("/home/user/README_COMPENDIUM.md", job_context["output_dir"] + "/README.md")
+    # Copy LICENSE.txt and correct README.md files.
+    if job_context["dataset"].quant_sf_only:
+        readme_file = "/home/user/README_QUANT.md"
+    else:
+        readme_file = "/home/user/README_NORMALIZED.md"
+
+    shutil.copy(readme_file, job_context["output_dir"] + "/README.md")
     shutil.copy("/home/user/LICENSE_DATASET.txt", job_context["output_dir"] + "/LICENSE.TXT")
     archive_path = shutil.make_archive(final_zip_base, 'zip', job_context["output_dir"])
 


### PR DESCRIPTION
## Issue Number

#1661 - this currently addresses the first two points there. This is where the change needs to be made to address the third point: 

https://github.com/AlexsLemonade/refinebio/blob/c20389265b38dedba0bc31c302582167ca9f293f/workers/data_refinery_workers/processors/create_compendia.py#L329

I was going to make the change myself but because there are now two files to choose from based on the _type_ of compendium being created, this turns out to be more logic than I am comfortable writing right this moment.

## Purpose/Implementation Notes

- Changes the file that was formally `README_COMPENDIUM.md` to be named `README_NORMALIZED.md` and changes the text contained within to reflect our new terminology for this offering: `normalized compendium`.
- Adds a new file `README_QUANT.md` that is written to be included with quantpendia.

## Types of changes

What types of changes does your code introduce?

<!-- Remove any which your PR isn't -->
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Functional tests

N/A

## Checklist

_Put an `x` in the boxes that apply._

- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules
