### PR TITLE
Increase ram for quantpendia and smasher constraint

### DIFF
--- a/workers/nomad-job-specs/create_quantpendia.nomad.tpl
+++ b/workers/nomad-job-specs/create_quantpendia.nomad.tpl
@@ -69,7 +69,7 @@ job "CREATE_QUANTPENDIA" {
       resources {
         # CPU is in AWS's CPU units.
         cpu =   4000
-        memory = 12288
+        memory = 16384
       }
 
       logs {

--- a/workers/nomad-job-specs/create_quantpendia.nomad.tpl
+++ b/workers/nomad-job-specs/create_quantpendia.nomad.tpl
@@ -69,14 +69,15 @@ job "CREATE_QUANTPENDIA" {
       resources {
         # CPU is in AWS's CPU units.
         cpu =   4000
-        # Memory is in MB of RAM. Instance has 1,952GB of RAM.
-        memory = 8192
+        memory = 12288
       }
 
       logs {
         max_files = 1
         max_file_size = 1
       }
+
+      ${{SMASHER_CONSTRAINT}}
 
       config {
         image = "${{DOCKERHUB_REPO}}/${{COMPENDIA_DOCKER_IMAGE}}"


### PR DESCRIPTION
## Issue Number

#1823

## Purpose/Implementation Notes

Add more ram for the next time we try the quantpendias. Also, ensure it runs on the smasher since the job will be running for a couple of hours and we don't want it to be interrupted.

## Types of changes

- Parameter change

## Functional tests

None

## Checklist

- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules
