### PR TITLE
WIP Remove public access from buckets

### DIFF
--- a/api/data_refinery_api/serializers.py
+++ b/api/data_refinery_api/serializers.py
@@ -250,7 +250,6 @@ class ComputedFileListSerializer(serializers.ModelSerializer):
             "sha1",
             "s3_bucket",
             "s3_key",
-            "s3_url",
             "download_url",
             "created_at",
             "last_modified",

--- a/api/data_refinery_api/views.py
+++ b/api/data_refinery_api/views.py
@@ -1579,9 +1579,24 @@ class ComputedFilesList(generics.ListAPIView):
     """
     computed_files_list
 
-    ComputedFiles are representation of files created by data-refinery processes.
+    ComputedFiles are representation of files created by refinebio processes.
 
-    This can also be used to fetch all the compendia files we have generated with:
+    It's possible to download each one of these files by providing a valid token. To
+    acquire and activate an API key see the documentation for the [/token](#tag/token) endpoint.
+    When a valid token is provided the url will be sent back in the field `download_url`. Example:
+
+    ```py
+    import requests
+    import json
+
+    headers = {
+        'Content-Type': 'application/json',
+        'API-KEY': token_id # requested from /token
+    }
+    requests.get('https://api.refine.bio/v1/computed_files/?id=5796866', {}, headers=headers)
+    ```
+
+    This endpoint can also be used to fetch all the compendia files we have generated with:
     ```
     GET /computed_files?is_compendia=True&is_public=True
     ```

--- a/infrastructure/disk.tf
+++ b/infrastructure/disk.tf
@@ -34,6 +34,13 @@ resource "aws_s3_bucket" "data_refinery_bucket" {
   }
 }
 
+resource "aws_s3_bucket_public_access_block" "data_refinery_bucket" {
+  bucket = "${aws_s3_bucket.data_refinery_bucket.id}"
+
+  block_public_acls   = true
+  block_public_policy = true
+}
+
 resource "aws_s3_bucket" "data_refinery_results_bucket" {
   bucket = "data-refinery-s3-results-${var.user}-${var.stage}"
   acl    = "private"
@@ -59,6 +66,13 @@ resource "aws_s3_bucket" "data_refinery_results_bucket" {
       days = 1
     }
   }
+}
+
+resource "aws_s3_bucket_public_access_block" "data_refinery_results_bucket" {
+  bucket = "${aws_s3_bucket.data_refinery_results_bucket.id}"
+
+  block_public_acls   = true
+  block_public_policy = true
 }
 
 resource "aws_s3_bucket" "data-refinery-static" {
@@ -92,6 +106,13 @@ resource "aws_s3_bucket" "data_refinery_transcriptome_index_bucket" {
   }
 }
 
+resource "aws_s3_bucket_public_access_block" "data_refinery_transcriptome_index_bucket" {
+  bucket = "${aws_s3_bucket.data_refinery_transcriptome_index_bucket.id}"
+
+  block_public_acls   = true
+  block_public_policy = true
+}
+
 resource "aws_s3_bucket" "data_refinery_qn_target_bucket" {
   bucket = "data-refinery-s3-qn-target-${var.user}-${var.stage}"
   acl    = "public-read"
@@ -103,6 +124,13 @@ resource "aws_s3_bucket" "data_refinery_qn_target_bucket" {
   }
 }
 
+resource "aws_s3_bucket_public_access_block" "data_refinery_qn_target_bucket" {
+  bucket = "${aws_s3_bucket.data_refinery_qn_target_bucket.id}"
+
+  block_public_acls   = true
+  block_public_policy = true
+}
+
 resource "aws_s3_bucket" "data_refinery_compendia_bucket" {
   bucket = "data-refinery-s3-compendia-${var.user}-${var.stage}"
   acl    = "private"
@@ -112,6 +140,13 @@ resource "aws_s3_bucket" "data_refinery_compendia_bucket" {
     Name        = "data-refinery-s3-compendia-${var.user}-${var.stage}"
     Environment = "${var.stage}"
   }
+}
+
+resource "aws_s3_bucket_public_access_block" "data_refinery_compendia_bucket" {
+  bucket = "${aws_s3_bucket.data_refinery_compendia_bucket.id}"
+
+  block_public_acls   = true
+  block_public_policy = true
 }
 
 resource "aws_s3_bucket" "data_refinery_cloudtrail_logs_bucket" {


### PR DESCRIPTION
**Work in progress:**

- [ ] Additional permission to allow the processor jobs to upload files when the buckets are blocked
- [ ] Confirm that the terraform configuration works
-  [ ] Update to a newer version of terraform that supports [aws_s3_bucket_public_access_block](https://www.terraform.io/docs/providers/aws/r/s3_bucket_public_access_block.html). Looks like it was introduced with [v1.54.0](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md#1540-december-21-2018) of the terraform aws provider. 

## Issue Number

close #731 

## Purpose/Implementation Notes

Files were still publicly available because the buckets had a public read only policy.

![image](https://user-images.githubusercontent.com/1882507/80035721-81874500-84be-11ea-9578-8726a1a47aa8.png)

This should make them private. In addition to adding documentation to the computed files endpoint with details to retrieve the download url.

## Types of changes

- Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Functional tests

Tested in Prod, to ensure everything worked after making the buckets private. This will cause issues when uploading computed files from the jobs.

Still need to test the terraform configuration, for which we'll have to update to a newer version.

## Checklist

- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules
