### PR TITLE
Try AmazonEC2SpotFleetTaggingRole instead of AmazonEC2SpotFleetRole.

### DIFF
--- a/infrastructure/permissions.tf
+++ b/infrastructure/permissions.tf
@@ -46,7 +46,7 @@ EOF
 resource "aws_iam_policy_attachment" "fleet_role" {
   name       = "EC2SpotFleetRole"
   roles      = ["${aws_iam_role.data_refinery_spot_fleet.name}"]
-  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonEC2SpotFleetRole"
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonEC2SpotFleetTaggingRole"
 }
 
 resource "aws_iam_instance_profile" "data_refinery_instance_profile" {


### PR DESCRIPTION
## Issue Number

#1879 

## Purpose/Implementation Notes

Looks like the policy has changed names or something? Let's try this since the deploy isn't working anyway.
