### PR TITLE
Bigger ES instance because we were hitting rate limits.

### DIFF
--- a/infrastructure/instances.tf
+++ b/infrastructure/instances.tf
@@ -509,7 +509,7 @@ resource "aws_elasticsearch_domain" "es" {
   # TODO: Figure out the power/cost balance of this type.
   # Prices are here: https://aws.amazon.com/elasticsearch-service/pricing/
   cluster_config {
-    instance_type = "t2.medium.elasticsearch"
+    instance_type = "m5.large.elasticsearch"
   }
 
   vpc_options {


### PR DESCRIPTION
## Issue Number

https://github.com/AlexsLemonade/refinebio/pull/2669
https://github.com/AlexsLemonade/refinebio/issues/2663

## Purpose/Implementation Notes

https://github.com/AlexsLemonade/refinebio/issues/2663 only rate limited individual users of our API, but multiple users could hit us simultaneously and cause us to hit our ES rate limit. This bumps up the size of the ES instance so that it can handle more requests. I'm going to see how this change affects our 500 rate once it lands.

## Types of changes

- Scaling

## Functional tests

I haven't, this should be a simple change.
