### PR TITLE
Add tests that make sure we can import our test files

### DIFF
--- a/api/data_refinery_api/test_imports.py
+++ b/api/data_refinery_api/test_imports.py
@@ -1,0 +1,16 @@
+from django.test import TestCase, tag
+
+
+class ImportTestCase(TestCase):
+    def test_imports(self):
+        # Make sure we can import the api tests
+        import data_refinery_api.management.commands.test_post_downloads_summary
+        import data_refinery_api.test.test_api_general
+        import data_refinery_api.test.test_compendia
+        import data_refinery_api.test.test_dataset
+        import data_refinery_api.test.test_dataset_stats
+        import data_refinery_api.test.test_processor
+        import data_refinery_api.test.test_qn_target
+        import data_refinery_api.test.test_search
+        import data_refinery_api.test.test_sentry_middleware
+        import data_refinery_api.test.test_stats

--- a/common/data_refinery_common/test_imports.py
+++ b/common/data_refinery_common/test_imports.py
@@ -1,0 +1,13 @@
+from django.test import TestCase, tag
+
+
+class ImportTestCase(TestCase):
+    def test_imports(self):
+        # Make sure we can import the common tests
+        import data_refinery_common.models.test_jobs
+        import data_refinery_common.models.test_models
+        import data_refinery_common.models.test_ontology_term
+        import data_refinery_common.models.test_organisms
+        import data_refinery_common.test_job_management
+        import data_refinery_common.test_microarray
+        import data_refinery_common.test_utils

--- a/foreman/data_refinery_foreman/test_imports.py
+++ b/foreman/data_refinery_foreman/test_imports.py
@@ -1,0 +1,29 @@
+from django.test import TestCase, tag
+
+
+class ImportTestCase(TestCase):
+    def test_imports(self):
+        # Make sure we can import the foreman tests
+        import data_refinery_foreman.foreman.management.commands.test_assoc_experiment_results
+        import data_refinery_foreman.foreman.management.commands.test_correct_affy_cdfs
+        import data_refinery_foreman.foreman.management.commands.test_create_compendia
+        import data_refinery_foreman.foreman.management.commands.test_create_missing_downloader_jobs
+        import data_refinery_foreman.foreman.management.commands.test_create_missing_processor_jobs
+        import data_refinery_foreman.foreman.management.commands.test_create_quantpendia
+        import data_refinery_foreman.foreman.management.commands.test_import_external_sample_attributes
+        import data_refinery_foreman.foreman.management.commands.test_import_external_sample_keywords
+        import data_refinery_foreman.foreman.management.commands.test_organism_shepherd
+        import data_refinery_foreman.foreman.management.commands.test_rerun_salmon_old_samples
+        import data_refinery_foreman.foreman.management.commands.test_retry_samples
+        import data_refinery_foreman.foreman.management.commands.test_run_tximport
+        import data_refinery_foreman.foreman.management.commands.test_update_experiment_metadata
+        import data_refinery_foreman.foreman.test_main
+        import data_refinery_foreman.surveyor.management.commands.test_unsurvey
+        import data_refinery_foreman.surveyor.test_array_express
+        import data_refinery_foreman.surveyor.test_end_to_end
+        import data_refinery_foreman.surveyor.test_external_source
+        import data_refinery_foreman.surveyor.test_geo
+        import data_refinery_foreman.surveyor.test_harmony
+        import data_refinery_foreman.surveyor.test_sra
+        import data_refinery_foreman.surveyor.test_surveyor
+        import data_refinery_foreman.surveyor.test_transcriptome_index

--- a/workers/data_refinery_workers/downloaders/test_imports.py
+++ b/workers/data_refinery_workers/downloaders/test_imports.py
@@ -1,0 +1,11 @@
+from django.test import TestCase, tag
+
+
+class ImportTestCase(TestCase):
+    @tag("downloaders")
+    def test_downloader_imports(self):
+        # Make sure we can import the downloader tests
+        import data_refinery_workers.downloaders.test_array_express
+        import data_refinery_workers.downloaders.test_geo
+        import data_refinery_workers.downloaders.test_sra
+        import data_refinery_workers.downloaders.test_transcriptome_index

--- a/workers/data_refinery_workers/processors/test_imports.py
+++ b/workers/data_refinery_workers/processors/test_imports.py
@@ -1,0 +1,54 @@
+from django.test import TestCase, tag
+
+
+class ImportTestCase(TestCase):
+    @tag("salmon")
+    def test_salmon_imports(self):
+        # Make sure we can import the salmon tests
+        import data_refinery_workers.processors.test_salmon
+
+    @tag("transcriptome")
+    def test_transcriptome_imports(self):
+        # Make sure we can import the transcriptome tests
+        import data_refinery_workers.processors.test_transcriptome_index
+
+    @tag("no_op")
+    def test_no_op_imports(self):
+        # Make sure we can import the no_op tests
+        import data_refinery_workers.processors.test_no_op
+
+    @tag("smasher")
+    def test_smasher_imports(self):
+        # Make sure we can import the smasher tests
+        import data_refinery_workers.processors.test_smasher
+
+    @tag("illumina")
+    def test_illumina_imports(self):
+        # Make sure we can import the illumina tests
+        import data_refinery_workers.processors.test_geo
+
+    @tag("agilent")
+    def test_agilent_imports(self):
+        # Make sure we can import the agilent tests
+        import data_refinery_workers.processors.test_geo
+
+    @tag("affymetrix")
+    def test_affymetrix_imports(self):
+        # Make sure we can import the affy tests
+        import data_refinery_workers.processors.test_array_express
+
+    @tag("qn")
+    def test_qn_imports(self):
+        # Make sure we can import the qn tests
+        import data_refinery_workers.processors.test_qn_reference
+
+    @tag("janitor")
+    def test_janitor_imports(self):
+        # Make sure we can import the janitor tests
+        import data_refinery_workers.processors.test_janitor
+
+    @tag("compendia")
+    def test_compendia_imports(self):
+        # Make sure we can import the compendia tests
+        import data_refinery_workers.processors.test_compendia
+        import data_refinery_workers.processors.test_create_quantpendia


### PR DESCRIPTION
## Issue Number

Fixes #2749 and #1348

## Purpose/Implementation Notes

When we run our tests, we sometimes filter based on specific tags. Django has a bug/feature that means that if it cannot load a specific test file, it just skips it. This turns out to be a necessary part of our tests, because, for example, only the compendia docker image contains all the packages needed to successfully import the compendia processor.

Unfortunately, a side effect of this is that even when we are on the right docker image, tests can sometimes fail silently. This fixes that by adding a test corresponding to each project/tag which imports each relevant test file dynamically, to make sure that no exceptions are thrown.

## Types of changes

What types of changes does your code introduce?

<!-- Remove any which your PR isn't -->
- Bugfix (non-breaking change which fixes an issue)

## Functional tests

All of the tests pass, except the compendia tests which we expect to fail because of the bug.

## Checklist

_Put an `x` in the boxes that apply._

- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots

Please attach any screenshots that illustrate these changes.
