### PR TITLE
Upgrade the kernel version when setting up new instances

### DIFF
--- a/infrastructure/nomad-configuration/client-instance-user-data.tpl.sh
+++ b/infrastructure/nomad-configuration/client-instance-user-data.tpl.sh
@@ -15,7 +15,7 @@
 
 export DEBIAN_FRONTEND=noninteractive
 apt-get update -y
-apt-get upgrade -y
+apt-get upgrade -y linux-aws
 apt-get install --yes jq iotop dstat speedometer awscli docker.io chrony htop monit
 
 ulimit -n 65536
@@ -204,3 +204,6 @@ if [[ $STAGE = *"prod"* ]]; then
     rm /var/log/cloud-init-output.log
     rm /var/log/syslog
 fi
+
+# Since we upgraded the kernel we have to restart
+reboot now

--- a/infrastructure/nomad-configuration/client-smasher-instance-user-data.tpl.sh
+++ b/infrastructure/nomad-configuration/client-smasher-instance-user-data.tpl.sh
@@ -15,7 +15,7 @@
 
 export DEBIAN_FRONTEND=noninteractive
 apt-get update -y
-apt-get upgrade -y
+apt-get upgrade -y linux-aws
 apt-get install --yes jq iotop dstat speedometer awscli docker.io monit
 
 ulimit -n 65536
@@ -109,3 +109,6 @@ if [[ $STAGE = *"prod"* ]]; then
     rm /var/log/cloud-init-output.log
     rm /var/log/syslog
 fi
+
+# Since we upgraded the kernel we have to restart
+reboot now


### PR DESCRIPTION
## Issue Number

#2237 

## Purpose/Implementation Notes

I read in a comment [here](https://kig.re/2018/05/15/aws-ebs-c5-read-only-file-system.html) that filesystems switching to read-only could be related to an issue that was patched in linux `4.4.0-1067` but our servers are still running `4.4.0-1050-aws`.

Original comment:
```
We ran into a similar problem today. This was not the first time we ran into this issue. AWS team suggested us to upgrade kernel to 4.4.0-1067 which according to the support guy had a patched this issue. Why was the fs corrupted has not been answered though. fsck was done to fix the filesystem and kernel was upgraded and AWS support guy insisted us to increase value for nvme io_timeout. I did some digging and found this http://changelogs.ubuntu.com/changelogs/pool/main/l/linux-aws/linux-aws_4.4.0-1067.77/changelog which in turn led me to this thread: http://lists.infradead.org/pipermail/linux-nvme/2016-March/004159.html. AWS support engineer kept mentioning a known issue that plagues earlier kernel versions.
```

## Types of changes

What types of changes does your code introduce?

<!-- Remove any which your PR isn't -->
- Bugfix (non-breaking change which fixes an issue)

## Functional tests

Can't really. We should definitely try this first on staging to make sure the scripts don't break anything.

## Checklist

_Put an `x` in the boxes that apply._

- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots

Please attach any screenshots that illustrate these changes.
