### PR TITLE
Enable Compendia Bucket Request Level Metrics

### DIFF
--- a/infrastructure/disk.tf
+++ b/infrastructure/disk.tf
@@ -114,6 +114,10 @@ resource "aws_s3_bucket" "data_refinery_compendia_bucket" {
   }
 }
 
+resource "aws_s3_bucket_metric" "compendia_metrics" {
+  bucket = "${aws_s3_bucket.data_refinery_compendia_bucket.bucket}"
+  name   = "data-refinery-compendia-metric-${var.user}-${var.stage}"
+}
 
 resource "aws_s3_bucket" "data-refinery-static-access-logs" {
   bucket = "data-refinery-static-access-logs-${var.user}-${var.stage}"


### PR DESCRIPTION
## Issue Number

#2043 

## Purpose/Implementation Notes

Metrics for compendia downloads. This is the terraform code to enable request level logs for the compendia bucket (staging and prod when deployed) this allows us to use CloudWatch Metrics to get the number of `GetRequests` that were made on Objects (compendia archives) in the bucket.

## Methods

`infrastructure/disk.tf`

## Types of changes

What types of changes does your code introduce?

- New feature (non-breaking change which adds functionality)

## Functional tests

None.

## Checklist

- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

