### PR TITLE
Merge compendia/smasher frames in chunks to save rams

### DIFF
--- a/workers/data_refinery_workers/processors/create_compendia.py
+++ b/workers/data_refinery_workers/processors/create_compendia.py
@@ -84,7 +84,10 @@ def _prepare_frames(job_context: Dict) -> Dict:
 
         # Once again, `key` is either a species name or an experiment accession
         for key, input_files in job_context['input_files'].items():
-            job_context = smashing_utils.process_frames_for_key(key, input_files, job_context)
+            job_context = smashing_utils.process_frames_for_key(key,
+                                                                input_files,
+                                                                job_context,
+                                                                merge_strategy='outer')
             # if len(job_context['all_frames']) < 1:
             # TODO: Enable this check?
 
@@ -155,6 +158,9 @@ def _perform_imputation(job_context: Dict) -> Dict:
                                              copy=False,
                                              sort=True)
 
+    # Should happen automatically but if we start allocating more data
+    # before this actually fires we're gonna increase our peak RAM
+    # usage.
     gc.collect()
 
     log_state("end microarray concatenation", job_context["job"], microarray_start)
@@ -169,6 +175,9 @@ def _perform_imputation(job_context: Dict) -> Dict:
                                          copy=False,
                                          sort=True)
 
+    # Should happen automatically but if we start allocating more data
+    # before this actually fires we're gonna increase our peak RAM
+    # usage.
     gc.collect()
 
     log_state("end rnaseq concatenation", job_context["job"], rnaseq_start)

--- a/workers/data_refinery_workers/processors/create_compendia.py
+++ b/workers/data_refinery_workers/processors/create_compendia.py
@@ -64,7 +64,7 @@ def _prepare_input(job_context: Dict) -> Dict:
     # Compendia jobs only run for one organism, so we know the only
     # key will be the organism name, unless of course we've already failed.
     if job_context['job'].success is not False:
-        job_context["organism_name"] = list(job_context['input_files'].keys())[0]
+        job_context["organism_name"] = job_context['group_by_keys'][0]
 
     log_state("prepare input done", job_context["job"], start_time)
     return job_context
@@ -83,7 +83,7 @@ def _prepare_frames(job_context: Dict) -> Dict:
                      job_id=job_context['job'].id)
 
         # Once again, `key` is either a species name or an experiment accession
-        for key, input_files in job_context['input_files'].items():
+        for key, input_files in job_context.pop('input_files').items():
             job_context = smashing_utils.process_frames_for_key(key,
                                                                 input_files,
                                                                 job_context,
@@ -95,7 +95,7 @@ def _prepare_frames(job_context: Dict) -> Dict:
         logger.exception("Could not prepare frames for compendia.",
                          dataset_id=job_context['dataset'].id,
                          processor_job_id=job_context['job_id'],
-                         num_input_files=len(job_context['input_files']))
+                         num_input_files=job_context['num_input_files'])
         job_context['dataset'].success = False
         job_context['job'].failure_reason = "Failure reason: " + str(e)
         job_context['dataset'].failure_reason = "Failure reason: " + str(e)
@@ -209,6 +209,8 @@ def _perform_imputation(job_context: Dict) -> Dict:
     log_state("actually calling drop()", job_context["job"])
 
     filtered_rnaseq_matrix = rnaseq_expression_matrix.drop(rows_to_filter)
+
+    del rows_to_filter
 
     log_state("end drop all rows", job_context["job"], drop_start)
     log2_start = log_state("start log2", job_context["job"])

--- a/workers/data_refinery_workers/processors/smasher.py
+++ b/workers/data_refinery_workers/processors/smasher.py
@@ -247,7 +247,10 @@ def _smash_key(job_context: Dict, key: str, input_files: List[ComputedFile]) -> 
         # we ONLY want to give quant sf files to the user if that's what they requested
         return job_context
 
-    job_context = smashing_utils.process_frames_for_key(key, input_files, job_context)
+    job_context = smashing_utils.process_frames_for_key(key,
+                                                        input_files,
+                                                        job_context,
+                                                        merge_strategy='inner')
 
     # Combine the two technologies into a single list of dataframes.
     ## Extend one list rather than adding the two together so we don't

--- a/workers/data_refinery_workers/processors/smasher.py
+++ b/workers/data_refinery_workers/processors/smasher.py
@@ -75,50 +75,6 @@ def log_state(message, job, start_time=False):
             return time.time()
 
 
-def _prepare_files(job_context: Dict) -> Dict:
-    """
-    Fetches and prepares the files to smash.
-    """
-    start_prepare_files = log_state("start prepare files", job_context["job"])
-    found_files = False
-    job_context['input_files'] = {}
-    # `key` can either be the species name or experiment accession.
-    for key, samples in job_context["samples"].items():
-        smashable_files = []
-        seen_files = set()
-        for sample in samples:
-            smashable_file = sample.get_most_recent_smashable_result_file()
-            if smashable_file is not None and smashable_file not in seen_files:
-                smashable_files = smashable_files + [(smashable_file, sample)]
-                seen_files.add(smashable_file)
-                found_files = True
-
-        job_context['input_files'][key] = smashable_files
-
-    if not found_files:
-        error_message = "Couldn't get any files to smash for Smash job!!"
-        logger.error(error_message,
-                     dataset_id=job_context['dataset'].id,
-                     num_samples=len(job_context["samples"]))
-
-        # Delay failing this pipeline until the failure notify has been sent
-        job_context['dataset'].failure_reason = error_message
-        job_context['dataset'].success = False
-        job_context['dataset'].save()
-        job_context['job'].success = False
-        job_context["job"].failure_reason = "Couldn't get any files to smash for Smash job - empty all_sample_files"
-        return job_context
-
-    job_context["work_dir"] = "/home/user/data_store/smashed/" + str(job_context["dataset"].pk) + "/"
-    # Ensure we have a fresh smash directory
-    shutil.rmtree(job_context["work_dir"], ignore_errors=True)
-    os.makedirs(job_context["work_dir"])
-
-    job_context["output_dir"] = job_context["work_dir"] + "output/"
-    os.makedirs(job_context["output_dir"])
-    log_state("end prepare files", job_context["job"], start_prepare_files)
-    return job_context
-
 def downlad_computed_file(download_tuple: Tuple[ComputedFile, str]):
     """ this function downloads the latest computed file. Receives a tuple with
     the computed file and the path where it needs to be downloaded
@@ -129,6 +85,7 @@ def downlad_computed_file(download_tuple: Tuple[ComputedFile, str]):
     except:
         # Let's not fail if there's an error syncing one of the quant.sf files
         logger.exception('Failed to sync computed file', computed_file_id=latest_computed_file.pk)
+
 
 def sync_quant_files(output_path, files_sample_tuple):
     """ Takes a list of ComputedFiles and copies the ones that are quant files to the provided directory.
@@ -159,6 +116,7 @@ def sync_quant_files(output_path, files_sample_tuple):
     pool.join()
 
     return num_samples
+
 
 def _inner_join(job_context: Dict) -> pd.DataFrame:
     """Performs an inner join across the all_frames key of job_context.
@@ -191,7 +149,6 @@ def _inner_join(job_context: Dict) -> pd.DataFrame:
 
         if breaker:
             logger.warning("Column repeated for smash job!",
-                           input_files=str(input_files),
                            dataset_id=job_context["dataset"].id,
                            job_id=job_context["job"].id,
                            column=column)
@@ -371,7 +328,7 @@ def _smash_all(job_context: Dict) -> Dict:
                      job_id=job_context['job'].id)
 
         # Once again, `key` is either a species name or an experiment accession
-        for key, input_files in job_context['input_files'].items():
+        for key, input_files in job_context.pop('input_files').items():
             job_context = _smash_key(job_context, key, input_files)
 
         smashing_utils.write_non_data_files(job_context)
@@ -382,9 +339,9 @@ def _smash_all(job_context: Dict) -> Dict:
         job_context["output_file"] = final_zip_base + ".zip"
     except Exception as e:
         logger.exception("Could not smash dataset.",
-                        dataset_id=job_context['dataset'].id,
-                        processor_job_id=job_context['job_id'],
-                        num_input_files=len(job_context['input_files']))
+                         dataset_id=job_context['dataset'].id,
+                         processor_job_id=job_context['job_id'],
+                         num_input_files=job_context['num_input_files'])
         job_context['dataset'].success = False
         job_context['job'].failure_reason = "Failure reason: " + str(e)
         job_context['dataset'].failure_reason = "Failure reason: " + str(e)

--- a/workers/data_refinery_workers/processors/smashing_utils.py
+++ b/workers/data_refinery_workers/processors/smashing_utils.py
@@ -350,23 +350,25 @@ def process_frames_for_key(key: str,
             # Merge the two types of frames from the chunk into only
             # two data frames so the gene identifiers aren't
             # duplicated for each sample.
-            job_context['microarray_frames'].append(
-                pd.concat(microarray_frames,
-                          axis=1,
-                          keys=None,
-                          join=merge_strategy,
-                          copy=False,
-                          sort=True))
+            if len(microarray_frames) > 0:
+                job_context['microarray_frames'].append(
+                    pd.concat(microarray_frames,
+                              axis=1,
+                              keys=None,
+                              join=merge_strategy,
+                              copy=False,
+                              sort=True))
 
             del microarray_frames
 
-            job_context['rnaseq_frames'].append(
-                pd.concat(rnaseq_frames,
-                          axis=1,
-                          keys=None,
-                          join=merge_strategy,
-                          copy=False,
-                          sort=True))
+            if len(rnaseq_frames) > 0:
+                job_context['rnaseq_frames'].append(
+                    pd.concat(rnaseq_frames,
+                              axis=1,
+                              keys=None,
+                              join=merge_strategy,
+                              copy=False,
+                              sort=True))
 
             del rnaseq_frames
 

--- a/workers/data_refinery_workers/processors/smashing_utils.py
+++ b/workers/data_refinery_workers/processors/smashing_utils.py
@@ -120,15 +120,12 @@ def prepare_files(job_context: Dict) -> Dict:
 
 def _load_and_sanitize_file(computed_file_path):
     """ Read and sanitize a computed file """
-    with open(computed_file_path, 'r') as input_file:
-        header = input_file.readline().strip()
 
     data = pd.read_csv(computed_file_path,
                        sep='\t',
                        header=0,
                        index_col=0,
-                       error_bad_lines=False,
-                       dtype={header: np.float32})
+                       error_bad_lines=False)
 
     # Strip any funky whitespace
     data.columns = data.columns.str.strip()

--- a/workers/data_refinery_workers/processors/smashing_utils.py
+++ b/workers/data_refinery_workers/processors/smashing_utils.py
@@ -27,6 +27,8 @@ from data_refinery_common.utils import get_env_variable
 from data_refinery_workers.processors import utils
 
 
+# Take one fewer than 1/2 the total available threads
+# also make the minimum threads 1.
 # Use floor here because multiprocessing raises an exception if this isn't an int.
 MULTIPROCESSING_WORKER_COUNT = max(1, math.floor(multiprocessing.cpu_count()/2) - 1)
 MULTIPROCESSING_CHUNK_SIZE = 2000
@@ -118,8 +120,15 @@ def prepare_files(job_context: Dict) -> Dict:
 
 def _load_and_sanitize_file(computed_file_path):
     """ Read and sanitize a computed file """
+    with open(computed_file_path, 'r') as input_file:
+        header = input_file.readline().strip()
 
-    data = pd.read_csv(computed_file_path, sep='\t', header=0, index_col=0, error_bad_lines=False)
+    data = pd.read_csv(computed_file_path,
+                       sep='\t',
+                       header=0,
+                       index_col=0,
+                       error_bad_lines=False,
+                       dtype={header: np.float32})
 
     # Strip any funky whitespace
     data.columns = data.columns.str.strip()
@@ -267,19 +276,37 @@ def process_frame(inputs) -> Dict:
     return smashable(data)
 
 
-def process_frames_for_key(key: str, input_files: List[ComputedFile], job_context: Dict) -> Dict:
+def process_frames_for_key(key: str,
+                           input_files: List[ComputedFile],
+                           job_context: Dict,
+                           merge_strategy: str) -> Dict:
+    """Download, read, and chunk processed sample files from s3.
+
+    `key` is the species or experiment whose samples are contained in `input_files`.
+
+    Will populate add to job_context the keys 'microarray_frames' and
+    'rnaseq_frames' with pandas dataframes containing
+    MULTIPROCESSING_CHUNK_SIZE samples worth of data. Also adds the
+    key 'unsmashable_files' containing a list of paths that were
+    determined to be unsmashable.
+
+    `merge_strategy` dictates how the chunks will be merged and must be
+    one of the two values `inner` or `outer.
+    """
+    if merge_strategy != 'inner' and merge_strategy != 'outer':
+        raise ValueError("merge_strategy must be either of the values 'inner' or 'outer'.")
+
     job_context['original_merged'] = pd.DataFrame()
 
     start_frames = log_state("building frames for species or experiment {}".format(key),
                              job_context["job"])
 
-    # Build up a list of microarray frames and a list of
-    # rnaseq frames.
+    # Build up a list of microarray frames and a list of rnaseq
+    # frames. Each one will have MULTIPROCESSING_CHUNK_SIZE samples
+    # worth of data in them.
     job_context['microarray_frames'] = []
     job_context['rnaseq_frames'] = []
 
-    # take one fewer than 1/2 the total available threads
-    # also make the minimum threads 1
     worker_pool = multiprocessing.Pool(processes=MULTIPROCESSING_WORKER_COUNT)
 
     chunk_of_frames = []
@@ -303,14 +330,34 @@ def process_frames_for_key(key: str, input_files: List[ComputedFile], job_contex
             processed_chunk = worker_pool.map(process_frame, chunk_of_frames)
             chunk_of_frames = []
 
+            microarray_frames = []
+            rnaseq_frames = []
             for frame in processed_chunk:
                 if frame['technology'] == 'microarray':
-                    job_context['microarray_frames'].append(frame['dataframe'])
+                    microarray_frames.append(frame['dataframe'])
                 elif frame['technology'] == 'rnaseq':
-                    job_context['rnaseq_frames'].append(frame['dataframe'])
-
-                if frame['unsmashable']:
+                    rnaseq_frames.append(frame['dataframe'])
+                elif frame['unsmashable']:
                     job_context['unsmashable_files'].append(frame['unsmashable_file'])
+
+            # Merge the two types of frames from the chunk into only
+            # two data frames so the gene identifiers aren't
+            # duplicated for each sample.
+            job_context['microarray_frames'].append(
+                pd.concat(microarray_frames,
+                          axis=1,
+                          keys=None,
+                          join=merge_strategy,
+                          copy=False,
+                          sort=True))
+
+            job_context['rnaseq_frames'].append(
+                pd.concat(rnaseq_frames,
+                          axis=1,
+                          keys=None,
+                          join=merge_strategy,
+                          copy=False,
+                          sort=True))
 
     # clean up the pool when we are done
     worker_pool.close()

--- a/workers/data_refinery_workers/processors/test_smasher.py
+++ b/workers/data_refinery_workers/processors/test_smasher.py
@@ -1403,6 +1403,7 @@ class AggregationTestCase(TransactionTestCase):
             'output_dir': self.smash_path,
             'metadata': self.unicode_metadata,
             'dataset': Dataset.objects.create(aggregate_by='ALL'),
+            'group_by_keys': [],
             'input_files': {
             }
         }
@@ -1417,6 +1418,7 @@ class AggregationTestCase(TransactionTestCase):
             'job': pj,
             'output_dir': self.smash_path,
             'metadata': self.unicode_metadata,
+            'group_by_keys': [],
             'dataset': Dataset.objects.create(aggregate_by='EXPERIMENT'),
             'input_files': {
             }
@@ -1433,6 +1435,7 @@ class AggregationTestCase(TransactionTestCase):
             'output_dir': self.smash_path,
             'metadata': self.unicode_metadata,
             'dataset': Dataset.objects.create(aggregate_by='SPECIES'),
+            'group_by_keys': ['homo_sapiens', 'fake_species'],
             'input_files': {
                 'homo_sapiens': [], # only the key matters in this test
                 'fake_species': []  # only the key matters in this test
@@ -1460,6 +1463,7 @@ class AggregationTestCase(TransactionTestCase):
             'dataset': Dataset.objects.create(aggregate_by='SPECIES',
                                               data={'GSE56409': ['GSM1361050'],
                                                     'E-GEOD-44719': ['E-GEOD-44719-GSM1089311']}),
+            'group_by_keys': ['homo_sapiens', 'fake_species'],
             'input_files': {
                 'homo_sapiens': [], # only the key matters in this test
                 'fake_species': []  # only the key matters in this test
@@ -1522,7 +1526,7 @@ class AggregationTestCase(TransactionTestCase):
         os.remove(json_filename)
 
     @tag("smasher")
-    def test_bad_overlap(self):
+    def test_bad_smash(self):
 
         pj = ProcessorJob()
         pj.pipeline_applied = "SMASHER"
@@ -1535,7 +1539,8 @@ class AggregationTestCase(TransactionTestCase):
         result = ComputationalResult()
         result.save()
 
-        homo_sapiens = Organism.get_object_for_name("HOMO_SAPIENS")
+        homo_sapiens = Organism(name="HOMO_SAPIENS", taxonomy_id=9606)
+        homo_sapiens.save()
 
         sample = Sample()
         sample.accession_code = 'GSM1237810'
@@ -1621,10 +1626,24 @@ class AggregationTestCase(TransactionTestCase):
 
         final_context = smasher.smash(pj.pk, upload=False)
         ds = Dataset.objects.get(id=ds.id)
+        self.assertTrue(ds.is_processed)
+
+    @tag("smasher")
+    def test_bad_overlap(self):
+
+        homo_sapiens = Organism(name="HOMO_SAPIENS", taxonomy_id=9606)
+        homo_sapiens.save()
 
         pj = ProcessorJob()
         pj.pipeline_applied = "SMASHER"
         pj.save()
+
+        experiment = Experiment()
+        experiment.accession_code = "GSE51081"
+        experiment.save()
+
+        result = ComputationalResult()
+        result.save()
 
         # Now, make sure the bad can't zero this out.
         sample = Sample()
@@ -1637,11 +1656,6 @@ class AggregationTestCase(TransactionTestCase):
         esa.experiment = experiment
         esa.sample = sample
         esa.save()
-
-        assoc = SampleComputedFileAssociation()
-        assoc.sample = sample
-        assoc.computed_file = computed_file
-        assoc.save()
 
         sra = SampleResultAssociation()
         sra.sample = sample


### PR DESCRIPTION
## Issue Number

#1797  

## Purpose/Implementation Notes

I realized we were keeping `input_files` around longer than we needed to. It's probably not too much but it's something.

The main focus of this PR is to merge the data for smasher/compendia in chunks of 2k instead of all at once once we've read them all in. The RAM patterns look pretty good I think:

```
2019-10-17 17:24:20,803 local [volume: 0] data_refinery_workers.processors.smashing_utils DEBUG [total_cpu: 96.9] [process_ram: 0.7738990783691406] [job_id: 1]: set frames for key DANIO_RERIO
2019-10-17 17:24:20,803 local [volume: 0] data_refinery_workers.processors.smashing_utils DEBUG [job_id: 1]: Duration: 103.00166034698486
2019-10-17 17:24:20,812 local [volume: 0] data_refinery_workers.processors.create_compendia DEBUG [total_cpu: 25.0] [process_ram: 0.7702369689941406] [job_id: 1]: end _prepare_frames
2019-10-17 17:24:20,812 local [volume: 0] data_refinery_workers.processors.create_compendia DEBUG [job_id: 1]: Duration: 103.01202917098999
2019-10-17 17:24:20,814 local [volume: 0] data_refinery_workers.processors.create_compendia DEBUG [total_cpu: 0.0] [process_ram: 0.7648658752441406] [job_id: 1]: start perform imputation
2019-10-17 17:24:20,814 local [volume: 0] data_refinery_workers.processors.create_compendia DEBUG [total_cpu: 0.0] [process_ram: 0.7648658752441406] [job_id: 1]: start microarray concatenation
2019-10-17 17:24:20,949 local [volume: 0] data_refinery_workers.processors.create_compendia DEBUG [total_cpu: 30.8] [process_ram: 0.7529029846191406] [job_id: 1]: end microarray concatenation
2019-10-17 17:24:20,950 local [volume: 0] data_refinery_workers.processors.create_compendia DEBUG [job_id: 1]: Duration: 0.13524198532104492
2019-10-17 17:24:20,950 local [volume: 0] data_refinery_workers.processors.create_compendia DEBUG [total_cpu: 100.0] [process_ram: 0.7529029846191406] [job_id: 1]: start rnaseq concatenation
2019-10-17 17:24:21,081 local [volume: 0] data_refinery_workers.processors.create_compendia DEBUG [total_cpu: 28.8] [process_ram: 0.7524147033691406] [job_id: 1]: end rnaseq concatenation
2019-10-17 17:24:21,081 local [volume: 0] data_refinery_workers.processors.create_compendia DEBUG [job_id: 1]: Duration: 0.13072896003723145
2019-10-17 17:24:21,082 local [volume: 0] data_refinery_workers.processors.create_compendia DEBUG [total_cpu: 100.0] [process_ram: 0.7524147033691406] [job_id: 1]: start rnaseq row sums
2019-10-17 17:24:21,243 local [volume: 0] data_refinery_workers.processors.create_compendia DEBUG [total_cpu: 31.8] [process_ram: 0.7616767883300781] [job_id: 1]: end rnaseq row sums
2019-10-17 17:24:21,243 local [volume: 0] data_refinery_workers.processors.create_compendia DEBUG [job_id: 1]: Duration: 0.1612398624420166
2019-10-17 17:24:21,244 local [volume: 0] data_refinery_workers.processors.create_compendia DEBUG [total_cpu: 0.0] [process_ram: 0.7616767883300781] [job_id: 1]: start rnaseq decile
2019-10-17 17:24:21,246 local [volume: 0] data_refinery_workers.processors.create_compendia DEBUG [total_cpu: 0.0] [process_ram: 0.7616767883300781] [job_id: 1]: end rnaseq decile
2019-10-17 17:24:21,246 local [volume: 0] data_refinery_workers.processors.create_compendia DEBUG [job_id: 1]: Duration: 0.0022203922271728516
2019-10-17 17:24:21,247 local [volume: 0] data_refinery_workers.processors.create_compendia DEBUG [total_cpu: 0.0] [process_ram: 0.7616767883300781] [job_id: 1]: drop all rows
2019-10-17 17:24:21,277 local [volume: 0] data_refinery_workers.processors.create_compendia DEBUG [total_cpu: 46.2] [process_ram: 0.7616767883300781] [job_id: 1]: actually calling drop()
2019-10-17 17:24:21,374 local [volume: 0] data_refinery_workers.processors.create_compendia DEBUG [total_cpu: 45.9] [process_ram: 0.8515129089355469] [job_id: 1]: end drop all rows
2019-10-17 17:24:21,374 local [volume: 0] data_refinery_workers.processors.create_compendia DEBUG [job_id: 1]: Duration: 0.12688159942626953
2019-10-17 17:24:21,375 local [volume: 0] data_refinery_workers.processors.create_compendia DEBUG [total_cpu: 0.0] [process_ram: 0.8515129089355469] [job_id: 1]: start log2
2019-10-17 17:24:21,730 local [volume: 0] data_refinery_workers.processors.create_compendia DEBUG [total_cpu: 38.8] [process_ram: 0.8516273498535156] [job_id: 1]: end log2
2019-10-17 17:24:21,730 local [volume: 0] data_refinery_workers.processors.create_compendia DEBUG [job_id: 1]: Duration: 0.35447072982788086
2019-10-17 17:24:21,730 local [volume: 0] data_refinery_workers.processors.create_compendia DEBUG [total_cpu: 0.0] [process_ram: 0.8516273498535156] [job_id: 1]: start caching zeroes
2019-10-17 17:24:22,066 local [volume: 0] data_refinery_workers.processors.create_compendia DEBUG [total_cpu: 30.5] [process_ram: 0.8516273498535156] [job_id: 1]: end caching zeroes
2019-10-17 17:24:22,066 local [volume: 0] data_refinery_workers.processors.create_compendia DEBUG [job_id: 1]: Duration: 0.3353006839752197
2019-10-17 17:24:22,067 local [volume: 0] data_refinery_workers.processors.create_compendia DEBUG [total_cpu: 0.0] [process_ram: 0.8516273498535156] [job_id: 1]: start outer merge
2019-10-17 17:24:22,592 local [volume: 0] data_refinery_workers.processors.create_compendia DEBUG [total_cpu: 31.6] [process_ram: 1.02685546875] [job_id: 1]: end outer merge
2019-10-17 17:24:22,593 local [volume: 0] data_refinery_workers.processors.create_compendia DEBUG [job_id: 1]: Duration: 0.5258626937866211
2019-10-17 17:24:22,593 local [volume: 0] data_refinery_workers.processors.create_compendia DEBUG [total_cpu: 0.0] [process_ram: 1.02685546875] [job_id: 1]: start drop NA genes
2019-10-17 17:24:23,495 local [volume: 0] data_refinery_workers.processors.create_compendia DEBUG [total_cpu: 35.2] [process_ram: 0.8604583740234375] [job_id: 1]: end drop NA genes
2019-10-17 17:24:23,495 local [volume: 0] data_refinery_workers.processors.create_compendia DEBUG [job_id: 1]: Duration: 0.9019875526428223
2019-10-17 17:24:23,496 local [volume: 0] data_refinery_workers.processors.create_compendia DEBUG [total_cpu: 0.0] [process_ram: 0.8604583740234375] [job_id: 1]: start drop NA samples
2019-10-17 17:24:23,694 local [volume: 0] data_refinery_workers.processors.create_compendia DEBUG [total_cpu: 35.4] [process_ram: 0.9440841674804688] [job_id: 1]: end drop NA genes
2019-10-17 17:24:23,695 local [volume: 0] data_refinery_workers.processors.create_compendia DEBUG [job_id: 1]: Duration: 0.1986522674560547
2019-10-17 17:24:23,695 local [volume: 0] data_refinery_workers.processors.create_compendia DEBUG [total_cpu: 0.0] [process_ram: 0.9440841674804688] [job_id: 1]: start replace zeroes
2019-10-17 17:24:25,050 local [volume: 0] data_refinery_workers.processors.create_compendia DEBUG [total_cpu: 34.2] [process_ram: 0.8877792358398438] [job_id: 1]: end replace zeroes
2019-10-17 17:24:25,050 local [volume: 0] data_refinery_workers.processors.create_compendia DEBUG [job_id: 1]: Duration: 1.3550500869750977
2019-10-17 17:24:25,051 local [volume: 0] data_refinery_workers.processors.create_compendia DEBUG [total_cpu: 0.0] [process_ram: 0.8877792358398438] [job_id: 1]: start replacing transposed zeroes
2019-10-17 17:24:25,181 local [volume: 0] data_refinery_workers.processors.create_compendia DEBUG [total_cpu: 31.4] [process_ram: 0.8878211975097656] [job_id: 1]: end replacing transposed zeroes
2019-10-17 17:24:25,182 local [volume: 0] data_refinery_workers.processors.create_compendia DEBUG [job_id: 1]: Duration: 0.13039326667785645
2019-10-17 17:24:25,785 local [volume: 0] data_refinery_workers.processors.create_compendia INFO [total_percent_imputed: 0.0]: Total percentage of data to impute!
2019-10-17 17:24:25,785 local [volume: 0] data_refinery_workers.processors.create_compendia DEBUG [total_cpu: 41.0] [process_ram: 0.9016647338867188] [job_id: 1]: start SVD
```
I now wanna try this on the rat compendium to see how the RAM usage looks there.

## Types of changes

- Optimization

## Functional tests

The unit tests cover this well
