### PR TITLE
Multiprocessing.pool dislikes floats.

### DIFF
--- a/workers/data_refinery_workers/processors/smashing_utils.py
+++ b/workers/data_refinery_workers/processors/smashing_utils.py
@@ -3,6 +3,7 @@
 import csv
 import itertools
 import logging
+import math
 import multiprocessing
 import os
 import psutil
@@ -39,7 +40,7 @@ logger = get_and_configure_logger(__name__)
 ### DEBUG ###
 logger.setLevel(logging.getLevelName('DEBUG'))
 
-MULTIPROCESSING_WORKER_COUNT = max(1, multiprocessing.cpu_count()/2 - 1)
+MULTIPROCESSING_WORKER_COUNT = max(1, math.floor(multiprocessing.cpu_count()/2) - 1)
 MULTIPROCESSING_CHUNK_SIZE = 2000
 
 

--- a/workers/data_refinery_workers/processors/smashing_utils.py
+++ b/workers/data_refinery_workers/processors/smashing_utils.py
@@ -27,6 +27,9 @@ from data_refinery_common.utils import get_env_variable
 from data_refinery_workers.processors import utils
 
 
+# Use floor here because multiprocessing raises an exception if this isn't an int.
+MULTIPROCESSING_WORKER_COUNT = max(1, math.floor(multiprocessing.cpu_count()/2) - 1)
+MULTIPROCESSING_CHUNK_SIZE = 2000
 RESULTS_BUCKET = get_env_variable("S3_RESULTS_BUCKET_NAME", "refinebio-results-bucket")
 S3_BUCKET_NAME = get_env_variable("S3_BUCKET_NAME", "data-refinery")
 BODY_HTML = Path(
@@ -39,9 +42,6 @@ BYTES_IN_GB = 1024 * 1024 * 1024
 logger = get_and_configure_logger(__name__)
 ### DEBUG ###
 logger.setLevel(logging.getLevelName('DEBUG'))
-
-MULTIPROCESSING_WORKER_COUNT = max(1, math.floor(multiprocessing.cpu_count()/2) - 1)
-MULTIPROCESSING_CHUNK_SIZE = 2000
 
 
 def log_failure(job_context: Dict, failure_reason: str) -> Dict:


### PR DESCRIPTION
## Issue Number

#1777 

## Purpose/Implementation Notes

Our human jobs died last night with errors like:
```
data-refinery-log-group-circleci-prod log-stream-processor-docker-circleci-prod 2019-10-15 03:57:19,497 i-0119de425230c426b [volume: -1] data_refinery_workers.processors.create_compendia ERROR [processor_job_id: 29205738] [dataset_id: 37626c56-1f6a-4b31-bf89-30b756c9c4b6] [num_input_files: 1]: Could not prepare frames for compendia.
data-refinery-log-group-circleci-prod log-stream-processor-docker-circleci-prod Traceback (most recent call last):
data-refinery-log-group-circleci-prod log-stream-processor-docker-circleci-prod   File "/home/user/data_refinery_workers/processors/create_compendia.py", line 86, in _prepare_frames
data-refinery-log-group-circleci-prod log-stream-processor-docker-circleci-prod     job_context = smashing_utils.process_frames_for_key(key, input_files, job_context)
data-refinery-log-group-circleci-prod log-stream-processor-docker-circleci-prod   File "/home/user/data_refinery_workers/processors/smashing_utils.py", line 282, in process_frames_for_key
data-refinery-log-group-circleci-prod log-stream-processor-docker-circleci-prod     worker_pool = multiprocessing.Pool(processes=MULTIPROCESSING_WORKER_COUNT)
data-refinery-log-group-circleci-prod log-stream-processor-docker-circleci-prod   File "/usr/lib/python3.5/multiprocessing/context.py", line 118, in Pool
data-refinery-log-group-circleci-prod log-stream-processor-docker-circleci-prod     context=self.get_context())
data-refinery-log-group-circleci-prod log-stream-processor-docker-circleci-prod   File "/usr/lib/python3.5/multiprocessing/pool.py", line 168, in __init__
data-refinery-log-group-circleci-prod log-stream-processor-docker-circleci-prod     self._repopulate_pool()
data-refinery-log-group-circleci-prod log-stream-processor-docker-circleci-prod   File "/usr/lib/python3.5/multiprocessing/pool.py", line 223, in _repopulate_pool
data-refinery-log-group-circleci-prod log-stream-processor-docker-circleci-prod     for i in range(self._processes - len(self._pool)):
data-refinery-log-group-circleci-prod log-stream-processor-docker-circleci-prod TypeError: 'float' object cannot be interpreted as an integer
```

I was able to reproduce this error by setting `MULTIPROCESSING_WORKER_COUNT = 1.5`.

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

Unit tests, but I dunno how to test having an odd number of cores.

## Checklist

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules
