### PR TITLE
dont create  all possible sample combos eagerly for qn verification

### DIFF
--- a/workers/data_refinery_workers/processors/smashing_utils.py
+++ b/workers/data_refinery_workers/processors/smashing_utils.py
@@ -510,7 +510,7 @@ def quantile_normalize(job_context: Dict, ks_check=True, ks_stat=0.001) -> Dict:
                 ar = np.array(combos)
                 np.random.shuffle(np.transpose(ar))
             else:
-                indexes = [*range(ncol(reso))]
+                indexes = [*range(ncolumns[0])]
                 np.random.shuffle(indexes)
                 ar = np.array([*zip(indexes[0:100], indexes[100:200])])
 

--- a/workers/data_refinery_workers/processors/smashing_utils.py
+++ b/workers/data_refinery_workers/processors/smashing_utils.py
@@ -499,11 +499,21 @@ def quantile_normalize(job_context: Dict, ks_check=True, ks_stat=0.001) -> Dict:
         n = ncol(reso)[0]
         m = 2
         if n >= m:
-            combos = combn(ncol(reso), 2)
 
-            # Convert to NP, Shuffle, Return to R
-            ar = np.array(combos)
-            np.random.shuffle(np.transpose(ar))
+            # This wont work with larger matricies
+            # https://github.com/AlexsLemonade/refinebio/issues/1860
+            ncolumns = ncol(reso)
+
+            if ncolumns[0] <= 200:
+                # Convert to NP, Shuffle, Return to R
+                combos = combn(ncolumns, 2)
+                ar = np.array(combos)
+                np.random.shuffle(np.transpose(ar))
+            else:
+                indexes = [*range(ncol(reso))]
+                np.random.shuffle(indexes)
+                ar = np.array([*zip(indexes[0:100], indexes[100:200])])
+
             nr, nc = ar.shape
             combos = ro.r.matrix(ar, nrow=nr, ncol=nc)
 


### PR DESCRIPTION
## Issue Number

#1860 

## Purpose/Implementation Notes

QN normalization verification was crashing because we were creating a lot (read every possible pair) before shuffling and selecting 100 of them. We can improve this by just shuffling the list and creating 200 pairs from that list.

## Methods

Quantile normalization verification.

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

`./workers/run_tests.sh -t qn`

## Checklist

- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules
