### PR TITLE
Change setting to disable ARP for our instances.

### DIFF
--- a/ami/instance-user-data.tpl.sh
+++ b/ami/instance-user-data.tpl.sh
@@ -53,5 +53,8 @@ chmod +x install_nomad.sh
 echo 'server 169.254.169.123 prefer iburst' | cat - /etc/chrony/chrony.conf > temp && mv temp /etc/chrony/chrony.conf
 /etc/init.d/chrony restart
 
+# We seem to have run into: https://medium.com/spaceapetech/what-the-arp-is-going-on-b4bc0e73e4d4
+echo 'net.ipv4.neigh.default.gc_thresh1 = 0' | tee /etc/sysctl.d/55-arp-gc_thresh1.conf
+
 # Restart to apply the updates
 reboot now


### PR DESCRIPTION
## Issue Number

N/A API went incommunicado again Friday

## Purpose/Implementation Notes

Apparently this happens if you don't have the setting. See https://medium.com/spaceapetech/what-the-arp-is-going-on-b4bc0e73e4d4

I don't know why that isn't set by default...

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

I can't really, although I can confirm it doesn't fail if I change the setting the other way the tool recommended.