### PR TITLE
Keep track of which samples are filtered in the compendia

### DIFF
--- a/workers/data_refinery_workers/processors/create_compendia.py
+++ b/workers/data_refinery_workers/processors/create_compendia.py
@@ -261,7 +261,7 @@ def _perform_imputation(job_context: Dict) -> Dict:
     for sample_accession_code in row_filtered_matrix.columns:
         if sample_accession_code not in row_col_filtered_matrix_samples_columns:
             job_context['filtered_samples'][sample_accession_code] = {
-                'reason': 'Sample was dropped because it less than 50% present values.',
+                'reason': 'Sample was dropped because it had less than 50% present values.',
             }
 
     del row_filtered_matrix

--- a/workers/data_refinery_workers/processors/create_compendia.py
+++ b/workers/data_refinery_workers/processors/create_compendia.py
@@ -20,7 +20,8 @@ from data_refinery_common.models import (ComputationalResult,
                                          CompendiumResultOrganismAssociation,
                                          ComputedFile,
                                          Organism,
-                                         Pipeline)
+                                         Pipeline,
+                                         Sample)
 from data_refinery_common.utils import get_env_variable
 from data_refinery_workers.processors import smashing_utils, utils
 
@@ -260,8 +261,12 @@ def _perform_imputation(job_context: Dict) -> Dict:
 
     for sample_accession_code in row_filtered_matrix.columns:
         if sample_accession_code not in row_col_filtered_matrix_samples_columns:
+            sample = Sample.objects.get(accession_code=sample_accession_code)
+            sample_metadata = sample.to_metadata_dict()
             job_context['filtered_samples'][sample_accession_code] = {
+                **sample_metadata,
                 'reason': 'Sample was dropped because it had less than 50% present values.',
+                'experiment_accession_code': smashing_utils.get_experiment_accession(sample.accession_code, job_context['dataset'].data)
             }
 
     del row_filtered_matrix

--- a/workers/data_refinery_workers/processors/create_quantpendia.py
+++ b/workers/data_refinery_workers/processors/create_quantpendia.py
@@ -41,6 +41,7 @@ def create_quantpendia(job_id: int) -> None:
 
 @utils.cache_keys('time_start', 'num_samples', 'time_end', 'formatted_command', work_dir_key='job_dir')
 def _download_files(job_context: Dict) -> Dict:
+    job_context['filtered_samples'] = {}
     job_context['time_start'] = timezone.now()
 
     num_samples = 0

--- a/workers/data_refinery_workers/processors/smashing_utils.py
+++ b/workers/data_refinery_workers/processors/smashing_utils.py
@@ -312,7 +312,7 @@ def process_frames_for_key(key: str,
                                job_id=job_context["job"].id)
                 job_context['filtered_samples'][sample.accession_code] = {
                     'reason': 'We were unable to smash the file associated with this sample during the first pass.',
-                    'source_url': computed_file.source_url
+                    'filename': computed_file.filename
                 }
                 continue
 
@@ -387,7 +387,7 @@ def process_frames_for_key(key: str,
             job_context['unsmashable_files'].append(computed_file.filename)
             job_context['filtered_samples'][sample.accession_code] = {
                 'reason': 'We were unable to smash the file associated with this sample during the first pass.',
-                'source_url': computed_file.source_url
+                'filename': computed_file.filename
             }
             continue
 
@@ -631,7 +631,7 @@ def compile_metadata(job_context: Dict) -> Dict:
 
     samples = {}
     for sample in job_context["dataset"].get_samples():
-        if job_context['filtered_samples'] and sample.accession_code in job_context['filtered_samples']:
+        if sample.accession_code in filtered_samples:
             # skip the samples that were filtered
             continue
         samples[sample.accession_code] = sample.to_metadata_dict()
@@ -675,7 +675,7 @@ def write_non_data_files(job_context: Dict) -> Dict:
         with open(aggregated_metadata_path, 'w', encoding='utf-8') as metadata_file:
             json.dump(job_context['metadata'], metadata_file, indent=4, sort_keys=True)
 
-        if 'filtered_samples' in job_context and job_context['filtered_samples']:
+        if job_context['filtered_samples']:
             # generate filtered samples file only if some samples were skipped
             filtered_samples_path = os.path.join(job_context["output_dir"],
                                                  'filtered_samples_metadata.json')

--- a/workers/data_refinery_workers/processors/smashing_utils.py
+++ b/workers/data_refinery_workers/processors/smashing_utils.py
@@ -691,6 +691,16 @@ def write_non_data_files(job_context: Dict) -> Dict:
                                                  'filtered_samples_metadata.json')
             with open(filtered_samples_path, 'w',encoding='utf-8') as metadata_file:
                 json.dump(job_context['filtered_samples'], metadata_file, indent=4, sort_keys=True)
+
+            columns = get_tsv_columns(job_context['filtered_samples'])
+            filtered_samples_tsv_path = os.path.join(job_context["output_dir"],
+                                                     'filtered_samples_metadata.tsv')
+            with open(filtered_samples_tsv_path, 'w', encoding='utf-8') as tsv_file:
+                dw = csv.DictWriter(tsv_file, columns, delimiter='\t', extrasaction='ignore')
+                dw.writeheader()
+                for sample_metadata in job_context['filtered_samples'].values():
+                    dw.writerow(get_tsv_row_data(sample_metadata, job_context["dataset"].data))
+
     except Exception as e:
         logger.exception("Failed to write metadata TSV!", job_id=job_context['job'].id)
 

--- a/workers/data_refinery_workers/processors/smashing_utils.py
+++ b/workers/data_refinery_workers/processors/smashing_utils.py
@@ -78,7 +78,7 @@ def prepare_files(job_context: Dict) -> Dict:
                 found_files = True
             else:
                 job_context['filtered_samples'][sample.accession_code] = {
-                    'reason': 'We could not find a valid smashable file for this sample.'
+                    'reason': 'This sample did not have a processed file associated with it in our database.'
                 }
 
         job_context['input_files'][key] = smashable_files
@@ -311,7 +311,7 @@ def process_frames_for_key(key: str,
                                dataset_id=job_context['dataset'].id,
                                job_id=job_context["job"].id)
                 job_context['filtered_samples'][sample.accession_code] = {
-                    'reason': 'We were unable to smash the file associated with this sample during the first pass.',
+                    'reason': 'The file associated with this sample did not pass the QC checks we apply before aggregating.',
                     'filename': computed_file.filename
                 }
                 continue
