### PR TITLE
Fix compendia test, we were filtering out unprocessed samples

### DIFF
--- a/foreman/data_refinery_foreman/foreman/management/commands/test_create_quantpendia.py
+++ b/foreman/data_refinery_foreman/foreman/management/commands/test_create_quantpendia.py
@@ -68,6 +68,7 @@ def make_test_data(organism):
     sample.title = 'GSM1237818'
     sample.organism = organism
     sample.technology = 'RNA-SEQ'
+    sample.is_processed = True
     sample.save()
 
     sra = SampleResultAssociation()


### PR DESCRIPTION
## Issue Number

N/A

## Purpose/Implementation Notes

Fixes the compendia test that is failing in `dev`

```
======================================================================
FAIL: test_compendia_command (data_refinery_foreman.foreman.management.commands.test_create_compendia.CompendiaCommandTestCase)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/user/data_refinery_foreman/foreman/management/commands/test_create_compendia.py", line 36, in test_compendia_command
    self.assertEquals(processor_job.datasets.first().data, {'GSE51088': ['GSM1237818']})
AssertionError: {'GSE51088': []} != {'GSE51088': ['GSM1237818']}
- {'GSE51088': []}
+ {'GSE51088': ['GSM1237818']}
```

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

Ran test locally

## Checklist

- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules
