### PR TITLE
Fix bad import that breaks foreman requeuing

### DIFF
--- a/common/data_refinery_common/message_queue.py
+++ b/common/data_refinery_common/message_queue.py
@@ -9,7 +9,7 @@ from nomad.api.exceptions import URLNotFoundNomadException
 
 from data_refinery_common.utils import get_env_variable, get_env_variable_gracefully, get_volume_index
 from data_refinery_common.models import ProcessorJob, SurveyJob, DownloaderJob
-from data_refinery_common.job_lookup import ProcessorPipeline, Downloaders, SurveyJobTypes
+from data_refinery_common.job_lookup import ProcessorPipeline, Downloaders, SurveyJobTypes, SMASHER_JOB_TYPES
 from data_refinery_common.logging import get_and_configure_logger
 
 logger = get_and_configure_logger(__name__)


### PR DESCRIPTION
## Issue Number

This was a dumb mistake. My guess is tests didn't catch it because we always mock send_job.

## Purpose/Implementation Notes

I didn't import my new constant. I'll look into getting a test that'll cover this but I wanna get this out ASAP.
