### PR TITLE
Fix metadata issues with quant sf files

### DIFF
--- a/workers/data_refinery_workers/processors/create_quantpendia.py
+++ b/workers/data_refinery_workers/processors/create_quantpendia.py
@@ -67,7 +67,9 @@ def _download_files(job_context: Dict) -> Dict:
         )
 
         # download quant.sf files directly into the dataset folder
-        num_samples += smashing_utils.sync_quant_files(outfile_dir, samples)
+        num_samples += smashing_utils.sync_quant_files(
+            outfile_dir, samples, job_context["filtered_samples"]
+        )
 
     job_context["num_samples"] = num_samples
     job_context["time_end"] = timezone.now()

--- a/workers/data_refinery_workers/processors/smasher.py
+++ b/workers/data_refinery_workers/processors/smasher.py
@@ -203,7 +203,9 @@ def _smash_key(job_context: Dict, key: str, input_files: List[ComputedFile]) -> 
         outfile_dir = job_context["output_dir"] + key + "/"
         os.makedirs(outfile_dir, exist_ok=True)
         samples = [sample for (_, sample) in input_files]
-        job_context["num_samples"] += smashing_utils.sync_quant_files(outfile_dir, samples)
+        job_context["num_samples"] += smashing_utils.sync_quant_files(
+            outfile_dir, samples, job_context["filtered_samples"]
+        )
         # we ONLY want to give quant sf files to the user if that's what they requested
         return job_context
 

--- a/workers/data_refinery_workers/processors/smashing_utils.py
+++ b/workers/data_refinery_workers/processors/smashing_utils.py
@@ -1034,8 +1034,9 @@ def download_computed_file(download_tuple: Tuple[ComputedFile, str]):
 
 
 def sync_quant_files(output_path, samples: List[Sample], filtered_samples: Dict):
-    """ Takes a list of ComputedFiles and copies the ones that are quant files to the provided directory.
-        Returns the total number of samples that were included """
+    """ Takes a list of ComputedFiles and copies the ones that are quant files
+    to the provided directory.  Returns the total number of samples that were
+    included, and adds those that were not included to `filtered_samples` """
     num_samples = 0
 
     page_size = 100

--- a/workers/data_refinery_workers/processors/smashing_utils.py
+++ b/workers/data_refinery_workers/processors/smashing_utils.py
@@ -1033,7 +1033,7 @@ def download_computed_file(download_tuple: Tuple[ComputedFile, str]):
         logger.exception("Failed to sync computed file", computed_file_id=latest_computed_file.pk)
 
 
-def sync_quant_files(output_path, samples: List[Sample]):
+def sync_quant_files(output_path, samples: List[Sample], filtered_samples: Dict):
     """ Takes a list of ComputedFiles and copies the ones that are quant files to the provided directory.
         Returns the total number of samples that were included """
     num_samples = 0
@@ -1051,6 +1051,11 @@ def sync_quant_files(output_path, samples: List[Sample]):
             for sample in sample_page:
                 latest_computed_file = sample.get_most_recent_quant_sf_file()
                 if not latest_computed_file:
+                    sample_metadata = sample.to_metadata_dict()
+                    filtered_samples[sample.accession_code] = {
+                        **sample_metadata,
+                        "reason": "This sample did not have a quant file associated with it in our database.",
+                    }
                     continue
                 output_file_path = output_path + sample.accession_code + "_quant.sf"
                 sample_and_computed_files.append((latest_computed_file, output_file_path))

--- a/workers/data_refinery_workers/processors/test_create_quantpendia.py
+++ b/workers/data_refinery_workers/processors/test_create_quantpendia.py
@@ -92,7 +92,7 @@ class QuantpendiaTestCase(TransactionTestCase):
         assoc.save()
 
         ds = Dataset()
-        ds.data = {"GSE51088": ["GSM1237818"]}
+        ds.data = {"GSE51088": ["GSM1237818", "GSM1237819"]}
         ds.aggregate_by = "EXPERIMENT"
         ds.scale_by = "STANDARD"
         ds.email_address = "null@derp.com"

--- a/workers/data_refinery_workers/processors/test_create_quantpendia.py
+++ b/workers/data_refinery_workers/processors/test_create_quantpendia.py
@@ -52,6 +52,20 @@ class QuantpendiaTestCase(TransactionTestCase):
         esa.sample = sample
         esa.save()
 
+        # Add a second non-downloadable sample. This one should not be included
+        # in the count of samples available in the metadata
+        sample2 = Sample()
+        sample2.accession_code = "GSM1237819"
+        sample2.title = "GSM1237819"
+        sample2.organism = homo_sapiens
+        sample2.technology = "RNA-SEQ"
+        sample2.save()
+
+        esa2 = ExperimentSampleAssociation()
+        esa2.experiment = experiment
+        esa2.sample = sample2
+        esa2.save()
+
         computed_file = ComputedFile()
         computed_file.s3_key = "smasher-test-quant.sf"
         computed_file.s3_bucket = "data-refinery-test-assets"


### PR DESCRIPTION
## Issue Number

#2289

## Purpose/Implementation Notes

Mark samples without quant.sf files as filtered so that they are not included in the metadata.

It looks like what was happening was that samples without quant.sf files were not being filtered out properly, so they would still be included in the metadata as samples in the compendia.

## Types of changes

What types of changes does your code introduce?

<!-- Remove any which your PR isn't -->
- Bugfix (non-breaking change which fixes an issue)

## Functional tests

I modified the quantpendia unit test, and checked that my fix made it pass.

## Checklist

_Put an `x` in the boxes that apply._

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots

Please attach any screenshots that illustrate these changes.
