### PR TITLE
Make signal handlers set job.success to False so they get restarted.

### DIFF
--- a/workers/data_refinery_workers/downloaders/utils.py
+++ b/workers/data_refinery_workers/downloaders/utils.py
@@ -39,6 +39,7 @@ def signal_handler(sig, frame):
     """Signal Handler, works for both SIGTERM and SIGINT"""
     global CURRENT_JOB
     if CURRENT_JOB:
+        CURRENT_JOB.success = False
         CURRENT_JOB.end_time = timezone.now()
         CURRENT_JOB.num_retries = CURRENT_JOB.num_retries - 1
         CURRENT_JOB.failure_reason = "Interruped by SIGTERM/SIGINT: " + str(sig)

--- a/workers/data_refinery_workers/processors/smasher.py
+++ b/workers/data_refinery_workers/processors/smasher.py
@@ -237,7 +237,7 @@ def _smash_key(job_context: Dict, key: str, input_files: List[ComputedFile]) -> 
         Scale features with sci-kit learn
         Transpose again such that samples are columns and genes are rows
     """
-    start_smash = log_state("end build all frames", job_context["job"])
+    start_smash = log_state("start _smash_key for {}".format(key), job_context["job"])
 
     # Check if we need to copy the quant.sf files
     if job_context['dataset'].quant_sf_only:
@@ -344,6 +344,8 @@ def _smash_key(job_context: Dict, key: str, input_files: List[ComputedFile]) -> 
     outfile = outfile_dir + key + ".tsv"
     job_context['smash_outfile'] = outfile
     untransposed.to_csv(outfile, sep='\t', encoding='utf-8')
+
+    log_state("end _smash_key for {}".format(key), job_context["job"], start_smash)
 
     return job_context
 

--- a/workers/data_refinery_workers/processors/utils.py
+++ b/workers/data_refinery_workers/processors/utils.py
@@ -49,6 +49,7 @@ def signal_handler(sig, frame):
     """Signal Handler, works for both SIGTERM and SIGINT"""
     global CURRENT_JOB
     if CURRENT_JOB:
+        CURRENT_JOB.success = False
         CURRENT_JOB.end_time = timezone.now()
         CURRENT_JOB.num_retries = CURRENT_JOB.num_retries - 1
         CURRENT_JOB.failure_reason = "Interruped by SIGTERM/SIGINT: " + str(sig)


### PR DESCRIPTION
## Issue Number

https://github.com/AlexsLemonade/refinebio/pull/1728

## Purpose/Implementation Notes

#1728 started setting end_time on jobs that got sig_killed. Well the issue with that is that the foreman only retries jobs with `end_time != NULL` if `success == False`, so we also gotta set success to false so these get retried.

## Types of changes

-  Bugfix (non-breaking change which fixes an issue)
