### PR TITLE
Let quantpendia run on the smasher instance

### DIFF
--- a/workers/nomad-job-specs/create_quantpendia.nomad.tpl
+++ b/workers/nomad-job-specs/create_quantpendia.nomad.tpl
@@ -69,7 +69,7 @@ job "CREATE_QUANTPENDIA" {
       resources {
         # CPU is in AWS's CPU units.
         cpu =   4000
-        memory = 65536
+        memory = 64000
       }
 
       logs {

--- a/workers/nomad-job-specs/create_quantpendia.nomad.tpl
+++ b/workers/nomad-job-specs/create_quantpendia.nomad.tpl
@@ -69,7 +69,7 @@ job "CREATE_QUANTPENDIA" {
       resources {
         # CPU is in AWS's CPU units.
         cpu =   4000
-        memory = 32768
+        memory = 65536
       }
 
       logs {
@@ -77,11 +77,7 @@ job "CREATE_QUANTPENDIA" {
         max_file_size = 1
       }
 
-      constraint {
-        attribute = "${meta.is_smasher}"
-        operator = "!="
-        value = "true"
-      }
+      ${{SMASHER_CONSTRAINT}}
 
       config {
         image = "${{DOCKERHUB_REPO}}/${{COMPENDIA_DOCKER_IMAGE}}"


### PR DESCRIPTION
## Issue Number

N/A

## Purpose/Implementation Notes

- Let quantpendia run on smasher
- Increase quantpendia RAM to 64gb

## Types of changes

- Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Functional tests

None

## Checklist

- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules
