### PR TITLE
Install aspera from HCC's conda repo instead

### DIFF
--- a/workers/dockerfiles/Dockerfile.downloaders
+++ b/workers/dockerfiles/Dockerfile.downloaders
@@ -53,9 +53,13 @@ RUN Rscript install_downloader_R_only.R
 # Even using `su - user &&` doesn't work...
 USER user
 
-# Install Aspera
-RUN wget -q https://download.asperasoft.com/download/sw/cli/3.7.7/aspera-cli-3.7.7.608.927cce8-linux-64-release.sh
-RUN sh aspera-cli-3.7.7.608.927cce8-linux-64-release.sh
+# Install Aspera. We have to install it using Holland Computing Center's conda
+# repo because download.asperasoft.com now returns 403s
+RUN wget -q https://anaconda.org/HCC/aspera-cli/3.9.1/download/linux-64/aspera-cli-3.9.1-0.tar.bz2
+RUN [ "$(sha256sum aspera-cli-3.9.1-0.tar.bz2 | cut -d' ' -f1)" = 60a09a7f3795186954079869106aa89a64183b7be8e0da7cbbe9d57c66c9bcdb ]
+RUN mkdir -p .aspera/cli
+RUN tar xf aspera-cli-3.9.1-0.tar.bz2 -C .aspera/cli
+RUN rm aspera-cli-3.9.1-0.tar.bz2
 
 # Now that we're done installing Aspera go back to being root for a bit.
 USER root


### PR DESCRIPTION
## Issue Number

Fixes https://github.com/AlexsLemonade/refinebio/issues/2479

## Purpose/Implementation Notes

Apparently HCC (Holland Computing Center) [has Aspera on their conda repo](https://anaconda.org/HCC/aspera-cli/files), so let's install Aspera from there instead.

I can't find another good way to install Aspera, because it looks like downloads.asperasoft.com was taken down, but I can't navigate the new IBM downloads page without an IBM account. And even if I made an account, it's not clear how we could then download the aspera cli in our docker images that don't have access to our credentials.

## Types of changes

What types of changes does your code introduce?

<!-- Remove any which your PR isn't -->
- Bugfix (non-breaking change which fixes an issue)

## Functional tests

All of the tests still pass locally, and they fail if Aspera isn't installed.

## Checklist

_Put an `x` in the boxes that apply._

- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules
