### PR TITLE
count samples not genes

### DIFF
--- a/workers/data_refinery_workers/processors/smashing_utils.py
+++ b/workers/data_refinery_workers/processors/smashing_utils.py
@@ -394,9 +394,9 @@ def process_frames_for_key(key: str,
 
     job_context['num_samples'] = 0
     if job_context['microarray_matrix'] is not None:
-        job_context['num_samples'] += len(job_context['microarray_matrix'].index)
+        job_context['num_samples'] += len(job_context['microarray_matrix'].columns)
     if job_context['rnaseq_matrix'] is not None:
-        job_context['num_samples'] += len(job_context['rnaseq_matrix'].index)
+        job_context['num_samples'] += len(job_context['rnaseq_matrix'].columns)
 
     log_state("set frames for key {}".format(key), job_context["job"], start_frames)
 


### PR DESCRIPTION
## Issue Number

N/A

## Purpose/Implementation Notes

Looks like we were counting number of genes in the merged microarray_matrix and rnaseq_matrix in smashing utils but calling them samples. This PR is a quick fix for that.

## Methods

`process_frames_for_key`
## Types of changes

What types of changes does your code introduce?
- Bugfix (non-breaking change which fixes an issue)

## Functional tests

`./workers/run_tests.sh -t smasher`

## Checklist

- [X] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

