### PR TITLE
Add helper to download url and retry 3 times on error

### DIFF
--- a/common/data_refinery_common/utils.py
+++ b/common/data_refinery_common/utils.py
@@ -545,7 +545,7 @@ def download_file(
     retry=1,
     *,
     backoff_factor=8,
-    max_retries=5,
+    max_retries=10,
     max_sleep_timeout=120  # 2 mins
 ):
     """

--- a/common/data_refinery_common/utils.py
+++ b/common/data_refinery_common/utils.py
@@ -2,6 +2,7 @@ import csv
 import hashlib
 import io
 import os
+import random
 import re
 import shutil
 import time
@@ -538,11 +539,21 @@ def queryset_iterator(queryset, page_size=2000):
             yield item
 
 
-def download_file(download_url, target_file_path, retry=2, sleep=15):
+def download_file(
+    download_url,
+    target_file_path,
+    retry=1,
+    *,
+    backoff_factor=8,
+    max_retries=5,
+    max_sleep_timeout=120  # 2 mins
+):
     """
     Downloads the given url into `target_file_path`.
 
-    The download will be retried `retry` times if it fails for any reason.
+    The download will be retried `max_retries` times if it fails for any reason.
+    We use the exponential backoff https://en.wikipedia.org/wiki/Exponential_backoff
+    algorithm to add some randomness between retries.
     """
     try:
         # thanks to https://stackoverflow.com/a/39217788/763705
@@ -550,11 +561,15 @@ def download_file(download_url, target_file_path, retry=2, sleep=15):
             with open(target_file_path, "wb") as f:
                 shutil.copyfileobj(r.raw, f)
     except Exception as e:
-        if retry > 0:
-            # wait for a bit
-            time.sleep(sleep)
+        if retry < max_retries:
+            # After the retry-th failed attempt, retry downloading after
+            # k*backoff_factor, where k is a random integer between 0 and 2^retry − 1.
+            k = random.randint(0, 2 ** retry - 1)
+            sleep_timeout = min(k * backoff_factor, max_sleep_timeout)
+            time.sleep(sleep_timeout)
+
             # and retry downloading again
-            download_file(download_url, target_file_path, retry - 1, sleep)
+            download_file(download_url, target_file_path, retry + 1)
         else:
             raise e
 

--- a/workers/data_refinery_workers/downloaders/sra.py
+++ b/workers/data_refinery_workers/downloaders/sra.py
@@ -21,7 +21,7 @@ from data_refinery_common.models import (
     Sample,
 )
 from data_refinery_common.rna_seq import _build_ena_file_url
-from data_refinery_common.utils import get_env_variable, get_https_sra_download
+from data_refinery_common.utils import download_file, get_env_variable, get_https_sra_download
 from data_refinery_workers.downloaders import utils
 
 logger = get_and_configure_logger(__name__)
@@ -102,10 +102,8 @@ def _download_file_http(
             target_file_path,
             downloader_job=downloader_job.id,
         )
-        # thanks to https://stackoverflow.com/a/39217788/763705
-        with requests.get(download_url, stream=True) as r:
-            with open(target_file_path, "wb") as f:
-                shutil.copyfileobj(r.raw, f)
+        # This function will try to recover if the download fails
+        download_file(download_url, target_file_path)
     except Exception as e:
         logger.exception(
             "Exception caught while downloading file.", downloader_job=downloader_job.id


### PR DESCRIPTION
## Issue Number

#2006

## Purpose/Implementation Notes

I'm running out of theories for this, [reading online](https://stackoverflow.com/a/17473795/763705) I saw that there might be multiple reasons why these `OSError Cannot allocate memory` are raised and that for some of them there isn't much to do from the python script.

This will be capturing the exception, waiting a few secs and retrying the download 3 times before failing the job.

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

None

## Checklist

- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules
