### PR TITLE
Fix smasher failing to include all samples in large studies

### DIFF
--- a/workers/data_refinery_workers/processors/smashing_utils.py
+++ b/workers/data_refinery_workers/processors/smashing_utils.py
@@ -1044,9 +1044,7 @@ def sync_quant_files(output_path, samples: List[Sample]):
         # for each sample we need it's latest quant.sf file we don't want to query the db
         # for all of them, so we do it in groups of 100, and then download all of the computed_files
         # in parallel
-        for sample_page in (
-            samples[i * page_size : i + page_size] for i in range(0, len(samples), page_size)
-        ):
+        for sample_page in (samples[i : i + page_size] for i in range(0, len(samples), page_size)):
             sample_and_computed_files = []
             for sample in sample_page:
                 latest_computed_file = sample.get_most_recent_quant_sf_file()

--- a/workers/data_refinery_workers/processors/smashing_utils.py
+++ b/workers/data_refinery_workers/processors/smashing_utils.py
@@ -1044,7 +1044,9 @@ def sync_quant_files(output_path, samples: List[Sample]):
         # for each sample we need it's latest quant.sf file we don't want to query the db
         # for all of them, so we do it in groups of 100, and then download all of the computed_files
         # in parallel
-        for sample_page in (samples[start : start + page_size] for start in range(0, len(samples), page_size)):
+        for sample_page in (
+            samples[start : start + page_size] for start in range(0, len(samples), page_size)
+        ):
             sample_and_computed_files = []
             for sample in sample_page:
                 latest_computed_file = sample.get_most_recent_quant_sf_file()

--- a/workers/data_refinery_workers/processors/smashing_utils.py
+++ b/workers/data_refinery_workers/processors/smashing_utils.py
@@ -1044,7 +1044,7 @@ def sync_quant_files(output_path, samples: List[Sample]):
         # for each sample we need it's latest quant.sf file we don't want to query the db
         # for all of them, so we do it in groups of 100, and then download all of the computed_files
         # in parallel
-        for sample_page in (samples[i : i + page_size] for i in range(0, len(samples), page_size)):
+        for sample_page in (samples[start : start + page_size] for start in range(0, len(samples), page_size)):
             sample_and_computed_files = []
             for sample in sample_page:
                 latest_computed_file = sample.get_most_recent_quant_sf_file()


### PR DESCRIPTION
## Issue Number

#2211

## Purpose/Implementation Notes

It looks like an indexing issue was preventing us from copying over any more than the first 100 quant files for each experiment in the smasher. Since the range's third parameter is `page_size`, on the second iteration `i` is `page_size`, so we effectively take `samples[page_size ** 2 : page_size * 2]` which will be empty.

## Methods

If this pull request has any implications for data or metadata processing or addresses an issue labeled `sci review`, please include an overview of the methods used (e.g., briefly explain _how_ the data gets processed).
See [#267](https://github.com/AlexsLemonade/refinebio/pull/267) for rationale.
Include sufficient detail for reviewers or users that are not expert developers to evaluate the validity of the approach.
Please attach or link to example input and output data if applicable.
It may also be appropriate to include a description of any functional or unit tests in this section depending on their content.
Any pull request with a methods section requires scientific review in addition to code review.

## Types of changes

What types of changes does your code introduce?

<!-- Remove any which your PR isn't -->
- Bugfix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Functional tests

List out the functional tests you've completed to verify your changes work locally.

## Checklist

_Put an `x` in the boxes that apply._

- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots

Please attach any screenshots that illustrate these changes.
