### PR TITLE
Mount correct volume in instance

### DIFF
--- a/infrastructure/nomad-configuration/client-instance-user-data.tpl.sh
+++ b/infrastructure/nomad-configuration/client-instance-user-data.tpl.sh
@@ -57,7 +57,10 @@ while [  $COUNTER -lt 99 ]; do
 done
 
 sleep 15
-ATTACHED_AS=`lsblk -n | grep 2T | cut -d' ' -f1`
+# We want to mount the biggest volume that its attached to the instance
+# The size of this volume can be controlled with the varialbe
+# `volume_size_in_gb` from the file `variables.tf`
+ATTACHED_AS=`lsblk -n --sort SIZE | tail -1 | cut -d' ' -f1`
 
 # grep -v ext4: make sure the disk is not already formatted.
 if file -s /dev/$ATTACHED_AS | grep data | grep -v ext4; then

--- a/infrastructure/nomad-configuration/client-instance-user-data.tpl.sh
+++ b/infrastructure/nomad-configuration/client-instance-user-data.tpl.sh
@@ -57,8 +57,7 @@ while [  $COUNTER -lt 99 ]; do
 done
 
 sleep 15
-ATTACHED_AS=`lsblk -n | grep 8.8T | cut -d' ' -f1`
-FILE_RESULT=`file -s /dev/$ATTACHED_AS`
+ATTACHED_AS=`lsblk -n | grep 2T | cut -d' ' -f1`
 
 # grep -v ext4: make sure the disk is not already formatted.
 if file -s /dev/$ATTACHED_AS | grep data | grep -v ext4; then


### PR DESCRIPTION
## Issue Number

#2006 

## Purpose/Implementation Notes

We had a 2T volume available for the instances but it was not being mounted correctly. This fixes that. I'm not sure if this would be acceptable since this line depends on the variable `volume_size_in_gb`, every time that this variable is changed we would have to change this line as well. I saw [some PR](https://github.com/AlexsLemonade/refinebio/pull/551/files#diff-903d68d2a6b999a095378b7c4e142d07R41) that did this modification.

At some point, we used to have:

```
ATTACHED_AS=`lsblk -n | grep T | cut -d' ' -f1`
```

However, the result of `lsblk -n` is:

```
ubuntu@ip-10-0-91-161:/var/ebs$ lsblk -n
xvda    202:0    0  100G  0 disk 
└─xvda1 202:1    0  100G  0 part /
xvdb    202:16   0  1.8T  0 disk 
xvdf    202:80   0    2T  0 disk /var/ebs
```

So that doesn't suffice to select the volume `xvdf`


## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

Tested on prod.

## Checklist

- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules
