### PR TITLE
correct compenium version based on computational result created at date

### DIFF
--- a/api/data_refinery_api/views.py
+++ b/api/data_refinery_api/views.py
@@ -1254,7 +1254,7 @@ class CompendiumResultList(generics.ListAPIView):
     filter_backends = (DjangoFilterBackend, filters.OrderingFilter,)
     filterset_fields = ['primary_organism__name', 'compendium_version', 'quant_sf_only']
     ordering_fields = ('primary_organism__name', 'compendium_version', 'id')
-    ordering = ('-primary_organism__name',)
+    ordering = ('primary_organism__name',)
 
     def get_queryset(self):
         public_result_queryset = CompendiumResult.objects.filter(result__is_public=True)
@@ -1262,9 +1262,9 @@ class CompendiumResultList(generics.ListAPIView):
         if latest_version:
             version_filter = Q(primary_organism=OuterRef('primary_organism'),
                                quant_sf_only=OuterRef('quant_sf_only'))
-            latest_version = CompendiumResult.objects.filter(version_filter)\
-                                                     .order_by('-compendium_version')\
-                                                     .values('compendium_version')
+            latest_version = public_result_queryset.filter(version_filter)\
+                                                   .order_by('-compendium_version')\
+                                                   .values('compendium_version')
             return public_result_queryset.annotate(
                 latest_version=Subquery(latest_version[:1])
             ).filter(compendium_version=F('latest_version'))

--- a/common/data_refinery_common/migrations/0046_compendium_version_number.py
+++ b/common/data_refinery_common/migrations/0046_compendium_version_number.py
@@ -1,0 +1,33 @@
+from django.db import migrations, models
+from django.db.models import F, Window
+from django.db.models.functions import RowNumber
+
+def compendium_version_number_fix(apps, schema_editor):
+    """ Fetch existing compendia and fix their version_number."""
+    CompendiumResult = apps.get_model('data_refinery_common', 'CompendiumResult')
+
+    # normalized compendia
+    # get each compendium against primary key sorted by created data
+    compendium_results = CompendiumResult.objects.filter(quant_sf_only=False)\
+                                                 .annotate(version_number=Window(
+                                                     expression=RowNumber(),
+                                                     partition_by=[F('primary_organism')],
+                                                     order_by=[F('result__created_at')]
+                                                 ))
+
+    for compendium_result in compendium_results:
+        # generate the version
+        if compendium_result.version_number is not 1:
+            compendium_result.compendium_version = compendium_result.version_number
+            compedium_result.save()
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('data_refinery_common', '0045_svd_algorithm'),
+    ]
+
+    operations = [
+        migrations.RunPython(compendium_version_number_fix),
+    ]

--- a/common/data_refinery_common/migrations/0046_compendium_version_number.py
+++ b/common/data_refinery_common/migrations/0046_compendium_version_number.py
@@ -7,7 +7,7 @@ def compendium_version_number_fix(apps, schema_editor):
     CompendiumResult = apps.get_model('data_refinery_common', 'CompendiumResult')
 
     # normalized compendia
-    # get each compendium against primary key sorted by created data
+    # get each compendium against primary key sorted by created date
     compendium_results = CompendiumResult.objects.filter(quant_sf_only=False)\
                                                  .annotate(version_number=Window(
                                                      expression=RowNumber(),
@@ -16,7 +16,7 @@ def compendium_version_number_fix(apps, schema_editor):
                                                  ))
 
     for compendium_result in compendium_results:
-        # generate the version
+        # assign the correct version if greater than 1
         if compendium_result.version_number is not 1:
             compendium_result.compendium_version = compendium_result.version_number
             compedium_result.save()

--- a/common/data_refinery_common/models/models.py
+++ b/common/data_refinery_common/models/models.py
@@ -649,8 +649,7 @@ class CompendiumResult(models.Model):
     #helper
     def get_computed_file(self):
         """ Short hand method for getting the computed file for this compendium"""
-        return ComputedFile.objects.filter(result=self.result,
-                                           is_compendia=True).first()
+        return ComputedFile.objects.filter(result=self.result).first()
 
 
 # TODO


### PR DESCRIPTION
## Issue Number

#1829 

## Purpose/Implementation Notes

This PR adds a migration that takes all `compendia_results` that are normalized comependia (quant_sf_only=False) and assigns a `compendium_version` based on its row number when grouped by `primary_organism` and sorted by its `computational_result`'s `created_at` date.

This PR also: (sorry)
 - prevents compendia from not showing up when `/compendia?latest_version=True`
 - fixes the reverse alphabetical order of the `/compendia` endpoint
 - removes the check on compendium_resuls.get_computed_file for is_compendia since it is no longer being set!

## Methods

None / API / Model / Common Migration

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

I've run the query on production and the migration locally.

## Checklist

- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots

Please attach any screenshots that illustrate these changes.
