### PR TITLE
Add command to check if computed files are in S3

### DIFF
--- a/common/data_refinery_common/models/models.py
+++ b/common/data_refinery_common/models/models.py
@@ -960,11 +960,13 @@ class ComputedFile(models.Model):
                     )
             self.save()
         except Exception as e:
-            logger.exception(e,
+            logger.exception('Error uploading computed file to S3',
                 computed_file_id=self.pk,
                 s3_key=self.s3_key,
                 s3_bucket=self.s3_bucket
             )
+            self.s3_bucket = None
+            self.s3_key = None
             return False
 
         return True

--- a/foreman/data_refinery_foreman/foreman/management/commands/check_computed_files.py
+++ b/foreman/data_refinery_foreman/foreman/management/commands/check_computed_files.py
@@ -1,0 +1,47 @@
+import boto3
+from botocore.client import Config
+from botocore.errorfactory import ClientError
+from django.core.management.base import BaseCommand
+
+from data_refinery_common.logging import get_and_configure_logger
+from data_refinery_common.models import ComputedFile
+
+# We have to set the signature_version to v4 since us-east-1 buckets require
+# v4 authentication.
+S3 = boto3.client('s3', config=Config(signature_version='s3v4'))
+
+logger = get_and_configure_logger(__name__)
+
+PAGE_SIZE = 2000
+
+class Command(BaseCommand):
+    def handle(self, *args, **options):
+        """ We found some computed files that seem to be in S3 but they don't exist for some reason.
+        This command will check all of them and ensure they exists in S3. For those that don't exist it
+        will clear their `s3_key`/`s3_bucket` fields.
+        ref https://github.com/AlexsLemonade/refinebio/issues/1696
+        """
+        computed_files_queryset = ComputedFile.objects.filter(s3_key__isnull=False, s3_bucket__isnull=False)
+        total_files = 0
+        modified_files = 0
+
+        # iterate over all computed files without loading them in memory
+        # https://docs.djangoproject.com/en/dev/ref/models/querysets/#iterator
+        for computed_file in computed_files_queryset.iterator():
+            total_files += 1
+            # check that file is present in S3, no need to download the entire object
+            # https://stackoverflow.com/a/38376288/763705
+            # https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/s3.html#S3.Client.head_object
+            try:
+                S3.head_object(Bucket=computed_file.s3_bucket, Key=computed_file.s3_key)
+            except ClientError:
+                # Not found
+                modified_files += 1
+                logger.debug('Computed file not found on S3. Removing s3 fields.', computed_file=computed_file)
+                computed_file.s3_key = None
+                computed_file.s3_bucket = None
+                computed_file.save()
+
+            # provide some info while the command is running.
+            if total_files % PAGE_SIZE == 0:
+                logger.info('Checked %i computed files to see if they are in S3, so far found %i' % (total_files, modified_files))


### PR DESCRIPTION
## Issue Number

#1696 

## Purpose/Implementation Notes

This adds a command that iterates over all computed files to check if they are in S3. If they aren't it clears their `s3_bucket` and `s3_key` fields.

I used [iterator()](https://docs.djangoproject.com/en/dev/ref/models/querysets/#iterator) to iterate over all computed objects, seems like this will do something similar to the `Paginator` we have used.

## Types of changes

- New feature (non-breaking change which adds functionality)

## Functional tests

None, should we test this on staging?

## Checklist

- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules
