### PR TITLE
Expose X-Source-Revision header in CORS requests

### DIFF
--- a/api/data_refinery_api/middleware.py
+++ b/api/data_refinery_api/middleware.py
@@ -49,4 +49,7 @@ class SentryCatchBadRequestMiddleware(MiddlewareMixin):
 class RevisionMiddleware(MiddlewareMixin):
     def process_response(self, request, response):
         response["X-Source-Revision"] = get_env_variable_gracefully("SYSTEM_VERSION")
+        # allow browsers to use the api directly and access the version
+        # https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS#Access-Control-Expose-Headers
+        response["Access-Control-Expose-Headers"] = "X-Source-Revision"
         return response


### PR DESCRIPTION
## Issue Number

https://github.com/AlexsLemonade/refinebio-docs/pull/122 We need to show refinebio's version on the docs

## Purpose/Implementation Notes

In order to be able to get this header in a request from the docs, we need to expose it with another header.

## Types of changes

- New feature (non-breaking change which adds functionality)

## Functional tests

None

## Checklist
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules
