### PR TITLE
Fix the tests by updating CA certificates

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,6 +28,7 @@ jobs:
       - run: ./scripts/rebuild_es_index.sh
 
       # Install Nomad
+      - run: sudo ./.circleci/fix_ca_certs.sh
       - run: sudo ./scripts/install_nomad.sh
         # Start Nomad and register jobs.
       - run:
@@ -167,6 +168,7 @@ jobs:
           no_output_timeout: 1h
 
       # Install Nomad
+      - run: sudo ./.circleci/fix_ca_certs.sh
       - run: sudo ./scripts/install_nomad.sh
         # Start Nomad and register jobs.
       - run:
@@ -265,6 +267,7 @@ jobs:
       - run: ./scripts/rebuild_es_index.sh
 
       # Install Nomad
+      - run: sudo ./.circleci/fix_ca_certs.sh
       - run: sudo ./scripts/install_nomad.sh
         # Start Nomad and register jobs.
       - run:

--- a/.circleci/fix_ca_certs.sh
+++ b/.circleci/fix_ca_certs.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+set -e
+
+# Update the apt keys for dl.google.com
+apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 78BD65473CB3BD13
+# Update the apt keys for packagecloud.io
+curl -L https://packagecloud.io/circleci/trusty/gpgkey | apt-key add -
+
+# Update the local CA certificates
+# adapted from: https://stackoverflow.com/questions/62107565/wget-and-curl-stopped-working-with-https-wrongly-complain-about-an-expired-cert
+apt update && apt install ca-certificates
+sed -i '/mozilla\/AddTrust_External/d' /etc/ca-certificates.conf
+update-ca-certificates -f -v


### PR DESCRIPTION
## Issue Number

Temporary relief for #2285

## Purpose/Implementation Notes

Apparently some root certificate expired on the 30th of May which was the cause of our problems. I adapted the instructions from https://stackoverflow.com/questions/62107565/wget-and-curl-stopped-working-with-https-wrongly-complain-about-an-expired-cert, but for some reason we have to update ca-certificates before removing the line from the config file to get it to work.

## Types of changes

What types of changes does your code introduce?

<!-- Remove any which your PR isn't -->
- Bugfix (non-breaking change which fixes an issue)

## Functional tests

The tests successfully download Nomad now!

## Checklist

_Put an `x` in the boxes that apply._

- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots

Please attach any screenshots that illustrate these changes.
