### PR TITLE
Revert "Revert adding a migration with new fields on processor jobs"

### DIFF
--- a/common/data_refinery_common/migrations/0048_processorjob_abort.py
+++ b/common/data_refinery_common/migrations/0048_processorjob_abort.py
@@ -1,0 +1,45 @@
+from django.db import migrations, models
+
+
+def batch_update(queryset, batch=1000, **changes):
+    """ Update per batch """
+    is_done = False
+    current = 0
+
+    while not is_done:
+        current = current + 1
+        start = (current - 1) * batch
+        end = start + batch
+        pks = queryset.values_list('pk', flat=True)[start:end][::1]
+        if pks:
+            queryset.model.objects.filter(pk__in=pks).update(**changes)
+
+        is_done = len(pks) < batch
+
+
+def set_default_abort_value(apps, schema_editor):
+    ProcessorJob = apps.get_model('data_refinery_common', 'ProcessorJob')
+    queryset = ProcessorJob.objects.all()
+    batch_update(queryset, abort=False)
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('data_refinery_common', '0047_clean_compendia_files'),
+    ]
+
+    # we need to add a new field `abort` with default value `False`
+    # The processor jobs table is big, that's why we add the field with no default
+    # and then set the default value
+    # the next migration alters the field to have a default value
+    operations = [
+        # 1. add fields with None as default value
+        migrations.AddField(
+            model_name='processorjob',
+            name='abort',
+            field=models.BooleanField(null=True),
+        ),
+        # 2. set default value in batches
+        migrations.RunPython(set_default_abort_value),
+    ]

--- a/common/data_refinery_common/migrations/0049_processorjob_abort_alter.py
+++ b/common/data_refinery_common/migrations/0049_processorjob_abort_alter.py
@@ -1,0 +1,17 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('data_refinery_common', '0048_processorjob_abort'),
+    ]
+
+    # Final steps to add the abort field to the processor jobs table
+    operations = [
+        migrations.AlterField(
+            model_name='processorjob',
+            name='abort',
+            field=models.BooleanField(default=False, null=False),
+        ),
+    ]

--- a/common/data_refinery_common/models/jobs.py
+++ b/common/data_refinery_common/models/jobs.py
@@ -171,6 +171,7 @@ class ProcessorJob(models.Model):
     original_files = models.ManyToManyField('OriginalFile', through='ProcessorJobOriginalFileAssociation')
     datasets = models.ManyToManyField('DataSet', through='ProcessorJobDataSetAssociation')
     no_retry = models.BooleanField(default=False)
+    abort = models.BooleanField(default=False)
 
     # Resources
     ram_amount = models.IntegerField(default=2048)

--- a/common/data_refinery_common/models/models.py
+++ b/common/data_refinery_common/models/models.py
@@ -839,7 +839,8 @@ class OriginalFile(models.Model):
     def has_blocking_jobs(self, own_processor_id=None) -> bool:
         # If the file has a processor job that should not have been
         # retried, then it still shouldn't be retried.
-        no_retry_processor_jobs = self.processor_jobs.filter(no_retry=True)
+        # Exclude the ones that were aborted.
+        no_retry_processor_jobs = self.processor_jobs.filter(no_retry=True).exclude(abort=True)
 
         # If the file has a processor job that hasn't even started
         # yet, then it doesn't need another.

--- a/foreman/data_refinery_foreman/surveyor/test_end_to_end.py
+++ b/foreman/data_refinery_foreman/surveyor/test_end_to_end.py
@@ -103,7 +103,7 @@ class NoOpEndToEndTestCase(TransactionTestCase):
                 downloader_job = wait_for_job(downloader_job, DownloaderJob, start_time)
                 self.assertTrue(downloader_job.success)
 
-            processor_jobs = ProcessorJob.objects.all()
+            processor_jobs = ProcessorJob.objects.all().exclude(abort=True) # exclude aborted processor jobs
             self.assertGreater(processor_jobs.count(), 0)
 
             logger.info("Downloader Jobs finished, waiting for processor Jobs to complete.")
@@ -186,8 +186,8 @@ class ArrayexpressRedownloadingTestCase(TransactionTestCase):
             )
 
             start_time = timezone.now()
-            with self.assertRaises(ProcessorJob.DoesNotExist):
-                wait_for_job(doomed_processor_job, ProcessorJob, start_time)
+            doomed_processor_job = wait_for_job(doomed_processor_job, ProcessorJob, start_time)
+            self.assertTrue(doomed_processor_job.abort)
 
             # The processor job that had a missing file will have
             # recreated its DownloaderJob, which means there should now be two.
@@ -212,7 +212,7 @@ class ArrayexpressRedownloadingTestCase(TransactionTestCase):
             # Once the Downloader job succeeds, it should create one
             # and only one processor job, after which the total goes back up
             # to NUM_SAMPLES_IN_EXPERIMENT:
-            processor_jobs = ProcessorJob.objects.all()
+            processor_jobs = ProcessorJob.objects.all().exclude(abort=True) # exclude aborted processor jobs
             self.assertEqual(processor_jobs.count(), NUM_SAMPLES_IN_EXPERIMENT)
 
             # And finally we can make sure that all of the
@@ -278,7 +278,7 @@ class GeoArchiveRedownloadingTestCase(TransactionTestCase):
             try:
                 doomed_processor_job = original_file.processor_jobs.all()[0]
             except:
-                # The doomed job may delete itself before we can get
+                # The doomed job may be aborted before we can get
                 # it. This is fine, we just can't look at it.
                 doomed_processor_job = None
 
@@ -289,8 +289,8 @@ class GeoArchiveRedownloadingTestCase(TransactionTestCase):
                 )
 
                 start_time = timezone.now()
-                with self.assertRaises(ProcessorJob.DoesNotExist):
-                    wait_for_job(doomed_processor_job, ProcessorJob, start_time)
+                doomed_processor_job = wait_for_job(doomed_processor_job, ProcessorJob, start_time)
+                self.assertTrue(doomed_processor_job.abort)
 
             # The processor job that had a missing file will have
             # recreated its DownloaderJob, which means there should now be two.
@@ -316,7 +316,7 @@ class GeoArchiveRedownloadingTestCase(TransactionTestCase):
             # processor jobs were successful, including the one that
             # got recreated.
             logger.info("Downloader Jobs finished, waiting for processor Jobs to complete.")
-            processor_jobs = ProcessorJob.objects.all()
+            processor_jobs = ProcessorJob.objects.all().exclude(abort=True) # exclude aborted processor jobs
             for processor_job in processor_jobs:
                 processor_job = wait_for_job(processor_job, ProcessorJob, start_time)
                 self.assertTrue(processor_job.success)
@@ -389,7 +389,7 @@ class GeoCelgzRedownloadingTestCase(TransactionTestCase):
             try:
                 doomed_processor_job = original_file.processor_jobs.all()[0]
             except:
-                # The doomed job may delete itself before we can get
+                # The doomed job may be aborted before we can get
                 # it. This is fine, we just can't look at it.
                 doomed_processor_job = None
 
@@ -400,8 +400,8 @@ class GeoCelgzRedownloadingTestCase(TransactionTestCase):
                 )
 
                 start_time = timezone.now()
-                with self.assertRaises(ProcessorJob.DoesNotExist):
-                    wait_for_job(doomed_processor_job, ProcessorJob, start_time)
+                doomed_processor_job = wait_for_job(doomed_processor_job, ProcessorJob, start_time)
+                self.assertTrue(doomed_processor_job.abort)
 
             # The processor job that had a missing file will have
             # recreated its DownloaderJob, which means there should
@@ -426,10 +426,10 @@ class GeoCelgzRedownloadingTestCase(TransactionTestCase):
 
             # And finally we can make sure that all of the processor
             # jobs were successful, including the one that got
-            # recreated. The processor job that recreated that job deleted
-            # itself rather than failing, so there's only successes!
+            # recreated. The processor job that recreated that job has
+            # abort=True
             logger.info("Downloader Jobs finished, waiting for processor Jobs to complete.")
-            processor_jobs = ProcessorJob.objects.all()
+            processor_jobs = ProcessorJob.objects.all().exclude(abort=True) # exclude aborted jobs
             for processor_job in processor_jobs:
                 processor_job = wait_for_job(processor_job, ProcessorJob, start_time)
                 self.assertTrue(processor_job.success)
@@ -530,17 +530,14 @@ class GeoCelgzRedownloadingTestCase(TransactionTestCase):
             successful_processor_jobs = []
             for processor_job in processor_jobs:
                 # One of the calls to wait_for_job will fail if the
-                # job deletes itself before it we selected all the
+                # job aborts before it we selected all the
                 # processor jobs.
-                try:
-                    processor_job = wait_for_job(processor_job, ProcessorJob, start_time)
-                    if processor_job.success:
-                        successful_processor_jobs.append(processor_job)
-                except:
-                    pass
+                processor_job = wait_for_job(processor_job, ProcessorJob, start_time)
+                if processor_job.success:
+                    successful_processor_jobs.append(processor_job)
 
-            # While one of the original ProcessorJobs will definitely
-            # delete itself, it is hard to be sure of what will happen
+            # While one of the original ProcessorJobs will  be aborted
+            # it is hard to be sure of what will happen
             # to the other because of the racing that happens between
             # processor jobs getting started and us deleting the files
             # they need.
@@ -611,7 +608,7 @@ class SraRedownloadingTestCase(TransactionTestCase):
                             break
 
             # There's a chance that the processor job with a missing
-            # file deletes itself before the last downloader job
+            # file is aborted before the last downloader job
             # completes, therefore just check that there's at least 3
             # processor jobs.
             processor_jobs = ProcessorJob.objects.all()
@@ -624,8 +621,7 @@ class SraRedownloadingTestCase(TransactionTestCase):
             )
 
             start_time = timezone.now()
-            with self.assertRaises(ProcessorJob.DoesNotExist):
-                wait_for_job(doomed_processor_job, ProcessorJob, start_time)
+            wait_for_job(doomed_processor_job, ProcessorJob, start_time)
 
             # The processor job that had a missing file will have
             # recreated its DownloaderJob, which means there should
@@ -666,7 +662,7 @@ class SraRedownloadingTestCase(TransactionTestCase):
             successful_processor_jobs = []
             for processor_job in processor_jobs:
                 # One of the two calls to wait_for_job will fail
-                # because the job is going to delete itself when it
+                # because the job is going to abort when it
                 # finds that the file it wants to process is missing.
                 try:
                     processor_job = wait_for_job(processor_job, ProcessorJob, start_time)


### PR DESCRIPTION
## Issue Number

N/A

## Purpose/Implementation Notes

The last deploy failed while executing the migration `0049`:

```
Running migrations:
  Applying data_refinery_common.0048_processorjob_abort... OK
  Applying data_refinery_common.0049_processorjob_abort_alter...Traceback (most recent call last):
  File "/usr/local/lib/python3.5/dist-packages/django/db/backends/utils.py", line 84, in _execute
    return self.cursor.execute(sql, params)
psycopg2.extensions.QueryCanceledError: canceling statement due to statement timeout
```

Looks like the `batch_update` from migration `0048` left 1.5mm rows with NULL values (not sure why). The next migration timed out when setting them to their default value `False`.

I updated those rows on the DB with:

```
data_refinery=> UPDATE processor_jobs SET abort='f' WHERE abort IS NULL;
UPDATE 1452029
```

Now, `0049` should run fine since all processor job have a value in `abort`.

## Types of changes

- Breaking change (fix or feature that would cause existing functionality to not work as expected)
