### PR TITLE
Add missing ftplib import

### DIFF
--- a/workers/data_refinery_workers/downloaders/sra.py
+++ b/workers/data_refinery_workers/downloaders/sra.py
@@ -1,3 +1,4 @@
+import ftplib
 import os
 import shutil
 import subprocess


### PR DESCRIPTION
## Issue Number

None

## Purpose/Implementation Notes

We were failing to catch `ftplib.error_perm: 550 Failed to change directory.` because I forgot to import `ftplib` to catch `ftplib.all_errors`.

## Types of changes

What types of changes does your code introduce?

<!-- Remove any which your PR isn't -->
- Bugfix (non-breaking change which fixes an issue)

## Functional tests

None

## Checklist

_Put an `x` in the boxes that apply._

- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots

Please attach any screenshots that illustrate these changes.
