### PR TITLE
Only include processed samples when building compendia dataset

### DIFF
--- a/foreman/data_refinery_foreman/foreman/management/commands/create_compendia.py
+++ b/foreman/data_refinery_foreman/foreman/management/commands/create_compendia.py
@@ -148,8 +148,11 @@ def get_dataset(organisms: List[Organism]):
     experiments = Experiment.objects.filter(filter_query).prefetch_related('samples')
 
     for experiment in queryset_iterator(experiments):
-        dataset[experiment.accession_code] = list(experiment.samples.filter(organism__in=organisms)
-                                                  .values_list('accession_code', flat=True))
+        experiment_samples = experiment.samples\
+            .filter(organism__in=organisms, is_processed=True)\
+            .values_list('accession_code', flat=True)
+
+        dataset[experiment.accession_code] = list(experiment_samples)
 
     return dataset
 


### PR DESCRIPTION
## Issue Number

N/A

## Purpose/Implementation Notes

Quick pr to avoid including unprocessed samples in the compendia dataset