### PR TITLE
Fix accession code filtering, allow searching by alternate_accession_code

### DIFF
--- a/api/data_refinery_api/tests.py
+++ b/api/data_refinery_api/tests.py
@@ -46,6 +46,7 @@ class APITestCases(APITestCase):
 
         experiment = Experiment()
         experiment.accession_code = "GSE000"
+        experiment.alternate_accession_code = "E-GEOD-000"
         experiment.title = "NONONONO"
         experiment.description = "Boooooourns. Wasabi."
         experiment.technology = "RNA-SEQ"
@@ -267,6 +268,20 @@ class APITestCases(APITestCase):
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(len(response.json()["results"]), 2)
+
+    # Test the query the front-end uses to find the experiment with a given
+    # accession or alternate accession
+    def test_experiment_alternate_accession(self):
+        response = self.client.get(
+            reverse("search", kwargs={"version": API_VERSION})
+            + "?search=alternate_accession_code:E-GEOD-000"
+            + "?search=accession_code:E-GEOD-000",
+            follow=True,
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.json()["results"]), 1)
+        self.assertEqual(response.json()["results"][0]["alternate_accession_code"], "E-GEOD-000")
 
     def test_sample_multiple_accessions(self):
         response = self.client.get(

--- a/api/data_refinery_api/views.py
+++ b/api/data_refinery_api/views.py
@@ -223,6 +223,7 @@ class ExperimentDocumentView(DocumentViewSet):
         "technology": "technology",
         "has_publication": "has_publication",
         "accession_code": "accession_code",
+        "alternate_accession_code": "alternate_accession_code",
         "platform": "platform_accession_codes",
         "organism": "organism_names",
         "num_processed_samples": {

--- a/api/data_refinery_api/views.py
+++ b/api/data_refinery_api/views.py
@@ -222,6 +222,7 @@ class ExperimentDocumentView(DocumentViewSet):
         "id": {"field": "_id", "lookups": [LOOKUP_FILTER_RANGE, LOOKUP_QUERY_IN],},
         "technology": "technology",
         "has_publication": "has_publication",
+        "accession_code": "accession_code",
         "platform": "platform_accession_codes",
         "organism": "organism_names",
         "num_processed_samples": {

--- a/common/data_refinery_common/models/documents.py
+++ b/common/data_refinery_common/models/documents.py
@@ -65,8 +65,8 @@ class ExperimentDocument(Document):
     )
 
     # Basic Fields
-    accession_code = fields.TextField()
-    alternate_accession_code = fields.TextField()
+    accession_code = fields.KeywordField()
+    alternate_accession_code = fields.KeywordField()
     submitter_institution = fields.TextField()
     publication_doi = fields.TextField()
     has_publication = fields.BooleanField()


### PR DESCRIPTION
## Issue Number

#2322
Back-end fixes for #2187 

## Purpose/Implementation Notes

Allow filtering by accession_code. I also changed accession_code and alternate_accession_code to keyword fields so that filtering by them in the search works better so that we can do #2187. I think the dashes in `E-GEOD-*` was messing with Elasticsearch when they were text fields so `/search/?search=alternate_accession_code:E-GEOD-44094` was not filtering properly.

## Types of changes

What types of changes does your code introduce?

<!-- Remove any which your PR isn't -->
- Bugfix (non-breaking change which fixes an issue)

## Functional tests

I added a test for `alternate_accession_code`, and I ran the API locally to make sure.

## Checklist

_Put an `x` in the boxes that apply._

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots

Please attach any screenshots that illustrate these changes.
