### PR TITLE
Quick fix for the foreman killing compendia jobs

### DIFF
--- a/foreman/data_refinery_foreman/foreman/main.py
+++ b/foreman/data_refinery_foreman/foreman/main.py
@@ -1307,7 +1307,7 @@ def cleanup_the_queue():
     logger.info("Removing all jobs from Nomad queue whose volumes are not mounted.")
 
     # Smasher and QN Reference jobs aren't tied to a specific EBS volume.
-    indexed_job_types = [e.value for e in ProcessorPipeline if e.value not in ["SMASHER", "QN_REFERENCE"]]
+    indexed_job_types = [e.value for e in ProcessorPipeline if e.value not in ["SMASHER", "QN_REFERENCE", "CREATE_COMPENDIA"]]
     # Special case for downloader jobs because they only have one
     # nomad job type for all downloader tasks.
     indexed_job_types.append("DOWNLOADER")
@@ -1354,21 +1354,19 @@ def cleanup_the_queue():
                 # will be incremented when it is requeued).
                 try:
                     nomad_client.job.deregister_job(job["ID"], purge=True)
-                    processor_jobs = ProcessorJob.objects.filter(nomad_job_id=job["ID"])
+                    logger.info('Foreman Killed nomad job because it did not have a volume assigned',
+                                nomad_job_id=job['ID'], job_type=job_type)
+                    processor_job = ProcessorJob.objects.filter(nomad_job_id=job["ID"]).first()
 
-                    if processor_jobs.count() > 0:
-                        job_record = processor_jobs[0]
-                    else:
+                    if not processor_job:
                         # If it's not a processor job, it's probably a downloader job.
                         job_record = DownloaderJob.objects.filter(nomad_job_id=job["ID"])[0]
-
                         # If it's a downloader job, then it doesn't
                         # have to run on the volume it was assigned
                         # to. We can let the foreman reassign it.
                         job_record.volume_index = None
+                        job_record.save()
 
-                    job_record.num_retries = job_record.num_retries - 1
-                    job_record.save()
                     num_jobs_killed += 1
                 except:
                     logger.exception("Could not remove Nomad job from the Nomad queue.",

--- a/foreman/data_refinery_foreman/foreman/main.py
+++ b/foreman/data_refinery_foreman/foreman/main.py
@@ -1354,8 +1354,8 @@ def cleanup_the_queue():
                 # will be incremented when it is requeued).
                 try:
                     nomad_client.job.deregister_job(job["ID"], purge=True)
-                    logger.info('Foreman Killed nomad job because it did not have a volume assigned',
-                                nomad_job_id=job['ID'], job_type=job_type)
+                    logger.debug('Foreman Killed nomad job because it had a volume that was not active',
+                                  nomad_job_id=job['ID'], job_type=job_type)
                     processor_job = ProcessorJob.objects.filter(nomad_job_id=job["ID"]).first()
 
                     if not processor_job:


### PR DESCRIPTION
## Issue Number

N/A

## Purpose/Implementation Notes

This is quick fix that prevents the foreman from killing compendia jobs. #1725 adds other improvements that we'll merge later.

## Types of changes

- Bugfix (non-breaking change which fixes an issue)
