### PR TITLE
Fix checking the return value of process_frames.

### DIFF
--- a/workers/data_refinery_workers/processors/smashing_utils.py
+++ b/workers/data_refinery_workers/processors/smashing_utils.py
@@ -372,11 +372,12 @@ def process_frames_for_key(key: str,
                                    computed_file,
                                    sample.accession_code,
                                    job_context['dataset'].aggregate_by)
-        frame_data = frame_data.reindex(all_gene_identifiers)
 
         if frame_data is None:
             job_context['unsmashable_files'].append(computed_file.filename)
             continue
+        else:
+            frame_data = frame_data.reindex(all_gene_identifiers)
 
         # The dataframe for each sample will only have one column
         # whose header will be the accession code.


### PR DESCRIPTION
## Issue Number

https://github.com/AlexsLemonade/refinebio/pull/1952

## Purpose/Implementation Notes

We refactored _process_frame to sometimes return None and we didn't check its output everywhere we used it. This broke the compendia jobs.

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

Unit tests should have caught this before :thinking: 

## Checklist

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules
