### PR TITLE
Use instances SSD disk instead of EBS

### DIFF
--- a/infrastructure/instances.tf
+++ b/infrastructure/instances.tf
@@ -235,7 +235,7 @@ resource "aws_spot_fleet_request" "cheap_ram" {
     key_name = "${aws_key_pair.data_refinery.key_name}"
 
     root_block_device {
-      volume_size = 100
+      volume_size = 900
       volume_type = "gp2"
     }
 
@@ -265,7 +265,7 @@ resource "aws_spot_fleet_request" "cheap_ram" {
     key_name = "${aws_key_pair.data_refinery.key_name}"
 
     root_block_device {
-      volume_size = 100
+      volume_size = 900
       volume_type = "gp2"
     }
 
@@ -295,7 +295,7 @@ resource "aws_spot_fleet_request" "cheap_ram" {
     key_name = "${aws_key_pair.data_refinery.key_name}"
 
     root_block_device {
-      volume_size = 100
+      volume_size = 900
       volume_type = "gp2"
     }
 
@@ -325,7 +325,7 @@ resource "aws_spot_fleet_request" "cheap_ram" {
     key_name = "${aws_key_pair.data_refinery.key_name}"
 
     root_block_device {
-      volume_size = 100
+      volume_size = 900
       volume_type = "gp2"
     }
 
@@ -355,7 +355,7 @@ resource "aws_spot_fleet_request" "cheap_ram" {
     key_name = "${aws_key_pair.data_refinery.key_name}"
 
     root_block_device {
-      volume_size = 100
+      volume_size = 900
       volume_type = "gp2"
     }
 

--- a/infrastructure/nomad-configuration/client-instance-user-data.tpl.sh
+++ b/infrastructure/nomad-configuration/client-instance-user-data.tpl.sh
@@ -40,33 +40,36 @@ fetch_and_mount_volume () {
 export STAGE=${stage}
 export USER=${user}
 
-until fetch_and_mount_volume "$USER" "$STAGE"; do
-    sleep 10
-done
+# until fetch_and_mount_volume "$USER" "$STAGE"; do
+#     sleep 10
+# done
 
 COUNTER=0
-while [  $COUNTER -lt 99 ]; do
-        EBS_VOLUME_INDEX=`aws ec2 describe-volumes --filters "Name=tag:Index,Values=*" "Name=volume-id,Values=$EBS_VOLUME_ID" --query "Volumes[*].{ID:VolumeId,Tag:Tags}" --region ${region} | jq ".[0].Tag[$COUNTER].Value" | tr -d '"'`
-        if echo "$EBS_VOLUME_INDEX" | egrep -q '^\-?[0-9]+$'; then
-            echo "$EBS_VOLUME_INDEX is an integer!"
-            break # This is a Volume Index
-        else
-            echo "$EBS_VOLUME_INDEX is not an integer"
-        fi
-        let COUNTER=COUNTER+1
-done
+# while [  $COUNTER -lt 99 ]; do
+#         EBS_VOLUME_INDEX=`aws ec2 describe-volumes --filters "Name=tag:Index,Values=*" "Name=volume-id,Values=$EBS_VOLUME_ID" --query "Volumes[*].{ID:VolumeId,Tag:Tags}" --region ${region} | jq ".[0].Tag[$COUNTER].Value" | tr -d '"'`
+#         if echo "$EBS_VOLUME_INDEX" | egrep -q '^\-?[0-9]+$'; then
+#             echo "$EBS_VOLUME_INDEX is an integer!"
+#             break # This is a Volume Index
+#         else
+#             echo "$EBS_VOLUME_INDEX is not an integer"
+#         fi
+#         let COUNTER=COUNTER+1
+# done
+
+# Only a single volume for now
+export EBS_VOLUME_INDEX=1
 
 sleep 25
-# We want to mount the biggest volume that its attached to the instance
-# The size of this volume can be controlled with the varialbe
-# `volume_size_in_gb` from the file `variables.tf`
-ATTACHED_AS=`lsblk -n --sort SIZE | tail -1 | cut -d' ' -f1`
+# # We want to mount the biggest volume that its attached to the instance
+# # The size of this volume can be controlled with the varialbe
+# # `volume_size_in_gb` from the file `variables.tf`
+# ATTACHED_AS=`lsblk -n --sort SIZE | tail -1 | cut -d' ' -f1`
 
-# grep -v ext4: make sure the disk is not already formatted.
-if file -s /dev/$ATTACHED_AS | grep data | grep -v ext4; then
-	mkfs -t ext4 /dev/$ATTACHED_AS # This is slow
-fi
-mount /dev/$ATTACHED_AS /var/ebs/
+# # grep -v ext4: make sure the disk is not already formatted.
+# if file -s /dev/$ATTACHED_AS | grep data | grep -v ext4; then
+# 	mkfs -t ext4 /dev/$ATTACHED_AS # This is slow
+# fi
+# mount /dev/$ATTACHED_AS /var/ebs/
 
 chown ubuntu:ubuntu /var/ebs/
 echo $EBS_VOLUME_INDEX >  /var/ebs/VOLUME_INDEX


### PR DESCRIPTION
## Issue Number

#2237

## Purpose/Implementation Notes

This should be reverted once we finish processing samples in #2237, since it uses the instance SSD hard drive instead of EBS.

We also want to confirm that this disk doesn't go RO when we are downloading samples.

## Types of changes

- Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Functional tests

Tested on dev stack, to ensure that `/var/ebs` was on the drive with `900gb`

```
ubuntu@ip-10-0-67-73:/var/ebs$ df -h
Filesystem      Size  Used Avail Use% Mounted on
udev            481G     0  481G   0% /dev
tmpfs            97G  8.9M   97G   1% /run
/dev/xvda1      873G  1.6G  871G   1% /
tmpfs           481G     0  481G   0% /dev/shm
tmpfs           5.0M     0  5.0M   0% /run/lock
tmpfs           481G     0  481G   0% /sys/fs/cgroup
/dev/loop0       94M   94M     0 100% /snap/core/8935
/dev/loop1       18M   18M     0 100% /snap/amazon-ssm-agent/1566
tmpfs            97G     0   97G   0% /run/user/1000

ubuntu@ip-10-0-67-73:/var/ebs$ lsblk
NAME    MAJ:MIN RM  SIZE RO TYPE MOUNTPOINT
xvda    202:0    0  900G  0 disk 
└─xvda1 202:1    0  900G  0 part /
xvdb    202:16   0  1.8T  0 disk 
loop0     7:0    0 93.8M  1 loop /snap/core/8935
loop1     7:1    0   18M  1 loop /snap/amazon-ssm-agent/1566
```

## Checklist

- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules
