### PR TITLE
Ensure quant.sf are in s3 when returning them

### DIFF
--- a/common/data_refinery_common/models/models.py
+++ b/common/data_refinery_common/models/models.py
@@ -1023,6 +1023,9 @@ class ComputedFile(models.Model):
         target_directory = os.path.dirname(self.absolute_file_path)
         os.makedirs(target_directory, exist_ok=True)
 
+        if not self.s3_bucket or not self.s3_key:
+            raise Exception('Tried to download a computed file with no s3_bucket or s3_key')
+
         try:
             S3.download_file(
                         self.s3_bucket,

--- a/common/data_refinery_common/models/models.py
+++ b/common/data_refinery_common/models/models.py
@@ -1024,7 +1024,7 @@ class ComputedFile(models.Model):
         os.makedirs(target_directory, exist_ok=True)
 
         if not self.s3_bucket or not self.s3_key:
-            raise Exception('Tried to download a computed file with no s3_bucket or s3_key')
+            raise ValueError('Tried to download a computed file with no s3_bucket or s3_key')
 
         try:
             S3.download_file(

--- a/common/data_refinery_common/models/models.py
+++ b/common/data_refinery_common/models/models.py
@@ -211,7 +211,8 @@ class Sample(models.Model):
         Note: We don't associate that file to the computed_files of this sample, that's
         why we have to go through the computational results. """
         return ComputedFile.objects\
-            .filter(result__in=self.results.all(), filename='quant.sf')\
+            .filter(result__in=self.results.all(), filename='quant.sf',
+                    s3_key__isnull=False, s3_bucket__isnull=False)\
             .order_by('-created_at')\
             .first()
 


### PR DESCRIPTION
## Issue Number

N/A

## Purpose/Implementation Notes

Came up while running a big dataset with quantfiles. We were trying to download files where their s3_key was empty.