### PR TITLE
Only use gene identifiers that are present in >50% of the samples.

### DIFF
--- a/workers/data_refinery_workers/processors/create_compendia.py
+++ b/workers/data_refinery_workers/processors/create_compendia.py
@@ -150,6 +150,10 @@ def _perform_imputation(job_context: Dict) -> Dict:
     # We potentially can have a microarray-only compendia but not a RNASeq-only compendia
     log2_rnaseq_matrix = None
     if job_context['rnaseq_matrix'] is not None:
+        # Drop any genes that are entirely NULL in the RNA-Seq matrix
+        job_context['rnaseq_matrix'] = job_context['rnaseq_matrix'].dropna(axis='columns',
+                                                                           how='all')
+
         # Calculate the sum of the lengthScaledTPM values for each row
         # (gene) of the rnaseq_matrix (rnaseq_row_sums)
         rnaseq_row_sums = np.sum(job_context['rnaseq_matrix'], axis=1)
@@ -207,8 +211,11 @@ def _perform_imputation(job_context: Dict) -> Dict:
     # Perform a full outer join of microarray_matrix and
     # log2_rnaseq_matrix; combined_matrix
     if log2_rnaseq_matrix is not None:
+        # Use how='right' because we've filtered some gene identifiers
+        # out of the the rnaseq_matrix and we want to keep those
+        # filtered out of the full matrix.
         combined_matrix = job_context.pop('microarray_matrix').merge(log2_rnaseq_matrix,
-                                                                     how='outer',
+                                                                     how='right',
                                                                      left_index=True,
                                                                      right_index=True)
     else:

--- a/workers/data_refinery_workers/processors/create_compendia.py
+++ b/workers/data_refinery_workers/processors/create_compendia.py
@@ -211,11 +211,8 @@ def _perform_imputation(job_context: Dict) -> Dict:
     # Perform a full outer join of microarray_matrix and
     # log2_rnaseq_matrix; combined_matrix
     if log2_rnaseq_matrix is not None:
-        # Use how='right' because we've filtered some gene identifiers
-        # out of the the rnaseq_matrix and we want to keep those
-        # filtered out of the full matrix.
         combined_matrix = job_context.pop('microarray_matrix').merge(log2_rnaseq_matrix,
-                                                                     how='right',
+                                                                     how='outer',
                                                                      left_index=True,
                                                                      right_index=True)
     else:

--- a/workers/data_refinery_workers/processors/smashing_utils.py
+++ b/workers/data_refinery_workers/processors/smashing_utils.py
@@ -362,9 +362,9 @@ def process_frames_for_key(key: str,
             if not frame['unsmashable']:
                 for gene_id in frame['dataframe'].index:
                     if gene_id in gene_identifier_counts:
-                        gene_identifier_counts[gene_id] = 1
-                    else:
                         gene_identifier_counts[gene_id] += 1
+                    else:
+                        gene_identifier_counts[gene_id] = 1
 
                 # Each dataframe should only have 1 column, but it's
                 # returned as a list so use extend.
@@ -377,8 +377,12 @@ def process_frames_for_key(key: str,
         all_gene_identifiers = []
         for gene_id, sample_count in gene_identifier_counts.items():
             # We only want to use gene identifiers which are present
-            # in >50% of the samples.
-            if sample_count > total_samples / 2:
+            # in >50% of the samples. We're doing this because a large
+            # number of gene identifiers present in only a modest
+            # number of experiments have leaked through. We wouldn't
+            # necessarily want to do this if we'd mapped all the data
+            # to ENSEMBL identifiers successfully.
+            if sample_count > (total_samples * 0.5):
                 all_gene_identifiers.append(gene_id)
 
         all_gene_identifiers.sort()


### PR DESCRIPTION
## Issue Number

https://github.com/AlexsLemonade/refinebio/issues/1882

## Purpose/Implementation Notes

This implements the second solution suggested in #1882:

> Another idea (probably more flexible/preferable) -> Since we're now doing two passes over the data, in the first pass don't create a set of all identifiers. Instead, create a dictionary. The keys would be the identifiers. The values would be number of samples in which that key was observed. We'd also store the number of samples processed.

> Then, after the first pass we'd only retain those identifiers that are in >= 50% of the samples. This should leave somewhat more identifiers than we remove here:
https://github.com/AlexsLemonade/refinebio/blob/dev/workers/data_refinery_workers/processors/create_compendia.py#L230
because it both filters to a lower threshold and also because we drop certain genes from the RNA-seq step if they are very lowly expressed:
https://github.com/AlexsLemonade/refinebio/blob/dev/workers/data_refinery_workers/processors/create_compendia.py#L170

We will have to make sure we blow away our cache so we make a new one rather than resuing the existing cache.

## Types of changes

- New feature (non-breaking change which adds functionality)

## Functional tests

Unit tests.
