### PR TITLE
Remove multiprocessing, preallocate entire matrix.

### DIFF
--- a/workers/data_refinery_workers/processors/create_compendia.py
+++ b/workers/data_refinery_workers/processors/create_compendia.py
@@ -87,8 +87,7 @@ def _prepare_frames(job_context: Dict) -> Dict:
         for key, input_files in job_context.pop('input_files').items():
             job_context = smashing_utils.process_frames_for_key(key,
                                                                 input_files,
-                                                                job_context,
-                                                                merge_strategy='outer')
+                                                                job_context)
             # if len(job_context['all_frames']) < 1:
             # TODO: Enable this check?
 

--- a/workers/data_refinery_workers/processors/create_compendia.py
+++ b/workers/data_refinery_workers/processors/create_compendia.py
@@ -31,23 +31,23 @@ logger = get_and_configure_logger(__name__)
 logger.setLevel(logging.getLevelName('DEBUG'))
 
 
-def log_state(message, job, start_time=False):
+def log_state(message, job_id, start_time=False):
     if logger.isEnabledFor(logging.DEBUG):
         process = psutil.Process(os.getpid())
         ram_in_GB = process.memory_info().rss / BYTES_IN_GB
         logger.debug(message,
                      total_cpu=psutil.cpu_percent(),
                      process_ram=ram_in_GB,
-                     job_id=job.id)
+                     job_id=job_id)
 
         if start_time:
-            logger.debug('Duration: %s' % (time.time() - start_time), job_id=job.id)
+            logger.debug('Duration: %s' % (time.time() - start_time), job_id=job_id)
         else:
             return time.time()
 
 
 def _prepare_input(job_context: Dict) -> Dict:
-    start_time = log_state("prepare input", job_context["job"])
+    start_time = log_state("prepare input", job_context["job"].id)
 
     job_context = smashing_utils.prepare_files(job_context)
     if job_context['job'].success is False:
@@ -67,12 +67,12 @@ def _prepare_input(job_context: Dict) -> Dict:
         if not os.path.exists(job_context["work_dir"]):
             os.makedirs(job_context["work_dir"])
 
-    log_state("prepare input done", job_context["job"], start_time)
+    log_state("prepare input done", job_context["job"].id, start_time)
     return job_context
 
 
 def _prepare_frames(job_context: Dict) -> Dict:
-    start_prepare_frames = log_state("start _prepare_frames", job_context["job"])
+    start_prepare_frames = log_state("start _prepare_frames", job_context["job"].id)
 
     try:
         job_context['unsmashable_files'] = []
@@ -109,7 +109,7 @@ def _prepare_frames(job_context: Dict) -> Dict:
     job_context['dataset'].success = True
     job_context['dataset'].save()
 
-    log_state("end _prepare_frames", job_context["job"], start_prepare_frames)
+    log_state("end _prepare_frames", job_context["job"].id, start_prepare_frames)
     return job_context
 
 
@@ -145,9 +145,9 @@ def _perform_imputation(job_context: Dict) -> Dict:
      - Quantile normalize imputed_matrix where genes are rows and samples are columns
 
     """
-    imputation_start = log_state("start perform imputation", job_context["job"])
+    imputation_start = log_state("start perform imputation", job_context["job"].id)
     job_context['time_start'] = timezone.now()
-    rnaseq_row_sums_start = log_state("start rnaseq row sums", job_context["job"])
+    rnaseq_row_sums_start = log_state("start rnaseq row sums", job_context["job"].id)
 
     # We potentially can have a microarray-only compendia but not a RNASeq-only compendia
     log2_rnaseq_matrix = None
@@ -156,14 +156,14 @@ def _perform_imputation(job_context: Dict) -> Dict:
         # (gene) of the rnaseq_matrix (rnaseq_row_sums)
         rnaseq_row_sums = np.sum(job_context['rnaseq_matrix'], axis=1)
 
-        log_state("end rnaseq row sums", job_context["job"], rnaseq_row_sums_start)
-        rnaseq_decile_start = log_state("start rnaseq decile", job_context["job"])
+        log_state("end rnaseq row sums", job_context["job"].id, rnaseq_row_sums_start)
+        rnaseq_decile_start = log_state("start rnaseq decile", job_context["job"].id)
 
         # Calculate the 10th percentile of rnaseq_row_sums
         rnaseq_tenth_percentile = np.percentile(rnaseq_row_sums, 10)
 
-        log_state("end rnaseq decile", job_context["job"], rnaseq_decile_start)
-        drop_start = log_state("drop all rows", job_context["job"])
+        log_state("end rnaseq decile", job_context["job"].id, rnaseq_decile_start)
+        drop_start = log_state("drop all rows", job_context["job"].id)
         # Drop all rows in rnaseq_matrix with a row sum < 10th
         # percentile of rnaseq_row_sums; this is now
         # filtered_rnaseq_matrix
@@ -175,14 +175,14 @@ def _perform_imputation(job_context: Dict) -> Dict:
 
         del rnaseq_row_sums
 
-        log_state("actually calling drop()", job_context["job"])
+        log_state("actually calling drop()", job_context["job"].id)
 
         filtered_rnaseq_matrix = job_context.pop('rnaseq_matrix').drop(rows_to_filter)
 
         del rows_to_filter
 
-        log_state("end drop all rows", job_context["job"], drop_start)
-        log2_start = log_state("start log2", job_context["job"])
+        log_state("end drop all rows", job_context["job"].id, drop_start)
+        log2_start = log_state("start log2", job_context["job"].id)
 
         # log2(x + 1) transform filtered_rnaseq_matrix; this is now log2_rnaseq_matrix
         filtered_rnaseq_matrix_plus_one = filtered_rnaseq_matrix + 1
@@ -190,8 +190,8 @@ def _perform_imputation(job_context: Dict) -> Dict:
         del filtered_rnaseq_matrix_plus_one
         del filtered_rnaseq_matrix
 
-        log_state("end log2", job_context["job"], log2_start)
-        cache_start = log_state("start caching zeroes", job_context["job"])
+        log_state("end log2", job_context["job"].id, log2_start)
+        cache_start = log_state("start caching zeroes", job_context["job"].id)
 
         # Cache our RNA-Seq zero values
         cached_zeroes = {}
@@ -202,9 +202,9 @@ def _perform_imputation(job_context: Dict) -> Dict:
         # to keep track of where these zeroes are
         log2_rnaseq_matrix[log2_rnaseq_matrix == 0] = np.nan
 
-        log_state("end caching zeroes", job_context["job"], cache_start)
+        log_state("end caching zeroes", job_context["job"].id, cache_start)
 
-    outer_merge_start = log_state("start outer merge", job_context["job"])
+    outer_merge_start = log_state("start outer merge", job_context["job"].id)
 
     # Perform a full outer join of microarray_matrix and
     # log2_rnaseq_matrix; combined_matrix
@@ -217,12 +217,12 @@ def _perform_imputation(job_context: Dict) -> Dict:
         logger.info("Building compendia with only microarray data.", job_id=job_context["job"].id)
         combined_matrix = job_context.pop('microarray_matrix')
 
-    log_state("ran outer merge, now deleteing log2_rnaseq_matrix", job_context["job"])
+    log_state("ran outer merge, now deleteing log2_rnaseq_matrix", job_context["job"].id)
 
     del log2_rnaseq_matrix
 
-    log_state("end outer merge", job_context["job"], outer_merge_start)
-    drop_na_genes_start = log_state("start drop NA genes", job_context["job"])
+    log_state("end outer merge", job_context["job"].id, outer_merge_start)
+    drop_na_genes_start = log_state("start drop NA genes", job_context["job"].id)
 
     # # Visualize Prefiltered
     # output_path = job_context['output_dir'] + "pre_filtered_" + str(time.time()) + ".png"
@@ -236,8 +236,8 @@ def _perform_imputation(job_context: Dict) -> Dict:
     del combined_matrix
     del thresh
 
-    log_state("end drop NA genes", job_context["job"], drop_na_genes_start)
-    drop_na_samples_start = log_state("start drop NA samples", job_context["job"])
+    log_state("end drop NA genes", job_context["job"].id, drop_na_genes_start)
+    drop_na_samples_start = log_state("start drop NA samples", job_context["job"].id)
 
     # # Visualize Row Filtered
     # output_path = job_context['output_dir'] + "row_filtered_" + str(time.time()) + ".png"
@@ -251,8 +251,8 @@ def _perform_imputation(job_context: Dict) -> Dict:
     row_col_filtered_matrix_samples_index = row_col_filtered_matrix_samples.index
     row_col_filtered_matrix_samples_columns = row_col_filtered_matrix_samples.columns
 
-    log_state("end drop NA genes", job_context["job"], drop_na_samples_start)
-    replace_zeroes_start = log_state("start replace zeroes", job_context["job"])
+    log_state("end drop NA genes", job_context["job"].id, drop_na_samples_start)
+    replace_zeroes_start = log_state("start replace zeroes", job_context["job"].id)
 
     del row_filtered_matrix
 
@@ -282,8 +282,8 @@ def _perform_imputation(job_context: Dict) -> Dict:
             logger.warn("Error when replacing zero")
             continue
 
-    log_state("end replace zeroes", job_context["job"], replace_zeroes_start)
-    transposed_zeroes_start = log_state("start replacing transposed zeroes", job_context["job"])
+    log_state("end replace zeroes", job_context["job"].id, replace_zeroes_start)
+    transposed_zeroes_start = log_state("start replacing transposed zeroes", job_context["job"].id)
 
     # Label our new replaced data
     combined_matrix_zero = row_col_filtered_matrix_samples
@@ -297,7 +297,7 @@ def _perform_imputation(job_context: Dict) -> Dict:
     transposed_matrix = transposed_matrix_with_zeros.replace([np.inf, -np.inf], np.nan)
     del transposed_matrix_with_zeros
 
-    log_state("end replacing transposed zeroes", job_context["job"], transposed_zeroes_start)
+    log_state("end replacing transposed zeroes", job_context["job"].id, transposed_zeroes_start)
 
     # Store the absolute/percentages of imputed values
     matrix_sum = transposed_matrix.isnull().sum()
@@ -310,7 +310,7 @@ def _perform_imputation(job_context: Dict) -> Dict:
     # transposed_matrix; imputed_matrix
     svd_algorithm = job_context['dataset'].svd_algorithm
     if svd_algorithm != 'NONE':
-        svd_start = log_state("start SVD", job_context["job"])
+        svd_start = log_state("start SVD", job_context["job"].id)
 
         logger.info("IterativeSVD algorithm: %s" % svd_algorithm)
         svd_algorithm = str.lower(svd_algorithm)
@@ -319,13 +319,13 @@ def _perform_imputation(job_context: Dict) -> Dict:
             svd_algorithm=svd_algorithm
         ).fit_transform(transposed_matrix)
 
-        svd_start = log_state("end SVD", job_context["job"], svd_start)
+        svd_start = log_state("end SVD", job_context["job"].id, svd_start)
     else:
         imputed_matrix = transposed_matrix
         logger.info("Skipping IterativeSVD")
     del transposed_matrix
 
-    untranspose_start = log_state("start untranspose", job_context["job"])
+    untranspose_start = log_state("start untranspose", job_context["job"].id)
 
     # Untranspose imputed_matrix (genes are now rows, samples are now columns)
     untransposed_imputed_matrix = imputed_matrix.T
@@ -345,13 +345,13 @@ def _perform_imputation(job_context: Dict) -> Dict:
     # visualized_merged_no_qn = visualize.visualize(untransposed_imputed_matrix_df.copy(),
     #                                               output_path)
 
-    log_state("end untranspose", job_context["job"], untranspose_start)
-    quantile_start = log_state("start quantile normalize", job_context["job"])
+    log_state("end untranspose", job_context["job"].id, untranspose_start)
+    quantile_start = log_state("start quantile normalize", job_context["job"].id)
 
     # Perform the Quantile Normalization
     job_context = smashing_utils.quantile_normalize(job_context, ks_check=False)
 
-    log_state("end quantile normalize", job_context["job"], quantile_start)
+    log_state("end quantile normalize", job_context["job"].id, quantile_start)
 
     # Visualize Final Compendia
     # output_path = job_context['output_dir'] + "compendia_with_qn_" + str(time.time()) + ".png"
@@ -359,7 +359,7 @@ def _perform_imputation(job_context: Dict) -> Dict:
 
     job_context['time_end'] = timezone.now()
     job_context['formatted_command'] = "create_compendia.py"
-    log_state("end prepare imputation", job_context["job"], imputation_start)
+    log_state("end prepare imputation", job_context["job"].id, imputation_start)
     return job_context
 
 
@@ -367,7 +367,7 @@ def _create_result_objects(job_context: Dict) -> Dict:
     """
     Store and host the result as a ComputationalResult object.
     """
-    result_start = log_state("start create result object", job_context["job"])
+    result_start = log_state("start create result object", job_context["job"].id)
     result = ComputationalResult()
     result.commands.append(" ".join(job_context['formatted_command']))
     result.is_ccdl = True
@@ -475,7 +475,7 @@ def _create_result_objects(job_context: Dict) -> Dict:
                                      archive_computed_file]
     job_context['success'] = True
 
-    log_state("end create result object", job_context["job"], result_start)
+    log_state("end create result object", job_context["job"].id, result_start)
 
     # TEMPORARY for iterating on compendia more quickly.
     # Reset this so the end_job does clean up the job's non-input-data stuff.

--- a/workers/data_refinery_workers/processors/smasher.py
+++ b/workers/data_refinery_workers/processors/smasher.py
@@ -176,7 +176,7 @@ def process_frames_for_key(key: str,
         if frame['unsmashable']:
             job_context['unsmashable_files'].append(frame['unsmashable_file'])
         else:
-            job_context['all_frames'].append(frame)
+            job_context['all_frames'].append(frame['dataframe'])
 
     log_state("Finished building list of all_frames key {}".format(key),
               job_context["job"].id,

--- a/workers/data_refinery_workers/processors/smashing_utils.py
+++ b/workers/data_refinery_workers/processors/smashing_utils.py
@@ -278,25 +278,16 @@ def process_frame(work_dir,
 
 def process_frames_for_key(key: str,
                            input_files: List[ComputedFile],
-                           job_context: Dict,
-                           merge_strategy: str) -> Dict:
+                           job_context: Dict) -> Dict:
     """Download, read, and chunk processed sample files from s3.
 
     `key` is the species or experiment whose samples are contained in `input_files`.
 
-    Will populate add to job_context the keys 'microarray_frames' and
-    'rnaseq_frames' with pandas dataframes containing
-    MULTIPROCESSING_CHUNK_SIZE samples worth of data. Also adds the
-    key 'unsmashable_files' containing a list of paths that were
-    determined to be unsmashable.
-
-    `merge_strategy` dictates how the chunks will be merged and must be
-    one of the two values `inner` or `outer.
+    Will add to job_context the keys 'microarray_matrix' and
+    'rnaseq_matrix' with pandas dataframes containing all of the
+    samples' data. Also adds the key 'unsmashable_files' containing a
+    list of paths that were determined to be unsmashable.
     """
-    if merge_strategy != 'inner' and merge_strategy != 'outer':
-        raise ValueError("merge_strategy must be either of the values 'inner' or 'outer'.")
-
-    job_context['original_merged'] = pd.DataFrame()
 
     start_gene_ids = log_state("Collecting all gene identifiers for key {}".format(key),
                                job_context["job"].id)

--- a/workers/data_refinery_workers/processors/smashing_utils.py
+++ b/workers/data_refinery_workers/processors/smashing_utils.py
@@ -330,7 +330,7 @@ def process_frames_for_key(key: str,
     log_state(log_template.format(len(all_gene_identifiers),
                                   key,
                                   len(microarray_columns),
-                                  len(rnaseq_columns))
+                                  len(rnaseq_columns)),
               job_context["job"].id,
               start_gene_ids)
     start_build_matrix = log_state("Beginning to build the full matrices.",

--- a/workers/data_refinery_workers/processors/smashing_utils.py
+++ b/workers/data_refinery_workers/processors/smashing_utils.py
@@ -2,8 +2,6 @@
 
 import csv
 import logging
-import math
-import multiprocessing
 import os
 import shutil
 import time
@@ -16,7 +14,6 @@ from rpy2.robjects import r as rlang
 from rpy2.robjects.packages import importr
 import numpy as np
 import pandas as pd
-import dask.dataframe as dd
 import psutil
 import rpy2.robjects as ro
 import simplejson as json
@@ -26,12 +23,6 @@ from data_refinery_common.models import ComputedFile, Sample
 from data_refinery_common.utils import get_env_variable
 from data_refinery_workers.processors import utils
 
-# Take one fewer than 1/2 the total available threads
-# also make the minimum threads 1.
-# Use floor here because multiprocessing raises an exception if this isn't an int.
-MULTIPROCESSING_WORKER_COUNT = max(1, math.floor(multiprocessing.cpu_count()/2) - 1)
-MULTIPROCESSING_CHUNK_SIZE = 2000
-INDEX_DASK_START = 200000
 RESULTS_BUCKET = get_env_variable("S3_RESULTS_BUCKET_NAME", "refinebio-results-bucket")
 S3_BUCKET_NAME = get_env_variable("S3_BUCKET_NAME", "data-refinery")
 BODY_HTML = Path(
@@ -56,17 +47,17 @@ def log_failure(job_context: Dict, failure_reason: str) -> Dict:
     return job_context
 
 
-def log_state(message, job, start_time=False):
+def log_state(message, job_id, start_time=False):
     if logger.isEnabledFor(logging.DEBUG):
         process = psutil.Process(os.getpid())
         ram_in_GB = process.memory_info().rss / BYTES_IN_GB
         logger.debug(message,
                      total_cpu=psutil.cpu_percent(),
                      process_ram=ram_in_GB,
-                     job_id=job.id)
+                     job_id=job_id)
 
         if start_time:
-            logger.debug('Duration: %s' % (time.time() - start_time), job_id=job.id)
+            logger.debug('Duration: %s' % (time.time() - start_time), job_id=job_id)
         else:
             return time.time()
 
@@ -75,7 +66,7 @@ def prepare_files(job_context: Dict) -> Dict:
     """
     Fetches and prepares the files to smash.
     """
-    start_prepare_files = log_state("start prepare files", job_context["job"])
+    start_prepare_files = log_state("start prepare files", job_context["job"].id)
     found_files = False
     job_context['input_files'] = {}
     # `key` can either be the species name or experiment accession.
@@ -117,7 +108,7 @@ def prepare_files(job_context: Dict) -> Dict:
 
     job_context["output_dir"] = job_context["work_dir"] + "output/"
     os.makedirs(job_context["output_dir"])
-    log_state("end prepare files", job_context["job"], start_prepare_files)
+    log_state("end prepare files", job_context["job"].id, start_prepare_files)
     return job_context
 
 
@@ -172,19 +163,16 @@ def _load_and_sanitize_file(computed_file_path, index=None):
     return data
 
 
-def process_frame(inputs) -> Dict:
-    (
-        work_dir,
-        computed_file,
-        sample_accession_code,
-        dataset_id,
-        aggregate_by,
-        index,
-        gene_ids,
-        job_id
-    ) = inputs
+def process_frame(work_dir,
+                  computed_file,
+                  sample_accession_code,
+                  dataset_id,
+                  aggregate_by,
+                  index,
+                  gene_ids,
+                  job_id) -> Dict:
 
-    logger.debug('processing frame {}'.format(index), job_id=job_id)
+    log_state('processing frame {}'.format(index), job_id)
 
     frame = {
         "unsmashable": False,
@@ -303,157 +291,85 @@ def process_frames_for_key(key: str,
 
     job_context['original_merged'] = pd.DataFrame()
 
-    start_frames = log_state("building frames for species or experiment {}".format(key),
-                             job_context["job"])
-
-    worker_pool = multiprocessing.Pool(processes=MULTIPROCESSING_WORKER_COUNT,
-                                       maxtasksperchild=MULTIPROCESSING_CHUNK_SIZE)
+    start_gene_ids = log_state("Collecting all gene identifiers for key {}".format(key),
+                               job_context["job"].id)
 
     # Build up a list of gene identifiers because these will be the
     # rows of our matrices, and we want to preallocate them so we need
     # to know them all.
     all_gene_identifiers = set()
 
-    chunk_of_frames = []
+    microarray_columns = []
+    rnaseq_columns = []
     for index, (computed_file, sample) in enumerate(input_files):
+        frame = process_frame(job_context["work_dir"],
+                              computed_file,
+                              sample.accession_code,
+                              job_context['dataset'].id,
+                              job_context['dataset'].aggregate_by,
+                              index,
+                              None,
+                              job_context["job"].id)
 
-        # Create a tuple containing the inputs for process_frame.
-        frame_input = (
-            job_context["work_dir"],
-            computed_file,
-            sample.accession_code,
-            job_context['dataset'].id,
-            job_context['dataset'].aggregate_by,
-            index,
-            None,
-            job_context["job"].id
-        )
+        # Count how many frames are in each tech so we can preallocate
+        # the matrices in both directions.
+        if not frame['unsmashable']:
+            all_gene_identifiers = all_gene_identifiers.union(frame['dataframe'].index)
 
-        chunk_of_frames.append(frame_input)
-        # Make sure to handle the last chunk even if it's not a full chunk.
-        if index > 0 and index % MULTIPROCESSING_CHUNK_SIZE == 0 or index == len(input_files) - 1:
-            processed_chunk = worker_pool.map(process_frame, chunk_of_frames)
-            chunk_of_frames = []
-
-            for frame in processed_chunk:
-                if not frame['unsmashable']:
-                    all_gene_identifiers = all_gene_identifiers.union(frame['dataframe'].index)
-
-            del processed_chunk
+            # Each dataframe should only have 1 column, but it's returned as a list so use extend.
+            if frame['technology'] == 'microarray':
+                microarray_columns.extend(frame['dataframe'].columns)
+            elif frame['technology'] == 'rnaseq':
+                rnaseq_columns.extend(frame['dataframe'].columns)
 
     all_gene_identifiers = list(all_gene_identifiers)
     all_gene_identifiers.sort()
 
-    # Build up a list of microarray frames and a list of rnaseq
-    # frames. Each one will have MULTIPROCESSING_CHUNK_SIZE samples
-    # worth of data in them.
-    job_context['microarray_matrix'] = None
-    job_context['rnaseq_matrix'] = None
+    log_template = ("Collected {0} gene identifiers for {1} across"
+                    " {2} micrarry samples and {3} RNA-Seq samples.")
+    log_state(log_template.format(len(all_gene_identifiers),
+                                  key,
+                                  len(microarray_columns),
+                                  len(rnaseq_columns))
+              job_context["job"].id,
+              start_gene_ids)
+    start_build_matrix = log_state("Beginning to build the full matrices.",
+                                   job_context["job"].id)
 
-    chunk_of_frames = []
+    # Preallocate the matrices to be the exact size we will need. This
+    # should prevent any operations from happening while we build it
+    # up, so the only RAM used will be needed.
+    job_context['microarray_matrix'] = pd.DataFrame(data=None,
+                                                    index=all_gene_identifiers,
+                                                    columns=microarray_columns,
+                                                    dtype=np.float64)
+    job_context['rnaseq_matrix'] = pd.DataFrame(data=None,
+                                                index=all_gene_identifiers,
+                                                columns=rnaseq_columns,
+                                                dtype=np.float64)
+
     for index, (computed_file, sample) in enumerate(input_files):
+        processed_frame = process_frame(job_context["work_dir"],
+                                        computed_file,
+                                        sample.accession_code,
+                                        job_context['dataset'].id,
+                                        job_context['dataset'].aggregate_by,
+                                        index,
+                                        all_gene_identifiers,
+                                        job_context["job"].id)
 
-        # Create a tuple containing the inputs for process_frame.
-        frame_input = (
-            job_context["work_dir"],
-            computed_file,
-            sample.accession_code,
-            job_context['dataset'].id,
-            job_context['dataset'].aggregate_by,
-            index,
-            all_gene_identifiers,
-            job_context["job"].id
-        )
+        if frame['unsmashable']:
+            job_context['unsmashable_files'].append(frame['unsmashable_file'])
+        else:
+            # The dataframe for each sample will only have one column
+            # whose header will be the accession code.
+            column = processed_frame['dataframe'].columns[0]
+            if processed_frame['technology'] == 'microarray':
+                job_context['microarray_matrix'][column] = processed_frame['dataframe'].values
+            elif processed_frame['technology'] == 'rnaseq':
+                job_context['rnaseq_matrix'][column] = processed_frame['dataframe'].values
 
-        chunk_of_frames.append(frame_input)
-        # Make sure to handle the last chunk even if it's not a full chunk.
-        if index > 0 and index % MULTIPROCESSING_CHUNK_SIZE == 0 or index == len(input_files) - 1:
-
-            start_frame_chunk = log_state("merging chunk of frames",
-                                     job_context["job"])
-            processed_chunk = worker_pool.map(process_frame, chunk_of_frames)
-            chunk_of_frames = []
-
-            microarray_frames = []
-            rnaseq_frames = []
-            for frame in processed_chunk:
-                if frame['technology'] == 'microarray':
-                    microarray_frames.append(frame['dataframe'])
-                elif frame['technology'] == 'rnaseq':
-                    rnaseq_frames.append(frame['dataframe'])
-                elif frame['unsmashable']:
-                    job_context['unsmashable_files'].append(frame['unsmashable_file'])
-
-            del processed_chunk
-
-            # Merge the two types of frames from the chunk into only
-            # two data frames so the gene identifiers aren't
-            # duplicated for each sample.
-            if len(microarray_frames) > 0:
-                microarray_chunk_frame = pd.concat(microarray_frames,
-                                                   axis=1,
-                                                   keys=None,
-                                                   join=merge_strategy,
-                                                   copy=False,
-                                                   sort=True)
-
-                del microarray_frames
-
-                if job_context['microarray_matrix'] is not None:
-                    job_context['microarray_matrix'] = job_context['microarray_matrix'].merge(
-                        microarray_chunk_frame,
-                        how=merge_strategy,
-                        left_index=True,
-                        right_index=True
-                    )
-                else:
-                    job_context['microarray_matrix'] = microarray_chunk_frame
-
-                del microarray_chunk_frame
-                # start using dask to save ram at scale
-                if index > INDEX_DASK_START and type(job_context['microarray_matrix']) is pd.DataFrame:
-                    job_context['microarray_matrix'] = dd.from_pandas(job_context.pop('microarray_matrix'),
-                                                                      npartitions=MULTIPROCESSING_WORKER_COUNT)
-
-            if len(rnaseq_frames) > 0:
-                rnaseq_chunk_frame = pd.concat(rnaseq_frames,
-                                               axis=1,
-                                               keys=None,
-                                               join=merge_strategy,
-                                               copy=False,
-                                               sort=True)
-
-                del rnaseq_frames
-
-                if job_context['rnaseq_matrix'] is not None:
-                    job_context['rnaseq_matrix'] = job_context['rnaseq_matrix'].merge(
-                        rnaseq_chunk_frame,
-                        how=merge_strategy,
-                        left_index=True,
-                        right_index=True
-                    )
-                else:
-                    job_context['rnaseq_matrix'] = rnaseq_chunk_frame
-
-                del rnaseq_chunk_frame
-                # start using dask to save ram at scale
-                if index > INDEX_DASK_START and type(job_context['rnaseq_matrix']) is pd.DataFrame:
-                    job_context['rnaseq_matrix'] = dd.from_pandas(job_context.pop('rnaseq_matrix'),
-                                                                      npartitions=MULTIPROCESSING_WORKER_COUNT)
-
-            log_state("end merging chunk of frames",
-                      job_context["job"],
-                      start_frame_chunk)
-
-    # convert from dask to pandas dataframe if it is dask
-    if type(job_context['microarray_matrix']) is dd.DataFrame:
-        job_context['microarray_matrix'] = job_context.pop('microarray_matrix').compute()
-    if type(job_context['rnaseq_matrix']) is dd.DataFrame:
-        job_context['rnaseq_matrix'] = job_context.pop('rnaseq_matrix').compute()
-
-    # clean up the pool when we are done
-    worker_pool.close()
-    worker_pool.join()
+        del processed_frame
 
     job_context['num_samples'] = 0
     if job_context['microarray_matrix'] is not None:
@@ -461,7 +377,9 @@ def process_frames_for_key(key: str,
     if job_context['rnaseq_matrix'] is not None:
         job_context['num_samples'] += len(job_context['rnaseq_matrix'].columns)
 
-    log_state("set frames for key {}".format(key), job_context["job"], start_frames)
+    log_state("Built full matrices for key {}".format(key),
+              job_context["job"].id,
+              start_build_matrix)
 
     return job_context
 
@@ -787,7 +705,7 @@ def get_tsv_columns(job_context, samples_metadata):
     Some nested annotation fields are taken out as separate columns
     because they are more important than the others.
     """
-    tsv_start = log_state("start get tsv columns", job_context["job"])
+    tsv_start = log_state("start get tsv columns", job_context["job"].id)
     refinebio_columns = set()
     annotation_columns = set()
     for sample_metadata in samples_metadata.values():
@@ -833,7 +751,7 @@ def get_tsv_columns(job_context, samples_metadata):
     # always first, followed by the other refinebio columns (in alphabetic order), and
     # annotation columns (in alphabetic order) at the end.
     refinebio_columns.discard('refinebio_accession_code')
-    log_state("end get tsv columns", job_context["job"], tsv_start)
+    log_state("end get tsv columns", job_context["job"].id, tsv_start)
     return ['refinebio_accession_code', 'experiment_accession'] + sorted(refinebio_columns) \
         + sorted(annotation_columns)
 
@@ -893,7 +811,7 @@ def write_tsv_json(job_context):
                         progress_template = ('Done with {0} out of {1} lines of metadata '
                                              'for species {2}')
                         log_state(progress_template.format(i, len(metadata['samples']), species),
-                                  job_context['job'])
+                                  job_context['job'].id)
 
             # Writes a json file for current species:
             if len(samples_in_species):


### PR DESCRIPTION
## Issue Number

#1258 

## Purpose/Implementation Notes

So it turns out that maxtasksperchild doesn't work like we thought it did. At least within the context of that parameter-name, `task` means one chunk of work, so really that parameter is specifying how many chunks each Process will do instead of tasks. Turns out that's about `2k/num_cores`....

Anyway this is causing multiprocessing to blow up our RAM usage. I'm looking into ways to use it without having it quintuple our RAM usage, but since we're no longer redownloading samples doing this sequentially should finish in a reasonable amount of time.

I also used the first pass over the data to count how many microarray and rnaseq samples would be found, so that I could actually preallocate the full matrix. This seems to make the `process_frames_for_key` function take a rather flat amount of RAM for the tests: right around .57 GB consistently. This makes me hopeful that we'll see flat RAM usage in prod as well.

## Methods

We're no longer using `concat` or `merge` anywhere in our code and instead we're preallocating the matrix and just directly setting the values. This should work well because we sort the indices on each matrix before doing this.

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

The unit tests look pretty good! I'm excited to see how it does in prod.
