### PR TITLE
Enable cloudtrail logging for S3 compendia bucket and others

### DIFF
--- a/infrastructure/deploy.sh
+++ b/infrastructure/deploy.sh
@@ -281,7 +281,7 @@ docker run \
 
 # Make sure to clear out any old nomad job specifications since we
 # will register everything in this directory.
-rm -r nomad-job-specs
+rm -rf nomad-job-specs
 
 # Template the environment variables for production into the Nomad Job
 # specs and API confs.

--- a/infrastructure/logging.tf
+++ b/infrastructure/logging.tf
@@ -6,8 +6,11 @@ resource "aws_cloudtrail" "data_refinery_s3_cloudtrail" {
   include_global_service_events = false
   depends_on                    = ["aws_s3_bucket.data_refinery_bucket"]
 
+  cloud_watch_logs_group_arn    = "${aws_cloudwatch_log_group.data_refinery_log_group.arn}"
+  cloud_watch_logs_role_arn     = "${aws_iam_role.cloudtrail_role.arn}"
+
   event_selector {
-    read_write_type           = "All"
+    read_write_type           = "ReadOnly"
     include_management_events = false
 
     data_resource {

--- a/infrastructure/logging.tf
+++ b/infrastructure/logging.tf
@@ -1,3 +1,30 @@
+# CloudTrail
+
+resource "aws_cloudtrail" "data_refinery_s3_cloudtrail" {
+  name                          = "data-refinery-s3-cloudtrail-${var.user}-${var.stage}"
+  s3_bucket_name                = "${aws_s3_bucket.data_refinery_bucket.id}"
+  include_global_service_events = false
+  depends_on                    = ["aws_s3_bucket.data_refinery_bucket"]
+
+  event_selector {
+    read_write_type           = "All"
+    include_management_events = false
+
+    data_resource {
+      type = "AWS::S3::Object"
+
+      # Make sure to append a trailing '/' to your ARN if you want
+      # to monitor all objects in a bucket.
+      # ref https://www.terraform.io/docs/providers/aws/r/cloudtrail.html#logging-individual-s3-bucket-events
+      values = [
+        "${aws_s3_bucket.data_refinery_compendia_bucket.arn}/",
+        "${aws_s3_bucket.data_refinery_transcriptome_index_bucket.arn}/",
+        "${aws_s3_bucket.data_refinery_qn_target_bucket.arn}/",
+      ]
+    }
+  }
+}
+
 # CloudWatch Log Groups and Streams
 
 ##


### PR DESCRIPTION
## Issue Number

close #2043 

## Purpose/Implementation Notes

This should add the configuration to start logging read events for the buckets `data_refinery_compendia_bucket`, `data_refinery_transcriptome_index_bucket`, `data_refinery_qn_target_bucket`.

All events are saved in S3 to the bucket `data_refinery_bucket` and also they are pushed to cloudfront. To a stream named [`589864003899_CloudTrail_us-east-1`](https://console.aws.amazon.com/cloudwatch/home?region=us-east-1#logEventViewer:group=data-refinery-log-group-arielsvn-dev;stream=589864003899_CloudTrail_us-east-1) I wasn't able to find a way to rename this stream. We could alternatively create a different group for cloudtrail events?

@kurtwheeler let me know what do you think, spent some time with the IAM roles, not sure if that's the right way to have them.

## Types of changes

- Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Functional tests

Created a dev environment and made sure that the trail configuration was correct and that we were logging to cloudfront in the right log group.

## Checklist

- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots

![image](https://user-images.githubusercontent.com/1882507/72475727-82228800-37b9-11ea-93c6-2752f1cc37a3.png)

[created with [blast-radius](https://github.com/28mm/blast-radius)]
