### PR TITLE
Change the float size for the matrices to reduce RAM requirements.

### DIFF
--- a/workers/data_refinery_workers/processors/smashing_utils.py
+++ b/workers/data_refinery_workers/processors/smashing_utils.py
@@ -126,6 +126,7 @@ def _load_and_sanitize_file(computed_file_path, index=None):
                        sep='\t',
                        header=0,
                        index_col=0,
+                       dtype={0: str, 1: np.float32},
                        error_bad_lines=False)
 
     # Strip any funky whitespace
@@ -399,11 +400,11 @@ def process_frames_for_key(key: str,
     job_context['microarray_matrix'] = pd.DataFrame(data=None,
                                                     index=all_gene_identifiers,
                                                     columns=microarray_columns,
-                                                    dtype=np.float64)
+                                                    dtype=np.float32)
     job_context['rnaseq_matrix'] = pd.DataFrame(data=None,
                                                 index=all_gene_identifiers,
                                                 columns=rnaseq_columns,
-                                                dtype=np.float64)
+                                                dtype=np.float32)
 
     for index, (computed_file, sample) in enumerate(input_files):
         frame = process_frame(job_context["work_dir"],


### PR DESCRIPTION
## Issue Number

#1258 

## Purpose/Implementation Notes

We got OOM-killed during the merge step of the two technology specific matrices. It makes sense, because pandas' `merge` function creates a new matrix the size of the other two combined, which is a full 2x. Since we were using more than half the RAM already, it makes sense that doubling up OOM-killed us.

This should drop our RAM usage by almost half across the board, because each value will take half as much data.

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

I printed out the `dtypes` attribute of the `combined_matrix` while running unit tests and it was all:
```
2xudu7weg98dz8j19my00peh_GSM1058035_1gluc1b.PCL                        float32
                                                                        ...   
xefr1rp4v17issz35pzae3cw_ERR015566_output_gene_lengthScaledTPM.tsv     float32
````
Which is what we were looking for!

## Checklist

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules
