### PR TITLE
Do not allow non-downloadable samples to be added to a dataset

### DIFF
--- a/api/data_refinery_api/serializers.py
+++ b/api/data_refinery_api/serializers.py
@@ -592,35 +592,53 @@ class ProcessorJobSerializer(serializers.ModelSerializer):
 
 
 def validate_dataset(data):
-    """ Basic dataset validation. Currently only checks formatting, not values. """
-    if data.get("data") is not None:
-        if type(data["data"]) != dict:
-            raise serializers.ValidationError("`data` must be a dict of lists.")
-
-        if data.get("start") and len(data["data"]) == 0:
-            raise serializers.ValidationError("`data` must contain at least one experiment..")
-
-        for key, value in data["data"].items():
-            if type(value) != list:
-                raise serializers.ValidationError(
-                    "`data` must be a dict of lists. Problem with `" + str(key) + "`"
-                )
-
-            if len(value) < 1:
-                raise serializers.ValidationError(
-                    "`data` must be a dict of lists, each with one or more elements. Problem with `"
-                    + str(key)
-                    + "`"
-                )
-
-            try:
-                if len(value) != len(set(value)):
-                    raise serializers.ValidationError("Duplicate values detected in " + str(value))
-            except Exception as e:
-                raise serializers.ValidationError("Received bad dataset data: " + str(e))
-
-    else:
+    """
+    Dataset validation. Each experiment should always have at least one
+    sample, all samples should be downloadable, and when starting the smasher
+    there should be at least one experiment.
+    """
+    if data.get("data") is None or type(data["data"]) != dict:
         raise serializers.ValidationError("`data` must be a dict of lists.")
+
+    if data.get("start") and len(data["data"]) == 0:
+        raise serializers.ValidationError("`data` must contain at least one experiment..")
+
+    accessions = []
+    for key, value in data["data"].items():
+        if type(value) != list:
+            raise serializers.ValidationError(
+                "`data` must be a dict of lists. Problem with `" + str(key) + "`"
+            )
+
+        if len(value) < 1:
+            raise serializers.ValidationError(
+                "`data` must be a dict of lists, each with one or more elements. Problem with `"
+                + str(key)
+                + "`"
+            )
+
+        try:
+            if len(value) != len(set(value)):
+                raise serializers.ValidationError("Duplicate values detected in " + str(value))
+        except Exception as e:
+            raise serializers.ValidationError("Received bad dataset data: " + str(e))
+
+        # If they want "ALL", just make sure that the experiment has at least one downloadable sample
+        if value == ["ALL"]:
+            try:
+                experiment = Experiment.processed_public_objects.get(accession_code=key)
+            except Exception as e:
+                raise serializers.ValidationError(
+                    "Experiment " + key + " does not have at least one downloadable sample"
+                )
+        # Otherwise, we will check that all the samples they requested are downloadable
+        else:
+            accessions.extend(value)
+
+    if len(accessions) > 0:
+        processed_samples = Sample.processed_objects.filter(accession_code__in=accessions)
+        if len(accessions) != processed_samples.count():
+            raise serializers.ValidationError("Non-downloadable samples in " + str(accessions))
 
 
 class CreateDatasetSerializer(serializers.ModelSerializer):

--- a/api/data_refinery_api/serializers.py
+++ b/api/data_refinery_api/serializers.py
@@ -636,9 +636,15 @@ def validate_dataset(data):
             accessions.extend(value)
 
     if len(accessions) > 0:
-        processed_samples = Sample.processed_objects.filter(accession_code__in=accessions)
-        if len(accessions) != processed_samples.count():
-            raise serializers.ValidationError("Non-downloadable samples in " + str(accessions))
+        unprocessed_samples = Sample.public_objects.filter(
+            accession_code__in=accessions, is_processed=False
+        )
+        if unprocessed_samples.count() > 0:
+            raise serializers.ValidationError(
+                "Non-downloadable sample(s) '"
+                + ", ".join([s.accession_code for s in unprocessed_samples])
+                + "' in dataset"
+            )
 
 
 class CreateDatasetSerializer(serializers.ModelSerializer):

--- a/api/data_refinery_api/tests.py
+++ b/api/data_refinery_api/tests.py
@@ -558,6 +558,9 @@ class APITestCases(APITestCase):
             content_type="application/json",
         )
         self.assertEqual(response.status_code, 400)
+        self.assertEqual(
+            response.json()["non_field_errors"][0], "Non-downloadable sample(s) '456' in dataset"
+        )
 
         # Good, 789 is processed
         jdata = json.dumps({"email_address": "baz@gmail.com", "data": {"GSE123": ["789"]}})


### PR DESCRIPTION
## Issue Number

Fixes #2329

## Purpose/Implementation Notes

Add more validation to the `validate_dataset` method to disallow more ways to create an invalid dataset.

## Methods

If this pull request has any implications for data or metadata processing or addresses an issue labeled `sci review`, please include an overview of the methods used (e.g., briefly explain _how_ the data gets processed).
See [#267](https://github.com/AlexsLemonade/refinebio/pull/267) for rationale.
Include sufficient detail for reviewers or users that are not expert developers to evaluate the validity of the approach.
Please attach or link to example input and output data if applicable.
It may also be appropriate to include a description of any functional or unit tests in this section depending on their content.
Any pull request with a methods section requires scientific review in addition to code review.

## Types of changes

What types of changes does your code introduce?

<!-- Remove any which your PR isn't -->
- Bugfix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Functional tests

I added unit tests

## Checklist

_Put an `x` in the boxes that apply._

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots

Please attach any screenshots that illustrate these changes.
