### PR TITLE
Ignore curl errors while deploying

### DIFF
--- a/infrastructure/deploy.sh
+++ b/infrastructure/deploy.sh
@@ -188,6 +188,9 @@ export NOMAD_ADDR=http://$NOMAD_LEAD_SERVER_IP:4646
 
 # Wait for Nomad to get started in case the server just went up for
 # the first time.
+
+set +e # curl fails if the nomad server isn't up
+
 echo "Confirming Nomad cluster.."
 start_time=$(date +%s)
 diff=0
@@ -203,6 +206,8 @@ if [[ $nomad_status != "200" ]]; then
     echo "Either the timeout needs to be raised or there's something else broken."
     exit 1
 fi
+
+set -e # Turn errors back on after we confirm that the nomad server is up
 
 # Kill Base Nomad Jobs so no new jobs can be queued.
 echo "Killing base jobs.. (this takes a while..)"


### PR DESCRIPTION
## Issue Number

Fixes https://github.com/AlexsLemonade/refinebio/issues/2401

## Purpose/Implementation Notes

Our deploy script sometimes fails while confirming the nomad cluster with exit code 7, which is the `curl` error code for a host not being up. Since we're waiting for the host to come up anyway, let's just ignore `curl` errors.

## Types of changes

What types of changes does your code introduce?

<!-- Remove any which your PR isn't -->
- Bugfix (non-breaking change which fixes an issue)

## Functional tests

List out the functional tests you've completed to verify your changes work locally.

## Checklist

_Put an `x` in the boxes that apply._

- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots

Please attach any screenshots that illustrate these changes.
