### PR TITLE
Change the circleci syntax check to make sure that black runs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -121,11 +121,10 @@ jobs:
       - checkout
 
       # Install flake8
-      - run: sudo pip install flake8
+      - run: sudo pip install black
 
-      # Check for syntax errors in our project
-      # (--select=E9 only checks for SyntaxErrors)
-      - run: flake8 foreman workers common api --count --select=E9 --show-source --statistics
+      # Check for syntax errors in our project. Also make sure the code is formatted correctly.
+      - run: black . --line-length=100 --check --quiet
 
   # This tests workers tests tagged as 'salmon'
   salmon_and_api_tests:

--- a/README.md
+++ b/README.md
@@ -337,11 +337,14 @@ Python Files in this repo follow
 [PEP 8](https://www.python.org/dev/peps/pep-0008/). All files (including
 Python and R) have a line length limit of 100 characters.
 
-A `setup.cfg` file has been included in the root of this repo which specifies
-the line length limit for the autopep8 and flake8 linters. If you run either
-linter within the project's directory tree, it will enforce a line length limit
-of 100 instead of 80. This will also be true for editors which rely on either
-linter.
+In addition to following pep8, python files must also conform to the formatting style enforced by [black](https://black.readthedocs.io/en/stable/).
+`black` is a highly opinionated auto-formatter.
+(`black`'s highly opinionated style is a strict sub-set of pep8.)
+The easiest way to conform to this style is to run `black . --line-length=100`.
+This will auto-format your code.
+Running the `./scripts/install_all.sh` script will install a pre-commit git hook that will run this formatter on every commit you make locally.
+To install `black` see the [installation instructions](#installation).
+Any Pull Requests that do not conform to the style enforced by `black` will be flagged by our continous integration and will not be accepted until that check passes.
 
 All user-facing scripts have been linted with `shellcheck` for common
 warnings and POSIX-correctness. If a script is user-facing, it should ideally


### PR DESCRIPTION
## Issue Number

#2033 

## Purpose/Implementation Notes

In #2033 we reformatted all our code using `black`. However we didn't add any check to make sure that all contributions pass `black`'s lint. This replaces our previous syntax check which used flake8 with `black . --line-length=100 --check --quiet`. This command will output nothing and exit with status code 0 if everything is okay, otherwise it will complain so the check fails.

## Types of changes

- New feature (non-breaking change which adds functionality)

## Functional tests

I made sure that a syntax issue would make black complain. Other than that this should be covered by unit tests.

## Checklist

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules
