### PR TITLE
Install aws cli on deploy box startup.

### DIFF
--- a/infrastructure/deploy_box_instance_data.sh
+++ b/infrastructure/deploy_box_instance_data.sh
@@ -57,6 +57,7 @@ apt-get update -qq
 apt-get install -y \
         make \
         g++ \
+        awscli \
         libssl-dev \
         python3 \
         python3-pip \


### PR DESCRIPTION
## Issue Number

#2517 

## Purpose/Implementation Notes

AWS's cli wasn't available for the deploy. I already installed it on the deploybox, but that should be added here as well.
