### PR TITLE
Lower desired work depth

### DIFF
--- a/foreman/data_refinery_foreman/foreman/main.py
+++ b/foreman/data_refinery_foreman/foreman/main.py
@@ -68,7 +68,7 @@ TIME_OF_LAST_DOWNLOADER_JOB_CHECK = timezone.now() - datetime.timedelta(minutes=
 
 # The desired number of active + pending jobs on a volume. Downloader jobs
 # will be assigned to instances until this limit is reached.
-DESIRED_WORK_DEPTH = 200
+DESIRED_WORK_DEPTH = 100
 
 # This is the absolute max number of downloader jobs that should ever
 # be queued across the whole cluster no matter how many nodes we

--- a/foreman/data_refinery_foreman/foreman/test_main.py
+++ b/foreman/data_refinery_foreman/foreman/test_main.py
@@ -144,7 +144,7 @@ class ForemanTestCase(TestCase):
         mock_send_job.return_value = True
         mock_breakdown.return_value = {
             "nomad_pending_jobs_by_volume": {"0": 7, "1": 9},
-            "nomad_running_jobs_by_volume": {"0": 100, "1": 150},
+            "nomad_running_jobs_by_volume": {"0": 75, "1": 50},
         }
         mock_active_volumes.return_value = ["0", "1"]
 
@@ -155,8 +155,8 @@ class ForemanTestCase(TestCase):
             self.create_processor_job()
 
         EXPECTED_WORK_DEPTH = {
-            "0": 107,  # 7 pending + 100 running
-            "1": 189,  # 9 pending + 150 running + 30 processor jobs
+            "0": 82,  # 7 pending + 75 running
+            "1": 89,  # 9 pending + 50 running + 30 processor jobs
         }
 
         # Make sure that we set sensible values for EXPECTED_WORK_DEPTH.


### PR DESCRIPTION
## Issue Number

#2424 

## Purpose/Implementation Notes
Lower the desired work depth to 100, since our disk was still just about filling up. It looks like those salmon jobs took >4gb on average. Our small instances run less than 100 salmon jobs at a time, so we are still not throttling ourselves too much.

## Types of changes

What types of changes does your code introduce?

<!-- Remove any which your PR isn't -->
- Bugfix (non-breaking change which fixes an issue)

## Functional tests

N/A

## Checklist

_Put an `x` in the boxes that apply._

- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots

Please attach any screenshots that illustrate these changes.
