### PR TITLE
Fixes the order in which we run parts of the smasher pipeline 

### DIFF
--- a/api/data_refinery_api/views.py
+++ b/api/data_refinery_api/views.py
@@ -744,7 +744,9 @@ class SampleList(generics.ListAPIView):
         """
         queryset = (
             Sample.public_objects.prefetch_related("organism")
-            .prefetch_related(Prefetch("results", queryset=ComputationalResult.objects.order_by('time_start')))
+            .prefetch_related(
+                Prefetch("results", queryset=ComputationalResult.objects.order_by("time_start"))
+            )
             .prefetch_related("results__processor")
             .prefetch_related("results__computationalresultannotation_set")
             .prefetch_related("results__computedfile_set")

--- a/workers/data_refinery_workers/processors/smasher.py
+++ b/workers/data_refinery_workers/processors/smasher.py
@@ -523,11 +523,12 @@ def _update_result_objects(job_context: Dict) -> Dict:
     dataset.expires_on = timezone.now() + timedelta(days=7)
     dataset.save()
 
-    # File is uploaded and the metadata is updated, can delete the local.
-    try:
-        os.remove(job_context["output_file"])
-    except OSError:
-        pass
+    if settings.RUNNING_IN_CLOUD and job_context.get("upload", True):
+        # File is uploaded and the metadata is updated, can delete the local.
+        try:
+            os.remove(job_context["output_file"])
+        except OSError:
+            pass
 
     job_context["success"] = True
 

--- a/workers/data_refinery_workers/processors/smasher.py
+++ b/workers/data_refinery_workers/processors/smasher.py
@@ -543,8 +543,8 @@ def smash(job_id: int, upload=True) -> None:
             utils.start_job,
             smashing_utils.prepare_files,
             _smash_all,
-            _upload,
             _update_result_objects,
+            _upload,
             utils.end_job,
         ],
     )

--- a/workers/data_refinery_workers/processors/smasher.py
+++ b/workers/data_refinery_workers/processors/smasher.py
@@ -352,12 +352,6 @@ def _upload(job_context: Dict) -> Dict:
 
     logger.debug("Result uploaded!", result_url=job_context["result_url"])
 
-    # File is uploaded, we can delete the local.
-    try:
-        os.remove(job_context["output_file"])
-    except OSError:
-        pass
-
     return job_context
 
 
@@ -529,6 +523,12 @@ def _update_result_objects(job_context: Dict) -> Dict:
     dataset.expires_on = timezone.now() + timedelta(days=7)
     dataset.save()
 
+    # File is uploaded and the metadata is updated, can delete the local.
+    try:
+        os.remove(job_context["output_file"])
+    except OSError:
+        pass
+
     job_context["success"] = True
 
     return job_context
@@ -543,8 +543,8 @@ def smash(job_id: int, upload=True) -> None:
             utils.start_job,
             smashing_utils.prepare_files,
             _smash_all,
-            _update_result_objects,
             _upload,
+            _update_result_objects,
             utils.end_job,
         ],
     )


### PR DESCRIPTION
## Issue Number

https://github.com/AlexsLemonade/refinebio/pull/2014

## Purpose/Implementation Notes

Deepa noticed her datasets failed this morning.

We were deleting the dataset before calculating its size. This switches it so we calculate the size of the dataset before deleting it.

This has affected datasets since the 4th of January. I will rerun those jobs once this change is deployed.

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

This stuff won't even happen locally, which is probably why it never came up before. We should probably improve these tests more but right now I wanna get this bug fixed.