### PR TITLE
Add CREATE_COMPENDIA to job switch.

### DIFF
--- a/common/data_refinery_common/message_queue.py
+++ b/common/data_refinery_common/message_queue.py
@@ -54,6 +54,8 @@ def send_job(job_type: Enum, job, is_dispatch=False) -> bool:
         nomad_job = ProcessorPipeline.JANITOR.value
     elif job_type is ProcessorPipeline.QN_REFERENCE:
         nomad_job = ProcessorPipeline.QN_REFERENCE.value
+    elif job_type is ProcessorPipeline.CREATE_COMPENDIA:
+        nomad_job = ProcessorPipeline.CREATE_COMPENDIA.value
     elif job_type is ProcessorPipeline.AGILENT_TWOCOLOR_TO_PCL:
         # Agilent twocolor uses the same job specification as Affy.
         nomad_job = ProcessorPipeline.AFFY_TO_PCL.value


### PR DESCRIPTION
## Issue Number

#1258 

## Purpose/Implementation Notes

We still can't dispatch multiple compendia jobs with a single command. This isn't urgent at all cause I can do them one by one in prod until we're ready for another deploy.
