### PR TITLE
Allow experiments to be filtered by multiple accessions.

### DIFF
--- a/api/data_refinery_api/tests.py
+++ b/api/data_refinery_api/tests.py
@@ -258,6 +258,25 @@ class APITestCases(APITestCase):
         response = self.client.get(reverse("create_dataset", kwargs={"version": API_VERSION}))
         self.assertEqual(response.status_code, status.HTTP_405_METHOD_NOT_ALLOWED)
 
+    def test_experiment_multiple_accessions(self):
+        response = self.client.get(
+            reverse("search", kwargs={"version": API_VERSION})
+            + "?accession_code=GSE000&accession_code=GSE123",
+            follow=True,
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.json()["results"]), 2)
+
+    def test_sample_multiple_accessions(self):
+        response = self.client.get(
+            reverse("samples", kwargs={"version": API_VERSION}) + "?accession_codes=123,789",
+            follow=True,
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.json()["results"]), 2)
+
     def test_sample_pagination(self):
         response = self.client.get(reverse("samples", kwargs={"version": API_VERSION}))
         self.assertEqual(response.status_code, status.HTTP_200_OK)

--- a/api/data_refinery_api/views.py
+++ b/api/data_refinery_api/views.py
@@ -128,6 +128,12 @@ class FacetedSearchFilterBackendExtended(FacetedSearchFilterBackend):
     decorator=swagger_auto_schema(
         manual_parameters=[
             openapi.Parameter(
+                name="accession_code",
+                in_=openapi.IN_QUERY,
+                type=openapi.TYPE_STRING,
+                description="Allows filtering the results by accession code, can have multiple values. Eg: `?accession_code=microarray&accession_code=rna-seq`",
+            ),
+            openapi.Parameter(
                 name="technology",
                 in_=openapi.IN_QUERY,
                 type=openapi.TYPE_STRING,
@@ -800,8 +806,8 @@ class ComputationalResultsList(generics.ListAPIView):
 
 class OrganismList(generics.ListAPIView):
     """
-	Unpaginated list of all the available organisms.
-	"""
+    Unpaginated list of all the available organisms.
+    """
 
     queryset = Organism.objects.all()
     serializer_class = OrganismSerializer
@@ -810,8 +816,8 @@ class OrganismList(generics.ListAPIView):
 
 class PlatformList(generics.ListAPIView):
     """
-	Unpaginated list of all the available "platform" information
-	"""
+    Unpaginated list of all the available "platform" information
+    """
 
     serializer_class = PlatformSerializer
     paginator = None
@@ -826,8 +832,8 @@ class PlatformList(generics.ListAPIView):
 
 class InstitutionList(generics.ListAPIView):
     """
-	Unpaginated list of all the available "institution" information
-	"""
+    Unpaginated list of all the available "institution" information
+    """
 
     serializer_class = InstitutionSerializer
     paginator = None


### PR DESCRIPTION
## Issue Number

https://github.com/AlexsLemonade/refinebio/issues/2301#issuecomment-644144431

## Purpose/Implementation Notes

https://api.refine.bio/v1/samples?accession_codes=123,789 already works, but we don't have a way to do similar filtering with experiments. This is because we moved the advanced filtering to the `/search` interface, and then didn't add a field for accession codes. This PR addresses that, adding the additional field for accession codes and testing that filtering works for both endpoints.

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

The unit tests work after the change, but not before.

## Checklist

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules
