### PR TITLE
Fix transcriptome indices for microbes.

### DIFF
--- a/common/data_refinery_common/models/organism.py
+++ b/common/data_refinery_common/models/organism.py
@@ -65,6 +65,7 @@ def get_taxonomy_id(organism_name: str) -> int:
         raise
 
     if len(id_list) == 0:
+        # If we can't find the taxonomy id, it's likely a bad organism name.
         error_message = (
             "Unable to retrieve NCBI taxonomy ID number for organism "
             + "with name: {}".format(organism_name)

--- a/common/data_refinery_common/models/organism.py
+++ b/common/data_refinery_common/models/organism.py
@@ -28,6 +28,10 @@ class InvalidNCBITaxonomyId(Exception):
     pass
 
 
+class UnknownOrganismId(Exception):
+    pass
+
+
 def get_scientific_name(taxonomy_id: int) -> str:
     parameters = {"db": TAXONOMY_DATABASE, "id": str(taxonomy_id), "api_key": NCBI_API_KEY}
     response = requests.get(EFETCH_URL, parameters)
@@ -61,11 +65,12 @@ def get_taxonomy_id(organism_name: str) -> int:
         raise
 
     if len(id_list) == 0:
-        logger.error(
-            "Unable to retrieve NCBI taxonomy ID number for organism " + "with name: %s",
-            organism_name,
+        error_message = (
+            "Unable to retrieve NCBI taxonomy ID number for organism "
+            + "with name: {}".format(organism_name)
         )
-        return 0
+        logger.error(error_message)
+        raise UnknownOrganismId(error_message)
     elif len(id_list) > 1:
         logger.warn(
             "Organism with name %s returned multiple NCBI taxonomy ID " + "numbers.", organism_name

--- a/workers/data_refinery_workers/processors/transcriptome_index.py
+++ b/workers/data_refinery_workers/processors/transcriptome_index.py
@@ -34,6 +34,15 @@ LOCAL_ROOT_DIR = get_env_variable("LOCAL_ROOT_DIR", "/home/user/data_store")
 IDS_CLEANUP_TABLE = str.maketrans({";": None, '"': None})
 
 
+def get_organism_name_from_path(directory_path: str) -> str:
+    """Sometimes these files have strain information appended to
+    them, so we want to make sure we only use the first two parts of
+    a name like Candida_albicans_sc5314_gca_000784635.
+    """
+    organism_directory = directory_path.split("/")[-1]
+    return "_".join(organism_directory.split("_")[:2]).upper()
+
+
 def _compute_paths(job_context: Dict) -> str:
     """Computes the paths for all the directories used/created by this processor.
 
@@ -68,11 +77,8 @@ def _compute_paths(job_context: Dict) -> str:
 
     # We don't actually associated the organism with the job, so we
     # have to determine the organism name from the file
-    # path. Sometimes these files have strain information appended to
-    # them, so we want to make sure we only use the first two parts of
-    # a name like Candida_albicans_sc5314_gca_000784635
-    organism_directory = job_context["base_file_path"].split("/")[-1]
-    job_context["organism_name"] = "_".join(organism_directory.split("_")[:2]).upper()
+    # path.
+    job_context["organism_name"] = get_organism_name_from_path(job_context["base_file_path"])
 
     stamp = str(timezone.now().timestamp()).split(".")[0]
     archive_file_name = (

--- a/workers/data_refinery_workers/processors/transcriptome_index.py
+++ b/workers/data_refinery_workers/processors/transcriptome_index.py
@@ -66,8 +66,13 @@ def _compute_paths(job_context: Dict) -> str:
     job_context["rsem_index_dir"] = job_context["work_dir"] + "rsem_index/"
     os.makedirs(job_context["rsem_index_dir"], exist_ok=True)
 
-    # I think this is a bit sketchy.
-    job_context["organism_name"] = job_context["base_file_path"].split("/")[-1]
+    # We don't actually associated the organism with the job, so we
+    # have to determine the organism name from the file
+    # path. Sometimes these files have strain information appended to
+    # them, so we want to make sure we only use the first two parts of
+    # a name like Candida_albicans_sc5314_gca_000784635
+    organism_directory = job_context["base_file_path"].split("/")[-1]
+    job_context["organism_name"] = "_".join(organism_directory.split("_")[:2]).upper()
 
     stamp = str(timezone.now().timestamp()).split(".")[0]
     archive_file_name = (


### PR DESCRIPTION
## Issue Number

#2096 

## Purpose/Implementation Notes

We were trying to ask NCBI for taxonomy ids for names like Candida_albicans_sc5314_gca_000784635. This didn't work but the lookup code returned a taxonomy id of 0 for some dumb reason. (Almost certainly my fault from a long time ago.)

This meant that when I tested one locally it would go into the DB with a taxonomy_id of 0, which worked once but the second one would violate a DB constraint and fail the job.

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

I've created a transcriptome index for E. coli and am currently running processing SRP242240 locally to test it.

## Checklist

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules
