### PR TITLE
Fix Github Actions set-env change that broke our deploys

### DIFF
--- a/.github/workflows/config.yml
+++ b/.github/workflows/config.yml
@@ -414,7 +414,7 @@ jobs:
       - name: Set the $CI_TAG environment variable
         run: |
           # Remove /ref/tags/ from the beginning of the tag name
-          echo ::set-env name=CI_TAG::${GITHUB_REF#refs/tags/}
+          echo "CI_TAG=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
 
       - name: Install git crypt
         run: ./.github/scripts/install_git_decrypt.sh
@@ -449,7 +449,7 @@ jobs:
       - name: Set the $CI_TAG environment variable
         run: |
           # Remove /ref/tags/ from the beginning of the tag name
-          echo ::set-env name=CI_TAG::${GITHUB_REF#refs/tags/}
+          echo "CI_TAG=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
 
       - name: Install git crypt
         run: git status && ./.github/scripts/install_git_decrypt.sh


### PR DESCRIPTION
## Issue Number

#2615 

## Purpose/Implementation Notes

This got deprecated: https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/

I think this should do the same thing: https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-commands-for-github-actions#setting-an-environment-variable

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

The deploys are only tested on deploys.
