### PR TITLE
Follows best practices around Enums to fix retrying CREATE_COMPENDIA jobs

### DIFF
--- a/common/data_refinery_common/job_lookup.py
+++ b/common/data_refinery_common/job_lookup.py
@@ -30,7 +30,7 @@ class PipelineEnum(Enum):
     TX_INDEX = "Transcriptome Index"
     QN_REFERENCE = "Quantile Normalization Reference"
     JANITOR = "Janitor"
-    COMPENDIA = "Compendia"
+    CREATE_COMPENDIA = "Compendia"
 
 
 @unique
@@ -102,7 +102,7 @@ class ProcessorEnum(Enum):
         "yml_file": "qn.yml"
     }
 
-    COMPENDIA = {
+    CREATE_COMPENDIA = {
         "name": "Compendia Creation",
         "docker_img": "dr_compendia",
         "yml_file": "compendia.yml"

--- a/workers/data_refinery_workers/processors/create_compendia.py
+++ b/workers/data_refinery_workers/processors/create_compendia.py
@@ -277,7 +277,7 @@ def _create_result_objects(job_context: Dict) -> Dict:
     result.time_start = job_context['time_start']
     result.time_end = job_context['time_end']
     try:
-        processor_key = "COMPENDIA"
+        processor_key = "CREATE_COMPENDIA"
         result.processor = utils.find_processor(processor_key)
     except Exception as e:
         return utils.handle_processor_exception(job_context, processor_key, e)
@@ -379,7 +379,7 @@ def _create_result_objects(job_context: Dict) -> Dict:
     return job_context
 
 def create_compendia(job_id: int) -> None:
-    pipeline = Pipeline(name=PipelineEnum.COMPENDIA.value)
+    pipeline = Pipeline(name=PipelineEnum.CREATE_COMPENDIA.value)
     job_context = utils.run_pipeline({"job_id": job_id, "pipeline": pipeline},
                        [utils.start_job,
                         _prepare_input,

--- a/workers/data_refinery_workers/processors/management/commands/create_compendia.py
+++ b/workers/data_refinery_workers/processors/management/commands/create_compendia.py
@@ -42,7 +42,7 @@ def create_job_for_organism(organism=Organism, quant_sf_only=False, svd_algorith
             page = paginator.page(page.next_page_number())
 
     job = ProcessorJob()
-    job.pipeline_applied = "COMPENDIA"
+    job.pipeline_applied = ProcessorPipeline.CREATE_COMPENDIA.value
     job.save()
 
     dset = Dataset()

--- a/workers/data_refinery_workers/processors/test_compendia.py
+++ b/workers/data_refinery_workers/processors/test_compendia.py
@@ -3,6 +3,7 @@ import shutil
 from contextlib import closing
 from django.test import TransactionTestCase, TestCase, tag
 from unittest.mock import MagicMock
+from data_refinery_common.job_lookup import ProcessorPipeline
 from data_refinery_common.models import (
     SurveyJob,
     ProcessorJob,
@@ -33,7 +34,7 @@ class CompendiaTestCase(TransactionTestCase):
     @tag('compendia')
     def test_create_compendia(self):
         job = ProcessorJob()
-        job.pipeline_applied = "COMPENDIA"
+        job.pipeline_applied = ProcessorPipeline.CREATE_COMPENDIA.value
         job.save()
 
         # MICROARRAY TECH
@@ -131,12 +132,12 @@ class CompendiaTestCase(TransactionTestCase):
         final_context = create_compendia.create_compendia(job.id)
 
         self.assertFalse(job.success)
- 
+
 
     @tag('compendia')
     def test_create_compendia_danio(self):
         job = ProcessorJob()
-        job.pipeline_applied = "COMPENDIA"
+        job.pipeline_applied = ProcessorPipeline.CREATE_COMPENDIA.value
         job.save()
 
         # MICROARRAY TECH
@@ -149,7 +150,7 @@ class CompendiaTestCase(TransactionTestCase):
 
         danio_rerio = Organism.get_object_for_name("DANIO_RERIO")
 
-        micros = [] 
+        micros = []
         for file in os.listdir('/home/user/data_store/raw/TEST/MICROARRAY/'):
 
             if 'microarray.txt' in file:

--- a/workers/data_refinery_workers/processors/utils.py
+++ b/workers/data_refinery_workers/processors/utils.py
@@ -214,9 +214,11 @@ def start_job(job_context: Dict):
     # Janitor jobs don't operate on file objects.
     # Tximport jobs don't need to download the original file, they
     # just need it to know what experiment to process.
-    if job.pipeline_applied not in ["JANITOR", "TXIMPORT"]:
+    if job.pipeline_applied not in [ProcessorPipeline.JANITOR.value, ProcessorPipeline.TXIMPORT.value]:
         # Some jobs take OriginalFiles, other take Datasets
-        if job.pipeline_applied not in ["SMASHER", "QN_REFERENCE", "COMPENDIA"]:
+        if job.pipeline_applied not in [ProcessorPipeline.SMASHER.value,
+                                        ProcessorPipeline.QN_REFERENCE.value,
+                                        ProcessorPipeline.CREATEC_OMPENDIA.value]:
             job_context = prepare_original_files(job_context)
             if not job_context.get("success", True):
                 return job_context
@@ -276,8 +278,11 @@ def end_job(job_context: Dict, abort=False):
                 computed_file.delete()
 
     if not abort:
-        if job_context.get("success", False) and not (job_context["job"].pipeline_applied in ["SMASHER", "QN_REFERENCE", "COMPENDIA", "JANITOR"]):
-
+        if job_context.get("success", False) \
+           and not (job_context["job"].pipeline_applied in [ProcessorPipeline.SMASHER.value,
+                                                            ProcessorPipeline.QN_REFERENCE.value,
+                                                            ProcessorPipeline.CREATE_COMPENDIA.value,
+                                                            ProcessorPipeline.JANITOR.value]):
             # Salmon requires the final `tximport` step to be fully `is_processed`.
             mark_as_processed = True
             if (job_context["job"].pipeline_applied == "SALMON" and not job_context.get('tximported', False)):

--- a/workers/data_refinery_workers/processors/utils.py
+++ b/workers/data_refinery_workers/processors/utils.py
@@ -218,7 +218,7 @@ def start_job(job_context: Dict):
         # Some jobs take OriginalFiles, other take Datasets
         if job.pipeline_applied not in [ProcessorPipeline.SMASHER.value,
                                         ProcessorPipeline.QN_REFERENCE.value,
-                                        ProcessorPipeline.CREATEC_OMPENDIA.value]:
+                                        ProcessorPipeline.CREATE_COMPENDIA.value]:
             job_context = prepare_original_files(job_context)
             if not job_context.get("success", True):
                 return job_context


### PR DESCRIPTION
## Issue Number

#1258 

## Purpose/Implementation Notes

We have a lot of compendia jobs with failure reason like `Caught either a SIGTERM or SIGINT signal.` and none of these or the rest of the failures got retried. This should make it so that compendia jobs are actually retried.

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

I'm thinking about how to functionally test this...

## Checklist

- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules
