### PR TITLE
Add script to get data on quant.sf file sizes.

### DIFF
--- a/foreman/data_refinery_foreman/foreman/management/commands/get_quant_sf_size.py
+++ b/foreman/data_refinery_foreman/foreman/management/commands/get_quant_sf_size.py
@@ -1,0 +1,37 @@
+import csv
+
+from django.core.management.base import BaseCommand
+
+from data_refinery_common.logging import get_and_configure_logger
+from data_refinery_common.models import Experiment
+
+logger = get_and_configure_logger(__name__)
+
+csv_headers = ["sample_accession_code", "experiment_accession_code", "organism", "size_in_bytes"]
+
+
+class Command(BaseCommand):
+    def handle(self, *args, **options):
+        with open("/tmp/quant_sf_file_sizes.csv", "w", newline="") as csvfile:
+            writer = csv.DictWriter(csvfile, fieldnames=csv_headers)
+            writer.writeheader()
+
+            rnaseq_experiments = Experiment.objects.filter(technology="RNA-SEQ").prefetch_related(
+                "samples__results"
+            )
+            for experiment in rnaseq_experiments:
+                logger.info("Crunching experiment %s", experiment.accession_code)
+                for sample in experiment.samples.all():
+                    # Some experiments are multi-technology, but we only want RNASeq samples.
+                    if sample.technology == "RNA-SEQ":
+                        for result in sample.results.all():
+                            quant_sf_file = result.get_quant_sf_file()
+                            if quant_sf_file:
+                                writer.writerow(
+                                    {
+                                        "sample_accession_code": sample.accession_code,
+                                        "experiment_accession_code": experiment.accession_code,
+                                        "organism": sample.organism.name,
+                                        "size_in_bytes": quant_sf_file.size_in_bytes,
+                                    }
+                                )


### PR DESCRIPTION
## Issue Number

#2191 

## Purpose/Implementation Notes

This script spits out a CSV file like:

```
sample_accession_code,experiment_accession_code,organism,size_in_bytes
SRR8140707,SRP166447,HOMO_SAPIENS,9138640
```

For every sample with a quant.sf file. This is to identify what samples may need reprocessing.

## Types of changes

- New feature (non-breaking change which adds functionality)

## Functional tests

I ran it on my local DB and it generated the output that I pasted above.

## Checklist

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules
