### PR TITLE
add source for organism name

### DIFF
--- a/api/data_refinery_api/serializers.py
+++ b/api/data_refinery_api/serializers.py
@@ -66,7 +66,7 @@ class ProcessorSerializer(serializers.ModelSerializer):
 
 class OrganismIndexSerializer(serializers.ModelSerializer):
 
-    organism_name = serializers.StringRelatedField(read_only=True)
+    organism_name = serializers.StringRelatedField(source='organism', read_only=True)
     download_url = serializers.SerializerMethodField()
 
     class Meta:


### PR DESCRIPTION
## Issue Number

#1993 

fixes small bug where the organism name wasn't appearing in the results for 

`/v1/transcriptome_indices/1`