@@ -386,7 +386,7 @@ def process_frames_for_key(key: str,
         if frame_data is None:
             job_context['unsmashable_files'].append(computed_file.filename)
             job_context['filtered_samples'][sample.accession_code] = {
-                'reason': 'We were unable to smash the file associated with this sample during the second pass.',
+                'reason': 'The file associated with this sample did not contain a vector that fit the expected dimensions of the matrix.',
                 'filename': computed_file.filename
             }
             continue

--- a/workers/data_refinery_workers/processors/smashing_utils.py
+++ b/workers/data_refinery_workers/processors/smashing_utils.py
@@ -386,7 +386,7 @@ def process_frames_for_key(key: str,
         if frame_data is None:
             job_context['unsmashable_files'].append(computed_file.filename)
             job_context['filtered_samples'][sample.accession_code] = {
-                'reason': 'We were unable to smash the file associated with this sample during the first pass.',
+                'reason': 'We were unable to smash the file associated with this sample during the second pass.',
                 'filename': computed_file.filename
             }
             continue

--- a/workers/data_refinery_workers/processors/smashing_utils.py
+++ b/workers/data_refinery_workers/processors/smashing_utils.py
@@ -807,14 +807,13 @@ def get_tsv_row_data(sample_metadata, dataset_data):
     return row_data
 
 
-def get_tsv_columns(job_context, samples_metadata):
+def get_tsv_columns(samples_metadata):
     """Returns an array of strings that will be written as a TSV file's
     header. The columns are based on fields found in samples_metadata.
 
     Some nested annotation fields are taken out as separate columns
     because they are more important than the others.
     """
-    tsv_start = log_state("start get tsv columns", job_context["job"].id)
     refinebio_columns = set()
     annotation_columns = set()
     for sample_metadata in samples_metadata.values():
@@ -860,7 +859,6 @@ def get_tsv_columns(job_context, samples_metadata):
     # always first, followed by the other refinebio columns (in alphabetic order), and
     # annotation columns (in alphabetic order) at the end.
     refinebio_columns.discard('refinebio_accession_code')
-    log_state("end get tsv columns", job_context["job"].id, tsv_start)
     return ['refinebio_accession_code', 'experiment_accession'] + sorted(refinebio_columns) \
         + sorted(annotation_columns)
 
@@ -874,7 +872,7 @@ def write_tsv_json(job_context):
     metadata = job_context['metadata']
 
     # Uniform TSV header per dataset
-    columns = get_tsv_columns(job_context, metadata['samples'])
+    columns = get_tsv_columns(metadata['samples'])
 
     # Per-Experiment Metadata
     if job_context["dataset"].aggregate_by == "EXPERIMENT":

--- a/workers/data_refinery_workers/processors/smashing_utils.py
+++ b/workers/data_refinery_workers/processors/smashing_utils.py
@@ -77,8 +77,11 @@ def prepare_files(job_context: Dict) -> Dict:
                 seen_files.add(smashable_file)
                 found_files = True
             else:
+                sample_metadata = sample.to_metadata_dict()
                 job_context['filtered_samples'][sample.accession_code] = {
-                    'reason': 'This sample did not have a processed file associated with it in our database.'
+                    **sample_metadata,
+                    'reason': 'This sample did not have a processed file associated with it in our database.',
+                    'experiment_accession_code': get_experiment_accession(sample.accession_code, job_context['dataset'].data)
                 }
 
         job_context['input_files'][key] = smashable_files
@@ -310,9 +313,13 @@ def process_frames_for_key(key: str,
                                computed_file=computed_file.id,
                                dataset_id=job_context['dataset'].id,
                                job_id=job_context["job"].id)
+
+                sample_metadata = sample.to_metadata_dict()
                 job_context['filtered_samples'][sample.accession_code] = {
+                    **sample_metadata,
                     'reason': 'The file associated with this sample did not pass the QC checks we apply before aggregating.',
-                    'filename': computed_file.filename
+                    'filename': computed_file.filename,
+                    'experiment_accession_code': get_experiment_accession(sample.accession_code, job_context['dataset'].data)
                 }
                 continue
 
@@ -385,9 +392,12 @@ def process_frames_for_key(key: str,
 
         if frame_data is None:
             job_context['unsmashable_files'].append(computed_file.filename)
+            sample_metadata = sample.to_metadata_dict()
             job_context['filtered_samples'][sample.accession_code] = {
+                **sample_metadata,
                 'reason': 'The file associated with this sample did not contain a vector that fit the expected dimensions of the matrix.',
-                'filename': computed_file.filename
+                'filename': computed_file.filename,
+                'experiment_accession_code': get_experiment_accession(sample.accession_code, job_context['dataset'].data)
             }
             continue
 

--- a/workers/data_refinery_workers/processors/test_compendia.py
+++ b/workers/data_refinery_workers/processors/test_compendia.py
@@ -165,6 +165,7 @@ class CompendiaTestCase(TransactionTestCase):
 
         # check that sample with no computed file was skipped
         self.assertTrue('GSM1487222' in final_context['filtered_samples'])
+        self.assertEqual(final_context['filtered_samples']['GSM1487222']['experiment_accession_code'], 'GSE1487313')
 
 
     @tag('compendia')

--- a/workers/data_refinery_workers/processors/test_smasher.py
+++ b/workers/data_refinery_workers/processors/test_smasher.py
@@ -1289,7 +1289,7 @@ class AggregationTestCase(TransactionTestCase):
             'job': pj
         }
 
-        columns = smashing_utils.get_tsv_columns(job_context, self.metadata['samples'])
+        columns = smashing_utils.get_tsv_columns(self.metadata['samples'])
         self.assertEqual(len(columns), 22)
         self.assertEqual(columns[0], 'refinebio_accession_code')
         self.assertTrue('refinebio_accession_code' in columns)


### PR DESCRIPTION
## Issue Number

close #1838 

## Purpose/Implementation Notes

This adds `job_context['filtered_samples']` to keep track of the samples that are dropped at each step during the smashing pipeline. Then creates the file `filtered_samples_metadata.json` with the samples that were filtered and the reasons why - as described by https://github.com/alexslemonade/refinebio/issues/1838#issuecomment-559143625

## Types of changes

- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Functional tests

Added tests for a compendium where we skip one sample.

## Checklist

- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules
