### PR TITLE
Try to use less rams.

### DIFF
--- a/workers/data_refinery_workers/processors/create_compendia.py
+++ b/workers/data_refinery_workers/processors/create_compendia.py
@@ -1,3 +1,4 @@
+import gc
 import logging
 import os
 import psutil
@@ -154,6 +155,8 @@ def _perform_imputation(job_context: Dict) -> Dict:
                                              copy=False,
                                              sort=True)
 
+    gc.collect()
+
     log_state("end microarray concatenation", job_context["job"], microarray_start)
     rnaseq_start = log_state("start rnaseq concatenation", job_context["job"])
 
@@ -165,6 +168,8 @@ def _perform_imputation(job_context: Dict) -> Dict:
                                          join='outer',
                                          copy=False,
                                          sort=True)
+
+    gc.collect()
 
     log_state("end rnaseq concatenation", job_context["job"], rnaseq_start)
     rnaseq_row_sums_start = log_state("start rnaseq row sums", job_context["job"])

--- a/workers/data_refinery_workers/processors/test_compendia.py
+++ b/workers/data_refinery_workers/processors/test_compendia.py
@@ -148,7 +148,8 @@ class CompendiaTestCase(TransactionTestCase):
         result = ComputationalResult()
         result.save()
 
-        danio_rerio = Organism.get_object_for_name("DANIO_RERIO")
+        danio_rerio = Organism(name="DANIO_RERIO", taxonomy_id=1)
+        danio_rerio.save()
 
         micros = []
         for file in os.listdir('/home/user/data_store/raw/TEST/MICROARRAY/'):


### PR DESCRIPTION
## Issue Number

#1258 

## Purpose/Implementation Notes

We're thinking that we're allocating more memory before the garbage collector was able to run and clean up the old reference.

:ram: :ram: :ram: