### PR TITLE
Add slack web hook to the smasher env variables

### DIFF
--- a/workers/nomad-job-specs/smasher.nomad.tpl
+++ b/workers/nomad-job-specs/smasher.nomad.tpl
@@ -60,6 +60,8 @@ job "SMASHER" {
         NOMAD_PORT = "${{NOMAD_PORT}}"
 
         LOG_LEVEL = "${{LOG_LEVEL}}"
+
+        ENGAGEMENTBOT_WEBHOOK = "${{ENGAGEMENTBOT_WEBHOOK}}"
       }
 
       # The resources the job will require.


### PR DESCRIPTION
## Issue Number

close #2030 

## Purpose/Implementation Notes

The env variable `ENGAGEMENTBOT_WEBHOOK` was not declared for the smasher instance, this ensures it get's set.

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

None

## Checklist

- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules
