### PR TITLE
Add `ProcessorJobError` to be used when processor jobs fail

### DIFF
--- a/workers/data_refinery_workers/processors/utils.py
+++ b/workers/data_refinery_workers/processors/utils.py
@@ -64,10 +64,7 @@ def prepare_original_files(job_context):
     original_files = job.original_files.all()
 
     if original_files.count() == 0:
-        logger.error("No files found.", processor_job=job.id)
-        job_context["success"] = False
-        job.failure_reason = "No files were found for the job."
-        return job_context
+        raise ProcessorJobError('No files were found for the job.', success=False)
 
     undownloaded_files = set()
     for original_file in original_files:
@@ -95,11 +92,8 @@ def prepare_original_files(job_context):
             force=True
         )
         if not was_job_created:
-            failure_reason = "Missing file for processor job but unable to recreate downloader jobs!"
-            logger.error(failure_reason, processor_job=job.id)
-            job_context["success"] = False
-            job.failure_reason = failure_reason
-            return job_context
+            raise ProcessorJobError('Missing file for processor job but unable to recreate downloader jobs!',
+                                    success=False)
 
         # If we can't process the data because it's not on the disk we
         # can't mark the job as a success since it obviously didn't
@@ -108,9 +102,7 @@ def prepare_original_files(job_context):
         # to re-download the data. Therefore the best option is to
         # delete this job.
         job.delete()
-        job_context["delete_self"] = True
-
-        return job_context
+        raise ProcessorJobDeleteSelf('We can not process the data because it is not on the disk')
 
     job_context["original_files"] = original_files
     first_original_file = original_files.first()
@@ -125,23 +117,15 @@ def prepare_dataset(job_context):
     """ Provision in the Job context for Dataset-driven processors
     """
     job = job_context["job"]
-    relations = ProcessorJobDatasetAssociation.objects.filter(processor_job=job)
+    job_datasets = job.datasets.all()
 
     # This should never be more than one!
-    if relations.count() > 1:
-        failure_reason = "More than one dataset for processor job!"
-        logger.error(failure_reason, processor_job=job.id)
-        job_context["success"] = False
-        job.failure_reason = failure_reason
-        return job_context
-    elif relations.count() == 0:
-        failure_reason = "No datasets found for processor job!"
-        logger.error(failure_reason, processor_job=job.id)
-        job_context["success"] = False
-        job.failure_reason = failure_reason
-        return job_context
+    if job_datasets.count() > 1:
+        raise ProcessorJobError('More than one dataset for processor job!', success=False)
+    elif job_datasets.count() == 0:
+        raise ProcessorJobError('No datasets found for processor job!', success=False)
 
-    dataset = Dataset.objects.get(id=relations[0].dataset_id)
+    dataset = job_datasets.first()
     dataset.is_processing = True
     dataset.save()
 
@@ -373,14 +357,22 @@ def run_pipeline(start_value: Dict, pipeline: List[Callable]):
         return
 
     if len(pipeline) == 0:
-        logger.error("Empty pipeline specified.",
-                     procesor_job=job_id)
+        logger.error("Empty pipeline specified.", procesor_job=job_id)
 
     last_result = start_value
     last_result["job"] = job
     for processor in pipeline:
         try:
             last_result = processor(last_result)
+        except ProcessorJobDeleteSelf as e:
+            logger.info('Processor Job deleted itself.', reason=e.reason, processor_job=job_id)
+            break
+        except ProcessorJobError as e:
+            job.failure_reason = e.failure_reason
+            if e.success is not None:
+                job.succeess = e.success
+            logger.exception(e.failure_reason, processor_job=job.id)
+            return end_job(last_result)
         except Exception as e:
             failure_reason = ("Unhandled exception caught while running processor"
                               " function {} in pipeline: ").format(processor.__name__)
@@ -398,15 +390,26 @@ def run_pipeline(start_value: Dict, pipeline: List[Callable]):
                          failure_reason=last_result["job"].failure_reason)
             return end_job(last_result)
 
-        # We don't want to run end_job at all if the job has deleted
-        # itself, which happens if the data for the job was missing.
-        if last_result.get("delete_self", False):
-            break
-
         if last_result.get("abort", False):
             return end_job(last_result, abort=True)
 
     return last_result
+
+
+class ProcessorJobError(Exception):
+    """ General processor job error class. """
+    def __init__(self, failure_reason, *, success=None, original_exception=None):
+        super(ProcessorJobError, self).__init__(failure_reason)
+        self.failure_reason = failure_reason
+        self.success = success
+        self.original_exception = original_exception
+
+
+class ProcessorJobDeleteSelf(Exception):
+    """ Triggered when a processor job deletes itself. """
+    def __init__(self, reason):
+        super(ProcessorJobDeleteSelf, self).__init__(reason)
+        self.reason = reason
 
 
 def get_os_distro():


### PR DESCRIPTION
## Issue Number

N/A

## Purpose/Implementation Notes

Got this idea to refactor how we handle errors on the processor jobs, instead of using the `job_context['failure_reason']` this uses an exception that is handled in a single place.

What do you think @kurtwheeler?

## Types of changes

- Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Functional tests

None

## Checklist

- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules
