### PR TITLE
Reduce the RAM requirements for the quantpendia

### DIFF
--- a/infrastructure/variables.tf
+++ b/infrastructure/variables.tf
@@ -116,8 +116,9 @@ variable "nomad_server_instance_type" {
 }
 
 variable "smasher_instance_type" {
-  # 64GiB Memory, smasher and compendia jobs need 30.
-  default = "m5.4xlarge"
+  # 128GiB Memory, smasher and compendia jobs need 30.
+  # RNA-seq compendia needs 64gb
+  default = "m5.8xlarge"
 }
 
 variable "spot_price" {

--- a/workers/nomad-job-specs/create_quantpendia.nomad.tpl
+++ b/workers/nomad-job-specs/create_quantpendia.nomad.tpl
@@ -67,7 +67,7 @@ job "CREATE_QUANTPENDIA" {
       resources {
         # CPU is in AWS's CPU units.
         cpu =   4000
-        memory = 54000
+        memory = 64000
       }
 
       logs {

--- a/workers/nomad-job-specs/create_quantpendia.nomad.tpl
+++ b/workers/nomad-job-specs/create_quantpendia.nomad.tpl
@@ -67,7 +67,7 @@ job "CREATE_QUANTPENDIA" {
       resources {
         # CPU is in AWS's CPU units.
         cpu =   4000
-        memory = 64000
+        memory = 54000
       }
 
       logs {


### PR DESCRIPTION
## Issue Number

#2246 

## Purpose/Implementation Notes

We will need to re-process some rna-seq compendias. However, right now they can't run because the smasher uses an `m5.4xlarge` instance with 64GB of RAM and that's the exact amount of RAM required for the job.

This PR reduces the amount of ram required by the RNA-seq compendia so that it can run on the smasher instance.

## Types of changes

- Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Functional tests

None

## Checklist

- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules
