### PR TITLE
Fix smasher job database timeout for large datasets

### DIFF
--- a/workers/data_refinery_workers/processors/smasher.py
+++ b/workers/data_refinery_workers/processors/smasher.py
@@ -228,7 +228,7 @@ def _smash_key(job_context: Dict, key: str, input_files: List[ComputedFile]) -> 
     # Quantile Normalization
     if job_context["dataset"].quantile_normalize:
         job_context["merged_no_qn"] = merged
-        job_context["organism"] = job_context["dataset"].get_samples().first().organism
+        job_context["organism"] = job_context["dataset"].get_samples()[0].organism
         job_context = smashing_utils.quantile_normalize(job_context)
         merged = job_context.get("merged_qn", None)
 


### PR DESCRIPTION
## Issue Number

N/A just saw some smasher jobs failing.

## Purpose/Implementation Notes

The query doesn't time out unless we order it. Order isnt important here, so dont.

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

I've tested that the query won't time out if we just take the first result rather than the `first()` result.

## Checklist

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules
