### PR TITLE
Give affy jobs a higher tier and add a readable name for huex.

### DIFF
--- a/common/data_refinery_common/job_lookup.py
+++ b/common/data_refinery_common/job_lookup.py
@@ -315,8 +315,8 @@ def determine_ram_amount(sample: Sample, job) -> int:
         if 'u133' in platform:
             return 2048
         if 'gene' in platform:
-            return 3072
-        if 'hta20' in platform:
+            return 4096
+        if 'hta20' in platform or 'huex10st' in platform:
             return 32768
         # Not sure what the ram usage of this platform is! Investigate!
         logger.debug("Unsure of RAM usage for platform! Using default.",

--- a/config/readable_affymetrix_names.csv
+++ b/config/readable_affymetrix_names.csv
@@ -122,3 +122,4 @@ GeneChip® PrimeView™ Human Gene Expression Array (with External spike-in RNAs
 [Xenopus_laevis] Affymetrix Xenopus laevis Genome Array,xenopuslaevis
 [X_laevis_2] Affymetrix Xenopus laevis Genome 2.0 Array,xlaevis2
 [X_tropicalis] Affymetrix Xenopus tropicalis Genome Array,xtropicalis
+[HuEx-1_0-st] Affymetrix Human Human Exon 1.0 ST Array,huex10st

--- a/foreman/data_refinery_foreman/foreman/main.py
+++ b/foreman/data_refinery_foreman/foreman/main.py
@@ -686,6 +686,8 @@ def requeue_processor_job(last_job: ProcessorJob) -> None:
                 new_ram_amount = 4096
             elif new_ram_amount == 4096:
                 new_ram_amount = 8192
+            elif new_ram_amount == 8192:
+                new_ram_amount = 16384
 
     volume_index = last_job.volume_index
     # Make sure volume_index is set to something, unless it's a

--- a/foreman/data_refinery_foreman/foreman/main.py
+++ b/foreman/data_refinery_foreman/foreman/main.py
@@ -687,7 +687,7 @@ def requeue_processor_job(last_job: ProcessorJob) -> None:
             elif new_ram_amount == 4096:
                 new_ram_amount = 8192
             elif new_ram_amount == 8192:
-                new_ram_amount = 16384
+                new_ram_amount = 32768
 
     volume_index = last_job.volume_index
     # Make sure volume_index is set to something, unless it's a


### PR DESCRIPTION
## Issue Number

#1831 

## Purpose/Implementation Notes

Whole lotta failures with:
```
2019-12-06 14:27:35,482 i-056f1616d982e5f85 [volume: 0] data_refinery_workers.processors.utils ERROR [no_retry: False] [processor_job: 29481557]: Unhandled exception caught while running processor function _run_scan_upc in pipeline:
Traceback (most recent call last):
  File "/home/user/data_refinery_workers/processors/utils.py", line 369, in run_pipeline
    last_result = processor(last_result)
  File "/home/user/data_refinery_workers/processors/array_express.py", line 149, in _run_scan_upc
    platform_name = get_readable_affymetrix_names()[platform_accession_code]
KeyError: 'huex10st'
```

We added a new platform but not a readable name for it. This fixes that. This also gives Affy a higher RAM tier it can go to since we expect this platform to be big enough that they get OOM-killed.

## Types of changes

- Bugfix (non-breaking change which fixes an issue)
