### PR TITLE
Unversioned API response

### DIFF
--- a/api/data_refinery_api/middleware.py
+++ b/api/data_refinery_api/middleware.py
@@ -13,22 +13,21 @@ class SentryCatchBadRequestMiddleware(MiddlewareMixin):
         if not client.is_enabled():
             return response
 
+        # format error message
+        message = (
+            "{status_code} code returned for URL: {url}"
+            "with message: {message}"
+        ).format(status_code=response.status_code,
+                 url=request.build_absolute_uri(),
+                 message=str(response.content))
+
+        # create data representation
         data = client.get_data_from_request(request)
         data.update({
             "level": logging.WARN,
             "logger": "BadRequestMiddleware",
         })
-        message_template = "{status_code} code returned for URL: {url} {content}"
 
-        content = ""
-        try:
-            content = "with message: {}".format(str(response.content))
-        except Exception:
-            pass
-
-        message = message_template.format(status_code=response.status_code,
-                                          url=request.build_absolute_uri(),
-                                          content=content)
         client.captureMessage(message=message, data=data)
 
         return response

--- a/api/data_refinery_api/middleware.py
+++ b/api/data_refinery_api/middleware.py
@@ -2,6 +2,7 @@ import logging
 from django.utils.deprecation import MiddlewareMixin
 from data_refinery_common.utils import get_env_variable_gracefully
 
+
 class SentryCatchBadRequestMiddleware(MiddlewareMixin):
     def process_response(self, request, response):
         if response.status_code < 400 or response.status_code == 404:
@@ -22,13 +23,13 @@ class SentryCatchBadRequestMiddleware(MiddlewareMixin):
         content = ""
         try:
             content = "with message: {}".format(str(response.content))
-        except:
+        except Exception:
             pass
 
         message = message_template.format(status_code=response.status_code,
                                           url=request.build_absolute_uri(),
                                           content=content)
-        result = client.captureMessage(message=message, data=data)
+        client.captureMessage(message=message, data=data)
 
         return response
 
@@ -45,6 +46,7 @@ class SentryCatchBadRequestMiddleware(MiddlewareMixin):
         })
 
         client.captureMessage(message=str(exception), data=data)
+
 
 class RevisionMiddleware(MiddlewareMixin):
     def process_response(self, request, response):

--- a/api/data_refinery_api/settings.py
+++ b/api/data_refinery_api/settings.py
@@ -67,7 +67,6 @@ INSTALLED_APPS = [
 ]
 
 MIDDLEWARE = [
-
     'data_refinery_api.middleware.RevisionMiddleware',
     'data_refinery_api.middleware.SentryCatchBadRequestMiddleware',
     'django.middleware.security.SecurityMiddleware',

--- a/api/data_refinery_api/settings.py
+++ b/api/data_refinery_api/settings.py
@@ -12,7 +12,6 @@ https://docs.djangoproject.com/en/1.10/ref/settings/
 
 import os
 import sys
-from django.core.exceptions import ImproperlyConfigured
 
 from data_refinery_common.utils import get_env_variable, get_env_variable_gracefully
 
@@ -98,7 +97,7 @@ TEMPLATES = [
 ]
 
 # Uncomment this line to use Django Debug Toolbar inside Docker
-#INTERNAL_IPS = type(str('c'), (), {'__contains__': lambda *a: True})()
+# INTERNAL_IPS = type(str('c'), (), {'__contains__': lambda *a: True})()
 
 # Database
 # https://docs.djangoproject.com/en/1.10/ref/settings/#databases

--- a/api/data_refinery_api/urls.py
+++ b/api/data_refinery_api/urls.py
@@ -41,14 +41,19 @@ from .views import (
     OriginalFileList,
     AboutStats,
     FailedDownloaderJobStats,
-    FailedProcessorJobStats
+    FailedProcessorJobStats,
+    handle404error,
+    handle500error,
 )
+
 
 # This provides _public_ access to the /admin interface!
 # Enabling this by setting DEBUG to true this will allow unauthenticated access to the admin interface.
 # Very useful for debugging (since we have no User accounts), but very dangerous for prod!
 class AccessUser:
     has_module_perms = has_perm = __getattr__ = lambda s, *a, **kw: True
+
+
 if settings.DEBUG:
     admin.site.has_permission = lambda r: setattr(r, 'user', AccessUser()) or True
 
@@ -138,3 +143,7 @@ urlpatterns = [
 
 # This adds support explicitly typed endpoints such that appending '.json' returns that application type.
 urlpatterns = format_suffix_patterns(urlpatterns)
+
+# handle errors
+handler404 = handle404error
+handler500 = handle500error

--- a/api/data_refinery_api/views.py
+++ b/api/data_refinery_api/views.py
@@ -1451,7 +1451,7 @@ def handle404error(request, exception):
     url = 'https://api.refine.bio/'
 
     # check to see if the 404ed request contained a version
-    if not match(r'\v[1-9]/.*/gc', request.path):
+    if not match(r'^/v[1-9]/.*', request.path):
         message = 'refine.bio API resources are only available through versioned requests.'
 
     return JsonResponse({

--- a/api/data_refinery_api/views.py
+++ b/api/data_refinery_api/views.py
@@ -10,40 +10,31 @@ from django.db.models import Count, Prefetch, DateTimeField, OuterRef, Subquery
 from django.db.models.functions import Trunc, Left
 from django.db.models.aggregates import Avg, Sum
 from django.db.models.expressions import F, Q
-from django.http import Http404, HttpResponse, HttpResponseRedirect, HttpResponseBadRequest
+from django.http import (
+    Http404,
+    JsonResponse,
+)
 from django.shortcuts import get_object_or_404
 from django.utils import timezone
 from django_elasticsearch_dsl_drf.constants import (
-    LOOKUP_FILTER_TERMS,
     LOOKUP_FILTER_RANGE,
-    LOOKUP_FILTER_PREFIX,
-    LOOKUP_FILTER_WILDCARD,
     LOOKUP_QUERY_IN,
     LOOKUP_QUERY_GT,
-    LOOKUP_QUERY_GTE,
-    LOOKUP_QUERY_LT,
-    LOOKUP_QUERY_LTE,
-    LOOKUP_QUERY_EXCLUDE,
 )
 from django_elasticsearch_dsl_drf.viewsets import DocumentViewSet
 from django_elasticsearch_dsl_drf.filter_backends import (
     FilteringFilterBackend,
-    IdsFilterBackend,
     OrderingFilterBackend,
     DefaultOrderingFilterBackend,
     CompoundSearchFilterBackend,
     FacetedSearchFilterBackend
 )
 from django_filters.rest_framework import DjangoFilterBackend
-import django_filters
-from elasticsearch_dsl import TermsFacet, DateHistogramFacet
-from rest_framework import status, filters, generics, mixins
+from elasticsearch_dsl import TermsFacet
+from rest_framework import status, filters, generics
 from rest_framework.exceptions import APIException, NotFound
-from rest_framework.exceptions import ValidationError
 from rest_framework.pagination import LimitOffsetPagination
 from rest_framework.response import Response
-from rest_framework.reverse import reverse
-from rest_framework.settings import api_settings
 from rest_framework.views import APIView
 
 from data_refinery_api.serializers import (
@@ -57,7 +48,6 @@ from data_refinery_api.serializers import (
     OrganismSerializer,
     PlatformSerializer,
     ProcessorSerializer,
-    SampleSerializer,
     CompendiumResultSerializer,
     CompendiumResultWithUrlSerializer,
     QNTargetSerializer,
@@ -85,7 +75,6 @@ from data_refinery_common.models import (
     Dataset,
     DownloaderJob,
     Experiment,
-    ExperimentSampleAssociation,
     Organism,
     OrganismIndex,
     OriginalFile,
@@ -99,7 +88,6 @@ from data_refinery_common.models.documents import (
     ExperimentDocument
 )
 from data_refinery_common.utils import (
-    get_env_variable,
     get_active_volumes,
     get_nomad_jobs_breakdown,
     get_nomad_jobs
@@ -111,6 +99,13 @@ from django.utils.decorators import method_decorator
 from drf_yasg import openapi
 from drf_yasg.utils import swagger_auto_schema
 
+##
+# ElasticSearch
+##
+from django_elasticsearch_dsl_drf.pagination import LimitOffsetPagination as ESLimitOffsetPagination
+from six import iteritems
+
+
 logger = get_and_configure_logger(__name__)
 
 ##
@@ -118,12 +113,6 @@ logger = get_and_configure_logger(__name__)
 ##
 
 JOB_CREATED_AT_CUTOFF = datetime(2019, 6, 5, tzinfo=timezone.utc)
-
-##
-# ElasticSearch
-##
-from django_elasticsearch_dsl_drf.pagination import LimitOffsetPagination as ESLimitOffsetPagination
-from six import iteritems
 
 class FacetedSearchFilterBackendExtended(FacetedSearchFilterBackend):
     def aggregate(self, request, queryset, view):
@@ -1454,6 +1443,29 @@ class OriginalFileList(generics.ListAPIView):
     filterset_fields = OriginalFileListSerializer.Meta.fields
     ordering_fields = ('id', 'created_at', 'last_modified',)
     ordering = ('-id',)
+
+
+# error handlers
+def handle404error(request, exception):
+    message = 'The requested resource was not found on this server.'
+    url = 'https://api.refine.bio/'
+
+    # check to see if the 404ed request contained a version
+    if not match(r'\v[1-9]/.*/gc', request.path):
+        message = 'refine.bio API resources are only available through versioned requests.'
+
+    return JsonResponse({
+        'message': message,
+        'docs': url,
+        'status_code': 404,
+    }, status=404)
+
+
+def handle500error(request):
+    return JsonResponse({
+        'message': 'A server error occured. This has been reported.',
+        'status_code': 500,
+    }, status=500)
 
 
 ##


### PR DESCRIPTION
## Issue Number

#1795 

## Purpose/Implementation Notes

This PR ensures that the response type for 404 and 500 errors will be JSON. 
If a 404 error will be returned it will check to see if the request began with `r"^/v[1-9]"` and if so it will respond with a message mentioning that the api is versioned.
Also, the 404 errors will return a link to the docs.

## Methods

`data_refinery_api/urls.py`

## Types of changes

- New feature (non-breaking change which adds functionality)

## Functional tests

Tested with debug = False
