### PR TITLE
Fix requeuing for some edge cases and add --last-modified to retry_samples

### DIFF
--- a/common/data_refinery_common/job_lookup.py
+++ b/common/data_refinery_common/job_lookup.py
@@ -133,6 +133,13 @@ class ProcessorPipeline(Enum):
     CREATE_COMPENDIA = "CREATE_COMPENDIA"
 
 
+SMASHER_JOB_TYPES = [
+    ProcessorPipeline.SMASHER,
+    ProcessorPipeline.QN_REFERENCE,
+    ProcessorPipeline.CREATE_COMPENDIA,
+]
+
+
 def does_processor_job_have_samples(job: ProcessorJob):
     return not (job.pipeline_applied == ProcessorPipeline.SMASHER.value \
                 or job.pipeline_applied == ProcessorPipeline.JANITOR.value \

--- a/common/data_refinery_common/message_queue.py
+++ b/common/data_refinery_common/message_queue.py
@@ -85,7 +85,7 @@ def send_job(job_type: Enum, job, is_dispatch=False) -> bool:
 
         # Smasher doesn't need to be on a specific instance since it will
         # download all the data to its instance anyway.
-        if isinstance(job, ProcessorJob) and job_type not in [ProcessorPipeline.SMASHER, ProcessorPipeline.QN_REFERENCE]:
+        if isinstance(job, ProcessorJob) and job_type not in SMASHER_JOB_TYPES:
             # Make sure this job goes to the correct EBS resource.
             # If this is being dispatched for the first time, make sure that
             # we store the currently attached index.

--- a/foreman/data_refinery_foreman/foreman/main.py
+++ b/foreman/data_refinery_foreman/foreman/main.py
@@ -714,7 +714,7 @@ def requeue_processor_job(last_job: ProcessorJob) -> None:
     if ProcessorPipeline[last_job.pipeline_applied] not in SMASHER_JOB_TYPES \
        and (not volume_index or volume_index == "-1"):
         active_volumes = get_active_volumes()
-        if len(active_volumes) < 1 or not settings.RUNNING_IN_CLOUD::
+        if len(active_volumes) < 1 or not settings.RUNNING_IN_CLOUD:
             logger.debug("No active volumes to requeue processor job.", job_id=last_job.id)
         else:
             volume_index = random.choice(active_volumes)

--- a/foreman/data_refinery_foreman/foreman/main.py
+++ b/foreman/data_refinery_foreman/foreman/main.py
@@ -719,6 +719,7 @@ def requeue_processor_job(last_job: ProcessorJob) -> None:
         active_volumes = get_active_volumes()
         if len(active_volumes) < 1 or not settings.RUNNING_IN_CLOUD:
             logger.debug("No active volumes to requeue processor job.", job_id=last_job.id)
+            return
         else:
             volume_index = random.choice(list(active_volumes))
 

--- a/foreman/data_refinery_foreman/foreman/main.py
+++ b/foreman/data_refinery_foreman/foreman/main.py
@@ -711,13 +711,16 @@ def requeue_processor_job(last_job: ProcessorJob) -> None:
                 new_ram_amount = 8192
 
     volume_index = last_job.volume_index
-    if ProcessorPipeline[last_job.pipeline_applied] not in SMASHER_JOB_TYPES \
-       and (not volume_index or volume_index == "-1"):
+    # Make sure volume_index is set to something, unless it's a
+    # smasher job type because the smasher instance doesn't have a
+    # volume_index.
+    if (not volume_index or volume_index == "-1") \
+       and ProcessorPipeline[last_job.pipeline_applied] not in SMASHER_JOB_TYPES:
         active_volumes = get_active_volumes()
         if len(active_volumes) < 1 or not settings.RUNNING_IN_CLOUD:
             logger.debug("No active volumes to requeue processor job.", job_id=last_job.id)
         else:
-            volume_index = random.choice(active_volumes)
+            volume_index = random.choice(list(active_volumes))
 
     new_job = ProcessorJob(num_retries=num_retries,
                            pipeline_applied=last_job.pipeline_applied,

--- a/foreman/data_refinery_foreman/foreman/management/commands/retry_samples.py
+++ b/foreman/data_refinery_foreman/foreman/management/commands/retry_samples.py
@@ -6,6 +6,7 @@ from typing import Dict, List
 
 from django.core.management.base import BaseCommand
 from django.db.models import OuterRef, Subquery, Count
+from dateutil.parser import parse as parse_date
 from data_refinery_common.models import (
     ProcessorJob,
     Sample,
@@ -69,12 +70,17 @@ def retry_by_accession_codes(accession_codes_param):
     total_samples_queued = requeue_samples(eligible_samples)
     logger.info("Re-queued %d samples with accession codes %s.", total_samples_queued, accession_codes_param)
 
-def retry_by_regex(pattern):
+def retry_by_regex(pattern, last_modified=None):
     """ Finds the samples where the failure reason of the latest processor job that was applied to them
     matches the given regex
     https://docs.djangoproject.com/en/dev/ref/models/querysets/#regex
     """
-    latest_processor_job_for_sample = ProcessorJob.objects\
+    if last_modified:
+        processor_jobs = ProcessorJob.objects.filter(last_modified__gt=last_modified)
+    else:
+        processor_jobs = ProcessorJob.objects
+
+    latest_processor_job_for_sample = processor_jobs\
         .filter(start_time__isnull=False, original_files__samples=OuterRef('id'))\
         .order_by('-start_time')
 
@@ -92,14 +98,21 @@ def retry_by_regex(pattern):
 
     logger.info("Re-queued %d samples that had failed with the pattern %s.", total_samples_queued, pattern)
 
-def retry_computed_files_not_uploaded():
-    samples_with_computed_files = ComputedFile.objects\
-        .filter(s3_bucket__isnull=True, samples__isnull=False)\
-        .values_list('samples', flat=True)
+def retry_computed_files_not_uploaded(last_modified=None):
+    if last_modified:
+        computed_files = ComputedFile.objects.filter(last_modified__gt=last_modified)
+    else:
+        computed_files = ComputedFile.objects
 
-    samples_with_results = ComputedFile.objects\
-        .filter(s3_bucket__isnull=True, result__samples__isnull=False)\
-        .values_list('result__samples', flat=True)
+    samples_with_computed_files = computed_files.filter(
+        s3_bucket__isnull=True,
+        samples__isnull=False
+    ).values_list('samples', flat=True)
+
+    samples_with_results = computed_files.filter(
+        s3_bucket__isnull=True,
+        result__samples__isnull=False
+    ).values_list('result__samples', flat=True)
 
     sample_ids = set(samples_with_results) | set(samples_with_computed_files)
 
@@ -120,7 +133,7 @@ class Command(BaseCommand):
         parser.add_argument(
             "--accession-codes",
             type=str,
-            help=("Comma sepparated sample accession codes that need to be requeued.")
+            help=("Comma separated sample accession codes that need to be requeued.")
         )
         # https://docs.djangoproject.com/en/dev/ref/models/querysets/#regex
         parser.add_argument(
@@ -135,6 +148,10 @@ class Command(BaseCommand):
             help='Finds the samples that are associated with computed files that were not uploaded to S3 and requeue them',
         )
 
+        parser.add_argument('--last-modified',
+                            type=parse_date,
+                            help='Only recreated computed files or retry processor jobs modified after this date')
+
     def handle(self, *args, **options):
         """ Re-queues all unprocessed RNA-Seq samples for an organism. """
         if options["source_database"]:
@@ -148,7 +165,7 @@ class Command(BaseCommand):
             # Examples
             # --failure-regex="ProcessorJob has already completed .*"
             # --failure-regex="Encountered error in R code while running AFFY_TO_PCL pipeline .*"
-            retry_by_regex(options['failure_regex'])
+            retry_by_regex(options['failure_regex'], options.get('last_modified', None))
 
         if options['computed_files_not_uploaded']:
-            retry_computed_files_not_uploaded()
+            retry_computed_files_not_uploaded(options.get('last_modified', None))


### PR DESCRIPTION
## Issue Number

N/A came up while trying to get a compendia job running this morning and/or I noticed it in the Foreman logs

## Purpose/Implementation Notes

A very small number of processor jobs didn't have volume_id set. This made the Foreman endlessly fail to requeue them.

We also didn't properly handle CREATE_COMPENDIA jobs in the same way we did for QN_REFERENCE and SMASHER jobs.

Finally this adds a `--last-modified` option to retry_samples for two of it's subcommands.

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

I don't have data locally for this but I ran it successfully regardless:
```
./foreman/run_surveyor.sh retry_samples --computed-files-not-uploaded --last-modified='2019-10-01'
/usr/local/lib/python3.5/dist-packages/django/db/models/fields/__init__.py:1421: RuntimeWarning: DateTimeField ComputedFile.last_modified received a naive datetime (2019-10-01 00:00:00) while time zone support is active.
  RuntimeWarning)
2019-10-01 19:04:17,865 local [volume: 0] data_refinery_foreman.foreman.management.commands.retry_samples INFO: Re-queued 0 samples that were associated with computed files that were not uploaded to S3
```

Along with the unit tests I added to the Foreman.

## Checklist

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules
