### PR TITLE
Scale smasher back now that big compendia are done.

### DIFF
--- a/infrastructure/instances.tf
+++ b/infrastructure/instances.tf
@@ -185,7 +185,7 @@ resource "aws_instance" "smasher_instance" {
   root_block_device = {
     volume_type = "gp2"
     # 2000 is the largest we can use without reformatting the disk.
-    volume_size = 1000
+    volume_size = 200
   }
 }
 

--- a/infrastructure/variables.tf
+++ b/infrastructure/variables.tf
@@ -116,8 +116,8 @@ variable "nomad_server_instance_type" {
 }
 
 variable "smasher_instance_type" {
-  # 976GiB Memory, smasher and compendia jobs need 900.
-  default = "x1.16xlarge"
+  # 64GiB Memory, smasher and compendia jobs need 30.
+  default = "m5.4xlarge"
 }
 
 variable "spot_price" {

--- a/workers/nomad-job-specs/create_compendia.nomad.tpl
+++ b/workers/nomad-job-specs/create_compendia.nomad.tpl
@@ -67,8 +67,8 @@ job "CREATE_COMPENDIA" {
       resources {
         # CPU is in AWS's CPU units.
         cpu =   4000
-        # Memory is in MB of RAM. Instance has 976GiB of RAM.
-        memory = 900000
+        # Memory is in MB of RAM. Instance has 64GiB of RAM.
+        memory = 30000
       }
 
       logs {


### PR DESCRIPTION
## Issue Number

https://github.com/AlexsLemonade/refinebio/pull/2200

## Purpose/Implementation Notes

Time to scale back down. I'm keeping the smasher twice as big standard though so we can run smasher and compendia jobs at the same time.