### PR TITLE
Bring back "Possible solution to avoid removing jobs from db"

### DIFF
--- a/common/data_refinery_common/migrations/0048_processorjob_abort.py
+++ b/common/data_refinery_common/migrations/0048_processorjob_abort.py
@@ -1,0 +1,60 @@
+from django.db import migrations, models
+
+
+def batch_update(queryset, batch=1000, **changes):
+    """ Update per batch """
+    is_done = False
+    current = 0
+
+    while not is_done:
+        current = current + 1
+        start = (current - 1) * batch
+        end = start + batch
+        pks = queryset.values_list('pk', flat=True)[start:end][::1]
+        if pks:
+            queryset.model.objects.filter(pk__in=pks).update(**changes)
+
+        is_done = len(pks) < batch
+
+
+def set_default_abort_value(apps, schema_editor):
+    ProcessorJob = apps.get_model('data_refinery_common', 'ProcessorJob')
+    queryset = ProcessorJob.objects.all()
+    batch_update(queryset, abort=False)
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('data_refinery_common', '0047_clean_compendia_files'),
+    ]
+
+    # we need to add a new field `abort` with default value `False`
+    # The processor jobs table is big, so it the migration might time out
+    # that's why we add the default value in batches
+    operations = [
+        # 1. remove indexes
+        migrations.RemoveIndex(
+            model_name='processorjob',
+            name='processor_jobs_created_at',
+        ),
+        # 2. add fields with None as default value
+        migrations.AddField(
+            model_name='processorjob',
+            name='abort',
+            field=models.BooleanField(),
+        ),
+        # 3. set default value in batches
+        migrations.RunPython(set_default_abort_value),
+        # 4. add default value for field
+        migrations.AlterField(
+            model_name='processorjob',
+            name='abort',
+            field=models.BooleanField(default=False),
+        ),
+        # 5. re-add indexes
+        migrations.AddIndex(
+            model_name='processorjob',
+            index=models.Index(fields=['created_at'], name='processor_jobs_created_at'),
+        ),
+    ]

--- a/common/data_refinery_common/migrations/0048_processorjob_abort.py
+++ b/common/data_refinery_common/migrations/0048_processorjob_abort.py
@@ -50,7 +50,7 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name='processorjob',
             name='abort',
-            field=models.BooleanField(default=False),
+            field=models.BooleanField(default=False, null=False),
         ),
         # 5. re-add indexes
         migrations.AddIndex(

--- a/common/data_refinery_common/migrations/0048_processorjob_abort.py
+++ b/common/data_refinery_common/migrations/0048_processorjob_abort.py
@@ -42,7 +42,7 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name='processorjob',
             name='abort',
-            field=models.BooleanField(),
+            field=models.BooleanField(null=True),
         ),
         # 3. set default value in batches
         migrations.RunPython(set_default_abort_value),

--- a/common/data_refinery_common/models/jobs.py
+++ b/common/data_refinery_common/models/jobs.py
@@ -171,6 +171,7 @@ class ProcessorJob(models.Model):
     original_files = models.ManyToManyField('OriginalFile', through='ProcessorJobOriginalFileAssociation')
     datasets = models.ManyToManyField('DataSet', through='ProcessorJobDataSetAssociation')
     no_retry = models.BooleanField(default=False)
+    abort = models.BooleanField(default=False)
 
     # Resources
     ram_amount = models.IntegerField(default=2048)

--- a/common/data_refinery_common/models/models.py
+++ b/common/data_refinery_common/models/models.py
@@ -839,7 +839,8 @@ class OriginalFile(models.Model):
     def has_blocking_jobs(self, own_processor_id=None) -> bool:
         # If the file has a processor job that should not have been
         # retried, then it still shouldn't be retried.
-        no_retry_processor_jobs = self.processor_jobs.filter(no_retry=True)
+        # Exclude the ones that were aborted.
+        no_retry_processor_jobs = self.processor_jobs.filter(no_retry=True).exclude(abort=True)
 
         # If the file has a processor job that hasn't even started
         # yet, then it doesn't need another.

--- a/foreman/data_refinery_foreman/surveyor/test_end_to_end.py
+++ b/foreman/data_refinery_foreman/surveyor/test_end_to_end.py
@@ -103,7 +103,7 @@ class NoOpEndToEndTestCase(TransactionTestCase):
                 downloader_job = wait_for_job(downloader_job, DownloaderJob, start_time)
                 self.assertTrue(downloader_job.success)
 
-            processor_jobs = ProcessorJob.objects.all()
+            processor_jobs = ProcessorJob.objects.all().exclude(abort=True) # exclude aborted processor jobs
             self.assertGreater(processor_jobs.count(), 0)
 
             logger.info("Downloader Jobs finished, waiting for processor Jobs to complete.")
@@ -186,8 +186,8 @@ class ArrayexpressRedownloadingTestCase(TransactionTestCase):
             )
 
             start_time = timezone.now()
-            with self.assertRaises(ProcessorJob.DoesNotExist):
-                wait_for_job(doomed_processor_job, ProcessorJob, start_time)
+            doomed_processor_job = wait_for_job(doomed_processor_job, ProcessorJob, start_time)
+            self.assertTrue(doomed_processor_job.abort)
 
             # The processor job that had a missing file will have
             # recreated its DownloaderJob, which means there should now be two.
@@ -212,7 +212,7 @@ class ArrayexpressRedownloadingTestCase(TransactionTestCase):
             # Once the Downloader job succeeds, it should create one
             # and only one processor job, after which the total goes back up
             # to NUM_SAMPLES_IN_EXPERIMENT:
-            processor_jobs = ProcessorJob.objects.all()
+            processor_jobs = ProcessorJob.objects.all().exclude(abort=True) # exclude aborted processor jobs
             self.assertEqual(processor_jobs.count(), NUM_SAMPLES_IN_EXPERIMENT)
 
             # And finally we can make sure that all of the
@@ -278,7 +278,7 @@ class GeoArchiveRedownloadingTestCase(TransactionTestCase):
             try:
                 doomed_processor_job = original_file.processor_jobs.all()[0]
             except:
-                # The doomed job may delete itself before we can get
+                # The doomed job may be aborted before we can get
                 # it. This is fine, we just can't look at it.
                 doomed_processor_job = None
 
@@ -289,8 +289,8 @@ class GeoArchiveRedownloadingTestCase(TransactionTestCase):
                 )
 
                 start_time = timezone.now()
-                with self.assertRaises(ProcessorJob.DoesNotExist):
-                    wait_for_job(doomed_processor_job, ProcessorJob, start_time)
+                doomed_processor_job = wait_for_job(doomed_processor_job, ProcessorJob, start_time)
+                self.assertTrue(doomed_processor_job.abort)
 
             # The processor job that had a missing file will have
             # recreated its DownloaderJob, which means there should now be two.
@@ -316,7 +316,7 @@ class GeoArchiveRedownloadingTestCase(TransactionTestCase):
             # processor jobs were successful, including the one that
             # got recreated.
             logger.info("Downloader Jobs finished, waiting for processor Jobs to complete.")
-            processor_jobs = ProcessorJob.objects.all()
+            processor_jobs = ProcessorJob.objects.all().exclude(abort=True) # exclude aborted processor jobs
             for processor_job in processor_jobs:
                 processor_job = wait_for_job(processor_job, ProcessorJob, start_time)
                 self.assertTrue(processor_job.success)
@@ -389,7 +389,7 @@ class GeoCelgzRedownloadingTestCase(TransactionTestCase):
             try:
                 doomed_processor_job = original_file.processor_jobs.all()[0]
             except:
-                # The doomed job may delete itself before we can get
+                # The doomed job may be aborted before we can get
                 # it. This is fine, we just can't look at it.
                 doomed_processor_job = None
 
@@ -400,8 +400,8 @@ class GeoCelgzRedownloadingTestCase(TransactionTestCase):
                 )
 
                 start_time = timezone.now()
-                with self.assertRaises(ProcessorJob.DoesNotExist):
-                    wait_for_job(doomed_processor_job, ProcessorJob, start_time)
+                doomed_processor_job = wait_for_job(doomed_processor_job, ProcessorJob, start_time)
+                self.assertTrue(doomed_processor_job.abort)
 
             # The processor job that had a missing file will have
             # recreated its DownloaderJob, which means there should
@@ -426,10 +426,10 @@ class GeoCelgzRedownloadingTestCase(TransactionTestCase):
 
             # And finally we can make sure that all of the processor
             # jobs were successful, including the one that got
-            # recreated. The processor job that recreated that job deleted
-            # itself rather than failing, so there's only successes!
+            # recreated. The processor job that recreated that job has
+            # abort=True
             logger.info("Downloader Jobs finished, waiting for processor Jobs to complete.")
-            processor_jobs = ProcessorJob.objects.all()
+            processor_jobs = ProcessorJob.objects.all().exclude(abort=True) # exclude aborted jobs
             for processor_job in processor_jobs:
                 processor_job = wait_for_job(processor_job, ProcessorJob, start_time)
                 self.assertTrue(processor_job.success)
@@ -530,17 +530,14 @@ class GeoCelgzRedownloadingTestCase(TransactionTestCase):
             successful_processor_jobs = []
             for processor_job in processor_jobs:
                 # One of the calls to wait_for_job will fail if the
-                # job deletes itself before it we selected all the
+                # job aborts before it we selected all the
                 # processor jobs.
-                try:
-                    processor_job = wait_for_job(processor_job, ProcessorJob, start_time)
-                    if processor_job.success:
-                        successful_processor_jobs.append(processor_job)
-                except:
-                    pass
+                processor_job = wait_for_job(processor_job, ProcessorJob, start_time)
+                if processor_job.success:
+                    successful_processor_jobs.append(processor_job)
 
-            # While one of the original ProcessorJobs will definitely
-            # delete itself, it is hard to be sure of what will happen
+            # While one of the original ProcessorJobs will  be aborted
+            # it is hard to be sure of what will happen
             # to the other because of the racing that happens between
             # processor jobs getting started and us deleting the files
             # they need.
@@ -611,7 +608,7 @@ class SraRedownloadingTestCase(TransactionTestCase):
                             break
 
             # There's a chance that the processor job with a missing
-            # file deletes itself before the last downloader job
+            # file is aborted before the last downloader job
             # completes, therefore just check that there's at least 3
             # processor jobs.
             processor_jobs = ProcessorJob.objects.all()
@@ -624,8 +621,7 @@ class SraRedownloadingTestCase(TransactionTestCase):
             )
 
             start_time = timezone.now()
-            with self.assertRaises(ProcessorJob.DoesNotExist):
-                wait_for_job(doomed_processor_job, ProcessorJob, start_time)
+            wait_for_job(doomed_processor_job, ProcessorJob, start_time)
 
             # The processor job that had a missing file will have
             # recreated its DownloaderJob, which means there should
@@ -666,7 +662,7 @@ class SraRedownloadingTestCase(TransactionTestCase):
             successful_processor_jobs = []
             for processor_job in processor_jobs:
                 # One of the two calls to wait_for_job will fail
-                # because the job is going to delete itself when it
+                # because the job is going to abort when it
                 # finds that the file it wants to process is missing.
                 try:
                     processor_job = wait_for_job(processor_job, ProcessorJob, start_time)


### PR DESCRIPTION
Reverts AlexsLemonade/refinebio#1989

Originally failed with the error:

```
Running migrations:
  Applying data_refinery_common.0048_processorjob_abort...Traceback (most recent call last):
  File "/usr/local/lib/python3.5/dist-packages/django/db/backends/utils.py", line 84, in _execute
    return self.cursor.execute(sql, params)
psycopg2.IntegrityError: column "abort" contains null values
The above exception was the direct cause of the following exception:
Traceback (most recent call last):
  File "manage.py", line 23, in <module>
    execute_from_command_line(sys.argv)
  File "/usr/local/lib/python3.5/dist-packages/django/core/management/__init__.py", line 381, in execute_from_command_line
    utility.execute()
  File "/usr/local/lib/python3.5/dist-packages/django/core/management/__init__.py", line 375, in execute
    self.fetch_command(subcommand).run_from_argv(self.argv)
  File "/usr/local/lib/python3.5/dist-packages/django/core/management/base.py", line 323, in run_from_argv
    self.execute(*args, **cmd_options)
  File "/usr/local/lib/python3.5/dist-packages/django/core/management/base.py", line 364, in execute
    output = self.handle(*args, **options)
  File "/usr/local/lib/python3.5/dist-packages/django/core/management/base.py", line 83, in wrapped
    res = handle_func(*args, **kwargs)
  File "/usr/local/lib/python3.5/dist-packages/django/core/management/commands/migrate.py", line 234, in handle
    fake_initial=fake_initial,
  File "/usr/local/lib/python3.5/dist-packages/django/db/migrations/executor.py", line 117, in migrate
    state = self._migrate_all_forwards(state, plan, full_plan, fake=fake, fake_initial=fake_initial)
  File "/usr/local/lib/python3.5/dist-packages/django/db/migrations/executor.py", line 147, in _migrate_all_forwards
    state = self.apply_migration(state, migration, fake=fake, fake_initial=fake_initial)
  File "/usr/local/lib/python3.5/dist-packages/django/db/migrations/executor.py", line 245, in apply_migration
    state = migration.apply(state, schema_editor)
  File "/usr/local/lib/python3.5/dist-packages/django/db/migrations/migration.py", line 124, in apply
    operation.database_forwards(self.app_label, schema_editor, old_state, project_state)
  File "/usr/local/lib/python3.5/dist-packages/django/db/migrations/operations/fields.py", line 112, in database_forwards
    field,
  File "/usr/local/lib/python3.5/dist-packages/django/db/backends/base/schema.py", line 447, in add_field
    self.execute(sql, params)
  File "/usr/local/lib/python3.5/dist-packages/django/db/backends/base/schema.py", line 137, in execute
    cursor.execute(sql, params)
  File "/usr/local/lib/python3.5/dist-packages/raven/contrib/django/client.py", line 127, in execute
    return real_execute(self, sql, params)
  File "/usr/local/lib/python3.5/dist-packages/django/db/backends/utils.py", line 67, in execute
    return self._execute_with_wrappers(sql, params, many=False, executor=self._execute)
  File "/usr/local/lib/python3.5/dist-packages/django/db/backends/utils.py", line 76, in _execute_with_wrappers
    return executor(sql, params, many, context)
  File "/usr/local/lib/python3.5/dist-packages/django/db/backends/utils.py", line 84, in _execute
    return self.cursor.execute(sql, params)
  File "/usr/local/lib/python3.5/dist-packages/django/db/utils.py", line 89, in __exit__
    raise dj_exc_value.with_traceback(traceback) from exc_value
  File "/usr/local/lib/python3.5/dist-packages/django/db/backends/utils.py", line 84, in _execute
    return self.cursor.execute(sql, params)
django.db.utils.IntegrityError: column "abort" contains null values
This reverts that pr to bring back the API.
```

Will push a fix on this branch and test it on staging.