### PR TITLE
Don't use multiprocessing for compendia because it skipped so many frames.

### DIFF
--- a/infrastructure/variables.tf
+++ b/infrastructure/variables.tf
@@ -120,8 +120,8 @@ variable "client_instance_type" {
 }
 
 variable "smasher_instance_type" {
-  # ~2TB Memory, smasher jobs need 28 and we're giving the rest to the compendia job.
-  default = "x1.32xlarge"
+  # ~1TB Memory, smasher jobs need 28 and we're giving the rest to the compendia job.
+  default = "x1.16xlarge"
 }
 
 variable "spot_price" {


### PR DESCRIPTION
## Issue Number

#1766 

## Purpose/Implementation Notes

For some reason we skipped most of the frames the last time we ran rat. I can't figure out what we have wrong but it skipped tons of frames. This rips out multiprocessing because we know without it it'll work just slowly.