### PR TITLE
Increase downloads buffer size to 4mb

### DIFF
--- a/common/data_refinery_common/utils.py
+++ b/common/data_refinery_common/utils.py
@@ -559,7 +559,7 @@ def download_file(
         # thanks to https://stackoverflow.com/a/39217788/763705
         with requests.get(download_url, stream=True) as r:
             with open(target_file_path, "wb") as f:
-                shutil.copyfileobj(r.raw, f)
+                shutil.copyfileobj(r.raw, f, 4 * 1024 * 1024)  # 4mb buffer size
     except Exception as e:
         if retry < max_retries:
             # After the retry-th failed attempt, retry downloading after


### PR DESCRIPTION
## Issue Number

#2237

## Purpose/Implementation Notes

Increase downloads buffer size to 4mb to see if that prevents the disk from going read-only