### PR TITLE
Make install_with_url fail if any of its packages fail to install.

### DIFF
--- a/workers/affymetrix_dependencies.R
+++ b/workers/affymetrix_dependencies.R
@@ -7,7 +7,12 @@ options(Ncpus=parallel::detectCores())
 
 # Helper function that installs a list of packages based on input URL
 install_with_url <- function(main_url, packages) {
-  devtools::install_url(paste0(main_url, packages))
+  pkg_ids <- devtools::install_url(paste0(main_url, packages))
+  if(any(is.na(pkg_ids))) {
+    pkg_fails <- paste(packages[is.na(pkg_ids)], collapse = "; ")
+    stop(paste("Failed to install package(s):", pkg_fails ))
+  }
+  return(pkg_ids)
 }
 
 devtools::install_version('dplyr', version='1.0.2')

--- a/workers/illumina_dependencies.R
+++ b/workers/illumina_dependencies.R
@@ -4,8 +4,12 @@ options(Ncpus=parallel::detectCores())
 
 # Helper function that installs a list of packages based on input URL
 install_with_url <- function(main_url, packages) {
-  lapply(packages,
-         function(pkg) devtools::install_url(paste0(main_url, pkg)))
+  pkg_ids <- devtools::install_url(paste0(main_url, packages))
+  if(any(is.na(pkg_ids))) {
+    pkg_fails <- paste(packages[is.na(pkg_ids)], collapse = "; ")
+    stop(paste("Failed to install package(s):", pkg_fails ))
+  }
+  return(pkg_ids)
 }
 
 devtools::install_version('dplyr', version='1.0.2')

--- a/workers/install_affy_only.R
+++ b/workers/install_affy_only.R
@@ -11,8 +11,12 @@ devtools::install_version('ff', version='2.2-14')
 
 # Helper function that installs a list of packages based on input URL
 install_with_url <- function(main_url, packages) {
-  lapply(packages,
-         function(pkg) devtools::install_url(paste0(main_url, pkg), upgrade=F))
+  pkg_ids <- devtools::install_url(paste0(main_url, packages))
+  if(any(is.na(pkg_ids))) {
+    pkg_fails <- paste(packages[is.na(pkg_ids)], collapse = "; ")
+    stop(paste("Failed to install package(s):", pkg_fails ))
+  }
+  return(pkg_ids)
 }
 
 bioc_url <- 'https://bioconductor.org/packages/release/bioc/src/contrib/'

--- a/workers/install_downloader_R_only.R
+++ b/workers/install_downloader_R_only.R
@@ -8,8 +8,12 @@ options(Ncpus=parallel::detectCores())
 
 # Helper function that installs a list of packages based on input URL
 install_with_url <- function(main_url, packages) {
-  lapply(packages,
-         function(pkg) devtools::install_url(paste0(main_url, pkg)))
+  pkg_ids <- devtools::install_url(paste0(main_url, packages))
+  if(any(is.na(pkg_ids))) {
+    pkg_fails <- paste(packages[is.na(pkg_ids)], collapse = "; ")
+    stop(paste("Failed to install package(s):", pkg_fails ))
+  }
+  return(pkg_ids)
 }
 
 bioc_url <- 'https://bioconductor.org/packages/release/bioc/src/contrib/'

--- a/workers/install_gene_convert.R
+++ b/workers/install_gene_convert.R
@@ -6,8 +6,12 @@ options(repos=structure(c(CRAN="https://cloud.r-project.org")))
 
 # Helper function that installs a list of packages based on input URL
 install_with_url <- function(main_url, packages) {
-  lapply(packages,
-         function(pkg) devtools::install_url(paste0(main_url, pkg)))
+  pkg_ids <- devtools::install_url(paste0(main_url, packages))
+  if(any(is.na(pkg_ids))) {
+    pkg_fails <- paste(packages[is.na(pkg_ids)], collapse = "; ")
+    stop(paste("Failed to install package(s):", pkg_fails ))
+  }
+  return(pkg_ids)
 }
 
 devtools::install_version('dplyr', version='1.0.2')

--- a/workers/qn_dependencies.R
+++ b/workers/qn_dependencies.R
@@ -4,8 +4,12 @@ options(Ncpus=parallel::detectCores())
 
 # Helper function that installs a list of packages based on input URL
 install_with_url <- function(main_url, packages) {
-  lapply(packages,
-         function(pkg) devtools::install_url(paste0(main_url, pkg)))
+  pkg_ids <- devtools::install_url(paste0(main_url, packages))
+  if(any(is.na(pkg_ids))) {
+    pkg_fails <- paste(packages[is.na(pkg_ids)], collapse = "; ")
+    stop(paste("Failed to install package(s):", pkg_fails ))
+  }
+  return(pkg_ids)
 }
 
 bioc_url <- 'https://bioconductor.org/packages/release/bioc/src/contrib/'


### PR DESCRIPTION
## Issue Number

#2612 

## Purpose/Implementation Notes

SCAN.UPC failed to install, but we didn't know because no error was raised. This fixes the `install_with_url` function to fail if any of the packages it is installing fail to install.

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

I put an invalid version and it failed to install it.

## Checklist

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules
