### PR TITLE
Improve slack notifications when datasets are submitted

### DIFF
--- a/api/data_refinery_api/views.py
+++ b/api/data_refinery_api/views.py
@@ -512,6 +512,7 @@ class DatasetView(generics.RetrieveUpdateAPIView):
                             city = "COULD_NOT_DETERMINE"
 
                         user_agent = self.request.META.get('HTTP_USER_AGENT', None)
+                        total_samples = len(set([accession_code for experiment in new_data.values() for accession_code in experiment]))
                         response = requests.post(
                             settings.ENGAGEMENTBOT_WEBHOOK,
                             json={
@@ -531,11 +532,15 @@ class DatasetView(generics.RetrieveUpdateAPIView):
                                             {
                                                 'title': 'Dataset id',
                                                 'value': str(old_object.id),
+                                            },
+                                            {
+                                                'title': 'Total downloads',
+                                                'value': Dataset.objects.filter(email_address=supplied_email_address).count(),
                                                 'short': True
                                             },
                                             {
-                                                'title': 'Total',
-                                                'value': Dataset.objects.filter(email_address=supplied_email_address).count(),
+                                                'title': 'Samples',
+                                                'value': total_samples,
                                                 'short': True
                                             }
                                         ]

--- a/api/data_refinery_api/views.py
+++ b/api/data_refinery_api/views.py
@@ -524,9 +524,13 @@ class DatasetView(generics.RetrieveUpdateAPIView):
                                         'color': 'good',
                                         'title': 'New dataset download',
                                         'fallback': 'New dataset download',
-                                        'title_link': 'http://www.refine.bio/dataset/' + str(old_object.id),
-                                        'text': 'New user ' + supplied_email_address + ' from ' + city + ' downloaded a dataset!',
-                                        'footer': 'Refine.bio | ' + remote_ip + ' | ' + user_agent,
+                                        'title_link': 'http://www.refine.bio/dataset/{0}'.format(
+                                            old_object.id
+                                        ),
+                                        'text': 'New user {0} from {1} downloaded a dataset!'.format(
+                                            supplied_email_address, city
+                                        ),
+                                        'footer': 'Refine.bio | {0} | {1}'.format(remote_ip, user_agent),
                                         'footer_icon': 'https://s3.amazonaws.com/refinebio-email/logo-2x.png',
                                         'fields': [
                                             {

--- a/workers/data_refinery_workers/processors/smasher.py
+++ b/workers/data_refinery_workers/processors/smasher.py
@@ -446,20 +446,25 @@ def _notify_slack_failed_dataset(job_context: Dict):
         settings.ENGAGEMENTBOT_WEBHOOK,
         json={
             'channel': 'ccdl-general', # Move to robots when we get sick of these
-            'username': 'EngagementBot',
-            'icon_emoji': ':halal:',
-            'fallback': 'Dataset failed processing.',
-            'title': 'Dataset failed processing',
-            'title_link': dataset_url,
+            "username": "EngagementBot",
+            "icon_emoji": ":halal:",
             'attachments':[
                 {
-                    'color': 'warning',
+                    'fallback': 'Dataset failed processing.',
+                    'title': 'Dataset failed processing',
+                    'title_link': dataset_url,
+                    'color': '#db3b28',
                     'text': job_context['job'].failure_reason,
-                    'author_name': job_context['dataset'].email_address,
                     'fields': [
                         {
                             'title': 'Dataset id',
-                            'value': str(job_context['dataset'].id)
+                            'value': str(job_context['dataset'].id),
+                            'short': True
+                        },
+                        {
+                            'title': 'Email',
+                            'value': job_context['dataset'].email_address,
+                            'short': True
                         }
                     ]
                 }

--- a/workers/data_refinery_workers/processors/smasher.py
+++ b/workers/data_refinery_workers/processors/smasher.py
@@ -466,7 +466,9 @@ def _notify_slack_failed_dataset(job_context: Dict):
                             'value': job_context['dataset'].email_address,
                             'short': True
                         }
-                    ]
+                    ],
+                    'footer': 'Refine.bio',
+                    'footer_icon': 'https://s3.amazonaws.com/refinebio-email/logo-2x.png',
                 }
             ]
         },

--- a/workers/data_refinery_workers/settings.py
+++ b/workers/data_refinery_workers/settings.py
@@ -164,7 +164,7 @@ RUNNING_IN_CLOUD = get_env_variable('RUNNING_IN_CLOUD') == "True"
 # Elastic Search
 ELASTICSEARCH_DSL = {
     'default': {
-        'hosts': get_env_variable('ELASTICSEARCH_HOST') + ":" + get_env_variable('ELASTICSEARCH_PORT') 
+        'hosts': get_env_variable('ELASTICSEARCH_HOST') + ":" + get_env_variable('ELASTICSEARCH_PORT')
     }
 }
 
@@ -177,3 +177,6 @@ else:
         'data_refinery_common.models.documents': 'experiments',
     }
     ELASTICSEARCH_DSL_AUTOSYNC = False
+
+# EngagementBot
+ENGAGEMENTBOT_WEBHOOK = get_env_variable_gracefully('ENGAGEMENTBOT_WEBHOOK')


### PR DESCRIPTION
## Issue Number

#1944

## Purpose/Implementation Notes

Include additional information in slack notifications when new datasets are submitted or they fail processing.

![image](https://user-images.githubusercontent.com/1882507/71527920-74a96a80-28ab-11ea-92a0-0f5b81bf0849.png)

![image](https://user-images.githubusercontent.com/1882507/71527931-7c690f00-28ab-11ea-96aa-41c8700cb6c5.png)


## Types of changes

- Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Functional tests

Tested sending notifications to #robots

## Checklist

- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules
