### PR TITLE
Better error message for missing SRA experiment

### DIFF
--- a/foreman/data_refinery_foreman/surveyor/sra.py
+++ b/foreman/data_refinery_foreman/surveyor/sra.py
@@ -552,6 +552,11 @@ class SraSurveyor(ExternalSourceSurveyor):
             response = utils.requests_retry_session().get(
                 ENA_METADATA_URL_TEMPLATE.format(accession)
             )
+
+            # If the status code is 404, then SRA doesn't know about this accession
+            if response.status_code == 404:
+                return None, None
+
             experiment_xml = ET.fromstring(response.text)[0]
             study_links = experiment_xml[2]  # STUDY_LINKS
 

--- a/foreman/data_refinery_foreman/surveyor/test_sra.py
+++ b/foreman/data_refinery_foreman/surveyor/test_sra.py
@@ -14,6 +14,7 @@ from data_refinery_common.models import (
     SurveyJobKeyValue,
 )
 from data_refinery_foreman.surveyor.sra import SraSurveyor
+from data_refinery_foreman.surveyor.surveyor import run_job
 
 EXPERIMENT_ACCESSION = "DRX001563"
 RUN_ACCESSION = "DRR002116"
@@ -110,6 +111,23 @@ class SraSurveyorTestCase(TestCase):
         self.assertEqual(experiment.accession_code, "DRP003977")
         self.assertEqual(experiment.alternate_accession_code, None)
         self.assertEqual(len(samples), 9)
+
+    @vcr.use_cassette("/home/user/data_store/cassettes/surveyor.sra.survey_nonexistant.yaml")
+    def test_nonexistant_srp_survey(self):
+        """Try surveying an accession that does not exist
+        """
+        survey_job = SurveyJob(source_type="SRA")
+        survey_job.save()
+        key_value_pair = SurveyJobKeyValue(
+            survey_job=survey_job, key="experiment_accession_code", value="ERP006216"
+        )
+        key_value_pair.save()
+
+        run_job(survey_job)
+
+        survey_job.refresh_from_db()
+        self.assertFalse(survey_job.success)
+        self.assertEqual(survey_job.failure_reason, "No experiment found.")
 
     @vcr.use_cassette(
         "/home/user/data_store/cassettes/surveyor.sra.metadata_is_gathered_correctly.yaml"

--- a/test_volume/cassettes/surveyor.sra.survey_nonexistant.yaml
+++ b/test_volume/cassettes/surveyor.sra.survey_nonexistant.yaml
@@ -1,0 +1,62 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.20.0
+    method: GET
+    uri: https://www.ebi.ac.uk/ena/data/view/ERP006216&display=xml
+  response:
+    body:
+      string: ''
+    headers:
+      Content-Length:
+      - '0'
+      Date:
+      - Wed, 12 Aug 2020 15:12:15 GMT
+      Location:
+      - https://www.ebi.ac.uk/ena/browser/api/xml/ERP006216
+      Server:
+      - Apache-Coyote/1.1
+      Strict-Transport-Security:
+      - max-age=0
+    status:
+      code: 302
+      message: Found
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.20.0
+    method: GET
+    uri: https://www.ebi.ac.uk/ena/browser/api/xml/ERP006216
+  response:
+    body:
+      string: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<ErrorDetails>\n  <timestamp>1597245135507</timestamp>\n\
+        \  <status>404</status>\n  <error>Not Found</error>\n  <message>ERP006216\
+        \ not found.</message>\n  <path>/ena/browser/api/xml/ERP006216</path>\n</ErrorDetails>\n"
+    headers:
+      Content-Type:
+      - application/xml
+      Date:
+      - Wed, 12 Aug 2020 15:12:15 GMT
+      Strict-Transport-Security:
+      - max-age=0
+      Transfer-Encoding:
+      - chunked
+    status:
+      code: 404
+      message: ''
+version: 1


### PR DESCRIPTION
## Issue Number

None, I was digging into an error message I saw while running the management command to refresh experiment metadata.

## Purpose/Implementation Notes

Before, the actual exception you would see when you try to survey an SRA accession that doesn't exist would be a `KeyError`, but now you will only see the message that no experiment was found.

## Types of changes

What types of changes does your code introduce?

<!-- Remove any which your PR isn't -->
- Bugfix (non-breaking change which fixes an issue)

## Functional tests

I looked at the error messages before and after using the `test_survey.sh` script.

## Checklist

_Put an `x` in the boxes that apply._

- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots

Please attach any screenshots that illustrate these changes.
