### PR TITLE
Remove the x1e.4xlarge because its disk is too small

### DIFF
--- a/infrastructure/instances.tf
+++ b/infrastructure/instances.tf
@@ -218,36 +218,6 @@ resource "aws_spot_fleet_request" "cheap_ram" {
   ]
 
   ##
-  # x1e.4xlarge
-  ##
-  launch_specification {
-
-    # Client Specific
-    instance_type             = "x1e.4xlarge"
-    weighted_capacity         = 5 # via https://aws.amazon.com/ec2/instance-types/
-    spot_price                = "${var.spot_price}"
-    ami                       = "${data.aws_ami.ubuntu.id}"
-    iam_instance_profile_arn  = "${aws_iam_instance_profile.data_refinery_instance_profile.arn}"
-    user_data                 = "${data.template_file.nomad_client_script_smusher.rendered}"
-    vpc_security_group_ids    = ["${aws_security_group.data_refinery_worker.id}"]
-    subnet_id                 = "${aws_subnet.data_refinery_1a.id}"
-    availability_zone         = "${var.region}a"
-    key_name = "${aws_key_pair.data_refinery.key_name}"
-
-    root_block_device {
-      volume_size = 900
-      volume_type = "gp2"
-    }
-
-    tags {
-        Name = "Spot Fleet Launch Specification x1e.4xlarge ${var.user}-${var.stage}"
-        User = "${var.user}"
-        Stage = "${var.stage}"
-    }
-
-  }
-
-  ##
   # x1e.8xlarge
   ##
   launch_specification {


### PR DESCRIPTION
## Issue Number

N/A

## Purpose/Implementation Notes

It turns out that the disk on the x1e.4xlarge is too small, so it causes jobs to fail.

## Methods

If this pull request has any implications for data or metadata processing or addresses an issue labeled `sci review`, please include an overview of the methods used (e.g., briefly explain _how_ the data gets processed).
See [#267](https://github.com/AlexsLemonade/refinebio/pull/267) for rationale.
Include sufficient detail for reviewers or users that are not expert developers to evaluate the validity of the approach.
Please attach or link to example input and output data if applicable.
It may also be appropriate to include a description of any functional or unit tests in this section depending on their content.
Any pull request with a methods section requires scientific review in addition to code review.

## Types of changes

What types of changes does your code introduce?

<!-- Remove any which your PR isn't -->
- Bugfix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Functional tests

List out the functional tests you've completed to verify your changes work locally.

## Checklist

_Put an `x` in the boxes that apply._

- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots

Please attach any screenshots that illustrate these changes.
