### PR TITLE
Add migration to remove invalid tximport associations

### DIFF
--- a/common/data_refinery_common/migrations/0052_remove_invalid_tximport_associations.py
+++ b/common/data_refinery_common/migrations/0052_remove_invalid_tximport_associations.py
@@ -1,5 +1,4 @@
-from django.db import migrations, models
-from django.db.models import Count, F
+from django.db import migrations
 
 
 def remove_tximport_invalid_associations(apps, schema_editor):

--- a/common/data_refinery_common/migrations/0052_remove_invalid_tximport_associations.py
+++ b/common/data_refinery_common/migrations/0052_remove_invalid_tximport_associations.py
@@ -1,0 +1,24 @@
+from django.db import migrations, models
+from django.db.models import Count, F
+
+
+def remove_tximport_invalid_associations(apps, schema_editor):
+    """ We were associating tximport with all samples in an experiment
+    even though some of them were unprocessed.
+    Ref https://github.com/AlexsLemonade/refinebio/issues/2054 """
+    SampleResultAssociation = apps.get_model("data_refinery_common", "SampleResultAssociation")
+
+    SampleResultAssociation.objects.filter(
+        sample__is_processed=False, result__processor__name__iexact="tximport"
+    ).delete()
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("data_refinery_common", "0051_remove_dataset_email_sent"),
+    ]
+
+    operations = [
+        migrations.RunPython(remove_tximport_invalid_associations),
+    ]


### PR DESCRIPTION
## Issue Number

close #2054 

## Purpose/Implementation Notes

Removes associations between tximport computational results and samples that are not processed.

## Types of changes

- Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Functional tests

Ran migrations locally

## Checklist

- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules
