### PR TITLE
Tweak organism facet

### DIFF
--- a/api/data_refinery_api/tests.py
+++ b/api/data_refinery_api/tests.py
@@ -1134,6 +1134,9 @@ class StatsTestCases(APITestCase):
         self.assertEqual(response.json()["nomad_running_jobs_by_volume"]["2"], 1)
 
 
+ECOLI_STRAIN_NAME = "Escherichia coli str. k-12 substr. mg1655"
+
+
 class ESTestCases(APITestCase):
     @classmethod
     def setUpClass(cls):
@@ -1169,9 +1172,7 @@ class ESTestCases(APITestCase):
         sample.accession_code = "123"
         sample.save()
 
-        organism = Organism(
-            name="AILUROPODA_MELANOLEUCA", taxonomy_id=9646, is_scientific_name=True
-        )
+        organism = Organism(name=ECOLI_STRAIN_NAME, taxonomy_id=879462, is_scientific_name=True,)
         organism.save()
 
         sample = Sample()
@@ -1264,6 +1265,10 @@ class ESTestCases(APITestCase):
         self.assertEqual(response.json()["facets"]["has_publication"]["false"], 1)
         self.assertEqual(response.json()["facets"]["technology"]["microarray"], 1)
         self.assertEqual(response.json()["facets"]["technology"]["rna-seq"], 0)
+        self.assertEqual(
+            list(response.json()["facets"]["organism_names"].keys()), [ECOLI_STRAIN_NAME]
+        )
+        self.assertEqual(response.json()["facets"]["organism_names"][ECOLI_STRAIN_NAME], 1)
 
         # Basic Search
         response = self.client.get(

--- a/api/data_refinery_api/views.py
+++ b/api/data_refinery_api/views.py
@@ -263,7 +263,7 @@ class ExperimentDocumentView(DocumentViewSet):
             "enabled": True,  # These are enabled by default, which is more expensive but more simple.
         },
         "organism_names": {
-            "field": "organism_names",
+            "field": "organism_names.raw",
             "facet": TermsFacet,
             "enabled": True,
             "options": {"size": 999999},


### PR DESCRIPTION
## Issue Number

https://github.com/AlexsLemonade/refinebio/issues/1799

I am not sure if we want to call #1799 fixed, but this is at least a good first step since it treats all of the organism names as one term for the facets.

## Purpose/Implementation Notes

Change the `organism_names` facet to use `organism_names.raw`, since we want to filter based on the organism names themselves instead of the Elasticsearch terms generated.

## Types of changes

What types of changes does your code introduce?

<!-- Remove any which your PR isn't -->
- Bugfix (non-breaking change which fixes an issue)

## Functional tests

I modified the ES tests to check that it works as expected. Before the change, the `organism_names` facet was `{'12': 1, 'coli': 1, 'escherichia': 1, 'k[36 chars]': 1}`, and now it is `{'Escherichia coli str. k-12 substr. mg1655': 1}`.

## Checklist

_Put an `x` in the boxes that apply._

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots

Please attach any screenshots that illustrate these changes.
