### PR TITLE
Added alternate_accession_code field for Experiment Detail

### DIFF
--- a/api/data_refinery_api/serializers.py
+++ b/api/data_refinery_api/serializers.py
@@ -463,6 +463,7 @@ class DetailedExperimentSerializer(serializers.ModelSerializer):
             "samples",
             "protocol_description",
             "accession_code",
+            "alternate_accession_code",
             "source_database",
             "source_url",
             "has_publication",


### PR DESCRIPTION
## Issue Number

Related to [#871](https://github.com/AlexsLemonade/refinebio-frontend/issues/871) for the frontend

## Purpose/Implementation Notes

The [Experiment Detail](https://api.refine.bio/v1/experiments/GSE23616/) endpoint seems to be missing the `alternate_accession_code` field unlike [Experiment List](https://api.refine.bio/v1/experiments/).

## Methods

Looks like it was just missing in the serializer for a specific experiment, so I added it there.

## Types of changes

What types of changes does your code introduce?

<!-- Remove any which your PR isn't -->
- Bugfix (non-breaking change which fixes an issue)

## Functional tests

The field shows up when the API is hosted locally

## Checklist

_Put an `x` in the boxes that apply._

- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules
