### PR TITLE
Post engagement bot to default hook channel

### DIFF
--- a/api/data_refinery_api/views.py
+++ b/api/data_refinery_api/views.py
@@ -536,7 +536,6 @@ class DatasetView(generics.RetrieveUpdateAPIView):
                         requests.post(
                             settings.ENGAGEMENTBOT_WEBHOOK,
                             json={
-                                "channel": "ccdl-general",  # Move to robots when we get sick of these
                                 "username": "EngagementBot",
                                 "icon_emoji": ":halal:",
                                 "attachments": [
@@ -617,16 +616,6 @@ class CreateApiTokenView(generics.CreateAPIView):
 
 @method_decorator(name="patch", decorator=swagger_auto_schema(auto_schema=None))
 class APITokenView(generics.RetrieveUpdateAPIView):
-    """
-    Read and modify Api Tokens.
-
-    get:
-    Return details about a specific token.
-
-    put:
-    This can be used to activate a specific token by sending `is_activated: true`.
-    """
-
     model = APIToken
     lookup_field = "id"
     queryset = APIToken.objects.all()

--- a/api/data_refinery_api/views.py
+++ b/api/data_refinery_api/views.py
@@ -616,6 +616,16 @@ class CreateApiTokenView(generics.CreateAPIView):
 
 @method_decorator(name="patch", decorator=swagger_auto_schema(auto_schema=None))
 class APITokenView(generics.RetrieveUpdateAPIView):
+    """
+    Read and modify Api Tokens.
+
+    get:
+    Return details about a specific token.
+
+    put:
+    This can be used to activate a specific token by sending `is_activated: true`.
+    """
+
     model = APIToken
     lookup_field = "id"
     queryset = APIToken.objects.all()

--- a/workers/data_refinery_workers/processors/smasher.py
+++ b/workers/data_refinery_workers/processors/smasher.py
@@ -400,7 +400,6 @@ def _notify_slack_failed_dataset(job_context: Dict):
     requests.post(
         settings.ENGAGEMENTBOT_WEBHOOK,
         json={
-            "channel": "ccdl-general",  # Move to robots when we get sick of these
             "username": "EngagementBot",
             "icon_emoji": ":halal:",
             "attachments": [


### PR DESCRIPTION
## Issue Number

N/A

## Purpose/Implementation Notes

Remove the channel when posting a new download on the engagement bot, so that messages are posted to the default hook channel. This will make it easier to change this with the slack configuration.