### PR TITLE
paginate multiprocessing pool maps

### DIFF
--- a/workers/data_refinery_workers/processors/smashing_utils.py
+++ b/workers/data_refinery_workers/processors/smashing_utils.py
@@ -292,11 +292,11 @@ def process_frames_for_key(key: str, input_files: List[ComputedFile], job_contex
             )
 
     def get_chunked_frame_inputs():
-        """Helper method for chunking the generator retured from get_frame_inputs.
+        """Helper method for chunking the generator results returned from get_frame_inputs.
         We want to be able to pass a single generator that returns a chunk of
         frame_inputs to a multiprocessing.Pool.map and we want a generator that will
         return those generators. This function returns a generator that returns the chunked
-        generator which returns a single frame_input tuple.
+        generator when iterated on which returns a single frame_input tuple when iterated on.
         Essentially it returns a lazily loaded list of lists of tuples.
         """
         # get the resulting generator that returns all tuples for


### PR DESCRIPTION
## Issue Number

#1537 

## Purpose/Implementation Notes

There were a few problems with the previous iteration of parallelizing the process_frame method in smasher.py. One of which was the amount of data being passed between threads was too large and this caused the smasher to crasher. This implements a nested generator which allows for the chunking of frames to be processed while keeping overhead at a minimum.

## Methods

```process_frames_for_key``` in ```smasher.py```

## Types of changes

What types of changes does your code introduce?

- New feature (non-breaking change which adds functionality)


## Functional tests

```./workers/run_tests.py -t smasher```
and 
```./workers/run_tests.py -t compendia```
are passing
also tested compendia with various ```MULTIPROCESS_CHUNK_SIZE``` which good results

## Checklist

- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

