### PR TITLE
Scale the smasher down to a more ecnomical size.

### DIFF
--- a/infrastructure/variables.tf
+++ b/infrastructure/variables.tf
@@ -120,8 +120,9 @@ variable "client_instance_type" {
 }
 
 variable "smasher_instance_type" {
-  # 3,904 GiB Memory, compendia jobs needs 220 and smasher jobs need 28.
-  default = "x1e.32xlarge"
+  # 512 GiB Memory, compendia jobs needs 220 and smasher jobs need 28.
+  # So we can run 2 compendia jobs and still have room for smasher jobs.
+  default = "r5.16xlarge"
 }
 
 variable "spot_price" {

--- a/workers/data_refinery_workers/processors/create_compendia.py
+++ b/workers/data_refinery_workers/processors/create_compendia.py
@@ -64,7 +64,8 @@ def _prepare_input(job_context: Dict) -> Dict:
     if not 'final_frame' in job_context.keys():
         logger.warn("Unable to prepare files for creating compendia.",
             job_id=job_context['job'].id)
-        job_context["job"].failure_reason = "Couldn't prepare files creating compendia."
+        if not job_context["job"].failure_reason:
+            job_context["job"].failure_reason = "Couldn't prepare files creating compendia."
         job_context['success'] = False
         return job_context
 


### PR DESCRIPTION
## Issue Number

#1721 

## Purpose/Implementation Notes

We ran a lot of compendia and now we just need to drill down on a few of them. While we do that we don't need such an expensive instance.

This also fixes failure_reasons on compendia a little.
