### PR TITLE
Set maxtasksperchild on the worker pool for multiprocessing to 

### DIFF
--- a/workers/data_refinery_workers/processors/smashing_utils.py
+++ b/workers/data_refinery_workers/processors/smashing_utils.py
@@ -270,7 +270,7 @@ def process_frames_for_key(key: str, input_files: List[ComputedFile], job_contex
     # Merge all the frames into one
     cpus = max(1, psutil.cpu_count()/2)
     log_state("Using {} cpus".format(cpus), job_context["job"])
-    pool = multiprocessing.Pool(processes=int(cpus))
+    pool = multiprocessing.Pool(processes=int(cpus), maxtasksperchild=100)
 
     def get_frame_inputs():
         """Helper method to create a generator."""


### PR DESCRIPTION
## Issue Number

N/A Came up while running human/rat compendia.

## Purpose/Implementation Notes

Prevent pickling error caused by large size of data.
