### PR TITLE
AWS lied to us about the size of the instance they sold us.

### DIFF
--- a/workers/nomad-job-specs/create_compendia.nomad.tpl
+++ b/workers/nomad-job-specs/create_compendia.nomad.tpl
@@ -70,7 +70,7 @@ job "CREATE_COMPENDIA" {
         # CPU is in AWS's CPU units.
         cpu =   4000
         # Memory is in MB of RAM. Instance has 384GiB of RAM.
-        memory = 380000
+        memory = 350000
       }
 
       logs {


### PR DESCRIPTION
## Issue Number

350 GB should be enough, I was just gonna use as much as they said they were going to give us.