### PR TITLE
Use systemd instead of monit for the nomad client

### DIFF
--- a/infrastructure/instances.tf
+++ b/infrastructure/instances.tf
@@ -81,6 +81,11 @@ resource "aws_instance" "nomad_server_1" {
   }
 }
 
+# This service takes care of restarting the nomad client if it goes down
+data "local_file" "nomad_client_service" {
+  filename = "nomad-configuration/nomad-client.service"
+}
+
 # The Nomad Client needs to be aware of the Nomad Server's IP address,
 # so we template it into its configuration.
 data "template_file" "nomad_client_config" {
@@ -106,6 +111,7 @@ data "template_file" "nomad_client_script_smusher" {
   vars {
     install_nomad_script = "${data.local_file.install_nomad_script.content}"
     nomad_client_config = "${data.template_file.nomad_client_config.rendered}"
+    nomad_client_service = "${data.local_file.nomad_client_service.content}"
     user = "${var.user}"
     stage = "${var.stage}"
     region = "${var.region}"

--- a/infrastructure/nomad-configuration/nomad-client.service
+++ b/infrastructure/nomad-configuration/nomad-client.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=CCDL nomad client runtime
+Documentation=https://github.com/AlexsLemonade/refinebio
+After=network.target local-fs.target
+
+[Service]
+ExecStart=sh -c "nomad agent -config /home/ubuntu/client.hcl >> /var/log/nomad_client.log 2>&1"
+
+# Keep us alive always
+Restart=always
+
+LimitNOFILE=65536
+
+[Install]
+WantedBy=multi-user.target

--- a/infrastructure/nomad-configuration/nomad-client.service
+++ b/infrastructure/nomad-configuration/nomad-client.service
@@ -4,7 +4,7 @@ Documentation=https://github.com/AlexsLemonade/refinebio
 After=network.target local-fs.target
 
 [Service]
-ExecStart=sh -c "nomad agent -config /home/ubuntu/client.hcl >> /var/log/nomad_client.log 2>&1"
+ExecStart=/bin/sh -c "nomad agent -config /home/ubuntu/client.hcl >> /var/log/nomad_client.log 2>&1"
 
 # Keep us alive always
 Restart=always


### PR DESCRIPTION
## Issue Number

None, doing work on prod

## Purpose/Implementation Notes

Nomad seems way more reliable after I stopped monit from running. Since we only need monit to restart the nomad client when it goes down, let's just use a systemd service instead.

## Types of changes

What types of changes does your code introduce?

<!-- Remove any which your PR isn't -->
- Bugfix (non-breaking change which fixes an issue)

## Functional tests

None, we should probably test this on staging first, just spin up a spot instance and make sure that nomad is running.

## Checklist

_Put an `x` in the boxes that apply._

- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots

Please attach any screenshots that illustrate these changes.
