### PR TITLE
Add processor information to sample metadata

### DIFF
--- a/common/data_refinery_common/models/sample.py
+++ b/common/data_refinery_common/models/sample.py
@@ -113,6 +113,14 @@ class Sample(models.Model):
         metadata["refinebio_annotations"] = [
             data for data in self.sampleannotation_set.all().values_list("data", flat=True)
         ]
+        metadata["refinebio_processor_info"] = [
+            {
+                "id": result.processor.id,
+                "name": result.processor.name,
+                "version": result.processor.version,
+            }
+            for result in self.results.filter(processor__isnull=False)
+        ]
 
         if self.attributes.count() > 0:
             metadata["other_metadata"] = [

--- a/common/data_refinery_common/models/sample.py
+++ b/common/data_refinery_common/models/sample.py
@@ -88,7 +88,7 @@ class Sample(models.Model):
         self.last_modified = current_time
         return super(Sample, self).save(*args, **kwargs)
 
-    def to_metadata_dict(self):
+    def to_metadata_dict(self, computed_file=None):
         """Render this Sample as a dict."""
         metadata = {}
         metadata["refinebio_title"] = self.title
@@ -113,14 +113,11 @@ class Sample(models.Model):
         metadata["refinebio_annotations"] = [
             data for data in self.sampleannotation_set.all().values_list("data", flat=True)
         ]
-        metadata["refinebio_processor_info"] = [
-            {
-                "id": result.processor.id,
-                "name": result.processor.name,
-                "version": result.processor.version,
-            }
-            for result in self.results.filter(processor__isnull=False)
-        ]
+
+        if computed_file and computed_file.result and computed_file.result.processor:
+            metadata["refinebio_processor_id"] = computed_file.result.processor.id
+            metadata["refinebio_processor_name"] = computed_file.result.processor.name
+            metadata["refinebio_processor_version"] = computed_file.result.processor.version
 
         if self.attributes.count() > 0:
             metadata["other_metadata"] = [

--- a/workers/data_refinery_workers/processors/smashing_utils.py
+++ b/workers/data_refinery_workers/processors/smashing_utils.py
@@ -668,7 +668,9 @@ def compile_metadata(job_context: Dict) -> Dict:
     metadata["num_experiments"] = job_context["experiments"].count()
     metadata["quant_sf_only"] = job_context["dataset"].quant_sf_only
 
-    if not job_context["dataset"].quant_sf_only:
+    quant_sf_only = job_context["dataset"].quant_sf_only
+
+    if not quant_sf_only:
         metadata["aggregate_by"] = job_context["dataset"].aggregate_by
         metadata["scale_by"] = job_context["dataset"].scale_by
         # https://github.com/AlexsLemonade/refinebio/pull/421#discussion_r203799646
@@ -686,7 +688,12 @@ def compile_metadata(job_context: Dict) -> Dict:
         if sample.accession_code in filtered_samples:
             # skip the samples that were filtered
             continue
-        samples[sample.accession_code] = sample.to_metadata_dict()
+        computed_file = None
+        if quant_sf_only:
+            computed_file = sample.get_most_recent_quant_sf_file
+        else:
+            computed_file = sample.get_most_recent_smashable_result_file
+        samples[sample.accession_code] = sample.to_metadata_dict(computed_file)
 
     metadata["samples"] = samples
     metadata["num_samples"] = len(metadata["samples"])

--- a/workers/data_refinery_workers/processors/smashing_utils.py
+++ b/workers/data_refinery_workers/processors/smashing_utils.py
@@ -690,9 +690,9 @@ def compile_metadata(job_context: Dict) -> Dict:
             continue
         computed_file = None
         if quant_sf_only:
-            computed_file = sample.get_most_recent_quant_sf_file
+            computed_file = sample.get_most_recent_quant_sf_file()
         else:
-            computed_file = sample.get_most_recent_smashable_result_file
+            computed_file = sample.get_most_recent_smashable_result_file()
         samples[sample.accession_code] = sample.to_metadata_dict(computed_file)
 
     metadata["samples"] = samples

--- a/workers/data_refinery_workers/processors/utils.py
+++ b/workers/data_refinery_workers/processors/utils.py
@@ -380,7 +380,7 @@ def run_pipeline(start_value: Dict, pipeline: List[Callable]):
         return
 
     if len(pipeline) == 0:
-        logger.error("Empty pipeline specified.", procesor_job=job_id)
+        logger.error("Empty pipeline specified.", processor_job=job_id)
 
     last_result = start_value
     last_result["job"] = job
@@ -672,7 +672,7 @@ def get_runtime_env(yml_filename):
 
 
 def find_processor(enum_key):
-    """Retursn either a newly created Processor record, or the one in
+    """Returns either a newly created Processor record, or the one in
     database that matches the current processor name, version and environment.
     """
 


### PR DESCRIPTION
## Issue Number

#2646

## Purpose/Implementation Notes

Include columns for datasets, compendia, and quantpendia that specify what processor type, processor ID, and processor version was used for each sample so that the user has access to this information.

## Types of changes

What types of changes does your code introduce?

New feature (non-breaking change which adds functionality)

## Functional tests

I ran the compendia unit tests to make sure none got broken from this change.

## Checklist


- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Extra Info

I'm making this a draft PR because I'm not totally sure if I'm adding the correct stuff to the metadata.

Right now, I'm getting the processor information through the results objects that are associated with each Sample object.

The processor id and name seem correct to me, but I'm not so sure about the version.
It seems like the version I'm adding right now is actually a refine.bio version instead of the version of salmon/transcriptome index.

Here's an example of a random Sample object:

<details>
<summary>Example Sample</summary>
<p>

``` json
{
    "id": 1336178,
    "title": "E15.24H_LTHT7_18_29",
    "accession_code": "SRR7744195",
    "source_database": "SRA",
    "organism": {
        "name": "MUS_MUSCULUS",
        "taxonomy_id": 10090
    },
    "platform_accession_code": "IlluminaHiSeq2500",
    "platform_name": "Illumina HiSeq 2500",
    "pretty_platform": "Illumina HiSeq 2500 (IlluminaHiSeq2500)",
    "technology": "RNA-SEQ",
    "manufacturer": "ILLUMINA",
    "protocol_info": [
        {
            "Reference": "https://www.ebi.ac.uk/ena/data/view/SRP158666",
            "Description": "The putative primary somatosensory cortex S1 was microdissected and incubated in 0.05% trypsin at 37°C for 5 minutes. Following tissue digestion, fetal bovine serum was added to the mix and cells were manually dissociated via up-and-down pipetting. Cells were centrifuged 5min at 300g and the pellet was suspended in 1ml of HBSS then passed on a 70µm cell stainer. FT+ cells, gated on the top 5% brightest cells, were finally FAC-sorted on a MoFloAstrios (Beckman). FAC-sorted FT+ cells (18µl) were mixed with the C1 Suspension Reagent (2µl; Fluidigm) yielding a total of 20µl of cell suspension mix with ~500 cells/μl. The cell suspension mix was loaded on a C1 Single-Cell AutoPrep integrated fluidic circuit (IFC) designed for 10- to 17-µm cells (HT-800, Fluidigm #100-57-80). cDNA synthesis and preamplification was processed following the manufacturer's instructions (C1 system, Fluidigm). Single cell RNA-sequencing libraries of the cDNA were prepared using Nextera XT DNA library prep kit (Illumina). Libraries were multi-plexed and sequenced according to the manufacturer's recommendations with paired-end reads using HiSeq2500 platform (Illumina) with an expected depth of 1M reads per single cell, and a final mapping read length of 70bp. SMARTseq v4 kit (Clontech, # 634888)"
        }
    ],
    "annotations": [],
    "results": [
        {
            "id": 1651412,
            "processor": {
                "id": 348,
                "name": "Salmon Quant",
                "version": "v1.24.1-hotfix",
                "docker_image": "dr_salmon",
                "environment": {
                    "os_pkg": {
                        "python3": "3.5.1-3",
                        "python3-pip": "8.1.1-2ubuntu0.4"
                    },
                    "python": {
                        "Django": "2.1.8",
                        "data-refinery-common": "=v1.24.1-hotfix"
                    },
                    "cmd_line": {
                        "salmon --version": "salmon 0.13.1",
                        "sra-stat --version": "sra-stat : 2.9.1"
                    },
                    "os_distribution": "Ubuntu 16.04.6 LTS"
                }
            },
            "organism_index": {
                "id": 529,
                "assembly_name": "GRCm38",
                "organism_name": "MUS_MUSCULUS",
                "database_name": "EnsemblMain",
                "release_version": "96",
                "index_type": "TRANSCRIPTOME_SHORT",
                "salmon_version": "salmon 0.13.1",
                "download_url": "https://s3.amazonaws.com/data-refinery-s3-transcriptome-index-circleci-prod/MUS_MUSCULUS_TRANSCRIPTOME_SHORT_1559762392.tar.gz",
                "result_id": 1242727,
                "last_modified": "2019-06-05T19:20:34.596829Z"
            }
        },
        {
            "id": 1651467,
            "processor": {
                "id": 349,
                "name": "Salmontools",
                "version": "v1.24.1-hotfix",
                "docker_image": "dr_salmon",
                "environment": {
                    "os_pkg": {
                        "g++": "4:5.3.1-1ubuntu1",
                        "cmake": "3.5.1-1ubuntu3",
                        "python3": "3.5.1-3",
                        "python3-pip": "8.1.1-2ubuntu0.4"
                    },
                    "python": {
                        "Django": "2.1.8",
                        "data-refinery-common": "=v1.24.1-hotfix"
                    },
                    "cmd_line": {
                        "salmontools --version": "Salmon Tools 0.1.0"
                    },
                    "os_distribution": "Ubuntu 16.04.6 LTS"
                }
            },
            "organism_index": null
        },
        {
            "id": 1692329,
            "processor": {
                "id": 353,
                "name": "Tximport",
                "version": "v1.24.3-hotfix",
                "docker_image": "dr_salmon",
                "environment": {
                    "R": {
                        "readr": "1.1.1",
                        "rjson": "0.2.19",
                        "tximport": "1.6.0",
                        "Bioconductor": "3.5"
                    },
                    "os_pkg": {
                        "r-base": "r-base",
                        "python3": "3.5.1-3",
                        "python3-pip": "8.1.1-2ubuntu0.4"
                    },
                    "python": {
                        "numpy": "1.15.2",
                        "Django": "2.1.8",
                        "pandas": "0.23.4",
                        "data-refinery-common": "=v1.24.3-hotfix"
                    },
                    "os_distribution": "Ubuntu 16.04.6 LTS"
                }
            },
            "organism_index": null
        }
    ],
    "source_archive_url": "",
    "has_raw": true,
    "sex": "",
    "age": null,
    "specimen_part": "",
    "genotype": "",
    "disease": "",
    "disease_stage": "",
    "cell_line": "",
    "treatment": "",
    "race": "",
    "subject": "cortical cells",
    "compound": "",
    "time": "",
    "is_processed": true,
    "created_at": "2019-08-16T02:42:08.282081Z",
    "last_modified": "2019-08-16T23:12:33.842327Z",
    "original_files": [
        1994680
    ],
    "computed_files": [
        2936362,
        3003292,
        3005691
    ],
    "experiment_accession_codes": [
        "SRP158666"
    ]
}
```

</p>
</details>

If we only care about Transcriptome Index processor information, I could just add another filter for `organism_index__isnull=False` and get the salmon version from the organism index.

But I wasn't sure if we should also include information about salmon tools, tximport, and other processors in the metadata too.

LMK!
