### PR TITLE
Clean up disk space better in correct_affy_cdfs

### DIFF
--- a/infrastructure/instances.tf
+++ b/infrastructure/instances.tf
@@ -752,7 +752,8 @@ resource "aws_instance" "foreman_server_1" {
   # They should be removed or revisited.
   root_block_device = {
     volume_type = "gp2"
-    volume_size = 100
+    # TODO set this back 100 once correct_affy_cdfs finishes!
+    volume_size = 1000
   }
 }
 

--- a/infrastructure/instances.tf
+++ b/infrastructure/instances.tf
@@ -752,8 +752,7 @@ resource "aws_instance" "foreman_server_1" {
   # They should be removed or revisited.
   root_block_device = {
     volume_type = "gp2"
-    # TODO set this back 100 once correct_affy_cdfs finishes!
-    volume_size = 1000
+    volume_size = 100
   }
 }
 

--- a/workers/data_refinery_workers/processors/management/commands/correct_affy_samples.py
+++ b/workers/data_refinery_workers/processors/management/commands/correct_affy_samples.py
@@ -93,11 +93,12 @@ class Command(BaseCommand):
 
         Basically does what is described at the top of this file.
         """
-        # Create working dir
         LOCAL_ROOT_DIR = get_env_variable("LOCAL_ROOT_DIR", "/home/user/data_store")
         work_dir = LOCAL_ROOT_DIR + "/affy_correction/"
-        os.makedirs(work_dir, exist_ok=True)
         for sample in Sample.objects.filter(technology='RNA-SEQ', source_database='GEO'):
+            # Re-create working dir every iteration so we can't run out of disk space.
+            shutil.rmtree(work_dir, ignore_errors=True)
+            os.makedirs(work_dir, exist_ok=True)
             for original_file in sample.original_files.all():
                 if original_file.is_affy_data() :
                     input_file_path = work_dir + original_file.source_filename
@@ -134,6 +135,3 @@ class Command(BaseCommand):
                     # this sample, we don't need them because we
                     # already corrected the platform.
                     break
-
-        # Cleanup after ourselves:
-        shutil.rmtree(work_dir)


### PR DESCRIPTION
## Issue Number

#1276 

## Purpose/Implementation Notes

Ran out of disk space again. I think I didn't indent my previous "fix" enough. This should keep the disk space usage low for that command.

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

I ran it locally but I don't have much data to correct.
