### PR TITLE
Add new command to generate the quantpendia

### DIFF
--- a/foreman/data_refinery_foreman/foreman/management/commands/create_compendia.py
+++ b/foreman/data_refinery_foreman/foreman/management/commands/create_compendia.py
@@ -64,12 +64,11 @@ class Command(BaseCommand):
         for it. If not a new job will be dispatched for each organism
         with enough microarray samples except for human and mouse.
         """
-        svd_algorithm = 'ARPACK' # default algorithm to arpack until we decide that ranomized is preferred
+        svd_algorithm = options["svd_algorithm"] or 'ARPACK'
+
         svd_algorithm_choices = ['ARPACK', 'RANDOMIZED', 'NONE']
         if options['svd_algorithm'] and options['svd_algorithm'] not in svd_algorithm_choices:
             raise Exception('Invalid svd_algorithm option provided. Possible values are ' + str(svd_algorithm_choices))
-        else:
-            svd_algorithm = options["svd_algorithm"]
 
         # only include organisms with QN targets. We'll merge groups later.
         all_organisms = Organism.objects.all().filter(qn_target__isnull=False)

--- a/foreman/data_refinery_foreman/foreman/management/commands/create_quantpendia.py
+++ b/foreman/data_refinery_foreman/foreman/management/commands/create_quantpendia.py
@@ -19,8 +19,7 @@ def create_job_for_organism(organism: Organism):
             organisms=organism,
             samples__results__computedfile__filename='quant.sf'
         )\
-        .distinct()\
-        .prefetch_related('samples')
+        .distinct()
 
     for experiment in queryset_iterator(experiments):
         # only include the samples from the target organism that have quant.sf files

--- a/foreman/data_refinery_foreman/foreman/management/commands/create_quantpendia.py
+++ b/foreman/data_refinery_foreman/foreman/management/commands/create_quantpendia.py
@@ -65,9 +65,7 @@ class Command(BaseCommand):
     def handle(self, *args, **options):
         """Create a quantpendia for one or more organisms."""
         all_organisms = Organism.objects.all().filter(qn_target__isnull=False)
-        if options["organisms"] is None:
-            all_organisms = all_organisms.exclude(name__in=["HOMO_SAPIENS", "MUS_MUSCULUS"])
-        else:
+        if options["organisms"] is not None:
             organisms = options["organisms"].upper().replace(" ", "_").split(",")
             all_organisms = all_organisms.filter(name__in=organisms)
 

--- a/foreman/data_refinery_foreman/foreman/management/commands/create_quantpendia.py
+++ b/foreman/data_refinery_foreman/foreman/management/commands/create_quantpendia.py
@@ -1,0 +1,81 @@
+import sys
+
+from django.core.management.base import BaseCommand
+
+from data_refinery_common.job_lookup import ProcessorPipeline
+from data_refinery_common.logging import get_and_configure_logger
+from data_refinery_common.message_queue import send_job
+from data_refinery_common.models import (Dataset, Experiment, Organism,
+                                         ProcessorJob,
+                                         ProcessorJobDatasetAssociation)
+from data_refinery_common.utils import queryset_iterator
+
+logger = get_and_configure_logger(__name__)
+
+def create_job_for_organism(organism: Organism):
+    """Returns a quantpendia job for the provided organism."""
+    data = {}
+    experiments = Experiment.objects.filter(
+            organisms=organism,
+            samples__results__computedfile__filename='quant.sf'
+        )\
+        .distinct()\
+        .prefetch_related('samples')
+
+    for experiment in queryset_iterator(experiments):
+        # only include the samples from the target organism that have quant.sf files
+        samples_with_quantsf = experiment.samples\
+            .filter(
+                organism=organism,
+                results__computedfile__filename='quant.sf'
+            )\
+            .values_list('accession_code', flat=True)\
+            .distinct()
+        data[experiment.accession_code] = list(samples_with_quantsf)
+
+    job = ProcessorJob()
+    job.pipeline_applied = ProcessorPipeline.CREATE_QUANTPENDIA.value
+    job.save()
+
+    dset = Dataset()
+    dset.data = data
+    dset.scale_by = 'NONE'
+    dset.aggregate_by = 'EXPERIMENT'
+    dset.quantile_normalize = False
+    dset.quant_sf_only = True
+    dset.svd_algorithm = 'NONE'
+    dset.save()
+
+    pjda = ProcessorJobDatasetAssociation()
+    pjda.processor_job = job
+    pjda.dataset = dset
+    pjda.save()
+
+    return job
+
+
+class Command(BaseCommand):
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--organisms",
+            type=str,
+            help=("Comma separated list of organism names."))
+
+    def handle(self, *args, **options):
+        """Create a quantpendia for one or more organisms."""
+        all_organisms = Organism.objects.all().filter(qn_target__isnull=False)
+        if options["organisms"] is None:
+            all_organisms = all_organisms.exclude(name__in=["HOMO_SAPIENS", "MUS_MUSCULUS"])
+        else:
+            organisms = options["organisms"].upper().replace(" ", "_").split(",")
+            all_organisms = all_organisms.filter(name__in=organisms)
+
+        logger.debug('Generating quantpendia for organisms', organisms=all_organisms)
+
+        for organism in all_organisms:
+            job = create_job_for_organism(organism)
+            logger.info("Sending compendia job for Organism", job_id=str(job.pk), organism=str(organism))
+            send_job(ProcessorPipeline.CREATE_QUANTPENDIA, job)
+
+        sys.exit(0)

--- a/foreman/data_refinery_foreman/foreman/management/commands/create_quantpendia.py
+++ b/foreman/data_refinery_foreman/foreman/management/commands/create_quantpendia.py
@@ -72,6 +72,14 @@ class Command(BaseCommand):
         logger.debug('Generating quantpendia for organisms', organisms=all_organisms)
 
         for organism in all_organisms:
+            # only generate the quantpendia for organisms that have some samples
+            # with quant.sf files.
+            has_quantsf_files = organism.sample_set\
+                .filter(results__computedfile__filename='quant.sf')\
+                .exists()
+            if not has_quantsf_files:
+                continue
+
             job = create_job_for_organism(organism)
             logger.info("Sending compendia job for Organism", job_id=str(job.pk), organism=str(organism))
             send_job(ProcessorPipeline.CREATE_QUANTPENDIA, job)

--- a/foreman/data_refinery_foreman/foreman/management/commands/create_quantpendia.py
+++ b/foreman/data_refinery_foreman/foreman/management/commands/create_quantpendia.py
@@ -12,6 +12,7 @@ from data_refinery_common.utils import queryset_iterator
 
 logger = get_and_configure_logger(__name__)
 
+
 def create_job_for_organism(organism: Organism):
     """Returns a quantpendia job for the provided organism."""
     data = {}

--- a/foreman/data_refinery_foreman/foreman/management/commands/test_create_compendia.py
+++ b/foreman/data_refinery_foreman/foreman/management/commands/test_create_compendia.py
@@ -1,0 +1,35 @@
+from django.test import TransactionTestCase
+from django.core.management import call_command
+
+from data_refinery_common.models import (ComputationalResult,
+                                         ComputedFile,
+                                         Dataset,
+                                         Experiment,
+                                         ExperimentSampleAssociation,
+                                         Organism,
+                                         ProcessorJob,
+                                         Sample,
+                                         SampleComputedFileAssociation,
+                                         SampleResultAssociation,
+                                         ExperimentOrganismAssociation)
+
+from .test_create_quantpendia import get_organism_with_qn_target, make_test_data
+
+class QuantendiaCommandTestCase(TransactionTestCase):
+    def test_quantpendia_command(self):
+        organism = get_organism_with_qn_target()
+        make_test_data(organism)
+
+        try:
+            call_command('create_compendia', organisms=organism.name)
+        except SystemExit as e:  # this is okay!
+            pass
+
+        processor_job = ProcessorJob.objects\
+            .filter(pipeline_applied='CREATE_COMPENDIA')\
+            .order_by('-created_at')\
+            .first()
+
+        # check that the processor job was created correctly
+        self.assertIsNotNone(processor_job)
+        self.assertEquals(processor_job.datasets.first().data, {'GSE51088': ['GSM1237818']})

--- a/foreman/data_refinery_foreman/foreman/management/commands/test_create_compendia.py
+++ b/foreman/data_refinery_foreman/foreman/management/commands/test_create_compendia.py
@@ -15,8 +15,9 @@ from data_refinery_common.models import (ComputationalResult,
 
 from .test_create_quantpendia import get_organism_with_qn_target, make_test_data
 
-class QuantendiaCommandTestCase(TransactionTestCase):
-    def test_quantpendia_command(self):
+
+class CompendiaCommandTestCase(TransactionTestCase):
+    def test_compendia_command(self):
         organism = get_organism_with_qn_target()
         make_test_data(organism)
 
@@ -33,3 +34,4 @@ class QuantendiaCommandTestCase(TransactionTestCase):
         # check that the processor job was created correctly
         self.assertIsNotNone(processor_job)
         self.assertEquals(processor_job.datasets.first().data, {'GSE51088': ['GSM1237818']})
+

--- a/foreman/data_refinery_foreman/foreman/management/commands/test_create_quantpendia.py
+++ b/foreman/data_refinery_foreman/foreman/management/commands/test_create_quantpendia.py
@@ -1,8 +1,6 @@
 from django.test import TransactionTestCase
-from django.utils import timezone
 from django.core.management import call_command
 
-from data_refinery_common.job_lookup import ProcessorPipeline
 from data_refinery_common.models import (ComputationalResult,
                                          ComputedFile,
                                          Dataset,
@@ -10,23 +8,18 @@ from data_refinery_common.models import (ComputationalResult,
                                          ExperimentSampleAssociation,
                                          Organism,
                                          ProcessorJob,
-                                         ProcessorJobDatasetAssociation,
                                          Sample,
                                          SampleComputedFileAssociation,
                                          SampleResultAssociation,
                                          ExperimentOrganismAssociation)
-from data_refinery_foreman.surveyor.test_end_to_end import wait_for_job
 
-from .create_compendia import create_job_for_organism
-
-
-class CompendiaCommandTestCase(TransactionTestCase):
+class QuantendiaCommandTestCase(TransactionTestCase):
     def test_quantpendia_command(self):
         organism = self.get_organism_with_qn_target()
         self.make_test_data(organism)
 
         try:
-            call_command('create_compendia', organisms=organism.name, quant_sf_only=True)
+            call_command('create_quantpendia', organisms=organism.name)
         except SystemExit as e:  # this is okay!
             pass
 

--- a/foreman/data_refinery_foreman/foreman/management/commands/test_create_quantpendia.py
+++ b/foreman/data_refinery_foreman/foreman/management/commands/test_create_quantpendia.py
@@ -15,8 +15,8 @@ from data_refinery_common.models import (ComputationalResult,
 
 class QuantendiaCommandTestCase(TransactionTestCase):
     def test_quantpendia_command(self):
-        organism = self.get_organism_with_qn_target()
-        self.make_test_data(organism)
+        organism = get_organism_with_qn_target()
+        make_test_data(organism)
 
         try:
             call_command('create_quantpendia', organisms=organism.name)
@@ -32,71 +32,71 @@ class QuantendiaCommandTestCase(TransactionTestCase):
         self.assertIsNotNone(processor_job)
         self.assertEquals(processor_job.datasets.first().data, {'GSE51088': ['GSM1237818']})
 
-    def get_organism_with_qn_target(self):
-        result = ComputationalResult()
-        result.save()
+def get_organism_with_qn_target():
+    result = ComputationalResult()
+    result.save()
 
-        qn_target = ComputedFile()
-        qn_target.filename = "danio_target.tsv"
-        qn_target.absolute_file_path = '/home/user/data_store/QN/danio_target.tsv'
-        qn_target.is_qn_target = True
-        qn_target.size_in_bytes = "12345"
-        qn_target.sha1 = "aabbccddeeff"
-        qn_target.result = result
-        qn_target.save()
+    qn_target = ComputedFile()
+    qn_target.filename = "danio_target.tsv"
+    qn_target.absolute_file_path = '/home/user/data_store/QN/danio_target.tsv'
+    qn_target.is_qn_target = True
+    qn_target.size_in_bytes = "12345"
+    qn_target.sha1 = "aabbccddeeff"
+    qn_target.result = result
+    qn_target.save()
 
-        danio_rerio = Organism(name="DANIO_RERIO", taxonomy_id=1, qn_target=result)
-        danio_rerio.save()
-        return danio_rerio
+    danio_rerio = Organism(name="DANIO_RERIO", taxonomy_id=1, qn_target=result)
+    danio_rerio.save()
+    return danio_rerio
 
-    def make_test_data(self, organism):
-        experiment = Experiment()
-        experiment.accession_code = "GSE51088"
-        experiment.save()
+def make_test_data(organism):
+    experiment = Experiment()
+    experiment.accession_code = "GSE51088"
+    experiment.save()
 
-        xoa = ExperimentOrganismAssociation()
-        xoa.experiment=experiment
-        xoa.organism=organism
-        xoa.save()
+    xoa = ExperimentOrganismAssociation()
+    xoa.experiment=experiment
+    xoa.organism=organism
+    xoa.save()
 
-        result = ComputationalResult()
-        result.save()
+    result = ComputationalResult()
+    result.save()
 
-        sample = Sample()
-        sample.accession_code = 'GSM1237818'
-        sample.title = 'GSM1237818'
-        sample.organism = organism
-        sample.save()
+    sample = Sample()
+    sample.accession_code = 'GSM1237818'
+    sample.title = 'GSM1237818'
+    sample.organism = organism
+    sample.save()
 
-        sra = SampleResultAssociation()
-        sra.sample = sample
-        sra.result = result
-        sra.save()
+    sra = SampleResultAssociation()
+    sra.sample = sample
+    sra.result = result
+    sra.save()
 
-        esa = ExperimentSampleAssociation()
-        esa.experiment = experiment
-        esa.sample = sample
-        esa.save()
+    esa = ExperimentSampleAssociation()
+    esa.experiment = experiment
+    esa.sample = sample
+    esa.save()
 
-        computed_file = ComputedFile()
-        computed_file.s3_key = "smasher-test-quant.sf"
-        computed_file.s3_bucket = "data-refinery-test-assets"
-        computed_file.filename = "quant.sf"
-        computed_file.absolute_file_path = "/home/user/data_store/QUANT/smasher-test-quant.sf"
-        computed_file.result = result
-        computed_file.is_smashable = True
-        computed_file.size_in_bytes = 123123
-        computed_file.sha1 = "08c7ea90b66b52f7cd9d9a569717a1f5f3874967" # this matches with the downloaded file
-        computed_file.save()
+    computed_file = ComputedFile()
+    computed_file.s3_key = "smasher-test-quant.sf"
+    computed_file.s3_bucket = "data-refinery-test-assets"
+    computed_file.filename = "quant.sf"
+    computed_file.absolute_file_path = "/home/user/data_store/QUANT/smasher-test-quant.sf"
+    computed_file.result = result
+    computed_file.is_smashable = True
+    computed_file.size_in_bytes = 123123
+    computed_file.sha1 = "08c7ea90b66b52f7cd9d9a569717a1f5f3874967" # this matches with the downloaded file
+    computed_file.save()
 
-        computed_file = ComputedFile()
-        computed_file.filename = "logquant.tsv"
-        computed_file.is_smashable = True
-        computed_file.size_in_bytes = 123123
-        computed_file.result = result
-        computed_file.save()
+    computed_file = ComputedFile()
+    computed_file.filename = "logquant.tsv"
+    computed_file.is_smashable = True
+    computed_file.size_in_bytes = 123123
+    computed_file.result = result
+    computed_file.save()
 
-        assoc = SampleComputedFileAssociation()
-        assoc.sample = sample
-        assoc.computed_file = computed_file
-        assoc.save()
+    assoc = SampleComputedFileAssociation()
+    assoc.sample = sample
+    assoc.computed_file = computed_file
+    assoc.save()

--- a/workers/data_refinery_workers/processors/create_quantpendia.py
+++ b/workers/data_refinery_workers/processors/create_quantpendia.py
@@ -85,9 +85,18 @@ def create_result_objects(job_context: Dict) -> Dict:
     compendia_organism = _get_organisms(job_context['samples']).first()
 
     # Create the resulting archive
+    logger.debug("Writing metadata for quantpendia.",
+                 job_id=job_context['job_id'],
+                 organism_name=compendia_organism.name,
+                 **get_process_stats())
     smashing_utils.write_non_data_files(job_context)
     final_zip_base = job_context['job_dir'] + compendia_organism.name + "_rnaseq_compendia"
     shutil.copy("/home/user/README_QUANT.md", job_context["output_dir"] + "/README.md")
+
+    logger.debug("Finished metadata for quantpendia. Generating archive.",
+                 job_id=job_context['job_id'],
+                 organism_name=compendia_organism.name,
+                 **get_process_stats())
 
     archive_path = shutil.make_archive(final_zip_base, 'zip', job_context["output_dir"])
     compendia_version = _get_next_compendia_version(compendia_organism)
@@ -107,9 +116,11 @@ def create_result_objects(job_context: Dict) -> Dict:
     archive_computed_file.compendia_version = compendia_version
     archive_computed_file.save()
 
-    logger.info("Quantpendia created!",
+    logger.info("Quantpendia created! Uploading to S3.",
+                job_id=job_context['job_id'],
                 archive_path=archive_path,
-                organism_name=compendia_organism.name)
+                organism_name=compendia_organism.name,
+                **get_process_stats())
 
     # Upload the result to S3
     timestamp = str(int(time.time()))


### PR DESCRIPTION
## Issue Number

#1823 

## Purpose/Implementation Notes

https://github.com/AlexsLemonade/refinebio/issues/1823#issuecomment-549988470 the quantpendia job failed while it was generating the metadata, after downloading all `quant.sf` files. Upon further investigation, it looks like `json.dump` takes a lot of memory when writing large objects to a file.

I noticed, we were sending all `364334` human experiments to the job, while we only have `6316` with QN-Targets.

This creates a new quantpendia command, to generate a dataset that only includes experiments and samples with `quant.sf` files. This will make the metadata object considerably smaller.

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

Added tests

## Checklist

- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules
