### PR TITLE
swagger https on prod always

### DIFF
--- a/api/data_refinery_api/urls.py
+++ b/api/data_refinery_api/urls.py
@@ -102,6 +102,7 @@ If you have a question or comment, please [file an issue on GitHub](https://gith
     ),
     public=True,
     permission_classes=(permissions.AllowAny,),
+    url="https://api.refine.bio",
 )
 
 urlpatterns = [


### PR DESCRIPTION
## Issue Number

#2535 

## Purpose/Implementation Notes

Adds a url for swagger to determine the supported schemes

I would also recommend basing this off of the env down the road but this will make the local, stage, and prod all create requests against prod.

