### PR TITLE
Don't allow empty datasets.

### DIFF
--- a/api/data_refinery_api/serializers.py
+++ b/api/data_refinery_api/serializers.py
@@ -597,6 +597,10 @@ def validate_dataset(data):
         if type(data["data"]) != dict:
             raise serializers.ValidationError("`data` must be a dict of lists.")
 
+        # Don't allow empty datasaets.
+        if not data["data"]:
+            raise serializers.ValidationError("`data` must contain at least one experiment..")
+
         for key, value in data["data"].items():
             if type(value) != list:
                 raise serializers.ValidationError(

--- a/api/data_refinery_api/tests.py
+++ b/api/data_refinery_api/tests.py
@@ -498,6 +498,16 @@ class APITestCases(APITestCase):
 
         self.assertEqual(response.status_code, 400)
 
+        # Bad (Empty Experiment)
+        jdata = json.dumps({"email_address": "baz@gmail.com", "data": {}})
+        response = self.client.post(
+            reverse("create_dataset", kwargs={"version": API_VERSION}),
+            jdata,
+            content_type="application/json",
+        )
+
+        self.assertEqual(response.status_code, 400)
+
         # Update, just an experiment accession
         jdata = json.dumps({"email_address": "baz@gmail.com", "data": {"GSE123": ["ALL"]}})
         response = self.client.put(


### PR DESCRIPTION
## Issue Number

#2266 

## Purpose/Implementation Notes

The last PR stopped a little short, because it only made sure experiments all had samples, but it didn't check if the dataset had a least one experiment in it.

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

Unit test!
