### PR TITLE
Add an extra check to needs_downloading for transcriptome index jobs.

### DIFF
--- a/common/data_refinery_common/models/original_file.py
+++ b/common/data_refinery_common/models/original_file.py
@@ -230,6 +230,14 @@ class OriginalFile(models.Model):
         if unstarted_downloader_jobs.count() > 0:
             return False
 
+        # Do an extra check for blocking jobs for trancsriptome indices.
+        # This is necessary because needs_processing() won't check
+        # the blocking jobs for them because they're supposed to
+        # have multiple processor jobs. However if the file does need to
+        # be redownloaded, we only want one downloader job to be recreated.
+        if self.has_blocking_jobs(own_processor_id):
+            return False
+
         # If this file has been processed, then it doesn't need to be downloaded again.
         return self.needs_processing(own_processor_id)
 

--- a/workers/data_refinery_workers/processors/utils.py
+++ b/workers/data_refinery_workers/processors/utils.py
@@ -31,11 +31,7 @@ from data_refinery_common.models import (
     ProcessorJobOriginalFileAssociation,
     Sample,
 )
-from data_refinery_common.utils import (
-    get_env_variable,
-    get_env_variable_gracefully,
-    get_instance_id,
-)
+from data_refinery_common.utils import get_env_variable, get_instance_id
 
 logger = get_and_configure_logger(__name__)
 # Let this fail if SYSTEM_VERSION is unset.


### PR DESCRIPTION
## Issue Number

Not sure, but this started breaking intermittently yesterday.

## Purpose/Implementation Notes

Our transcriptome index jobs weren't handling a missing file quite correctly. This adds an additional check to `needs_downloading` to make sure they only recreate downloader jobs if they're the last processor job for the file.

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

The tests pass reliably!!!

## Checklist

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules
