### PR TITLE
Pop microarray_frames and rnaseq_frames off job_context to save RAM.

### DIFF
--- a/workers/data_refinery_workers/processors/create_compendia.py
+++ b/workers/data_refinery_workers/processors/create_compendia.py
@@ -147,7 +147,7 @@ def _perform_imputation(job_context: Dict) -> Dict:
 
     # Combine all microarray samples with a full outer join to form a
     # microarray_expression_matrix (a DataFrame).
-    microarray_expression_matrix = pd.concat(job_context['microarray_frames'],
+    microarray_expression_matrix = pd.concat(job_context.pop('microarray_frames'),
                                              axis=1,
                                              keys=None,
                                              join='outer',
@@ -159,7 +159,7 @@ def _perform_imputation(job_context: Dict) -> Dict:
 
     # Combine all RNA-seq samples (lengthScaledTPM) with a full outer
     # join to form a rnaseq_expression_matrix (a DataFrame).
-    rnaseq_expression_matrix = pd.concat(job_context['rnaseq_frames'],
+    rnaseq_expression_matrix = pd.concat(job_context.pop('rnaseq_frames'),
                                          axis=1,
                                          keys=None,
                                          join='outer',


### PR DESCRIPTION
## Issue Number

#1790 

## Purpose/Implementation Notes

We're getting logs from the rat job that's finishing:
```
[process_ram: 43.360443115234375] [total_cpu: 0.0] [job_id: 29205842]: start microarray conc
[process_ram: 96.11630630493164] [total_cpu: 0.8] [job_id: 29205842]: end microarray concate
[job_id: 29205842]: Duration: 437.846248626709
[process_ram: 96.11630630493164] [total_cpu: 1.8] [job_id: 29205842]: start rnaseq concatena
[process_ram: 96.11557388305664] [total_cpu: 0.8] [job_id: 29205842]: end rnaseq concatenati
[job_id: 29205842]: Duration: 12.71019196510315
```

Looks like we're doubling up our RAM usage here. Makes sense looking at the code. This should make it so we no longer store references to these lists of data frames once we concat them into a pandas matrix, so  there shouldn't be a second copy.