### PR TITLE
Don't use samples with NULL values in QN targets.

### DIFF
--- a/workers/data_refinery_workers/processors/qn_reference.py
+++ b/workers/data_refinery_workers/processors/qn_reference.py
@@ -72,8 +72,7 @@ def _build_qn_target(job_context: Dict) -> Dict:
             logger.warn("No file loaded for input file",
                         exc_info=1,
                         bad_file=file,
-                        num_valid_inputs_so_far=num_valid_inputs
-            )
+                        num_valid_inputs_so_far=num_valid_inputs)
             continue
 
         # If this input doesn't have the same geneset, we don't want it!
@@ -83,8 +82,18 @@ def _build_qn_target(job_context: Dict) -> Dict:
                         target_geneset_len=len(geneset),
                         bad_geneset_len=len(input_frame.index.values),
                         geneset_difference=list(geneset ^ set(input_frame.index.values))[:3],
-                        num_valid_inputs_so_far=num_valid_inputs
-            )
+                        num_valid_inputs_so_far=num_valid_inputs)
+            continue
+
+        # We don't want to build QNs that have Nulls in them, so
+        # filter out any samples that still have null genes at this
+        # point.
+        num_nulls = input_frame.isnull().sum(axis=0)[0]
+        if num_nulls != 0:
+            logger.warn("Input frame contains NA values, skipping!",
+                        bad_file=file,
+                        number_of_NAs=num_nulls,
+                        num_valid_inputs_so_far=num_valid_inputs)
             continue
 
         # Sort the input


### PR DESCRIPTION
## Issue Number

Our human QN target is mostly NULL values. This makes a lot of things bad.

## Purpose/Implementation Notes

This will prevent QN targets from being made like this in the future, because any samples that have any NULL values will not be used for the QN target.

## Methods

These methods were discussed in advance with @jaclyn-taroni and @cgreene 

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

We probably should get some better unit tests for this, but for now let's get this out so we can fix this big bug.

## Checklist

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules
