### PR TITLE
Only prevent retry of jobs if no_retry job was current version.

### DIFF
--- a/common/data_refinery_common/models/models.py
+++ b/common/data_refinery_common/models/models.py
@@ -33,6 +33,9 @@ LOCAL_ROOT_DIR = get_env_variable("LOCAL_ROOT_DIR", "/home/user/data_store")
 # we need something with the pattern: 'salmon X.X.X'
 CURRENT_SALMON_VERSION = "salmon " + get_env_variable("SALMON_VERSION", "0.13.1")
 CHUNK_SIZE = 1024 * 256  # chunk_size is in bytes
+# Let this fail if SYSTEM_VERSION is unset.
+SYSTEM_VERSION = get_env_variable("SYSTEM_VERSION")
+
 
 """
 # First Order Classes
@@ -915,7 +918,9 @@ class OriginalFile(models.Model):
         # If the file has a processor job that should not have been
         # retried, then it still shouldn't be retried.
         # Exclude the ones that were aborted.
-        no_retry_processor_jobs = self.processor_jobs.filter(no_retry=True).exclude(abort=True)
+        no_retry_processor_jobs = self.processor_jobs.filter(
+            no_retry=True, worker_version=SYSTEM_VERSION
+        ).exclude(abort=True)
 
         # If the file has a processor job that hasn't even started
         # yet, then it doesn't need another.

--- a/common/data_refinery_common/models/models.py
+++ b/common/data_refinery_common/models/models.py
@@ -20,7 +20,6 @@ from data_refinery_common.utils import (
     calculate_file_size,
     calculate_sha1,
     get_env_variable,
-    get_s3_url,
 )
 
 # We have to set the signature_version to v4 since us-east-1 buckets require

--- a/workers/data_refinery_workers/downloaders/array_express.py
+++ b/workers/data_refinery_workers/downloaders/array_express.py
@@ -12,11 +12,7 @@ from data_refinery_common.logging import get_and_configure_logger
 from data_refinery_common.models import (
     DownloaderJob,
     DownloaderJobOriginalFileAssociation,
-    Experiment,
-    ExperimentAnnotation,
-    ExperimentSampleAssociation,
     OriginalFile,
-    Sample,
 )
 from data_refinery_common.utils import (
     get_env_variable,


### PR DESCRIPTION
## Issue Number

#2031 

## Purpose/Implementation Notes

It was impossible to retry samples where a potential fix was created. This PR adresses that.

## Methods

`OriginalFile::has_blocking_jobs`

When checking if an original file has blocking jobs we first check if there are processor jobs where `no_retry=True` and  exclude where `abort=True`

However if we think that the error in processing that sample/original file has been resolved this prevents us from being able to queue up that file again. So this PR adds checking against the current version (same as `processor_job_instance.worker_version`) so the job will not be retried unless their has been a new deploy.

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

None.

## Checklist

- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules
