### PR TITLE
500 GB is the smallest for ST1s.

### DIFF
--- a/infrastructure/variables.tf
+++ b/infrastructure/variables.tf
@@ -160,7 +160,8 @@ variable "foreman_instance_type" {
 }
 
 variable "smasher_volume_size_in_gb" {
-  default = "200"
+  # 500 is the smallest for ST1s.
+  default = "500"
 }
 
 variable "max_downloader_jobs_per_node" {


### PR DESCRIPTION
## Issue Number

#2552 

## Purpose/Implementation Notes

This gets overwritten in staging, but needed to be changed for prod as well.