### PR TITLE
Fix dataset endpoint

### DIFF
--- a/api/data_refinery_api/tests.py
+++ b/api/data_refinery_api/tests.py
@@ -479,8 +479,8 @@ class APITestCases(APITestCase):
         self.assertEqual(3, len(response_json))
         self.assertIsNone(response_json[0]["download_url"])
 
-    @patch("data_refinery_common.message_queue.send_job")
-    def test_create_dataset_fails_without_email(self, mock_send_job):
+    @patch("data_refinery_api.views.dataset.send_job", lambda *args: True)
+    def test_create_dataset_fails_without_email(self):
 
         # Get a token first
         response = self.client.post(
@@ -542,8 +542,8 @@ class APITestCases(APITestCase):
 
         self.assertEqual(response.status_code, 400)
 
-    @patch("data_refinery_common.message_queue.send_job")
-    def test_starting_dataset_fails_without_experiments(self, mock_send_job):
+    @patch("data_refinery_api.views.dataset.send_job", lambda *args: True)
+    def test_starting_dataset_fails_without_experiments(self):
 
         # Get a token first
         response = self.client.post(
@@ -742,8 +742,8 @@ class APITestCases(APITestCase):
         )
         self.assertEqual(response.status_code, 200)
 
-    @patch("data_refinery_common.message_queue.send_job")
-    def test_create_update_dataset(self, mock_send_job):
+    @patch("data_refinery_api.views.dataset.send_job", lambda *args: True)
+    def test_create_update_dataset(self):
 
         # Get a token first
         response = self.client.post(

--- a/api/data_refinery_api/tests.py
+++ b/api/data_refinery_api/tests.py
@@ -861,7 +861,6 @@ class APITestCases(APITestCase):
                 "email_address": "baz@gmail.com",
                 "data": {"GSE123": ["789"]},
                 "start": True,
-                "no_send_job": True,
                 "token_id": "HEYO",
             }
         )
@@ -876,7 +875,6 @@ class APITestCases(APITestCase):
             {
                 "data": {"GSE123": ["789"]},
                 "start": True,
-                "no_send_job": True,
                 "token_id": token_id,
                 "email_address": "trust@verify.com",
                 "email_ccdl_ok": True,
@@ -905,7 +903,6 @@ class APITestCases(APITestCase):
             {
                 "data": {"GSE123": ["789"]},
                 "start": True,
-                "no_send_job": True,
                 "email_address": "trust@verify.com",
                 "email_ccdl_ok": True,
             }
@@ -928,7 +925,6 @@ class APITestCases(APITestCase):
             {
                 "data": {"GSE123": ["789"]},
                 "start": True,
-                "no_send_job": True,
                 "email_address": "trust@verify.com",
                 "email_ccdl_ok": True,
             }


### PR DESCRIPTION
## Issue Number

Came up while fixing https://github.com/AlexsLemonade/refinebio-frontend/issues/909

## Purpose/Implementation Notes

We were missing some imports in the `dataset.py` file, but these didn't error because they were inside a try-catch block. We also missed this in our tests because it was actually the code that sends the nomad jobs. I made the catch block log the error instead of just passing, and I modified the tests so we check that branch too.

## Types of changes

What types of changes does your code introduce?

<!-- Remove any which your PR isn't -->
- Bugfix (non-breaking change which fixes an issue)

## Functional tests

Downloading a dataset with my local instance and using the patched frontend works now!

## Checklist

_Put an `x` in the boxes that apply._

- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots

Please attach any screenshots that illustrate these changes.
