### PR TITLE
Try to fix and/or debug why the git_decrypt.sh script broke.

### DIFF
--- a/.github/scripts/git_decrypt.sh
+++ b/.github/scripts/git_decrypt.sh
@@ -3,7 +3,7 @@
 # Unlock encrypted files
 # Temporary attempt to debug this.
 pwd
-cd
+cd || exit
 pwd
 cd refinebio/.github/ || exit
 git clean -f

--- a/.github/scripts/git_decrypt.sh
+++ b/.github/scripts/git_decrypt.sh
@@ -1,7 +1,11 @@
 #!/bin/bash
 
 # Unlock encrypted files
-cd ~/refinebio/.github/ || exit
+# Temporary attempt to debug this.
+pwd
+cd
+pwd
+cd refinebio/.github/ || exit
 git clean -f
 openssl aes-256-cbc -md md5 -d -in git_crypt.key.enc -out git_crypt.key -k "$OPENSSL_KEY"
 git-crypt unlock git_crypt.key


### PR DESCRIPTION
## Issue Number

#2501's deploy failed

## Purpose/Implementation Notes

A raw `cd` seemed to work in `install_git_decrypt.sh`, so maybe doing it like that is better in github actions? If not I plan on learning where things happen in actions.

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

Can't really without a deploy. I want to test this on staging.