### PR TITLE
find pvalue header with search

### DIFF
--- a/workers/data_refinery_workers/processors/illumina.py
+++ b/workers/data_refinery_workers/processors/illumina.py
@@ -137,7 +137,7 @@ def _detect_columns(job_context: Dict) -> Dict:
         # Then the detection Pvalue string, which is always(?) some form of 'Detection Pval'
         for header in headers:
             # check if header contains something like "detection pval"
-            pvalue_header = re.match(r"(detection)(\W?)(pval\w*)", header, re.IGNORECASE)
+            pvalue_header = re.search(r"(detection)(\W?)(pval\w*)", header, re.IGNORECASE)
             if pvalue_header:
                 job_context["detectionPval"] = pvalue_header.string
                 break


### PR DESCRIPTION
## Issue Number

#2276 

This pr switches the regex to search so instead of testing at the beginning of the search string it will move along the string looking for a match.