### PR TITLE
disable api server side cursors

### DIFF
--- a/api/data_refinery_api/settings.py
+++ b/api/data_refinery_api/settings.py
@@ -178,6 +178,11 @@ CACHES = {
 }
 
 
+# Server Side Databse Cursors
+# https://code.djangoproject.com/ticket/28062
+
+ENABLE_SERVER_SIDE_CURSORS = False
+
 ##
 # Django Rest Framework
 ##


### PR DESCRIPTION
## Issue Number

#1562 

## Purpose/Implementation Notes

This PR disables the api server side cursors. I just want to see if this will fix issue 1562, I was able to run API locally with this setting off.

