### PR TITLE
Use github workspace env var correct paths.

### DIFF
--- a/.github/scripts/git_decrypt.sh
+++ b/.github/scripts/git_decrypt.sh
@@ -2,7 +2,7 @@
 
 # Unlock encrypted files
 # Temporary attempt to debug this.
-cd $GITHUB_WORKSPACE/.github/ || exit
+cd "$GITHUB_WORKSPACE"/.github/ || exit
 git clean -f
 openssl aes-256-cbc -md md5 -d -in git_crypt.key.enc -out git_crypt.key -k "$OPENSSL_KEY"
 git-crypt unlock git_crypt.key

--- a/.github/scripts/git_decrypt.sh
+++ b/.github/scripts/git_decrypt.sh
@@ -2,10 +2,7 @@
 
 # Unlock encrypted files
 # Temporary attempt to debug this.
-pwd
-cd || exit
-pwd
-cd refinebio/.github/ || exit
+cd $GITHUB_WORKSPACE/.github/ || exit
 git clean -f
 openssl aes-256-cbc -md md5 -d -in git_crypt.key.enc -out git_crypt.key -k "$OPENSSL_KEY"
 git-crypt unlock git_crypt.key

--- a/.github/scripts/remote_deploy.sh
+++ b/.github/scripts/remote_deploy.sh
@@ -19,7 +19,7 @@
 #     - AWS_SECRET_ACCESS_KEY -- The AWS secret key to use when interacting with AWS.
 
 
-cd ~/refinebio
+cd $GITHUB_WORKSPACE
 
 chmod 600 infrastructure/data-refinery-key.pem
 

--- a/.github/scripts/remote_deploy.sh
+++ b/.github/scripts/remote_deploy.sh
@@ -19,7 +19,7 @@
 #     - AWS_SECRET_ACCESS_KEY -- The AWS secret key to use when interacting with AWS.
 
 
-cd $GITHUB_WORKSPACE
+cd "$GITHUB_WORKSPACE" || exit
 
 chmod 600 infrastructure/data-refinery-key.pem
 


### PR DESCRIPTION
## Issue Number

Include an issue number if applicable.

## Purpose/Implementation Notes

The path was breaking cause we hardcoded what we shouldn't have. I think this is everywhere that's not run on the deploy box, which doesn't need a new root.