### PR TITLE
Raise smasher disk size for quantpendia processing.

### DIFF
--- a/infrastructure/instances.tf
+++ b/infrastructure/instances.tf
@@ -191,8 +191,10 @@ resource "aws_instance" "smasher_instance" {
   root_block_device = {
     volume_type = "gp2"
     # 2000 is the largest we can use without reformatting the disk.
+    # Necessary for human/mouse quantpendia.
+    volume_size = 2000
     # Necessary for human/mouse compendia.
-    volume_size = 1000
+    # volume_size = 1000
     # Appropriate for general processing.
     # volume_size = 200
   }


### PR DESCRIPTION
## Issue Number

Smasher ran out of disk space and stopped smashing.

## Purpose/Implementation Notes

Raise disk size so we don't interrupt processing.
