### PR TITLE
Seems like variables need to be declared in terraform

### DIFF
--- a/infrastructure/foreman-configuration/foreman-server-instance-user-data.tpl.sh
+++ b/infrastructure/foreman-configuration/foreman-server-instance-user-data.tpl.sh
@@ -30,8 +30,8 @@ docker run \\
        -e DATABASE_PASSWORD=${database_password} \\
        -e ELASTICSEARCH_HOST=${elasticsearch_host} \\
        -e ELASTICSEARCH_PORT=${elasticsearch_port} \\
-       -e AWS_ACCESS_KEY_ID=${aws_access_key_id_client} \\
-       -e AWS_SECRET_ACCESS_KEY=${aws_secret_access_key_client} \\
+       -e AWS_ACCESS_KEY_ID=${aws_access_key_id} \\
+       -e AWS_SECRET_ACCESS_KEY=${aws_secret_access_key} \\
        -v /tmp:/tmp \\
        --add-host=nomad:${nomad_lead_server_ip} \\
        --log-driver=awslogs \\
@@ -61,8 +61,8 @@ docker run \\
        -e DATABASE_PASSWORD=${database_password} \\
        -e ELASTICSEARCH_HOST=${elasticsearch_host} \\
        -e ELASTICSEARCH_PORT=${elasticsearch_port} \\
-       -e AWS_ACCESS_KEY_ID=${aws_access_key_id_client} \\
-       -e AWS_SECRET_ACCESS_KEY=${aws_secret_access_key_client} \\
+       -e AWS_ACCESS_KEY_ID=${aws_access_key_id} \\
+       -e AWS_SECRET_ACCESS_KEY=${aws_secret_access_key} \\
        -v /tmp:/tmp \\
        --add-host=nomad:${nomad_lead_server_ip} \\
        -it -d ${dockerhub_repo}/${foreman_docker_image} python3 manage.py \$@

--- a/infrastructure/instances.tf
+++ b/infrastructure/instances.tf
@@ -733,8 +733,8 @@ data "template_file" "foreman_server_script_smusher" {
     elasticsearch_host = "${aws_elasticsearch_domain.es.endpoint}"
     elasticsearch_port = "${var.elasticsearch_port}"
     log_group = "${aws_cloudwatch_log_group.data_refinery_log_group.name}"
-    aws_access_key_id_client = "${var.aws_access_key_id_client}"
-    aws_secret_access_key_client = "${var.aws_secret_access_key_client}"
+    aws_access_key_id = "${aws_iam_access_key.data_refinery_user_client_key.id}"
+    aws_secret_access_key = "${aws_iam_access_key.data_refinery_user_client_key.secret}"
   }
 }
 

--- a/infrastructure/variables.tf
+++ b/infrastructure/variables.tf
@@ -5,6 +5,16 @@
 # Annoyingly, TF can't have computed variables (${env.USER})
 # as default values for variables. So `TF_VAR_user=rjones tf plan`, etc.
 # Also, don't use any non-alphanumeric characters here or RDS will whinge.
+variable "aws_access_key_id_client" {
+  # This will be overwritten.
+  default = "aws-key"
+}
+
+variable "aws_secret_access_key_client" {
+  # This will be overwritten.
+  default = "aws-secret-access"
+}
+
 variable "user" {
   default = "myusername"
 }

--- a/infrastructure/variables.tf
+++ b/infrastructure/variables.tf
@@ -5,16 +5,6 @@
 # Annoyingly, TF can't have computed variables (${env.USER})
 # as default values for variables. So `TF_VAR_user=rjones tf plan`, etc.
 # Also, don't use any non-alphanumeric characters here or RDS will whinge.
-variable "aws_access_key_id_client" {
-  # This will be overwritten.
-  default = "aws-key"
-}
-
-variable "aws_secret_access_key_client" {
-  # This will be overwritten.
-  default = "aws-secret-access"
-}
-
 variable "user" {
   default = "myusername"
 }


### PR DESCRIPTION
## Issue Number

#2072

## Purpose/Implementation Notes

I got an error in terraform when deploying:

```
Error: resource 'data.template_file.foreman_server_script_smusher' config: unknown variable referenced: 'aws_secret_access_key_client'; define it with a 'variable' block

Error: resource 'data.template_file.foreman_server_script_smusher' config: unknown variable referenced: 'aws_access_key_id_client'; define it with a 'variable' block
```

This adds the two variable blocks. Also saw this comment:

> Annoyingly, TF can't have computed variables (${env.USER})
> as default values for variables. So `TF_VAR_user=rjones tf plan`, etc.

