### PR TITLE
Filter running nomad jobs on endpoints

### DIFF
--- a/api/data_refinery_api/views.py
+++ b/api/data_refinery_api/views.py
@@ -871,8 +871,8 @@ class DownloaderJobList(generics.ListAPIView):
 
         nomad = self.request.query_params.get('nomad', None)
         if nomad:
-            nomad_jobs_ids = [job['ID'] for job in get_nomad_jobs()]
-            queryset = queryset.filter(nomad_job_id__in=nomad_jobs_ids)
+            running_nomad_jobs_ids = [job['ID'] for job in get_nomad_jobs() if job['Status'] == 'running']
+            queryset = queryset.filter(nomad_job_id__in=running_nomad_jobs_ids)
 
         return queryset
 
@@ -906,8 +906,8 @@ class ProcessorJobList(generics.ListAPIView):
 
         nomad = self.request.query_params.get('nomad', None)
         if nomad:
-            nomad_jobs_ids = [job['ID'] for job in get_nomad_jobs()]
-            queryset = queryset.filter(nomad_job_id__in=nomad_jobs_ids)
+            running_nomad_jobs_ids = [job['ID'] for job in get_nomad_jobs() if job['Status'] == 'running']
+            queryset = queryset.filter(nomad_job_id__in=running_nomad_jobs_ids)
 
         return queryset
 


### PR DESCRIPTION
## Issue Number

N/A

## Purpose/Implementation Notes

The `/jobs` endpoint has a parameter `?nomad` to return the jobs that are currently running. 

This adds a check to ensure the jobs are actually running.

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

None

## Checklist

- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules
