### PR TITLE
Filter out samples that don't have raw data from the compendia.

### DIFF
--- a/foreman/data_refinery_foreman/foreman/management/commands/create_compendia.py
+++ b/foreman/data_refinery_foreman/foreman/management/commands/create_compendia.py
@@ -21,8 +21,12 @@ def create_job_for_organism(organism=Organism, quant_sf_only=False, svd_algorith
     experiments = Experiment.objects.filter(organisms=organism).prefetch_related('samples')
 
     for experiment in queryset_iterator(experiments):
-        data[experiment.accession_code] = list(experiment.samples.filter(organism=organism)\
-            .values_list('accession_code', flat=True))
+        data[experiment.accession_code] = list(
+            experiment.samples.filter(
+                organism=organism,
+                has_raw=True
+            ).values_list('accession_code', flat=True)
+        )
 
     job = ProcessorJob()
     if quant_sf_only:


### PR DESCRIPTION
## Issue Number

#1855 

## Purpose/Implementation Notes

Our human compendium has almost 600k gene ids. There should only be ~50k of them. This seems to be because some pre-processed samples are making it through our pipelines without being gene converted. Until we can track down every last one of these and fix them, we'll instead just want to make sure that they don't blow up the set of gene identifiers. This accomplishes that by only including in the compendium those samples which we processed from raw data.

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

N/A, the unit tests cover this a bit but it's really rather minor.

## Checklist

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules
