### PR TITLE
Don't force surveyor jobs to be run on smasher instances.

### DIFF
--- a/foreman/nomad-job-specs/surveyor.nomad.tpl
+++ b/foreman/nomad-job-specs/surveyor.nomad.tpl
@@ -72,9 +72,6 @@ job "SURVEYOR_${{RAM}}" {
         max_file_size = 1
       }
 
-      # Run this on the smasher instance so we can make sure they get run.
-      ${{SMASHER_CONSTRAINT}}
-
       config {
         image = "${{DOCKERHUB_REPO}}/${{FOREMAN_DOCKER_IMAGE}}"
         force_pull = false


### PR DESCRIPTION
## Issue Number

#2697 

## Purpose/Implementation Notes

I wanted to test #2697 but when I went to queue up the surveyor job for it it wouldn't get queued because we require surveyor jobs to run on the smasher instance, and we don't have a smasher instance for the staging stack unless we deploy a full stack.

This used to make sense when we were running at scale but right now it's just getting in the way of testing things on the staging stack and we won't be running at scale again until the Batch cutover happens, at which point this won't even be relevant any more.

## Types of changes

- Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Functional tests

This is just operational, and I haven't tested it yet. I will test on staging.

## Checklist

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules
