### PR TITLE
Use a hardcoded path because github actions docs seem off

### DIFF
--- a/.github/scripts/git_decrypt.sh
+++ b/.github/scripts/git_decrypt.sh
@@ -2,7 +2,7 @@
 
 # Unlock encrypted files
 # Temporary attempt to debug this.
-cd "$GITHUB_WORKSPACE"/.github/ || exit
+cd ~/work/refinebio/refinebio/.github/ || exit
 git clean -f
 openssl aes-256-cbc -md md5 -d -in git_crypt.key.enc -out git_crypt.key -k "$OPENSSL_KEY"
 git-crypt unlock git_crypt.key

--- a/.github/scripts/remote_deploy.sh
+++ b/.github/scripts/remote_deploy.sh
@@ -19,7 +19,7 @@
 #     - AWS_SECRET_ACCESS_KEY -- The AWS secret key to use when interacting with AWS.
 
 
-cd "$GITHUB_WORKSPACE" || exit
+cd ~/work/refinebio/refinebio || exit
 
 chmod 600 infrastructure/data-refinery-key.pem
 

--- a/.github/workflows/config.yml
+++ b/.github/workflows/config.yml
@@ -398,7 +398,6 @@ jobs:
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       ENGAGEMENT_WEBHOOK: ${{ secrets.ENGAGEMENT_WEBHOOK }}
       CI_USERNAME: ${{ github.actor }}
-      GITHUB_WORKSPACE: ${{ github.worksapce }}
     needs:
       - main_tests
       - common_smasher_tests
@@ -438,7 +437,6 @@ jobs:
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       ENGAGEMENT_WEBHOOK: ${{ secrets.ENGAGEMENT_WEBHOOK }}
       CI_USERNAME: ${{ github.actor }}
-      GITHUB_WORKSPACE: ${{ github.worksapce }}
     steps:
       - uses: actions/checkout@v2
 


### PR DESCRIPTION
## Issue Number

#2506 

## Purpose/Implementation Notes

`$GITHUB_WORKSPACE` was supposed to have the path, instead it just had `refinebio`. This should work based off of some debugging I did a few PRs ago.
