### PR TITLE
Refactor foreman and use managers to get failed/hung/lost jobs

### DIFF
--- a/common/data_refinery_common/models/jobs.py
+++ b/common/data_refinery_common/models/jobs.py
@@ -9,11 +9,54 @@ from data_refinery_common.models.models import Sample, Experiment, OriginalFile
 from data_refinery_common.utils import get_env_variable
 
 
+class FailedJobsManager(models.Manager):
+    """
+    Only returns Failed Jobs
+    """
+    def get_queryset(self):
+        return super().get_queryset().filter(success=False, retried=False, no_retry=False)
+
+
+class HungJobsManager(models.Manager):
+    """
+    Only returns jobs that are potentially hung
+    """
+    def get_queryset(self):
+        return super().get_queryset().filter(
+            success=None,
+            retried=False,
+            no_retry=False,
+            start_time__isnull=False,
+            end_time=None,
+            nomad_job_id__isnull=False
+        )
+
+
+class LostJobsManager(models.Manager):
+    """
+    Only returns lost jobs
+    """
+    def get_queryset(self):
+        return super().get_queryset().filter(
+            success=None,
+            retried=False,
+            no_retry=False,
+            start_time=None,
+            end_time=None,
+        )
+
+
 class SurveyJob(models.Model):
     """Records information about a Surveyor Job."""
 
     class Meta:
         db_table = "survey_jobs"
+
+    # Managers
+    objects = models.Manager()
+    failed_objects = FailedJobsManager()
+    hung_objects = HungJobsManager()
+    lost_objects = LostJobsManager()
 
     source_type = models.CharField(max_length=256)
     success = models.NullBooleanField(null=True)
@@ -115,6 +158,12 @@ class ProcessorJob(models.Model):
             ),
         ]
 
+    # Managers
+    objects = models.Manager()
+    failed_objects = FailedJobsManager()
+    hung_objects = HungJobsManager()
+    lost_objects = LostJobsManager()
+
     # This field will contain an enumerated value specifying which
     # processor pipeline was applied during the processor job.
     pipeline_applied = models.CharField(max_length=256)
@@ -207,6 +256,12 @@ class DownloaderJob(models.Model):
             ),
             models.Index(fields=['worker_id']),
         ]
+
+    # Managers
+    objects = models.Manager()
+    failed_objects = FailedJobsManager()
+    hung_objects = HungJobsManager()
+    lost_objects = LostJobsManager()
 
     # This field contains a string which corresponds to a valid
     # Downloader Task. Valid values are enumerated in:


### PR DESCRIPTION
## Issue Number

N/A

## Purpose/Implementation Notes

Adds several managers to the Jobs objects to get the ones that are failed, hung or lost.

## Types of changes

- Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Functional tests

none

## Checklist

- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules
