### PR TITLE
Catch exceptions raised while refreshing metadata

### DIFF
--- a/foreman/data_refinery_foreman/foreman/management/commands/update_experiment_metadata.py
+++ b/foreman/data_refinery_foreman/foreman/management/commands/update_experiment_metadata.py
@@ -54,37 +54,49 @@ class Command(BaseCommand):
                 logger.debug(
                     "Refreshing metadata for an experiment.", experiment=experiment.accession_code
                 )
-                if experiment.source_database == "SRA":
-                    metadata = SraSurveyor.gather_all_metadata(
-                        experiment.samples.first().accession_code
-                    )
-                    SraSurveyor._apply_metadata_to_experiment(experiment, metadata)
-
-                elif experiment.source_database == "GEO":
-                    gse = GEOparse.get_GEO(
-                        experiment.accession_code,
-                        destdir="/tmp/management",
-                        how="brief",
-                        silent=True,
-                    )
-
-                    GeoSurveyor._apply_metadata_to_experiment(experiment, gse)
-
-                elif experiment.source_database == "ARRAY_EXPRESS":
-                    request_url = EXPERIMENTS_URL + experiment.accession_code
-                    experiment_request = utils.requests_retry_session().get(request_url, timeout=60)
-                    try:
-                        parsed_json = experiment_request.json()["experiments"]["experiment"][0]
-                    except KeyError:
-                        logger.error(
-                            "Remote experiment has no Experiment data!",
-                            experiment_accession_code=experiment.accession_code,
-                            survey_job=self.survey_job.id,
+                try:
+                    if experiment.source_database == "SRA":
+                        metadata = SraSurveyor.gather_all_metadata(
+                            experiment.samples.first().accession_code
                         )
-                        continue
-                    ArrayExpressSurveyor._apply_metadata_to_experiment(experiment, parsed_json)
+                        SraSurveyor._apply_metadata_to_experiment(experiment, metadata)
 
-                experiment.save()
+                    elif experiment.source_database == "GEO":
+                        gse = GEOparse.get_GEO(
+                            experiment.accession_code,
+                            destdir="/tmp/management",
+                            how="brief",
+                            silent=True,
+                        )
+
+                        GeoSurveyor._apply_metadata_to_experiment(experiment, gse)
+
+                    elif experiment.source_database == "ARRAY_EXPRESS":
+                        request_url = EXPERIMENTS_URL + experiment.accession_code
+                        experiment_request = utils.requests_retry_session().get(
+                            request_url, timeout=60
+                        )
+                        try:
+                            parsed_json = experiment_request.json()["experiments"]["experiment"][0]
+                        except KeyError:
+                            logger.error(
+                                "Remote experiment has no Experiment data!",
+                                experiment_accession_code=experiment.accession_code,
+                                survey_job=self.survey_job.id,
+                            )
+                            continue
+                        ArrayExpressSurveyor._apply_metadata_to_experiment(experiment, parsed_json)
+
+                    experiment.save()
+
+                # If there are any errors, just continue. It's likely that it's
+                # just a problem with this experiment.
+                except Exception:
+                    logger.exception(
+                        "exception caught while updating metadata for {}".format(
+                            experiment.accession_code
+                        )
+                    )
 
             if not page.has_next():
                 break


### PR DESCRIPTION
## Issue Number

I think this is what was causing https://github.com/AlexsLemonade/refinebio/issues/2462

## Purpose/Implementation Notes

Some of our experiments have an invalid library type, which causes an exception to be thrown in the surveyor. We should catch exceptions so it doesn't kill our management command every time we run into a bad experiment.

## Types of changes

What types of changes does your code introduce?

<!-- Remove any which your PR isn't -->
- Bugfix (non-breaking change which fixes an issue)

## Functional tests

None

## Checklist

_Put an `x` in the boxes that apply._

- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots

Please attach any screenshots that illustrate these changes.
