### PR TITLE
Use the volume work depth to keep track of processor jobs

### DIFF
--- a/foreman/data_refinery_foreman/foreman/test_main.py
+++ b/foreman/data_refinery_foreman/foreman/test_main.py
@@ -144,12 +144,28 @@ class ForemanTestCase(TestCase):
         mock_send_job.return_value = True
         mock_breakdown.return_value = {
             "nomad_pending_jobs_by_volume": {"0": 7, "1": 9},
-            "nomad_running_jobs_by_volume": {"0": 300, "1": 400},
+            "nomad_running_jobs_by_volume": {"0": 100, "1": 150},
         }
         mock_active_volumes.return_value = ["0", "1"]
 
+        # Create 30 processor jobs to add to the volume work depth.
+        # This helper function adds them all to volume 1, which we have to keep
+        # in mind later
+        for x in range(0, 30):
+            self.create_processor_job()
+
+        EXPECTED_WORK_DEPTH = {
+            "0": 107,  # 7 pending + 100 running
+            "1": 189,  # 9 pending + 150 running + 30 processor jobs
+        }
+
+        # Make sure that we set sensible values for EXPECTED_WORK_DEPTH.
+        # Otherwise the rest of the test fails mysteriously
+        for num in EXPECTED_WORK_DEPTH.values():
+            self.assertTrue(num < main.DESIRED_WORK_DEPTH)
+
         main.update_volume_work_depth(datetime.timedelta(0))
-        self.assertEqual(main.VOLUME_WORK_DEPTH, {"0": 307, "1": 409})
+        self.assertEqual(main.VOLUME_WORK_DEPTH, EXPECTED_WORK_DEPTH)
 
         # Ensure that there are at least enough jobs to saturate the desired work depth
         # for both mocked volumes
@@ -163,8 +179,11 @@ class ForemanTestCase(TestCase):
         # No jobs actually make it in Nomad queue, but we keep a tally of the last reported work
         # depth plus any new queued jobs, so this should only queue up enough jobs to fill the
         # DESIRED_WORK_DEPTH for every node
-        # ((DESIRED_WORK_DEPTH - 67) + (DESIRED_WORK_DEPTH - 99) jobs in total)
-        self.assertEqual(len(mock_send_job.mock_calls), 2 * main.DESIRED_WORK_DEPTH - 307 - 409)
+        self.assertEqual(
+            len(mock_send_job.mock_calls),
+            (main.DESIRED_WORK_DEPTH - EXPECTED_WORK_DEPTH["0"])
+            + (main.DESIRED_WORK_DEPTH - EXPECTED_WORK_DEPTH["1"]),
+        )
         self.assertEqual(
             main.VOLUME_WORK_DEPTH, {"0": main.DESIRED_WORK_DEPTH, "1": main.DESIRED_WORK_DEPTH}
         )

--- a/foreman/data_refinery_foreman/foreman/test_main.py
+++ b/foreman/data_refinery_foreman/foreman/test_main.py
@@ -162,7 +162,7 @@ class ForemanTestCase(TestCase):
         # Make sure that we set sensible values for EXPECTED_WORK_DEPTH.
         # Otherwise the rest of the test fails mysteriously
         for num in EXPECTED_WORK_DEPTH.values():
-            self.assertTrue(num < main.DESIRED_WORK_DEPTH)
+            self.assertLess(num, main.DESIRED_WORK_DEPTH)
 
         main.update_volume_work_depth(datetime.timedelta(0))
         self.assertEqual(main.VOLUME_WORK_DEPTH, EXPECTED_WORK_DEPTH)


### PR DESCRIPTION
## Issue Number

https://github.com/AlexsLemonade/refinebio/issues/2424

## Purpose/Implementation Notes

The disk is filling up on our instances because we keep queuing downloader jobs to run even though we have a large backlog of processor jobs. Since we already have logic that stops us from queuing too many downloader jobs at once, let's just also include open processor jobs in our calculations of a volume's work depth.

We may have to fiddle with the `DESIRED_WORK_DEPTH` again, I dropped it down to 200 because I was worried 500 might be too much. We have ~800GB of useable space (a bit more than that but just to be safe), so how much space does a worst-case job take up in terms of downloaded raw data and processor output? 

## Types of changes

What types of changes does your code introduce?

<!-- Remove any which your PR isn't -->
- Bugfix (non-breaking change which fixes an issue)

## Functional tests

I am running it on a dev stack right now. Things are processing successfully, and the disk is staying empty.

```
ubuntu@ip-10-0-41-123:~$ df -h
Filesystem      Size  Used Avail Use% Mounted on
/dev/xvda1      873G   44G  829G   6% /
```

It would probably be filling up a bit more if I was running a larger instance that could run more jobs in parallel, but I'm on a `4xlarge` since before we filled up the disk easily on it.

## Checklist

_Put an `x` in the boxes that apply._

- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots

Please attach any screenshots that illustrate these changes.
