### PR TITLE
Ensure `filter_tests.sh` fails if the tests fail

### DIFF
--- a/.circleci/filter_tests.sh
+++ b/.circleci/filter_tests.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# Exit on failure
+set -e
+
 echo $(git log --format=oneline -n 1 "$CIRCLE_SHA1");
 if [[ $(git log --format=oneline -n 1 "$CIRCLE_SHA1") = *"noslow"* ]];
 then


### PR DESCRIPTION
## Issue Number

close #2145 

## Purpose/Implementation Notes

This ensures that `filter_tests.sh` exits on failure. 

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

None

## Checklist

- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules
