### PR TITLE
Link SRA experiments to their GEO alternate accessions

### DIFF
--- a/foreman/data_refinery_foreman/foreman/management/commands/test_update_experiment_metadata.py
+++ b/foreman/data_refinery_foreman/foreman/management/commands/test_update_experiment_metadata.py
@@ -48,6 +48,37 @@ class SurveyTestCase(TransactionTestCase):
         command = Command()
         command.handle()
 
+    def test_sra_experiment_missing_alternate_accession(self):
+        """Tests that an SRA experiment has its missing alternate_accession_code added."""
+
+        # 1. Create an experiment without an alternate_accession_code
+        experiment = Experiment()
+        experiment.accession_code = "SRP094947"
+        experiment.source_database = "SRA"
+        experiment.title = "Not important"
+        experiment.save()
+
+        # 2. We need to add a sample because the way that the SRA surveyor finds metadata is
+        # through run accessions
+        sample = Sample()
+        sample.accession_code = "SRR5099111"
+        sample.technology = "RNA-SEQ"
+        sample.source_database = "SRA"
+        sample.title = "Not important"
+        sample.save()
+
+        ExperimentSampleAssociation.objects.get_or_create(experiment=experiment, sample=sample)
+
+        # 3. Setup is done, actually run the command.
+        command = Command()
+        command.handle()
+
+        # 4. Refresh the experiment
+        experiment.refresh_from_db()
+
+        # Test that the correct alternate_accession_code was added
+        self.assertEquals(experiment.alternate_accession_code, "GSE92260")
+
     def test_geo_experiment_missing_metadata(self):
         """Tests that a GEO experiment has its missing metadata added."""
 

--- a/foreman/data_refinery_foreman/surveyor/test_sra.py
+++ b/foreman/data_refinery_foreman/surveyor/test_sra.py
@@ -79,6 +79,7 @@ class SraSurveyorTestCase(TestCase):
         sra_surveyor = SraSurveyor(survey_job)
         experiment, samples = sra_surveyor.discover_experiment_and_samples()
         self.assertEqual(experiment.accession_code, "SRP068364")
+        self.assertEqual(experiment.alternate_accession_code, "GSE76780")
         self.assertEqual(len(samples), 4)
 
         survey_job = SurveyJob(source_type="SRA")
@@ -92,6 +93,7 @@ class SraSurveyorTestCase(TestCase):
         experiment, samples = sra_surveyor.discover_experiment_and_samples()
 
         self.assertEqual(experiment.accession_code, "SRP111553")
+        self.assertEqual(experiment.alternate_accession_code, "GSE101204")
         self.assertEqual(len(samples), 16)  # 8 samples with 2 runs each
 
         survey_job = SurveyJob(source_type="SRA")
@@ -105,6 +107,7 @@ class SraSurveyorTestCase(TestCase):
         experiment, samples = sra_surveyor.discover_experiment_and_samples()
 
         self.assertEqual(experiment.accession_code, "DRP003977")
+        self.assertEqual(experiment.alternate_accession_code, None)
         self.assertEqual(len(samples), 9)
 
     @vcr.use_cassette(


### PR DESCRIPTION
## Issue Number

Closes https://github.com/AlexsLemonade/refinebio/issues/2186

## Purpose/Implementation Notes

I modified the SRA surveyor to get the GEO alternate accession from the ENA XML data. I also made sure that the `update_experiment_metadata` management command also works for alternate accessions

## Types of changes

What types of changes does your code introduce?

<!-- Remove any which your PR isn't -->
- New feature (non-breaking change which adds functionality)

## Functional tests

I added tests for both the initial survey and the management command that updates the metadata.

## Checklist

_Put an `x` in the boxes that apply._

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots

Please attach any screenshots that illustrate these changes.
