### PR TITLE
Don't remove quantpendia files when running tests

### DIFF
--- a/workers/data_refinery_workers/processors/create_quantpendia.py
+++ b/workers/data_refinery_workers/processors/create_quantpendia.py
@@ -3,6 +3,7 @@ import logging
 import shutil
 import time
 from django.utils import timezone
+from django.conf import settings
 from typing import Dict, List, Tuple
 import psutil
 
@@ -123,6 +124,9 @@ def create_result_objects(job_context: Dict) -> Dict:
 def remove_job_dir(job_context: Dict):
     """ remove the directory when the job is successful. At this point
     the quantpendia was already zipped and uploaded. """
+    # don't remove the files when running locally or for tests
+    if not settings.RUNNING_IN_CLOUD:
+        return
     shutil.rmtree(job_context["job_dir"], ignore_errors=True)
     return job_context
 

--- a/workers/data_refinery_workers/processors/create_quantpendia.py
+++ b/workers/data_refinery_workers/processors/create_quantpendia.py
@@ -115,7 +115,6 @@ def create_result_objects(job_context: Dict) -> Dict:
     archive_computed_file.sync_to_s3(S3_BUCKET_NAME, s3_key)
 
     job_context['result'] = result
-    job_context['computed_files'] = [archive_computed_file]
     job_context['success'] = True
 
     return job_context

--- a/workers/data_refinery_workers/processors/create_quantpendia.py
+++ b/workers/data_refinery_workers/processors/create_quantpendia.py
@@ -125,9 +125,8 @@ def remove_job_dir(job_context: Dict):
     """ remove the directory when the job is successful. At this point
     the quantpendia was already zipped and uploaded. """
     # don't remove the files when running locally or for tests
-    if not settings.RUNNING_IN_CLOUD:
-        return
-    shutil.rmtree(job_context["job_dir"], ignore_errors=True)
+    if settings.RUNNING_IN_CLOUD:
+        shutil.rmtree(job_context["job_dir"], ignore_errors=True)
     return job_context
 
 def make_dirs(job_context: Dict):

--- a/workers/data_refinery_workers/processors/test_create_quantpendia.py
+++ b/workers/data_refinery_workers/processors/test_create_quantpendia.py
@@ -96,3 +96,8 @@ class QuantpendiaTestCase(TransactionTestCase):
         self.assertTrue(final_context['metadata']['quant_sf_only'])
         self.assertEqual(final_context['metadata']['num_samples'], 1)
         self.assertEqual(final_context['metadata']['num_experiments'], 1)
+
+        # test that archive exists
+        quantpendia_file = ComputedFile.objects.filter(is_compendia=True, quant_sf_only=True).latest()
+        self.assertTrue(os.path.exists(quantpendia_file.absolute_file_path))
+


### PR DESCRIPTION
## Issue Number

#1823 
close #1836

## Purpose/Implementation Notes

Quantpendia tests are failing because they check the existence of some files that we remove in prod.

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

None

## Checklist

- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules
