### PR TITLE
Fixes error when importing ontologies

### DIFF
--- a/common/data_refinery_common/models/ontology_term.py
+++ b/common/data_refinery_common/models/ontology_term.py
@@ -83,13 +83,18 @@ class OntologyTerm(models.Model):
         # The other way is <rdf:Description> tags with an <rdfs:label> child
         for child in ontology_xml.findall("rdf:Description/[rdfs:label]", namespace):
             about = child.attrib.get("{" + namespace["rdf"] + "}about")
-            ontology_term = about.split("/")[-1].replace("_", ":")
-            human_readable_name = child.find("rdfs:label", namespace).text
 
-            if OntologyTerm._get_ontology_prefix(ontology_term) == ontology_prefix:
-                term, _ = OntologyTerm.objects.get_or_create(ontology_term=ontology_term)
-                term.human_readable_name = human_readable_name
-                term.save()
+            # Something seems to have changed and this no longer to
+            # match anything. I'm leaving it on the off chance that it
+            # ever does pick anything up.
+            if about:
+                ontology_term = about.split("/")[-1].replace("_", ":")
+                human_readable_name = child.find("rdfs:label", namespace).text
+
+                if OntologyTerm._get_ontology_prefix(ontology_term) == ontology_prefix:
+                    term, _ = OntologyTerm.objects.get_or_create(ontology_term=ontology_term)
+                    term.human_readable_name = human_readable_name
+                    term.save()
 
     @staticmethod
     def _create_from_api(ontology_term: str) -> "OntologyTerm":


### PR DESCRIPTION
## Issue Number

#1333 

## Purpose/Implementation Notes

I was getting an error when trying to run `./foreman/run_surveyor.sh import_ontology --ontology CL`. I guess the XML changed some, none of the elements I'm handling here seem to have an `about` anymore.

## Methods

The XML for those elements all looks similar to:

```
<?xml version='1.0' encoding='utf8'?>
<rdf:Description xmlns:ns1="http://www.w3.org/2000/01/rdf-schema#" xmlns:ns2="http://www.w3.org/2003/11/swrl#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
        <ns1:label>if effector directly negatively regulates X,  its parent MF directly negatively regulates X</ns1:label>
        <rdf:type rdf:resource="http://www.w3.org/2003/11/swrl#Imp" />
        <ns2:body>
            <rdf:Description>
                <rdf:type rdf:resource="http://www.w3.org/2003/11/swrl#AtomList" />
                <rdf:first>
                    <rdf:Description>
                        <rdf:type rdf:resource="http://www.w3.org/2003/11/swrl#IndividualPropertyAtom" />
                        <ns2:propertyPredicate rdf:resource="http://purl.obolibrary.org/obo/RO_0002630" />
                        <ns2:argument1 rdf:resource="urn:swrl#mf" />
                        <ns2:argument2 rdf:resource="urn:swrl#mf2" />
                    </rdf:Description>
                </rdf:first>
                <rdf:rest>
                    <rdf:Description>
                        <rdf:type rdf:resource="http://www.w3.org/2003/11/swrl#AtomList" />
                        <rdf:first>
                            <rdf:Description>
                                <rdf:type rdf:resource="http://www.w3.org/2003/11/swrl#IndividualPropertyAtom" />
                                <ns2:propertyPredicate rdf:resource="http://purl.obolibrary.org/obo/RO_0002025" />
                                <ns2:argument1 rdf:resource="urn:swrl#mf" />
                                <ns2:argument2 rdf:resource="urn:swrl#eff" />
                            </rdf:Description>
                        </rdf:first>
                        <rdf:rest rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#nil" />
                    </rdf:Description>
                </rdf:rest>
            </rdf:Description>
        </ns2:body>
        <ns2:head>
            <rdf:Description>
                <rdf:type rdf:resource="http://www.w3.org/2003/11/swrl#AtomList" />
                <rdf:first>
                    <rdf:Description>
                        <rdf:type rdf:resource="http://www.w3.org/2003/11/swrl#IndividualPropertyAtom" />
                        <ns2:propertyPredicate rdf:resource="http://purl.obolibrary.org/obo/RO_0002630" />
                        <ns2:argument1 rdf:resource="urn:swrl#eff" />
                        <ns2:argument2 rdf:resource="urn:swrl#mf2" />
                    </rdf:Description>
                </rdf:first>
                <rdf:rest rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#nil" />
            </rdf:Description>
        </ns2:head>
    </rdf:Description>
```

I don't see anything that looks like a term we need to pull out, so I think we're ok to miss this.

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

I've imported the ontologies with shorthand codes CL, DOID, EFO, UBERON, and UO. CVCL seems to have moved, see https://github.com/AlexsLemonade/refinebio/issues/2627

## Checklist

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules
