### PR TITLE
Set correct index for EBS volume

### DIFF
--- a/infrastructure/nomad-configuration/client-instance-user-data.tpl.sh
+++ b/infrastructure/nomad-configuration/client-instance-user-data.tpl.sh
@@ -57,7 +57,7 @@ COUNTER=0
 # done
 
 # Only a single volume for now
-export EBS_VOLUME_INDEX=1
+export EBS_VOLUME_INDEX=0
 
 sleep 25
 # # We want to mount the biggest volume that its attached to the instance


### PR DESCRIPTION
## Issue Number

#2006

## Purpose/Implementation Notes

Let all instances default to volume `0` for now.
