### PR TITLE
Send a single email on smasher jobs

### DIFF
--- a/workers/data_refinery_workers/processors/smasher.py
+++ b/workers/data_refinery_workers/processors/smasher.py
@@ -433,6 +433,11 @@ def _notify(job_context: Dict) -> Dict:
                                           exc_info=1,
                                           result_url=job_context['result_url'])
 
+    # We don't want to retry this dataset after we send a notification to users
+    # https://github.com/alexslemonade/refinebio/issues/1944
+    job_context['job'].no_retry = True
+    job_context['job'].save()
+
     return job_context
 
 


### PR DESCRIPTION
## Issue Number

close #1944 

## Purpose/Implementation Notes

Ensure `SMASHER` jobs are not retried after we send a notification to users. These jobs will still be retried multiple times until the notification is sent.

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

None

## Checklist

- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules
