### PR TITLE
Our throttle limits were so low we throttled our own frontend.

### DIFF
--- a/api/data_refinery_api/settings.py
+++ b/api/data_refinery_api/settings.py
@@ -179,7 +179,7 @@ REST_FRAMEWORK = {
         "rest_framework.throttling.AnonRateThrottle",
         "rest_framework.throttling.UserRateThrottle",
     ],
-    "DEFAULT_THROTTLE_RATES": {"anon": "3/second", "user": "3/second"},
+    "DEFAULT_THROTTLE_RATES": {"anon": "10/second", "user": "10/second"},
 }
 
 SWAGGER_SETTINGS = {


### PR DESCRIPTION
## Issue Number

N/A I fixed it rather than open an issue

## Purpose/Implementation Notes

These overly restrictive limits were an attempt to reduce load on ES, but that was the wrong way to do it because there's nothing stopping multiple users from making requests simultaneously. 

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

N/A just a config change.
