### PR TITLE
Take smasher from 512 GB to 256.

### DIFF
--- a/infrastructure/variables.tf
+++ b/infrastructure/variables.tf
@@ -121,7 +121,7 @@ variable "client_instance_type" {
 
 variable "smasher_instance_type" {
   # 512GiB Memory, smasher jobs need 28, compendia jobs use 64.
-  default = "r5.16xlarge"
+  default = "m5.16xlarge"
 }
 
 variable "spot_price" {


### PR DESCRIPTION
## Issue Number

#1258 

## Purpose/Implementation Notes

We're only going to run quantpendia tonight, so we only need half as much RAM.
