### PR TITLE
Parse dates correctly in sra surveyor.

### DIFF
--- a/foreman/data_refinery_foreman/surveyor/array_express.py
+++ b/foreman/data_refinery_foreman/surveyor/array_express.py
@@ -1,6 +1,6 @@
 from typing import Dict, List
 
-from django.utils.dateparse import parse_datetime
+from django.utils.dateparse import parse_date
 
 from data_refinery_common.job_lookup import Downloaders
 from data_refinery_common.logging import get_and_configure_logger
@@ -67,10 +67,8 @@ class ArrayExpressSurveyor(ExternalSourceSurveyor):
         experiment_object.technology = "MICROARRAY"
         experiment_object.description = experiment_descripton
 
-        experiment_object.source_first_published = parse_datetime(parsed_json["releasedate"])
-        experiment_object.source_last_modified = parse_datetime(
-            cls._get_last_update_date(parsed_json)
-        )
+        experiment_object.source_first_published = parse_date(parsed_json["releasedate"])
+        experiment_object.source_last_modified = parse_date(cls._get_last_update_date(parsed_json))
 
     def create_experiment_from_api(self, experiment_accession_code: str) -> (Experiment, Dict):
         """Given an experiment accession code, create an Experiment object.

--- a/foreman/data_refinery_foreman/surveyor/sra.py
+++ b/foreman/data_refinery_foreman/surveyor/sra.py
@@ -3,7 +3,7 @@ import re
 import xml.etree.ElementTree as ET
 from typing import Dict, List
 
-from django.utils.dateparse import parse_datetime
+from django.utils.dateparse import parse_date
 
 from data_refinery_common.job_lookup import Downloaders
 from data_refinery_common.logging import get_and_configure_logger
@@ -16,7 +16,6 @@ from data_refinery_common.models import (
     OriginalFile,
     OriginalFileSampleAssociation,
     Sample,
-    SampleAnnotation,
     SurveyJob,
 )
 from data_refinery_common.rna_seq import _build_ena_file_url
@@ -352,9 +351,9 @@ class SraSurveyor(ExternalSourceSurveyor):
             experiment.pubmed_id = metadata["pubmed_id"]
             experiment.has_publication = True
         if "study_ena_first_public" in metadata:
-            experiment.source_first_published = parse_datetime(metadata["study_ena_first_public"])
+            experiment.source_first_published = parse_date(metadata["study_ena_first_public"])
         if "study_ena_last_update" in metadata:
-            experiment.source_last_modified = parse_datetime(metadata["study_ena_last_update"])
+            experiment.source_last_modified = parse_date(metadata["study_ena_last_update"])
 
         # We only want GEO alternate accessions for SRA samples
         if re.match(r"^GSE\d{2,6}", metadata.get("external_id", "")) is not None:

--- a/foreman/data_refinery_foreman/surveyor/test_array_express.py
+++ b/foreman/data_refinery_foreman/surveyor/test_array_express.py
@@ -1,12 +1,15 @@
 from unittest.mock import patch
 
 from django.test import TestCase
+from django.utils import timezone
 
+import datetime
 import requests
 import vcr
 
 from data_refinery_common.models import (
     DownloaderJob,
+    Experiment,
     Organism,
     Sample,
     SurveyJob,
@@ -54,6 +57,15 @@ class SurveyTestCase(TestCase):
 
         # And for one DownloaderJob to be created for all of them.
         self.assertEqual(downloader_jobs.count(), 1)
+
+        experiment = Experiment.objects.first()
+        self.assertEqual(experiment.accession_code, "E-MTAB-3050")
+        self.assertEqual(
+            experiment.source_first_published, datetime.datetime(2014, 10, 31, tzinfo=timezone.utc)
+        )
+        self.assertEqual(
+            experiment.source_last_modified, datetime.datetime(2014, 10, 30, tzinfo=timezone.utc)
+        )
 
         sample = Sample.objects.first()
         self.assertTrue(" (hgu95av2)" in sample.pretty_platform)

--- a/foreman/data_refinery_foreman/surveyor/test_array_express.py
+++ b/foreman/data_refinery_foreman/surveyor/test_array_express.py
@@ -1,9 +1,9 @@
+import datetime
 from unittest.mock import patch
 
 from django.test import TestCase
 from django.utils import timezone
 
-import datetime
 import requests
 import vcr
 

--- a/foreman/data_refinery_foreman/surveyor/test_sra.py
+++ b/foreman/data_refinery_foreman/surveyor/test_sra.py
@@ -1,6 +1,7 @@
 from unittest.mock import patch
 
 from django.test import TestCase
+import datetime
 
 import vcr
 
@@ -169,6 +170,8 @@ class SraSurveyorTestCase(TestCase):
         self.assertEqual(metadata["sample_sample_name"], "DRS001521")
         self.assertEqual(metadata["sample_title"], "Gg_HH16_1_embryo_mRNAseq")
         self.assertEqual(metadata["spot_length"], "100")
+        self.assertEqual(metadata["study_ena_first_public"], "2013-07-20")
+        self.assertEqual(metadata["study_ena_last_update"], "2015-08-24")
         self.assertEqual(metadata["study_accession"], "DRP000595")
         self.assertEqual(metadata["submission_accession"], "DRA000567")
         self.assertEqual(
@@ -200,3 +203,13 @@ class SraSurveyorTestCase(TestCase):
         self.assertEqual(sample.treatment, "biliatresone")
         self.assertEqual(sample.subject, "liver")
         self.assertEqual(sample.specimen_part, "liver")
+
+        experiment = Experiment()
+        SraSurveyor._apply_metadata_to_experiment(experiment, metadata)
+        self.assertEqual(
+            experiment.title,
+            "Transcriptional profiling through RNA-seq of zebrafish larval"
+            " liver after exposure to biliatresone, a biliary toxin.",
+        )
+        self.assertEqual(experiment.source_first_published, datetime.date(2017, 9, 25))
+        self.assertEqual(experiment.source_last_modified, datetime.date(2017, 9, 25))

--- a/foreman/data_refinery_foreman/surveyor/test_sra.py
+++ b/foreman/data_refinery_foreman/surveyor/test_sra.py
@@ -1,7 +1,7 @@
+import datetime
 from unittest.mock import patch
 
 from django.test import TestCase
-import datetime
 
 import vcr
 
@@ -170,8 +170,8 @@ class SraSurveyorTestCase(TestCase):
         self.assertEqual(metadata["sample_sample_name"], "DRS001521")
         self.assertEqual(metadata["sample_title"], "Gg_HH16_1_embryo_mRNAseq")
         self.assertEqual(metadata["spot_length"], "100")
-        self.assertEqual(metadata["study_ena_first_public"], "2013-07-20")
-        self.assertEqual(metadata["study_ena_last_update"], "2015-08-24")
+        self.assertEqual(metadata["study_ena_first_public"], "2013-07-19")
+        self.assertEqual(metadata["study_ena_last_update"], "2015-06-22")
         self.assertEqual(metadata["study_accession"], "DRP000595")
         self.assertEqual(metadata["submission_accession"], "DRA000567")
         self.assertEqual(


### PR DESCRIPTION
## Issue Number

https://github.com/AlexsLemonade/refinebio/issues/2438

## Purpose/Implementation Notes

Turns out we haven't been parsing ENA metadata correctly. `parse_datetime` returns None if the string is only a date. This fixes it and verifies it with tests.

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

Unit tests cover it well.

## Checklist

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules
