### PR TITLE
Make smasher instance 2x as big, make compendia jobs 4x as big

### DIFF
--- a/infrastructure/instances.tf
+++ b/infrastructure/instances.tf
@@ -274,7 +274,8 @@ resource "aws_instance" "smasher_instance" {
   # Should be more than enough to store 2 jobs worth of data at a time.
   root_block_device = {
     volume_type = "gp2"
-    volume_size = 6000
+    # 2000 is the largest we can use without reformatting the disk.
+    volume_size = 2000
   }
 }
 

--- a/infrastructure/variables.tf
+++ b/infrastructure/variables.tf
@@ -120,9 +120,8 @@ variable "client_instance_type" {
 }
 
 variable "smasher_instance_type" {
-  # 512 GiB Memory, compendia jobs needs 220 and smasher jobs need 28.
-  # So we can run 2 compendia jobs and still have room for smasher jobs.
-  default = "r5.16xlarge"
+  # 976 GiB Memory, smasher jobs need 28 and we're giving the rest to the compendia job.
+  default = "x1.16xlarge"
 }
 
 variable "spot_price" {

--- a/workers/nomad-job-specs/create_compendia.nomad.tpl
+++ b/workers/nomad-job-specs/create_compendia.nomad.tpl
@@ -70,7 +70,7 @@ job "CREATE_COMPENDIA" {
         # CPU is in AWS's CPU units.
         cpu =   4000
         # Memory is in MB of RAM.
-        memory = 220000
+        memory = 940000
       }
 
       logs {


### PR DESCRIPTION
## Issue Number

#1258 

## Purpose/Implementation Notes

Also resize the smasher disk to the largest size we can use without addressing https://github.com/AlexsLemonade/refinebio/issues/1733

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

N/A infra

## Checklist

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules
