### PR TITLE
Bump up the github actions timeout for deploys to 24 hours.

### DIFF
--- a/.github/workflows/config.yml
+++ b/.github/workflows/config.yml
@@ -389,6 +389,7 @@ jobs:
   deploy:
     if: startsWith(github.ref, 'refs/tags/v') && ! endsWith(github.ref, '-hotfix')
     runs-on: ubuntu-latest
+    timeout-minutes: 1440
     env:
       DEPLOY_IP_ADDRESS: ${{ secrets.DEPLOY_IP_ADDRESS }}
       DOCKER_ID: ${{ secrets.DOCKER_ID }}
@@ -430,6 +431,7 @@ jobs:
   hotfix_deploy:
     if: startsWith(github.ref, 'refs/tags/v') && endsWith(github.ref, '-hotfix')
     runs-on: ubuntu-latest
+    timeout-minutes: 1440
     env:
       DEPLOY_IP_ADDRESS: ${{ secrets.DEPLOY_IP_ADDRESS }}
       DOCKER_ID: ${{ secrets.DOCKER_ID }}


### PR DESCRIPTION
## Issue Number

#2595 

## Purpose/Implementation Notes

I think the affy image should be able to build, but it did take like 10 hours or something on my local machine. This should be more than enough. I can lower it once we have a better idea of a good upper bound.

## Types of changes

- CD options.