### PR TITLE
Allow downloader jobs to run if file is partially downloaded

### DIFF
--- a/common/data_refinery_common/models/original_file.py
+++ b/common/data_refinery_common/models/original_file.py
@@ -221,7 +221,7 @@ class OriginalFile(models.Model):
         if self.absolute_file_path and os.path.exists(self.absolute_file_path):
             # ok a file exists, if this file has an SHA1 ensure that it's the same
             existing_file_sha1 = calculate_sha1(self.absolute_file_path)
-            if not self.sha1 or self.sha1 != existing_file_sha1:
+            if self.sha1 and self.sha1 != existing_file_sha1:
                 return True
             # otherwise, sha1 matches and the file doesn't need to be downloaded
             return False

--- a/common/data_refinery_common/models/original_file.py
+++ b/common/data_refinery_common/models/original_file.py
@@ -219,6 +219,11 @@ class OriginalFile(models.Model):
         # If the file is downloaded and the file actually exists on disk,
         # then it doens't need to be downloaded.
         if self.absolute_file_path and os.path.exists(self.absolute_file_path):
+            # ok a file exists, if this file has an SHA1 ensure that it's the same
+            existing_file_sha1 = calculate_sha1(self.absolute_file_path)
+            if not self.sha1 or self.sha1 != existing_file_sha1:
+                return True
+            # otherwise, sha1 matches and the file doesn't need to be downloaded
             return False
 
         unstarted_downloader_jobs = self.downloader_jobs.filter(

--- a/workers/data_refinery_workers/downloaders/sra.py
+++ b/workers/data_refinery_workers/downloaders/sra.py
@@ -306,14 +306,6 @@ def download_sra(job_id: int) -> None:
     downloaded_files = []
     success = None
     for original_file in original_files:
-        if original_file.is_downloaded:
-            logger.info(
-                "File already downloaded!", original_file=original_file.id, downloader_job=job_id
-            )
-            success = True
-            downloaded_files.append(original_file)
-            continue
-
         exp_path = LOCAL_ROOT_DIR + "/" + job.accession_code
         samp_path = exp_path + "/" + sample.accession_code
         os.makedirs(exp_path, exist_ok=True)

--- a/workers/data_refinery_workers/downloaders/sra.py
+++ b/workers/data_refinery_workers/downloaders/sra.py
@@ -311,6 +311,7 @@ def download_sra(job_id: int) -> None:
                 "File already downloaded!", original_file=original_file.id, downloader_job=job_id
             )
             success = True
+            downloaded_files.append(original_file)
             continue
 
         exp_path = LOCAL_ROOT_DIR + "/" + job.accession_code


### PR DESCRIPTION
## Issue Number

#2006

## Purpose/Implementation Notes

We found another corner case for the method `original_file.needs_downloading()`. If a downloader job gets OOM-Killed and it's not able to download the file fully, then on further retries we assume that the file is successfully downloaded.

This fixes it by adding an additional check to ensure that the SHA1 of the downloaded file matches what we have in the database. Files that we have never downloaded will get re-downloaded again since we don't have a way to check if it's complete.

@kurtwheeler We also need to increase the memory for the SRA jobs, it seems 1Gb isn't enough for these. Or do we re-try them with higher memory?

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

None

## Checklist

- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules
