### PR TITLE
Filename was reserved when logging

### DIFF
--- a/foreman/data_refinery_foreman/foreman/management/commands/check_computed_files.py
+++ b/foreman/data_refinery_foreman/foreman/management/commands/check_computed_files.py
@@ -26,7 +26,7 @@ def check_item(computed_file):
         S3.head_object(Bucket=computed_file.s3_bucket, Key=computed_file.s3_key)
     except ClientError:
         # Not found
-        logger.info('Computed file not found on S3 - will remove S3 fields.', computed_file=computed_file, filename=computed_file.filename)
+        logger.info('Computed file not found on S3 - will remove S3 fields.', computed_file=computed_file.id, file_name=computed_file.filename)
         return computed_file.pk
     return None
 


### PR DESCRIPTION
## Issue Number

#1696 

## Purpose/Implementation Notes

`filename` was a reserver argument for `logger.info` and got this error when running it:

```
Traceback (most recent call last):
  File "/usr/lib/python3.5/multiprocessing/pool.py", line 119, in worker
    result = (True, func(*args, **kwds))
  File "/usr/lib/python3.5/multiprocessing/pool.py", line 44, in mapstar
    return list(map(*args))
  File "/home/user/data_refinery_foreman/foreman/management/commands/check_computed_files.py", line 29, in check_item
    logger.info('Computed file not found on S3 - will remove S3 fields.', computed_file=computed_file, filename=computed_file.filename)
  File "/usr/lib/python3.5/logging/__init__.py", line 1602, in info
    self.log(INFO, msg, *args, **kwargs)
  File "/usr/lib/python3.5/logging/__init__.py", line 1640, in log
    self.logger._log(level, msg, args, **kwargs)
  File "/usr/lib/python3.5/logging/__init__.py", line 1414, in _log
    exc_info, func, extra, sinfo)
  File "/usr/lib/python3.5/logging/__init__.py", line 1388, in makeRecord
    raise KeyError("Attempt to overwrite %r in LogRecord" % key)
KeyError: "Attempt to overwrite 'filename' in LogRecord"
"""
```
