### PR TITLE
Larger smasher volumes

### DIFF
--- a/README.md
+++ b/README.md
@@ -894,7 +894,7 @@ This can take a long time (>30 minutes)!
 
 ### Tearing Down
 
-A stack that has been spun up via `deploy.sh -u myusername -e dev` can be taken down with `destroy_terraform.sh  -u myusername -e dev`.
+A stack that has been spun up via `deploy.sh -u myusername -e dev` can be taken down with `destroy_terraform.sh  -u myusername -e dev -r us-east-1`.
 The same username and environment must be passed into `destroy_terraform.sh` as were used to run `deploy.sh` either via the -e and -u options or by specifying `TF_VAR_stage` or `TF_VAR_user` so that the script knows which to take down.
 Note that this will prompt you for confirmation before actually destroying all of your cloud resources.
 

--- a/infrastructure/disk.tf
+++ b/infrastructure/disk.tf
@@ -4,20 +4,19 @@
 # EBS
 ##
 
-#resource "aws_ebs_volume" "data_refinery_ebs" {
-#  count = "${var.max_clients}"
-#  availability_zone = "${var.region}a"
-#  size = "${var.volume_size_in_gb}"
-#  type = "st1" # Throughput Optimized HDD
-#  tags {
-#    Name        = "data-refinery-ebs-${count.index}-${var.user}-${var.stage}"
-#    Environment = "${var.stage}"
-#    Index       = "${count.index}"
-#    User        = "${var.user}"
-#    Stage       = "${var.stage}"
-#    IsBig       = "True"
-#  }
-#}
+resource "aws_ebs_volume" "data_refinery_ebs_smasher" {
+ count = "${var.processing_compendia ? 1 :0}"
+ availability_zone = "${var.region}a"
+ size = "${var.volume_size_in_gb}"
+ type = "st1" # Throughput Optimized HDD
+ tags {
+   Name        = "data-refinery-ebs-smasher-${var.user}-${var.stage}"
+   Environment = "${var.stage}"
+   User        = "${var.user}"
+   Stage       = "${var.stage}"
+   IsBig       = "True"
+ }
+}
 
 ##
 # S3

--- a/infrastructure/instances.tf
+++ b/infrastructure/instances.tf
@@ -165,10 +165,10 @@ resource "aws_instance" "smasher_instance" {
   count = "${var.stage == "prod" || var.full_stack == "True" ? 1 : 0}"
   ami = "${data.aws_ami.ubuntu.id}"
   instance_type = "${var.smasher_instance_type}"
-  availability_zone = "${var.region}b"
+  availability_zone = "${var.region}a"
   vpc_security_group_ids = ["${aws_security_group.data_refinery_worker.id}"]
   iam_instance_profile = "${aws_iam_instance_profile.data_refinery_instance_profile.name}"
-  subnet_id = "${aws_subnet.data_refinery_1b.id}"
+  subnet_id = "${aws_subnet.data_refinery_1a.id}"
 
   tags = {
     Name = "smasher-instance-${var.user}-${var.stage}"

--- a/infrastructure/nomad-configuration/client-smasher-instance-user-data.tpl.sh
+++ b/infrastructure/nomad-configuration/client-smasher-instance-user-data.tpl.sh
@@ -30,9 +30,9 @@ mkdir -p /var/ebs/
 fetch_and_mount_volume () {
     INSTANCE_ID=$(curl http://169.254.169.254/latest/meta-data/instance-id)
 
-    EBS_VOLUME_ID=`aws ec2 describe-volumes --filters "Name=tag:User,Values=$1" "Name=tag:Stage,Values=$2" "Name=tag:IsBig,Values=True" "Name=status,Values=available" "Name=availability-zone,Values=us-east-1a" --region us-east-1 | jq '.Volumes[0].VolumeId' | tr -d '"'`
+    EBS_VOLUME_ID=$(aws ec2 describe-volumes --filters "Name=tag:User,Values=$1" "Name=tag:Stage,Values=$2" "Name=tag:IsBig,Values=True" "Name=status,Values=available" "Name=availability-zone,Values=us-east-1a" --region us-east-1 | jq '.Volumes[0].VolumeId' | tr -d '"')
 
-    aws ec2 attach-volume --volume-id $EBS_VOLUME_ID --instance-id $INSTANCE_ID --device "/dev/sdf" --region ${region}
+    aws ec2 attach-volume --volume-id "$EBS_VOLUME_ID" --instance-id "$INSTANCE_ID" --device "/dev/sdf" --region "${region}"
 }
 
 export STAGE="${stage}"
@@ -46,13 +46,13 @@ done
 # # We want to mount the biggest volume that its attached to the instance
 # # The size of this volume can be controlled with the varialbe
 # # `volume_size_in_gb` from the file `variables.tf`
-ATTACHED_AS=`lsblk -n --sort SIZE | tail -1 | cut -d' ' -f1`
+ATTACHED_AS=$(lsblk -n --sort SIZE | tail -1 | cut -d' ' -f1)
 
 # # grep -v ext4: make sure the disk is not already formatted.
-if file -s /dev/$ATTACHED_AS | grep data | grep -v ext4; then
-	mkfs -t ext4 /dev/$ATTACHED_AS # This is slow
+if file -s "/dev/$ATTACHED_AS" | grep data | grep -v ext4; then
+	mkfs -t ext4 "/dev/$ATTACHED_AS" # This is slow
 fi
-mount /dev/$ATTACHED_AS /var/ebs/
+mount "/dev/$ATTACHED_AS" /var/ebs/
 
 chown ubuntu:ubuntu /var/ebs/
 echo "$EBS_VOLUME_INDEX" > /var/ebs/VOLUME_INDEX

--- a/infrastructure/permissions.tf
+++ b/infrastructure/permissions.tf
@@ -127,10 +127,11 @@ resource "aws_iam_policy" "ec2_access_policy" {
       {
          "Effect":"Allow",
          "Action": [
-            "ec2:AttachVolumes"
+            "ec2:AttachVolume"
           ],
           "Resource": [
-            "${aws_ebs_volume.data_refinery_ebs_smasher}"
+            "${aws_ebs_volume.data_refinery_ebs_smasher.arn}",
+            "${aws_instance.smasher_instance.arn}"
           ]
       },
       {

--- a/infrastructure/permissions.tf
+++ b/infrastructure/permissions.tf
@@ -125,6 +125,15 @@ resource "aws_iam_policy" "ec2_access_policy" {
           ]
       },
       {
+         "Effect":"Allow",
+         "Action": [
+            "ec2:AttachVolumes"
+          ],
+          "Resource": [
+            "${aws_ebs_volume.data_refinery_ebs_smasher}"
+          ]
+      },
+      {
         "Effect": "Allow",
         "Action": [
           "sts:DecodeAuthorizationMessage"

--- a/infrastructure/variables.tf
+++ b/infrastructure/variables.tf
@@ -158,7 +158,7 @@ variable "foreman_instance_type" {
 }
 
 variable "volume_size_in_gb" {
-  default = "2000"
+  default = "5000"
 }
 
 variable "max_downloader_jobs_per_node" {
@@ -176,6 +176,10 @@ variable "engagementbot_webhook" {
 
 variable "full_stack" {
   default = "False"
+}
+
+variable "processing_compendia" {
+  default = true
 }
 
 # Configuration

--- a/infrastructure/variables.tf
+++ b/infrastructure/variables.tf
@@ -119,9 +119,9 @@ variable "smasher_instance_type" {
   # 128GiB Memory, smasher and compendia jobs need 30.
   # RNA-seq compendia needs 131gb
   # Appropriate for most compendia.
-  default = "m5.8xlarge"
+  # default = "m5.8xlarge"
   # Required for human and mouse quantpendia.
-  # default = "m5.16xlarge"
+  default = "m5.16xlarge"
 
   # 976GiB Memory, smasher and compendia jobs need 900.
   # Required for human and mouse compendia

--- a/workers/nomad-job-specs/create_compendia.nomad.tpl
+++ b/workers/nomad-job-specs/create_compendia.nomad.tpl
@@ -68,11 +68,11 @@ job "CREATE_COMPENDIA" {
         # CPU is in AWS's CPU units.
         cpu =   4000
 
-        # Memory is in MB of RAM. Instance has 64GiB of RAM.
+        # Memory is in MB of RAM. Instance should have 64GiB of RAM.
         # Appropriate for most compendia.
         memory = 30000
 
-        # Memory is in MB of RAM. Instance has 976GiB of RAM
+        # Memory is in MB of RAM. Instance should have 976GiB of RAM
         # Required for human and mouse compendia.
 	# memory = 900000
       }

--- a/workers/nomad-job-specs/create_quantpendia.nomad.tpl
+++ b/workers/nomad-job-specs/create_quantpendia.nomad.tpl
@@ -67,7 +67,7 @@ job "CREATE_QUANTPENDIA" {
       resources {
         # CPU is in AWS's CPU units.
         cpu =   4000
-        memory = 64000
+        memory = 131000
       }
 
       logs {


### PR DESCRIPTION
## Issue Number

https://github.com/AlexsLemonade/refinebio/issues/1733

Also relevant:
* https://github.com/AlexsLemonade/refinebio/issues/2121 (because at this point, the client instances can run without EBS volumes, and only the smasher needs it, so we don't need to make a number of EBS volumes anymore.)
* https://github.com/AlexsLemonade/refinebio/issues/2363 (still true)
* https://github.com/AlexsLemonade/refinebio/issues/2234

## Purpose/Implementation Notes

This PR mounts a large EBS volume onto the smasher instance and fixes the needed permissions.

It also tweaks the sizes of things for some processing I want to do.

## Types of changes

- New feature (non-breaking change which adds functionality)
- Devops
