### PR TITLE
Pass through the engagement webhook correctly.

### DIFF
--- a/.github/workflows/config.yml
+++ b/.github/workflows/config.yml
@@ -501,7 +501,8 @@ jobs:
           echo "DJANGO_SECRET_KEY=${STAGING_DJANGO_SECRET_KEY}" >> $GITHUB_ENV
           echo "RAVEN_DSN=${STAGING_RAVEN_DSN}" >> $GITHUB_ENV
           echo "RAVEN_DSN_API=${STAGING_RAVEN_DSN_API}" >> $GITHUB_ENV
-          echo "ENGAGEMENTBOT_WEBHOOK=${STAGING_ENGAGEMENTBOT_WEBHOOK}" >> $GITHUB_ENV
+          # Staging doesn't notify the engagementbot, so overwrite this to be blank.
+          echo "ENGAGEMENTBOT_WEBHOOK=" >> $GITHUB_ENV
 
       - name: Set prod specific environment variables
         if: ${{needs.determine_branch.outputs.branch == 'master'}}
@@ -510,7 +511,7 @@ jobs:
           echo "DJANGO_SECRET_KEY=${PROD_DJANGO_SECRET_KEY}" >> $GITHUB_ENV
           echo "RAVEN_DSN=${PROD_RAVEN_DSN}" >> $GITHUB_ENV
           echo "RAVEN_DSN_API=${PROD_RAVEN_DSN_API}" >> $GITHUB_ENV
-          echo "ENGAGEMENTBOT_WEBHOOK=${PROD_ENGAGEMENTBOT_WEBHOOK}" >> $GITHUB_ENV
+          echo "ENGAGEMENTBOT_WEBHOOK=${ENGAGEMENTBOT_WEBHOOK}" >> $GITHUB_ENV
 
       - name: Deploy
         run: ./.github/scripts/remote_deploy.sh
@@ -571,6 +572,7 @@ jobs:
           echo "DJANGO_SECRET_KEY=${PROD_DJANGO_SECRET_KEY}" >> $GITHUB_ENV
           echo "RAVEN_DSN=${PROD_RAVEN_DSN}" >> $GITHUB_ENV
           echo "RAVEN_DSN_API=${PROD_RAVEN_DSN_API}" >> $GITHUB_ENV
+          echo "ENGAGEMENTBOT_WEBHOOK=${ENGAGEMENTBOT_WEBHOOK}" >> $GITHUB_ENV
 
       - name: Deploy
         run: ./.github/scripts/remote_deploy.sh


### PR DESCRIPTION
## Issue Number

N/A Jay pointed out the weekly digests have stopped

## Purpose/Implementation Notes

We don't use one of these for staging, so it doesn't need to be namespaced for the env, just set blank during staging.

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

N/A only testable via deploys