### PR TITLE
Whoops, terraform expands template variables inside comments

### DIFF
--- a/infrastructure/api-configuration/api-server-instance-user-data.tpl.sh
+++ b/infrastructure/api-configuration/api-server-instance-user-data.tpl.sh
@@ -7,7 +7,7 @@
 # This script will be formatted by Terraform, which will read files from the
 # project into terraform variables, and then template them into the following
 # script. These will then be written out to files so that they can be used
-# locally. This means that any variable referenced as `${name}` is NOT a shell
+# locally. This means that any variable referenced using `{}` is NOT a shell
 # variable, it is a template variable for Terraform to fill in. DO NOT treat
 # them as normal shell variables.
 

--- a/infrastructure/foreman-configuration/foreman-server-instance-user-data.tpl.sh
+++ b/infrastructure/foreman-configuration/foreman-server-instance-user-data.tpl.sh
@@ -7,7 +7,7 @@
 # This script will be formatted by Terraform, which will read files from the
 # project into terraform variables, and then template them into the following
 # script. These will then be written out to files so that they can be used
-# locally. This means that any variable referenced as `${name}` is NOT a shell
+# locally. This means that any variable referenced using `{}` is NOT a shell
 # variable, it is a template variable for Terraform to fill in. DO NOT treat
 # them as normal shell variables.
 

--- a/infrastructure/nomad-configuration/client-instance-user-data.tpl.sh
+++ b/infrastructure/nomad-configuration/client-instance-user-data.tpl.sh
@@ -7,7 +7,7 @@
 # This script will be formatted by Terraform, which will read files from the
 # project into terraform variables, and then template them into the following
 # script. These will then be written out to files so that they can be used
-# locally. This means that any variable referenced as `${name}` is NOT a shell
+# locally. This means that any variable referenced using `{}` is NOT a shell
 # variable, it is a template variable for Terraform to fill in. DO NOT treat
 # them as normal shell variables.
 

--- a/infrastructure/nomad-configuration/client-smasher-instance-user-data.tpl.sh
+++ b/infrastructure/nomad-configuration/client-smasher-instance-user-data.tpl.sh
@@ -7,7 +7,7 @@
 # This script will be formatted by Terraform, which will read files from the
 # project into terraform variables, and then template them into the following
 # script. These will then be written out to files so that they can be used
-# locally. This means that any variable referenced as `${name}` is NOT a shell
+# locally. This means that any variable referenced using `{}` is NOT a shell
 # variable, it is a template variable for Terraform to fill in. DO NOT treat
 # them as normal shell variables.
 

--- a/infrastructure/nomad-configuration/lead-server-instance-user-data.tpl.sh
+++ b/infrastructure/nomad-configuration/lead-server-instance-user-data.tpl.sh
@@ -7,7 +7,7 @@
 # This script will be formatted by Terraform, which will read files from the
 # project into terraform variables, and then template them into the following
 # script. These will then be written out to files so that they can be used
-# locally. This means that any variable referenced as `${name}` is NOT a shell
+# locally. This means that any variable referenced using `{}` is NOT a shell
 # variable, it is a template variable for Terraform to fill in. DO NOT treat
 # them as normal shell variables.
 

--- a/infrastructure/nomad-configuration/pg-bouncer-instance-user-data.tpl.sh
+++ b/infrastructure/nomad-configuration/pg-bouncer-instance-user-data.tpl.sh
@@ -7,7 +7,7 @@
 # This script will be formatted by Terraform, which will read files from the
 # project into terraform variables, and then template them into the following
 # script. These will then be written out to files so that they can be used
-# locally. This means that any variable referenced as `${name}` is NOT a shell
+# locally. This means that any variable referenced using `{}` is NOT a shell
 # variable, it is a template variable for Terraform to fill in. DO NOT treat
 # them as normal shell variables.
 


### PR DESCRIPTION
## Issue Number

N/A deploy problems

## Purpose/Implementation Notes

Terraform failed trying to expand `${name}`, which was used inside comments.

## Types of changes

What types of changes does your code introduce?

<!-- Remove any which your PR isn't -->
- Bugfix (non-breaking change which fixes an issue)

## Functional tests

List out the functional tests you've completed to verify your changes work locally.

## Checklist

_Put an `x` in the boxes that apply._

- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots

Please attach any screenshots that illustrate these changes.
