### PR TITLE
Change version scheme for local versions

### DIFF
--- a/scripts/update_models.sh
+++ b/scripts/update_models.sh
@@ -20,9 +20,9 @@ if ! docker ps | tail -n +2 | awk '{ print $NF }' | grep drdb > /dev/null; then
     exit 1
 fi
 
-# Default to "local" for system version if we're not running in the cloud.
+# Default to "0.0.0.dev" for system version if we're not running in the cloud.
 if [ -z "$SYSTEM_VERSION" ]; then
-    SYSTEM_VERSION="local$(date +%s)"
+    SYSTEM_VERSION="0.0.0.dev$(date +%s)"
     export SYSTEM_VERSION
 fi
 


### PR DESCRIPTION
## Issue Number

Fix #2760

## Purpose/Implementation Notes

The old version scheme was not PEP 440 compatible, so there was a deprecation warning every time we installed the data_refinery_common package that might eventually turn into an error in future pip versions.

From https://www.python.org/dev/peps/pep-0440/#version-scheme, `0.0.0.devN` is a valid PEP 440 version, so we'll use that instead.

## Types of changes

What types of changes does your code introduce?

<!-- Remove any which your PR isn't -->
- Bugfix (non-breaking change which fixes an issue)

## Functional tests

I built some docker images locally and verified that the deprecation warning no longer appears.

## Checklist

_Put an `x` in the boxes that apply._

- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots

Please attach any screenshots that illustrate these changes.
