### PR TITLE
srastats sometimes lies about the number of reads

### DIFF
--- a/workers/data_refinery_workers/processors/salmon.py
+++ b/workers/data_refinery_workers/processors/salmon.py
@@ -191,11 +191,11 @@ def _determine_index_length_sra(job_context: Dict) -> Dict:
     try:
         bases_count = int(stats.Run.Bases["count"])
         reads_count = int(stats.Run.Statistics["nspots"]) * int(stats.Run.Statistics["nreads"])
-        job_context["sra_num_reads"] = int(stats.Run.Statistics["nreads"])
+        num_reads = int(stats.Run.Statistics["nreads"])
         job_context["index_length_raw"] = int(bases_count / reads_count)
     except Exception:
         try:
-            job_context["sra_num_reads"] = int(stats.Run.Statistics["nreads"])
+            num_reads = int(stats.Run.Statistics["nreads"])
             spot_count_mates = int(stats.Run["spot_count_mates"])
             base_count_bio_mates = int(stats.Run["base_count_bio_mates"])
             reads_count = spot_count_mates * int(stats.Run.Statistics["nreads"])
@@ -217,27 +217,28 @@ def _determine_index_length_sra(job_context: Dict) -> Dict:
     else:
         job_context["index_length"] = "short"
 
-    if not job_context.get("sra_num_reads", None):
-        try:
-            sample = job_context["sample"]
-            for exp in sample.experiments.all():
-                for annotation in exp.experimentannotation_set.all():
-                    if annotation.data.get("library_layout", "").upper() == "PAIRED":
-                        job_context["sra_num_reads"] = 2
-                        return job_context
-                    if annotation.data.get("library_layout", "").upper() == "SINGLE":
-                        job_context["sra_num_reads"] = 1
-                        return job_context
-        except Exception as e:
-            logger.exception(
-                "Problem trying to determine library strategy (single/paired)!",
-                file=job_context["sra_input_file_path"],
-            )
-            job_context[
-                "job"
-            ].failure_reason = "Unable to determine library strategy (single/paired): " + str(e)
-            job_context["success"] = False
-            return job_context
+    try:
+        sample = job_context["sample"]
+        for exp in sample.experiments.all():
+            for annotation in exp.experimentannotation_set.all():
+                if annotation.data.get("library_layout", "").upper() == "PAIRED":
+                    job_context["sra_num_reads"] = 2
+                    return job_context
+                if annotation.data.get("library_layout", "").upper() == "SINGLE":
+                    job_context["sra_num_reads"] = 1
+                    return job_context
+
+        job_context["sra_num_reads"] = num_reads
+    except Exception as e:
+        logger.exception(
+            "Problem trying to determine library strategy (single/paired)!",
+            file=job_context["sra_input_file_path"],
+        )
+        job_context[
+            "job"
+        ].failure_reason = "Unable to determine library strategy (single/paired): " + str(e)
+        job_context["success"] = False
+        return job_context
 
     if not job_context.get("sra_num_reads", None):
         logger.error(


### PR DESCRIPTION
## Issue Number

Salmon continued to not work on prod.

## Purpose/Implementation Notes

I looked into why, and it turns out that we were detecting that the sample had two reads when it really only had one. I dug into why and found out that srastats was returning that `sra_num_reads` should be 2, but we interpret that as having more than one read. Instead, let's trust the library strategy first because that should hopefully be more accurate.

## Methods

If this pull request has any implications for data or metadata processing or addresses an issue labeled `sci review`, please include an overview of the methods used (e.g., briefly explain _how_ the data gets processed).
See [#267](https://github.com/AlexsLemonade/refinebio/pull/267) for rationale.
Include sufficient detail for reviewers or users that are not expert developers to evaluate the validity of the approach.
Please attach or link to example input and output data if applicable.
It may also be appropriate to include a description of any functional or unit tests in this section depending on their content.
Any pull request with a methods section requires scientific review in addition to code review.

## Types of changes

What types of changes does your code introduce?

<!-- Remove any which your PR isn't -->
- Bugfix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Functional tests

List out the functional tests you've completed to verify your changes work locally.

## Checklist

_Put an `x` in the boxes that apply._

- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots

Please attach any screenshots that illustrate these changes.
