### PR TITLE
Give compendia jobs enough RAM to recreate the large ones.

### DIFF
--- a/infrastructure/variables.tf
+++ b/infrastructure/variables.tf
@@ -116,8 +116,8 @@ variable "nomad_server_instance_type" {
 }
 
 variable "smasher_instance_type" {
-  # 32GiB Memory, smasher and compendia jobs need 28.
-  default = "m5.2xlarge"
+  # 976GiB Memory, smasher and compendia jobs need 900.
+  default = "x1.16xlarge"
 }
 
 variable "spot_price" {

--- a/workers/nomad-job-specs/create_compendia.nomad.tpl
+++ b/workers/nomad-job-specs/create_compendia.nomad.tpl
@@ -67,8 +67,8 @@ job "CREATE_COMPENDIA" {
       resources {
         # CPU is in AWS's CPU units.
         cpu =   4000
-        # Memory is in MB of RAM. Instance has 32GiB of RAM.
-        memory = 28000
+        # Memory is in MB of RAM. Instance has 976GiB of RAM.
+        memory = 900000
       }
 
       logs {


### PR DESCRIPTION
## Issue Number

https://github.com/AlexsLemonade/refinebio/issues/1838
https://github.com/AlexsLemonade/refinebio/issues/2114

## Purpose/Implementation Notes

We want to recreate compandia so they have the changes from the two issues above.

This makes the smasher instance huge and makes the nomad job spec for compenida able to use most of its RAM.

## Types of changes

- Devops
