### PR TITLE
Add CREATE_COMPENDIA to job type switch in run_processor_job.

### DIFF
--- a/README.md
+++ b/README.md
@@ -568,25 +568,25 @@ nomad job dispatch -meta ORGANISM=DANIO_RERIO CREATE_QN_TARGET
 Creating species-wide compendia for a given species can be done in a production environment by running the following on the Foreman instance:
 
 ```bash
-./run_management_commands.sh create_compendia --organisms=DANIO_RERIO --quant-sf-only=False --svd-algorithm=ARPACK
+./run_management_command.sh create_compendia --organisms=DANIO_RERIO --quant-sf-only=False --svd-algorithm=ARPACK
 ```
 
 or for a list of organisms:
 
 ```bash
-./run_management_commands.sh create_compendia --organisms=DANIO_RERIO,HOMO_SAPIENS --quant-sf-only=False --svd-algorithm=ARPACK
+./run_management_command.sh create_compendia --organisms=DANIO_RERIO,HOMO_SAPIENS --quant-sf-only=False --svd-algorithm=ARPACK
 ```
 
 or for all organisms with sufficient data:
 
 ```bash
-./run_management_commands.sh create_compendia --quant-sf-only=False --svd-algorithm=ARPACK
+./run_management_command.sh create_compendia --quant-sf-only=False --svd-algorithm=ARPACK
 ```
 
 Alternatively a compendium can be created which only includes quant.sf files by specifying the nomad meta field `QUANT_SF_ONLY=True` like so:
 
 ```
-./run_management_commands.sh create_compendia --organisms=DANIO_RERIO --quant-sf-only=True --svd-algorithm=None
+./run_management_command.sh create_compendia --organisms=DANIO_RERIO --quant-sf-only=True --svd-algorithm=None
 ```
 
 Compendia jobs run on the smasher instance.

--- a/workers/data_refinery_workers/processors/management/commands/run_processor_job.py
+++ b/workers/data_refinery_workers/processors/management/commands/run_processor_job.py
@@ -59,6 +59,9 @@ class Command(BaseCommand):
         elif job_type is ProcessorPipeline.SMASHER:
             from data_refinery_workers.processors.smasher import smash
             smash(options["job_id"])
+        elif job_type is ProcessorPipeline.CREATE_COMPENDIA:
+            from data_refinery_workers.processors.create_compendia import create_compendia
+            create_compendia(options["job_id"])
         elif job_type is ProcessorPipeline.NO_OP:
             from data_refinery_workers.processors.no_op import no_op_processor
             no_op_processor(options["job_id"])


### PR DESCRIPTION
## Issue Number

#1716 

## Purpose/Implementation Notes

```
2019-10-02 19:03:29,517 i-0d3d003bcf758f6b8 [volume: -1] data_refinery_workers.processors.management.commands.run_processor_job ERROR: A valid job name was specified for job CREATE_COMPENDIA with id 239373 but no processor function is known to run it.
```

We were missing this job type in the switch statement.

Also fix typo in README.
