### PR TITLE
Fix version of GEOquery for affy image.

### DIFF
--- a/workers/R_dependencies/affymetrix/versions.tsv
+++ b/workers/R_dependencies/affymetrix/versions.tsv
@@ -7,7 +7,7 @@ BiocParallel	1.12.0
 Biostrings	2.46.0
 DBI	1.0.0
 DelayedArray	0.4.1
-GEOquery	2.46.15
+GEOquery	2.48.0
 GenomeInfoDb	1.14.0
 GenomeInfoDbData	1.0.0
 GenomicRanges	1.30.3

--- a/workers/affymetrix_dependencies.R
+++ b/workers/affymetrix_dependencies.R
@@ -11,10 +11,12 @@ install_with_url <- function(main_url, packages) {
          function(pkg) devtools::install_url(paste0(main_url, pkg)))
 }
 
+devtools::install_version('dplyr', version='1.0.2')
+
 bioc_url <- 'https://bioconductor.org/packages/release/bioc/src/contrib/'
 bioc_pkgs <- c(
   'oligo_1.54.0.tar.gz',
-  'GEOquery_2.56.0.tar.gz',
+  'GEOquery_2.58.0.tar.gz',
   'SCAN.UPC_2.30.0.tar.gz',
   'affy_1.66.0.tar.gz',
   'affyio_1.58.0.tar.gz',

--- a/workers/install_affy_only.R
+++ b/workers/install_affy_only.R
@@ -18,7 +18,7 @@ install_with_url <- function(main_url, packages) {
 bioc_url <- 'https://bioconductor.org/packages/release/bioc/src/contrib/'
 bioc_pkgs <- c(
   'oligo_1.54.0.tar.gz',
-  'GEOquery_2.56.0.tar.gz',
+  'GEOquery_2.58.0.tar.gz',
   'SCAN.UPC_2.30.0.tar.gz',
   'affy_1.66.0.tar.gz',
   'affyio_1.58.0.tar.gz',


### PR DESCRIPTION
## Issue Number

https://github.com/AlexsLemonade/refinebio/pull/2588

## Purpose/Implementation Notes

Affy didn't fail until we tried to deploy to staging because we don't build it for tests since it's so huge. This fixes that image, which should fix our deploys.

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

I built the image locally!! It took a while though.