### PR TITLE
Fix queryset iterator and setting of volume index

### DIFF
--- a/common/data_refinery_common/job_management.py
+++ b/common/data_refinery_common/job_management.py
@@ -13,6 +13,7 @@ from data_refinery_common.utils import (
     get_env_variable,
     get_env_variable_gracefully,
     get_instance_id,
+    get_volume_index,
 )
 from data_refinery_common.job_lookup import determine_processor_pipeline, determine_ram_amount, ProcessorEnum, ProcessorPipeline, Downloaders
 from data_refinery_common.message_queue import send_job
@@ -201,6 +202,10 @@ def create_processor_jobs_for_original_files(original_files: List[OriginalFile],
 
             if volume_index:
                 processor_job.volume_index = volume_index
+            elif downloader_job.volume_index:
+                processor_job.volume_index = downloader_job.volume_index
+            else:
+                processor_job.volume_index = get_volume_index()
 
             processor_job.save()
 
@@ -257,6 +262,10 @@ def create_processor_job_for_original_files(original_files: List[OriginalFile],
 
         if volume_index:
             processor_job.volume_index = volume_index
+        elif downloader_job.volume_index:
+            processor_job.volume_index = downloader_job.volume_index
+        else:
+            processor_job.volume_index = get_volume_index()
 
         processor_job.save()
 

--- a/common/data_refinery_common/test_utils.py
+++ b/common/data_refinery_common/test_utils.py
@@ -120,3 +120,5 @@ class UtilsTestCase(TestCase):
         names = []
         for pipeline in utils.queryset_iterator(pipelines):
             names.append(pipeline.name)
+
+        self.assertEqual(len(names), 3000)

--- a/common/data_refinery_common/test_utils.py
+++ b/common/data_refinery_common/test_utils.py
@@ -118,5 +118,5 @@ class UtilsTestCase(TestCase):
         # Build a list of the names just to do something with the data
         # so we know the query actually resolved.
         names = []
-        for pipeline in queryset_iterator(pipelines):
+        for pipeline in utils.queryset_iterator(pipelines):
             names.append(pipeline.name)

--- a/common/data_refinery_common/test_utils.py
+++ b/common/data_refinery_common/test_utils.py
@@ -1,6 +1,7 @@
 from unittest.mock import Mock, patch
 from django.test import TestCase
 from data_refinery_common import utils
+from data_refinery_common.models import Pipeline
 
 
 class UtilsTestCase(TestCase):
@@ -102,3 +103,20 @@ class UtilsTestCase(TestCase):
     def test_load_blacklist(self):
         blacklist = utils.load_blacklist()
         self.assertEqual(len(blacklist), 239449)
+
+    def test_queryset_iterator(self):
+        """Test that the queryset iterator by using it to actually iterate over a queryset.
+
+        Uses Pipeline just because it's easy to init."""
+        # Page size defaults to 2000, so use something bigger than
+        # that so there's more than one page.
+        for i in range(3000):
+            Pipeline(name=str(i)).save()
+
+        pipelines = Pipeline.objects.all()
+
+        # Build a list of the names just to do something with the data
+        # so we know the query actually resolved.
+        names = []
+        for pipeline in queryset_iterator(pipelines):
+            names.append(pipeline.name)

--- a/common/data_refinery_common/utils.py
+++ b/common/data_refinery_common/utils.py
@@ -456,5 +456,5 @@ def queryset_page_iterator(queryset, page_size = 2000):
 def queryset_iterator(queryset, page_size = 2000):
     """ use the performant paginator to iterate over a queryset """
     for page in queryset_page_iterator(queryset, page_size):
-        for item in page.object_list:
+        for item in page:
             yield item

--- a/foreman/data_refinery_foreman/foreman/main.py
+++ b/foreman/data_refinery_foreman/foreman/main.py
@@ -751,9 +751,9 @@ def requeue_processor_job(last_job: ProcessorJob) -> None:
             new_job.delete()
     except:
         logger.warn("Failed to requeue Processor Job which had ID %d with a new Processor Job with ID %d.",
-                    exc_info=1,
                     last_job.id,
-                    new_job.id,)
+                    new_job.id,
+                    exc_info=1)
         # Can't communicate with nomad just now, leave the job for a later loop.
         new_job.delete()
 

--- a/foreman/data_refinery_foreman/foreman/main.py
+++ b/foreman/data_refinery_foreman/foreman/main.py
@@ -750,9 +750,10 @@ def requeue_processor_job(last_job: ProcessorJob) -> None:
             # Can't communicate with nomad just now, leave the job for a later loop.
             new_job.delete()
     except:
-        logger.error("Failed to requeue Processor Job which had ID %d with a new Processor Job with ID %d.",
-                     last_job.id,
-                     new_job.id)
+        logger.warn("Failed to requeue Processor Job which had ID %d with a new Processor Job with ID %d.",
+                    exc_info=1,
+                    last_job.id,
+                    new_job.id,)
         # Can't communicate with nomad just now, leave the job for a later loop.
         new_job.delete()
 


### PR DESCRIPTION
## Issue Number

#1703 

## Purpose/Implementation Notes

We broke the queryset iterator so dispatching lots of compendia jobs fails.

For some reason the Foreman is also very broken. I saw some of it yesterday and tried to fix it with #1707 but that clearly didn't work. I tried to fix the issue in the downloader job utils but I don't think this'll fix the Foreman for jobs that already don't have volume index. However all it's telling me is that it couldn't queue the job so I've improved the logging there to get more visibility.

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

The unit tests cover this fairly well.

## Checklist

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules
