### PR TITLE
Stop using monit to monitor nomad

### DIFF
--- a/infrastructure/instances.tf
+++ b/infrastructure/instances.tf
@@ -24,6 +24,12 @@ data "local_file" "nomad_lead_server_config" {
   filename = "nomad-configuration/lead_server.hcl"
 }
 
+# This service takes care of restarting the nomad server if it goes down
+data "local_file" "nomad_server_service" {
+  filename = "nomad-configuration/nomad-server.service"
+}
+
+
 # This script smusher exists in order to be able to circumvent a
 # limitation of AWS which is that you get one script and one script
 # only to set up the instance when it boots up. Because there is only
@@ -38,6 +44,7 @@ data "template_file" "nomad_lead_server_script_smusher" {
   vars {
     install_nomad_script = "${data.local_file.install_nomad_script.content}"
     nomad_server_config = "${data.local_file.nomad_lead_server_config.content}"
+    nomad_server_service = "${data.local_file.nomad_server_service.content}"
     server_number = 1
     user = "${var.user}"
     stage = "${var.stage}"
@@ -141,6 +148,7 @@ data "template_file" "nomad_client_script_smasher_smusher" {
   vars {
     install_nomad_script = "${data.local_file.install_nomad_script.content}"
     nomad_client_smasher_config = "${data.template_file.nomad_client_smasher_config.rendered}"
+    nomad_client_service = "${data.local_file.nomad_client_service.content}"
     user = "${var.user}"
     stage = "${var.stage}"
     region = "${var.region}"

--- a/infrastructure/nomad-configuration/client-smasher-instance-user-data.tpl.sh
+++ b/infrastructure/nomad-configuration/client-smasher-instance-user-data.tpl.sh
@@ -19,7 +19,7 @@
 export DEBIAN_FRONTEND=noninteractive
 apt-get update -y
 apt-get upgrade -y
-apt-get install --yes jq iotop dstat speedometer awscli docker.io monit
+apt-get install --yes jq iotop dstat speedometer awscli docker.io
 
 ulimit -n 65536
 
@@ -78,31 +78,13 @@ EOF
 chmod +x install_nomad.sh
 ./install_nomad.sh
 
-# Start the Nomad agent in client mode via Monit
-echo "
-#!/bin/sh
-nomad status
-exit \$?
-" >> /home/ubuntu/nomad_status.sh
-chmod +x /home/ubuntu/nomad_status.sh
+# Start the Nomad agent in client mode via systemd
+cat <<"EOF" > /etc/systemd/system/nomad-client.service
+${nomad_client_service}
+EOF
 
-echo "
-#!/bin/sh
-killall nomad && sleep 120
-nomad agent -config /home/ubuntu/client.hcl > /var/log/nomad_client.log &
-" >> /home/ubuntu/kill_restart_nomad.sh
-chmod +x /home/ubuntu/kill_restart_nomad.sh
-/home/ubuntu/kill_restart_nomad.sh
-
-echo '
-check program nomad with path "/bin/bash /home/ubuntu/nomad_status.sh" as uid 0 and with gid 0
-    start program = "/bin/bash /home/ubuntu/kill_restart_nomad.sh" as uid 0 and with gid 0 with timeout 240 seconds
-    if status != 0
-        then restart
-set daemon 300
-' >> /etc/monit/monitrc
-
-service monit restart
+systemctl enable nomad-client.service
+systemctl start nomad-client.service
 
 # Delete the cloudinit and syslog in production.
 export STAGE=${stage}

--- a/infrastructure/nomad-configuration/nomad-server.service
+++ b/infrastructure/nomad-configuration/nomad-server.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=CCDL nomad client runtime
+Documentation=https://github.com/AlexsLemonade/refinebio
+After=network.target local-fs.target
+
+[Service]
+ExecStart=/bin/sh -c "nomad agent -config /home/ubuntu/server.hcl >> /var/log/nomad_server.log 2>&1"
+
+# Keep us alive always
+Restart=always
+
+LimitNOFILE=65536
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
## Issue Number

This should fix #2205

## Purpose/Implementation Notes

In https://github.com/AlexsLemonade/refinebio/pull/2422 we started using systemd to handle starting and restarting the nomad client instead of monit. This PR makes the same change for our other instances that run nomad.

## Types of changes

What types of changes does your code introduce?

<!-- Remove any which your PR isn't -->
- Bugfix (non-breaking change which fixes an issue)

## Functional tests

None so far, I should spin up a dev stack to test this first.

## Checklist

_Put an `x` in the boxes that apply._

- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots

Please attach any screenshots that illustrate these changes.
