### PR TITLE
Implement Multiprocessing with passing tests

### DIFF
--- a/workers/data_refinery_workers/processors/smasher.py
+++ b/workers/data_refinery_workers/processors/smasher.py
@@ -635,19 +635,18 @@ def _smash(job_context: Dict, how="inner") -> Dict:
 
             start_frames = log_state("build frames for species or experiment")
             # Merge all the frames into one
-            #cpus = max(1, psutil.cpu_count()/2)
-            #with multiprocessing.Pool(int(cpus)) as pool:
-            #    processed_frames = pool.map(
-            mapped_frames = map(
-                process_frame,
-                [(
-                    job_context,
-                    computed_file,
-                    sample,
-                    i
-                ) for i, (computed_file, sample) in enumerate(input_files)
+            cpus = max(1, psutil.cpu_count()/2)
+            with multiprocessing.Pool(int(cpus)) as pool:
+                processed_frames = pool.map(
+                    process_frame,
+                    [(
+                        job_context,
+                        computed_file,
+                        sample,
+                        i
+                    ) for i, (computed_file, sample) in enumerate(input_files)
             ])
-            processed_frames = list(mapped_frames)
+
             all_frames = [f['data'] for f in processed_frames if f['data'] is not None]
             num_samples = num_samples + len([x for x in all_frames])
             unsmashable_files = unsmashable_files + [f['unsmashable_file'] for f in processed_frames if f['unsmashable']]


### PR DESCRIPTION
## Issue Number

#1537 

## Purpose/Implementation Notes

This reimplements the multiprocessing of downloading the frames from s3 which wasn't testing well because of forked and persisting DB connections. This PR reimplements that logic and also manages those connections explicitly.

In the future we should consider making ```process_frame``` a better candidate for a subprocess by only passing in a data-structure we can mutate and not a complete django model.

## Methods

Smasher.py 

## Types of changes

What types of changes does your code introduce?

- New feature (non-breaking change which adds functionality)

## Functional tests

Compendia Tests working locally

## Checklist

- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

