### PR TITLE
Use instance c5d.9xlarge for spot fleet with 900gb disk

### DIFF
--- a/infrastructure/instances.tf
+++ b/infrastructure/instances.tf
@@ -217,13 +217,10 @@ resource "aws_spot_fleet_request" "cheap_ram" {
             "aws_instance.pg_bouncer"
   ]
 
-  ##
-  # x1e.8xlarge
-  ##
   launch_specification {
 
     # Client Specific
-    instance_type             = "x1e.8xlarge"
+    instance_type             = "c5d.9xlarge"
     weighted_capacity         = 10 # via https://aws.amazon.com/ec2/instance-types/
     spot_price                = "${var.spot_price}"
     ami                       = "${data.aws_ami.ubuntu.id}"
@@ -235,137 +232,18 @@ resource "aws_spot_fleet_request" "cheap_ram" {
     key_name = "${aws_key_pair.data_refinery.key_name}"
 
     root_block_device {
-      volume_size = 100
+      volume_size = 900
       volume_type = "gp2"
     }
 
     tags {
-        Name = "Spot Fleet Launch Specification x1e.16xlarge ${var.user}-${var.stage}"
+        Name = "Spot Fleet Launch Specification c5d.9xlarge ${var.user}-${var.stage}"
         User = "${var.user}"
         Stage = "${var.stage}"
     }
 
   }
 
-  ##
-  # x1.16xlarge
-  ##
-  launch_specification {
-
-    # Client Specific
-    instance_type             = "x1.16xlarge"
-    weighted_capacity         = 10 # via https://aws.amazon.com/ec2/instance-types/
-    spot_price                = "${var.spot_price}"
-    ami                       = "${data.aws_ami.ubuntu.id}"
-    iam_instance_profile_arn  = "${aws_iam_instance_profile.data_refinery_instance_profile.arn}"
-    user_data                 = "${data.template_file.nomad_client_script_smusher.rendered}"
-    vpc_security_group_ids    = ["${aws_security_group.data_refinery_worker.id}"]
-    subnet_id                 = "${aws_subnet.data_refinery_1a.id}"
-    availability_zone         = "${var.region}a"
-    key_name = "${aws_key_pair.data_refinery.key_name}"
-
-    root_block_device {
-      volume_size = 100
-      volume_type = "gp2"
-    }
-
-    tags {
-        Name = "Spot Fleet Launch Specification x1.32xlarge ${var.user}-${var.stage}"
-        User = "${var.user}"
-        Stage = "${var.stage}"
-    }
-
-  }
-
-  ##
-  # x1.32xlarge
-  ##
-  launch_specification {
-
-    # Client Specific
-    instance_type             = "x1.32xlarge"
-    weighted_capacity         = 20 # via https://aws.amazon.com/ec2/instance-types/
-    spot_price                = "${var.spot_price}"
-    ami                       = "${data.aws_ami.ubuntu.id}"
-    iam_instance_profile_arn  = "${aws_iam_instance_profile.data_refinery_instance_profile.arn}"
-    user_data                 = "${data.template_file.nomad_client_script_smusher.rendered}"
-    vpc_security_group_ids    = ["${aws_security_group.data_refinery_worker.id}"]
-    subnet_id                 = "${aws_subnet.data_refinery_1a.id}"
-    availability_zone         = "${var.region}a"
-    key_name = "${aws_key_pair.data_refinery.key_name}"
-
-    root_block_device {
-      volume_size = 100
-      volume_type = "gp2"
-    }
-
-    tags {
-        Name = "Spot Fleet Launch Specification x1.32xlarge ${var.user}-${var.stage}"
-        User = "${var.user}"
-        Stage = "${var.stage}"
-    }
-
-  }
-
-  ##
-  # x1e.16xlarge
-  ##
-  launch_specification {
-
-    # Client Specific
-    instance_type             = "x1e.16xlarge"
-    weighted_capacity         = 20 # via https://aws.amazon.com/ec2/instance-types/
-    spot_price                = "${var.spot_price}"
-    ami                       = "${data.aws_ami.ubuntu.id}"
-    iam_instance_profile_arn  = "${aws_iam_instance_profile.data_refinery_instance_profile.arn}"
-    user_data                 = "${data.template_file.nomad_client_script_smusher.rendered}"
-    vpc_security_group_ids    = ["${aws_security_group.data_refinery_worker.id}"]
-    subnet_id                 = "${aws_subnet.data_refinery_1a.id}"
-    availability_zone         = "${var.region}a"
-    key_name = "${aws_key_pair.data_refinery.key_name}"
-
-    root_block_device {
-      volume_size = 100
-      volume_type = "gp2"
-    }
-
-    tags {
-        Name = "Spot Fleet Launch Specification x1e.16xlarge ${var.user}-${var.stage}"
-        User = "${var.user}"
-        Stage = "${var.stage}"
-    }
-
-  }
-
-  ##
-  # x1e.32xlarge
-  ##
-  launch_specification {
-
-    # Client Specific
-    instance_type             = "x1e.32xlarge"
-    weighted_capacity         = 40 # via https://aws.amazon.com/ec2/instance-types/
-    spot_price                = "${var.spot_price}"
-    ami                       = "${data.aws_ami.ubuntu.id}"
-    iam_instance_profile_arn  = "${aws_iam_instance_profile.data_refinery_instance_profile.arn}"
-    user_data                 = "${data.template_file.nomad_client_script_smusher.rendered}"
-    vpc_security_group_ids    = ["${aws_security_group.data_refinery_worker.id}"]
-    subnet_id                 = "${aws_subnet.data_refinery_1a.id}"
-    availability_zone         = "${var.region}a"
-    key_name = "${aws_key_pair.data_refinery.key_name}"
-
-    root_block_device {
-      volume_size = 100
-      volume_type = "gp2"
-    }
-
-    tags {
-        Name = "Spot Fleet Launch Specification x1e.32xlarge ${var.user}-${var.stage}"
-        User = "${var.user}"
-        Stage = "${var.stage}"
-    }
-
-  }
 }
 
 ##

--- a/infrastructure/instances.tf
+++ b/infrastructure/instances.tf
@@ -232,7 +232,7 @@ resource "aws_spot_fleet_request" "cheap_ram" {
     key_name = "${aws_key_pair.data_refinery.key_name}"
 
     root_block_device {
-      volume_size = 900
+      volume_size = 100
       volume_type = "gp2"
     }
 

--- a/infrastructure/nomad-configuration/client-instance-user-data.tpl.sh
+++ b/infrastructure/nomad-configuration/client-instance-user-data.tpl.sh
@@ -56,17 +56,17 @@ while [  $COUNTER -lt 99 ]; do
         let COUNTER=COUNTER+1
 done
 
-sleep 25
-# We want to mount the biggest volume that its attached to the instance
-# The size of this volume can be controlled with the varialbe
-# `volume_size_in_gb` from the file `variables.tf`
-ATTACHED_AS=`lsblk -n --sort SIZE | tail -1 | cut -d' ' -f1`
+# sleep 25
+# # We want to mount the biggest volume that its attached to the instance
+# # The size of this volume can be controlled with the varialbe
+# # `volume_size_in_gb` from the file `variables.tf`
+# ATTACHED_AS=`lsblk -n --sort SIZE | tail -1 | cut -d' ' -f1`
 
-# grep -v ext4: make sure the disk is not already formatted.
-if file -s /dev/$ATTACHED_AS | grep data | grep -v ext4; then
-	mkfs -t ext4 /dev/$ATTACHED_AS # This is slow
-fi
-mount /dev/$ATTACHED_AS /var/ebs/
+# # grep -v ext4: make sure the disk is not already formatted.
+# if file -s /dev/$ATTACHED_AS | grep data | grep -v ext4; then
+# 	mkfs -t ext4 /dev/$ATTACHED_AS # This is slow
+# fi
+# mount /dev/$ATTACHED_AS /var/ebs/
 
 chown ubuntu:ubuntu /var/ebs/
 echo $EBS_VOLUME_INDEX >  /var/ebs/VOLUME_INDEX

--- a/infrastructure/nomad-configuration/client-instance-user-data.tpl.sh
+++ b/infrastructure/nomad-configuration/client-instance-user-data.tpl.sh
@@ -56,17 +56,17 @@ while [  $COUNTER -lt 99 ]; do
         let COUNTER=COUNTER+1
 done
 
-# sleep 25
-# # We want to mount the biggest volume that its attached to the instance
-# # The size of this volume can be controlled with the varialbe
-# # `volume_size_in_gb` from the file `variables.tf`
-# ATTACHED_AS=`lsblk -n --sort SIZE | tail -1 | cut -d' ' -f1`
+sleep 25
+# We want to mount the biggest volume that its attached to the instance
+# The size of this volume can be controlled with the varialbe
+# `volume_size_in_gb` from the file `variables.tf`
+ATTACHED_AS=`lsblk -n --sort SIZE | tail -1 | cut -d' ' -f1`
 
-# # grep -v ext4: make sure the disk is not already formatted.
-# if file -s /dev/$ATTACHED_AS | grep data | grep -v ext4; then
-# 	mkfs -t ext4 /dev/$ATTACHED_AS # This is slow
-# fi
-# mount /dev/$ATTACHED_AS /var/ebs/
+# grep -v ext4: make sure the disk is not already formatted.
+if file -s /dev/$ATTACHED_AS | grep data | grep -v ext4; then
+	mkfs -t ext4 /dev/$ATTACHED_AS # This is slow
+fi
+mount /dev/$ATTACHED_AS /var/ebs/
 
 chown ubuntu:ubuntu /var/ebs/
 echo $EBS_VOLUME_INDEX >  /var/ebs/VOLUME_INDEX


### PR DESCRIPTION
## Issue Number

#2237

## Purpose/Implementation Notes

EBS volumes seem to be giving problems when processing because they are going `Read-Only`. This changes the instance type to `c5d.9xlarge` which should come with it's own storage.

This PR should be reverted once the tests pass.

## Types of changes

- Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Functional tests

None
