### PR TITLE
Bump django versions

### DIFF
--- a/api/requirements.in
+++ b/api/requirements.in
@@ -1,5 +1,5 @@
 coverage
-django>=3.0.1
+django==2.2.9
 psycopg2-binary
 boto3
 requests>=2.20.0

--- a/api/requirements.in
+++ b/api/requirements.in
@@ -1,5 +1,5 @@
 coverage
-django>=2.1.11
+django>=3.0.1
 psycopg2-binary
 boto3
 requests>=2.20.0

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -12,13 +12,13 @@ chardet==3.0.4            # via requests
 coreapi==2.3.3
 coreschema==0.0.4         # via coreapi, drf-yasg
 coverage==4.5.1
-django-cors-headers==2.4.0
+django-cors-headers==3.2.0
 django-elasticsearch-dsl-drf==0.20.3
 django-elasticsearch-dsl==6.4.2
 django-filter==2.0.0
 django-hstore==1.4.2      # via djangorestframework-hstore
 django-nine==0.2.2        # via django-elasticsearch-dsl-drf
-django==2.2.7
+django==2.2.9
 djangorestframework-hstore==1.3
 djangorestframework==3.9.4
 docutils==0.14            # via botocore

--- a/common/requirements.in
+++ b/common/requirements.in
@@ -1,5 +1,5 @@
 coverage
-django>=3.0.1
+django==2.2.9
 psycopg2-binary
 boto3
 requests>=2.20.0

--- a/common/requirements.in
+++ b/common/requirements.in
@@ -1,5 +1,5 @@
 coverage
-django>=2.1.11
+django>=3.0.1
 psycopg2-binary
 boto3
 requests>=2.20.0

--- a/common/requirements.txt
+++ b/common/requirements.txt
@@ -13,7 +13,7 @@ daiquiri==1.5.0
 django-elasticsearch-dsl-drf==0.20.3
 django-elasticsearch-dsl==6.4.2
 django-nine==0.2.2        # via django-elasticsearch-dsl-drf
-django==2.2.7
+django==2.2.9
 djangorestframework==3.9.4
 docutils==0.14            # via botocore
 elasticsearch-dsl==6.4.0

--- a/foreman/requirements.in
+++ b/foreman/requirements.in
@@ -1,4 +1,4 @@
-django>=2.1.11
+django>=3.0.1
 psycopg2-binary
 requests>=2.20.0
 retrying

--- a/foreman/requirements.in
+++ b/foreman/requirements.in
@@ -1,4 +1,4 @@
-django>=3.0.1
+django==2.2.9
 psycopg2-binary
 requests>=2.20.0
 retrying

--- a/foreman/requirements.txt
+++ b/foreman/requirements.txt
@@ -11,7 +11,7 @@ coverage==4.5.1
 django-elasticsearch-dsl-drf==0.20.3
 django-elasticsearch-dsl==7.1.0  # via django-elasticsearch-dsl-drf
 django-nine==0.2.2        # via django-elasticsearch-dsl-drf
-django==2.2.7
+django==2.2.9
 djangorestframework==3.10.3  # via django-elasticsearch-dsl-drf
 elasticsearch-dsl==7.1.0
 elasticsearch==7.1.0      # via django-elasticsearch-dsl-drf, elasticsearch-dsl

--- a/workers/data_refinery_workers/downloaders/requirements.in
+++ b/workers/data_refinery_workers/downloaders/requirements.in
@@ -1,4 +1,4 @@
-django>=3.0.1
+django>=2.2.9
 requests>=2.20.0
 psycopg2-binary
 retrying

--- a/workers/data_refinery_workers/downloaders/requirements.in
+++ b/workers/data_refinery_workers/downloaders/requirements.in
@@ -1,4 +1,4 @@
-django>=2.2.9
+django==2.2.9
 requests>=2.20.0
 psycopg2-binary
 retrying

--- a/workers/data_refinery_workers/downloaders/requirements.in
+++ b/workers/data_refinery_workers/downloaders/requirements.in
@@ -1,4 +1,4 @@
-django>=2.1.11
+django>=3.0.1
 requests>=2.20.0
 psycopg2-binary
 retrying

--- a/workers/data_refinery_workers/downloaders/requirements.txt
+++ b/workers/data_refinery_workers/downloaders/requirements.txt
@@ -4,12 +4,13 @@
 #
 #    pip-compile --output-file requirements.txt requirements.in
 #
+asgiref==3.2.3            # via django
 certifi==2018.8.24        # via requests
 chardet==3.0.4            # via requests
 coverage==4.5.1           # via coveralls
 coveralls==1.5.1
 django-elasticsearch-dsl==0.5.1
-django==2.2.7
+django==3.0.1
 docopt==0.6.2             # via coveralls
 elasticsearch-dsl==6.1.0
 elasticsearch==6.2.0      # via elasticsearch-dsl

--- a/workers/data_refinery_workers/downloaders/requirements.txt
+++ b/workers/data_refinery_workers/downloaders/requirements.txt
@@ -4,13 +4,12 @@
 #
 #    pip-compile --output-file requirements.txt requirements.in
 #
-asgiref==3.2.3            # via django
 certifi==2018.8.24        # via requests
 chardet==3.0.4            # via requests
 coverage==4.5.1           # via coveralls
 coveralls==1.5.1
 django-elasticsearch-dsl==0.5.1
-django==3.0.1
+django==2.2.9
 docopt==0.6.2             # via coveralls
 elasticsearch-dsl==6.1.0
 elasticsearch==6.2.0      # via elasticsearch-dsl

--- a/workers/data_refinery_workers/processors/requirements.in
+++ b/workers/data_refinery_workers/processors/requirements.in
@@ -1,7 +1,7 @@
 boto3>=1.9.199
 coveralls
 django-elasticsearch-dsl
-django>=2.1.11
+django>=3.0.1
 elasticsearch-dsl
 matplotlib
 numpy

--- a/workers/data_refinery_workers/processors/requirements.in
+++ b/workers/data_refinery_workers/processors/requirements.in
@@ -1,7 +1,7 @@
 boto3>=1.9.199
 coveralls
 django-elasticsearch-dsl
-django>=3.0.1
+django>=2.2.9
 elasticsearch-dsl
 matplotlib
 numpy

--- a/workers/data_refinery_workers/processors/requirements.in
+++ b/workers/data_refinery_workers/processors/requirements.in
@@ -1,7 +1,7 @@
 boto3>=1.9.199
 coveralls
 django-elasticsearch-dsl
-django>=2.2.9
+django==2.2.9
 elasticsearch-dsl
 matplotlib
 numpy

--- a/workers/data_refinery_workers/processors/requirements.txt
+++ b/workers/data_refinery_workers/processors/requirements.txt
@@ -4,7 +4,6 @@
 #
 #    pip-compile --output-file requirements.txt requirements.in
 #
-asgiref==3.2.3            # via django
 bokeh==1.0.4              # via datashader
 boto3==1.9.199
 botocore==1.12.199        # via boto3, s3transfer
@@ -22,7 +21,7 @@ datashape==0.5.2
 decorator==4.4.0          # via networkx
 distributed==1.26.0       # via dask
 django-elasticsearch-dsl==6.4.2
-django==3.0.1
+django==2.2.9
 docopt==0.6.2             # via coveralls
 docutils==0.14            # via botocore
 elasticsearch-dsl==6.4.0

--- a/workers/data_refinery_workers/processors/requirements.txt
+++ b/workers/data_refinery_workers/processors/requirements.txt
@@ -4,6 +4,7 @@
 #
 #    pip-compile --output-file requirements.txt requirements.in
 #
+asgiref==3.2.3            # via django
 bokeh==1.0.4              # via datashader
 boto3==1.9.199
 botocore==1.12.199        # via boto3, s3transfer
@@ -21,7 +22,7 @@ datashape==0.5.2
 decorator==4.4.0          # via networkx
 distributed==1.26.0       # via dask
 django-elasticsearch-dsl==6.4.2
-django==2.2.7
+django==3.0.1
 docopt==0.6.2             # via coveralls
 docutils==0.14            # via botocore
 elasticsearch-dsl==6.4.0


### PR DESCRIPTION
## Issue Number

This replaces some of the auto-PRs that got generated.

## Purpose/Implementation Notes

Django released some security updates. This lets us take advantage of them.

We can't go up to Django 3.0.1 until https://github.com/sabricot/django-elasticsearch-dsl/pull/233 is released.


## Types of changes

- Version Increase

## Functional tests

I've run the API and hit it to make sure all the versions work  together.

## Checklist

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules
