### PR TITLE
Use job.success as success flag instead of dataset.failure_reason in smasher

### DIFF
--- a/workers/data_refinery_workers/processors/smasher.py
+++ b/workers/data_refinery_workers/processors/smasher.py
@@ -353,7 +353,7 @@ def _smash_all(job_context: Dict) -> Dict:
     """
     start_smash = log_state("start smash", job_context["job"])
     # We have already failed - return now so we can send our fail email.
-    if job_context['dataset'].failure_reason not in ['', None]:
+    if job_context['job'].success is False:
         return job_context
 
     try:
@@ -405,7 +405,8 @@ def _upload(job_context: Dict) -> Dict:
 
     # There has been a failure already, don't try to upload anything.
     if not job_context.get("output_file", None):
-        logger.error("Was told to upload a smash result without an output_file.")
+        logger.error("Was told to upload a smash result without an output_file.",
+                     job_id=job_context['job'].id)
         return job_context
 
     try:
@@ -462,7 +463,7 @@ def _notify(job_context: Dict) -> Dict:
         dataset_url = 'https://www.refine.bio/dataset/' + str(job_context['dataset'].id)
 
         # Send a notification to slack when a dataset fails to be processed
-        if job_context['job'].failure_reason not in ['', None]:
+        if job_context['job'].success is False:
             try:
                 requests.post(
                     "https://hooks.slack.com/services/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",
@@ -499,7 +500,7 @@ def _notify(job_context: Dict) -> Dict:
             CHARSET = "UTF-8"
 
 
-            if job_context['job'].failure_reason not in ['', None]:
+            if job_context['job'].success is False:
                 SUBJECT = "There was a problem processing your refine.bio dataset :("
                 BODY_TEXT = "We tried but were unable to process your requested dataset. Error was: \n\n" + str(job_context['job'].failure_reason) + "\nDataset ID: " + str(job_context['dataset'].id) + "\n We have been notified and are looking into the problem. \n\nSorry!"
 
@@ -569,10 +570,6 @@ def _notify(job_context: Dict) -> Dict:
 
             job_context["dataset"].email_sent = True
             job_context["dataset"].save()
-
-    # Handle non-cloud too
-    if job_context['job'].failure_reason:
-        job_context['success'] = False
 
     return job_context
 

--- a/workers/data_refinery_workers/processors/smashing_utils.py
+++ b/workers/data_refinery_workers/processors/smashing_utils.py
@@ -44,16 +44,6 @@ logger = get_and_configure_logger(__name__)
 logger.setLevel(logging.getLevelName('DEBUG'))
 
 
-def log_failure(job_context: Dict, failure_reason: str) -> Dict:
-    if not job_context["job"].failure_reason:
-        job_context["job"].failure_reason = failure_reason
-
-    job_context['success'] = False
-    logger.warn(job_context["job"].failure_reason, job_id=job_context['job'].id)
-
-    return job_context
-
-
 def log_state(message, job, start_time=False):
     if logger.isEnabledFor(logging.DEBUG):
         process = psutil.Process(os.getpid())


### PR DESCRIPTION
## Issue Number

#1774 

## Purpose/Implementation Notes

Someone thought that the dataset's failure_reason was a better indication if the job had succeeded or not than job.success.

Narrator: it wasn't

Once a dataset failed once, subsequent retries saw that failure_reason and gave up, badly too. This removes any checks against failure_reason and replaces them with checks against job.success. I also went through and made sure there's no where we set failure_reason without also setting job.success.


## Types of changes

- Bugfix (non-breaking change which fixes an issue)
