### PR TITLE
compendia merge with dask

### DIFF
--- a/workers/data_refinery_workers/processors/smashing_utils.py
+++ b/workers/data_refinery_workers/processors/smashing_utils.py
@@ -33,7 +33,7 @@ from data_refinery_workers.processors import utils
 # Use floor here because multiprocessing raises an exception if this isn't an int.
 MULTIPROCESSING_WORKER_COUNT = max(1, math.floor(multiprocessing.cpu_count()/2) - 1)
 MULTIPROCESSING_CHUNK_SIZE = 2000
-INDEX_DASK_START = 20000
+INDEX_DASK_START = 200000
 RESULTS_BUCKET = get_env_variable("S3_RESULTS_BUCKET_NAME", "refinebio-results-bucket")
 S3_BUCKET_NAME = get_env_variable("S3_BUCKET_NAME", "data-refinery")
 BODY_HTML = Path(


### PR DESCRIPTION
## Issue Number

#1537 

## Purpose/Implementation Notes

The idea here is to prevent either a MemoryError or OOM kill from docker as we try to merge substantially large dataframes into a compendium dataframe. This is happening before imputation as we prepare and merge the files. 

## Methods

`smashing_utils.py:_process_frame_for_key`

Keeps the pandas.concat for each chunk as this seems to fit into memory just fine. However the first concatenated frames are merged into a `dask.DataFrame` instead and we merge each chunk iteration into that. After we are done with all chunks we call `dask.DataFrame.compute` on the microarray_matrix dataframe and rnaseq_matrix dataframe to convert it back to pandas and place it in memory.

## Types of changes

- New feature (non-breaking change which adds functionality)

## Functional tests

ran `./workers/run_tests.sh -t compendia` test cases and also set the MULTIPROCESSING_CHUNK_SIZE to 20 and ran `./workers/run_tests.sh -t compendia` test cases 

All of which passes.

## Checklist

- [X] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules
