### PR TITLE
Set endtime when job gets sigkill signal

### DIFF
--- a/workers/data_refinery_workers/downloaders/utils.py
+++ b/workers/data_refinery_workers/downloaders/utils.py
@@ -38,14 +38,13 @@ CURRENT_JOB = None
 def signal_handler(sig, frame):
     """Signal Handler, works for both SIGTERM and SIGINT"""
     global CURRENT_JOB
-    if not CURRENT_JOB:
-        sys.exit(0)
-    else:
-        CURRENT_JOB.start_time = None
+    if CURRENT_JOB:
+        CURRENT_JOB.end_time = timezone.now()
         CURRENT_JOB.num_retries = CURRENT_JOB.num_retries - 1
         CURRENT_JOB.failure_reason = "Interruped by SIGTERM/SIGINT: " + str(sig)
         CURRENT_JOB.save()
-        sys.exit(0)
+
+    sys.exit(0)
 
 
 def start_job(job_id: int) -> DownloaderJob:

--- a/workers/data_refinery_workers/processors/utils.py
+++ b/workers/data_refinery_workers/processors/utils.py
@@ -48,15 +48,13 @@ CURRENT_JOB = None
 def signal_handler(sig, frame):
     """Signal Handler, works for both SIGTERM and SIGINT"""
     global CURRENT_JOB
-    if not CURRENT_JOB:
-        sys.exit(0)
-    else:
-        CURRENT_JOB.start_time = None
+    if CURRENT_JOB:
+        CURRENT_JOB.end_time = timezone.now()
         CURRENT_JOB.num_retries = CURRENT_JOB.num_retries - 1
-        CURRENT_JOB.failure_reason = "Caught either a SIGTERM or SIGINT signal."
-        CURRENT_JOB.success = False
+        CURRENT_JOB.failure_reason = "Interruped by SIGTERM/SIGINT: " + str(sig)
         CURRENT_JOB.save()
-        sys.exit(0)
+
+    sys.exit(0)
 
 def prepare_original_files(job_context):
     """ Provision in the Job context for OriginalFile-driven processors


### PR DESCRIPTION
## Issue Number

N/A

## Purpose/Implementation Notes

When jobs get's a sigkill signal we were clearing their `start_time`, this removes this part and sets `end_time`.

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

None