### PR TITLE
Keep the cache from the compendia's first pass even if the job fails.

### DIFF
--- a/workers/data_refinery_workers/processors/utils.py
+++ b/workers/data_refinery_workers/processors/utils.py
@@ -319,7 +319,9 @@ def end_job(job_context: Dict, abort=False):
         if len(pipeline.steps):
             pipeline.save()
 
-    if "work_dir" in job_context and settings.RUNNING_IN_CLOUD:
+    if "work_dir" in job_context \
+       and job_context["job"].pipeline_applied != ProcessorPipeline.CREATE_COMPENDIA.value \
+       and settings.RUNNING_IN_CLOUD:
         shutil.rmtree(job_context["work_dir"], ignore_errors=True)
 
     job.success = success


### PR DESCRIPTION
## Issue Number

#1833 

## Purpose/Implementation Notes

When the job failed, `utils.end_job` cleaned up the `work_dir`. This caused the cache and all downloaded files to get blown away. By adding this explicit check we make sure that the compendia jobs will not lose their work dirs in any circumstances.

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

I added `raise MemoryError("woaaaaaaaahhhh")` into the compendia code right before we call the merge. When I then ran the test without this change the work dir got blown away. With this change it stuck around past when the job failed and got wrapped up.

## Checklist

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules
