### PR TITLE
paginate multiprocessing pool maps -- REDUX

### DIFF
--- a/workers/data_refinery_workers/processors/smashing_utils.py
+++ b/workers/data_refinery_workers/processors/smashing_utils.py
@@ -295,6 +295,7 @@ def process_frames_for_key(key: str, input_files: List[ComputedFile], job_contex
             job_context["job"].id
         ))
 
+        # Make sure to handle the last chunk even if it's not a full chunk.
         if index % MULTIPROCESSING_CHUNK_SIZE == 0 or index == len(input_files) - 1:
             processed_chunk = worker_pool.map(process_frame, chunk_of_frames)
             chunk_of_frames = []

--- a/workers/data_refinery_workers/processors/smashing_utils.py
+++ b/workers/data_refinery_workers/processors/smashing_utils.py
@@ -281,8 +281,8 @@ def process_frames_for_key(key: str, input_files: List[ComputedFile], job_contex
     # also make the minimum threads 1
     worker_pool = multiprocessing.Pool(processes=MULTIPROCESSING_WORKER_COUNT)
 
+    chunk_of_frames = []
     for index, (computed_file, sample) in enumerate(input_files):
-        chunk_of_frames = []
 
         # Create a tuple containing the inputs for process_frame.
         frame_input = (

--- a/workers/data_refinery_workers/processors/smashing_utils.py
+++ b/workers/data_refinery_workers/processors/smashing_utils.py
@@ -285,7 +285,7 @@ def process_frames_for_key(key: str, input_files: List[ComputedFile], job_contex
         chunk_of_frames = []
 
         # Create a tuple containing the inputs for process_frame.
-        chunk_of_frames.append((
+        frame_input = (
             job_context["work_dir"],
             computed_file,
             sample.accession_code,
@@ -293,10 +293,12 @@ def process_frames_for_key(key: str, input_files: List[ComputedFile], job_contex
             job_context['dataset'].aggregate_by,
             index,
             job_context["job"].id
-        ))
+        )
+
+        chunk_of_frames.append(frame_input)
 
         # Make sure to handle the last chunk even if it's not a full chunk.
-        if index % MULTIPROCESSING_CHUNK_SIZE == 0 or index == len(input_files) - 1:
+        if index > 0 and index % MULTIPROCESSING_CHUNK_SIZE == 0 or index == len(input_files) - 1:
             processed_chunk = worker_pool.map(process_frame, chunk_of_frames)
             chunk_of_frames = []
 

--- a/workers/data_refinery_workers/processors/smashing_utils.py
+++ b/workers/data_refinery_workers/processors/smashing_utils.py
@@ -292,11 +292,11 @@ def process_frames_for_key(key: str, input_files: List[ComputedFile], job_contex
             )
 
     def get_chunked_frame_inputs():
-        """Helper method for chunking the generator retured from get_frame_inputs.
+        """Helper method for chunking the generator results returned from get_frame_inputs.
         We want to be able to pass a single generator that returns a chunk of
         frame_inputs to a multiprocessing.Pool.map and we want a generator that will
         return those generators. This function returns a generator that returns the chunked
-        generator which returns a single frame_input tuple.
+        generator when iterated on which returns a single frame_input tuple when iterated on.
         Essentially it returns a lazily loaded list of lists of tuples.
         """
         # get the resulting generator that returns all tuples for

--- a/workers/data_refinery_workers/processors/test_smasher.py
+++ b/workers/data_refinery_workers/processors/test_smasher.py
@@ -1663,10 +1663,9 @@ class AggregationTestCase(TransactionTestCase):
 
         ds = Dataset()
         ds.data = {'GSE51081': ['GSM1237810', 'GSM1237812', 'GSM999']}
-        ds.aggregate_by = 'ALL' # [ALL or SPECIES or EXPERIMENT]
-        ds.scale_by = 'NONE' # [NONE or MINMAX or STANDARD or ROBUST]
+        ds.aggregate_by = 'ALL'
+        ds.scale_by = 'NONE'
         ds.email_address = "null@derp.com"
-        #ds.email_address = "miserlou+heyo@gmail.com"
         ds.quantile_normalize = False
         ds.save()
 


### PR DESCRIPTION
## Issue Number

#1537
#1773 

## Purpose/Implementation Notes

#1773 seemed pretty complex to me, I think because it's doing things with generators and using some deep cuts from the itertools discography. I was curious if it'd be simpler without generators so I re-implemented it and it looks like it was to me.

I think the only downside this has over the implementation in #1773 is that it is stores a full chunk size of inputs for process_frame, but that should be rather small as it doesn't contain any actual data in it.

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

Unit tests?
