### PR TITLE
Fix filterset fields on transcriptome index view

### DIFF
--- a/api/data_refinery_api/views/transcriptome_index.py
+++ b/api/data_refinery_api/views/transcriptome_index.py
@@ -82,7 +82,7 @@ class TranscriptomeIndexListView(generics.ListAPIView):
         DjangoFilterBackend,
         filters.OrderingFilter,
     )
-    filterset_fields = ["salmon_version", "index_type", "result_id", "organism__name"]
+    filterset_fields = ["salmon_version", "index_type", "result__id", "organism__name"]
     ordering_fields = ("created_at", "salmon_version")
     ordering = ("-created_at",)
 


### PR DESCRIPTION
## Issue Number

https://github.com/AlexsLemonade/refinebio/issues/2459

## Purpose/Implementation Notes

I was trying to see if there was anything even slightly suspicious about the `TranscriptomeIndexListView`, and I found this. `result_id` is a field defined on the serializer but not on the model itself, which could be why the endpoint is timing out. Maybe.

## Types of changes

What types of changes does your code introduce?

<!-- Remove any which your PR isn't -->
- Bugfix (non-breaking change which fixes an issue)

## Functional tests

None, the bug only happens on staging and prod.

## Checklist

_Put an `x` in the boxes that apply._

- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots

Please attach any screenshots that illustrate these changes.
