### PR TITLE
create migration to remove extra computed_files

### DIFF
--- a/common/data_refinery_common/migrations/0047_clean_compendia_files.py
+++ b/common/data_refinery_common/migrations/0047_clean_compendia_files.py
@@ -10,7 +10,7 @@ def clean_compendium_files(apps, schema_editor):
     # normalized compendia
     compendium_results = CompendiumResult.objects.annotate(file_count=Count('result__computedfile'))\
                                                  .filter(quant_sf_only=False,
-                                                             file_count__gt=1)\
+                                                         file_count__gt=1)\
                                                  .values('result_id')
 
     ComputedFile.objects.filter(result_id__in=compendium_results)\

--- a/common/data_refinery_common/migrations/0047_clean_compendia_files.py
+++ b/common/data_refinery_common/migrations/0047_clean_compendia_files.py
@@ -1,0 +1,29 @@
+from django.db import migrations, models
+from django.db.models import F, Count
+
+def clean_compendium_files(apps, schema_editor):
+    """ We used to have more than one computed file for a compendium
+    Now we just want to keep the zipped file that lives on s3."""
+    CompendiumResult = apps.get_model('data_refinery_common', 'CompendiumResult')
+    ComputedFile = apps.get_model('data_refinery_common', 'ComputedFile')
+
+    # normalized compendia
+    compendium_results = CompendiumResult.objects.annotate(file_count=Count('result__computedfile'))\
+                                                     .filter(quant_sf_only=False,
+                                                             file_count__gt=1)\
+                                                     .values('result_id')
+
+    ComputedFile.objects.filter(result_id__in=compendium_results)\
+                        .filter(is_compendia=False)\
+                        .delete()
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('data_refinery_common', '0046_compendium_version_number'),
+    ]
+
+    operations = [
+        migrations.RunPython(clean_compendium_files),
+    ]

--- a/common/data_refinery_common/migrations/0047_clean_compendia_files.py
+++ b/common/data_refinery_common/migrations/0047_clean_compendia_files.py
@@ -9,9 +9,9 @@ def clean_compendium_files(apps, schema_editor):
 
     # normalized compendia
     compendium_results = CompendiumResult.objects.annotate(file_count=Count('result__computedfile'))\
-                                                     .filter(quant_sf_only=False,
+                                                 .filter(quant_sf_only=False,
                                                              file_count__gt=1)\
-                                                     .values('result_id')
+                                                 .values('result_id')
 
     ComputedFile.objects.filter(result_id__in=compendium_results)\
                         .filter(is_compendia=False)\


### PR DESCRIPTION
## Issue Number

#1849 

## Purpose/Implementation Notes

We are moving away from using the attribute `is_compendia` on a `computed_file` so part of moving away from that is to stop saving the other files generated during the `create_compendia` process.. We were saving a tsv and an annotations file to the DB but not persisting to S3. 

This PR includes a migration that selects all normalized compendia where there are more than 1 associated computed files and deletes the files where `is_compendia=False`

## Methods

None.

## Types of changes

- Breaking change (fix or feature that would cause existing functionality to not work as expected)
Not really breaking though.

## Functional tests

I ran the migration locally but also want to try it on staging first!

## Checklist

- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots

Please attach any screenshots that illustrate these changes.
