### PR TITLE
Switch from pip freeze to pip list in get_pip_pkgs

### DIFF
--- a/scripts/run_all_tests.sh
+++ b/scripts/run_all_tests.sh
@@ -1,5 +1,8 @@
 #!/bin/sh
 
+# Don't keep going if some of the tests fail
+set -e
+
 # Runs all common and app specific tests.
 # End to end tests require Nomad to be running for the test environment.
 # This can be done with:


### PR DESCRIPTION
## Issue Number

N/A

## Purpose/Implementation Notes

Stop using `pip freeze` to detect the installed package versions. It looks like their output syntax changed slightly and broke our code. Now, if a package is installed from a local file `pip freeze` outputs e.g.
```
data-refinery-common @ file:///home/user/common/data-refinery-common-1.0.0.tar.gz
```
instead of
```
data-refinery-common==1.0.0
```

Instead, there is a new `pip list` command that does what we want, and we can set it to output json instead for easier parsing.

## Types of changes

What types of changes does your code introduce?

<!-- Remove any which your PR isn't -->
- Bugfix (non-breaking change which fixes an issue)

## Functional tests

All of the tests now pass again.

## Checklist

_Put an `x` in the boxes that apply._

- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots

Please attach any screenshots that illustrate these changes.
