### PR TITLE
Compendia without submitter processed data

### DIFF
--- a/foreman/data_refinery_foreman/foreman/management/commands/create_compendia.py
+++ b/foreman/data_refinery_foreman/foreman/management/commands/create_compendia.py
@@ -161,9 +161,11 @@ def get_dataset(organisms: List[Organism]):
     experiments = Experiment.objects.filter(filter_query).prefetch_related("samples")
 
     for experiment in queryset_iterator(experiments):
-        experiment_samples = experiment.samples.filter(
-            organism__in=organisms, is_processed=True
-        ).values_list("accession_code", flat=True)
+        experiment_samples = (
+            experiment.samples.filter(organism__in=organisms, is_processed=True)
+            .exclude(results__processor__name="Submitter-processed")
+            .values_list("accession_code", flat=True)
+        )
 
         dataset[experiment.accession_code] = list(experiment_samples)
 

--- a/foreman/data_refinery_foreman/foreman/management/commands/create_compendia.py
+++ b/foreman/data_refinery_foreman/foreman/management/commands/create_compendia.py
@@ -161,11 +161,9 @@ def get_dataset(organisms: List[Organism]):
     experiments = Experiment.objects.filter(filter_query).prefetch_related("samples")
 
     for experiment in queryset_iterator(experiments):
-        experiment_samples = (
-            experiment.samples.filter(organism__in=organisms, is_processed=True)
-            .exclude(results__processor__name="Submitter-processed")
-            .values_list("accession_code", flat=True)
-        )
+        experiment_samples = experiment.samples.filter(
+            organism__in=organisms, is_processed=True, has_raw=True
+        ).values_list("accession_code", flat=True)
 
         dataset[experiment.accession_code] = list(experiment_samples)
 

--- a/workers/data_refinery_workers/processors/create_compendia.py
+++ b/workers/data_refinery_workers/processors/create_compendia.py
@@ -35,7 +35,7 @@ S3_COMPENDIA_BUCKET_NAME = get_env_variable("S3_COMPENDIA_BUCKET_NAME", "data-re
 BYTES_IN_GB = 1024 * 1024 * 1024
 SMASHING_DIR = "/home/user/data_store/smashed/"
 logger = get_and_configure_logger(__name__)
-### DEBUG ###
+# DEBUG #
 logger.setLevel(logging.getLevelName("DEBUG"))
 
 


### PR DESCRIPTION
## Issue Number

#2114 

## Purpose/Implementation Notes

Remove Submitter Processed Data from compendium datasets. 

## Methods

In the management command we loop through all of the samples to make sure they are processed. This adds an extra clause to that to exclude any samples where the result's process name is `Submittter-processed`. Which is as far as I can tell the best way to check for this sort of thing.

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

Was unable to run nomad locally.. something about unable to bind to port... so running tests here and will request review after I am able to run them locally.

## Checklist

- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules
