### PR TITLE
Fix the way the user instance data script was prepared for the nomad nodes.

### DIFF
--- a/infrastructure/deploy.sh
+++ b/infrastructure/deploy.sh
@@ -359,10 +359,10 @@ done
 echo "Job registrations have been fired off."
 
 # Prepare the client instance user data script for the nomad client instances.
-# The `prepare-client-instance-user-data.sh` script overwrites
+# The `prepare-client-instance-user-data.sh` script modifies
 # `client-instance-user-data.tpl.sh`, so we have to back it up first.
 if [ ! -f client-instance-user-data.tpl.sh.bak ]; then
-    mv nomad-configuration/client-instance-user-data.tpl.sh nomad-configuration/client-instance-user-data.tpl.sh.bak
+    cp nomad-configuration/client-instance-user-data.tpl.sh nomad-configuration/client-instance-user-data.tpl.sh.bak
 fi
 
 ./nomad-configuration/prepare-client-instance-user-data.sh

--- a/infrastructure/nomad-configuration/prepare-client-instance-user-data.sh
+++ b/infrastructure/nomad-configuration/prepare-client-instance-user-data.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/sh -e
 
 # On the nomad client instances, our instance user data script is responsible
 # for a lot of setup. This includes creating a bunch of files on the client


### PR DESCRIPTION
## Issue Number

N/A, I was trying to run some stuff and tracked this down

## Purpose/Implementation Notes

The node instance startup script wasn't really running because it was `mv`ing the base script instead of `cp`ing it. I checked the instance's user data script and its first line was `exit 0`.

## Types of changes

- Devops