### PR TITLE
Increase timeout before mounting volume

### DIFF
--- a/infrastructure/nomad-configuration/client-instance-user-data.tpl.sh
+++ b/infrastructure/nomad-configuration/client-instance-user-data.tpl.sh
@@ -56,7 +56,7 @@ while [  $COUNTER -lt 99 ]; do
         let COUNTER=COUNTER+1
 done
 
-sleep 15
+sleep 25
 # We want to mount the biggest volume that its attached to the instance
 # The size of this volume can be controlled with the varialbe
 # `volume_size_in_gb` from the file `variables.tf`


### PR DESCRIPTION
## Issue Number

N/A

## Purpose/Implementation Notes

After the last deploy, the volume wasn't mounted on the spot instance. I tested the commands and they worked afterward.

So I assume the `sleep` before selecting the disk wasn't big enough? @kurtwheeler what do you think?