### PR TITLE
Don't associate all samples with tximport result

### DIFF
--- a/workers/data_refinery_workers/processors/salmon.py
+++ b/workers/data_refinery_workers/processors/salmon.py
@@ -533,16 +533,6 @@ def _run_tximport_for_experiment(
     result.save()
     job_context["pipeline"].steps.append(result.id)
 
-    # Associate this result with all samples in this experiment.
-    # TODO: This may not be completely sensible, because `tximport` is
-    # done at experiment level, not at sample level.
-    # Could be very problematic if SRA's data model allows many
-    # Experiments to one Run.
-    # https://github.com/AlexsLemonade/refinebio/issues/297
-    for sample in experiment.samples.all():
-        s_r = SampleResultAssociation(sample=sample, result=result)
-        s_r.save()
-
     rds_file = ComputedFile()
     rds_file.absolute_file_path = rds_file_path
     rds_file.filename = rds_filename


### PR DESCRIPTION
## Issue Number

#2054

## Purpose/Implementation Notes

We were associating all samples in an experiment with the `ComputationalResult` that `tximport` generated. This removes that code.

We still associate the samples with the computational result below, but we ensure the samples are present in the actual tximport output.

In addition to these changes, we'll need to find a way to fix the inaccurate data from prod.

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

None

## Checklist

- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules
