### PR TITLE
Smasher end to end test

### DIFF
--- a/foreman/data_refinery_foreman/foreman/test_end_to_end.py
+++ b/foreman/data_refinery_foreman/foreman/test_end_to_end.py
@@ -168,7 +168,7 @@ class SmasherEndToEndTestCase(TestCase):
         dataset_path = "end_to_end_test_dataset"
         pyrefinebio.download_dataset(
             dataset_path,
-            "test@endtoend.com",
+            "testendtoend@example.com",
             dataset_dict={"GSE1487313": ["GSM1487313"], "SRP332914": ["SRR332914"]},
         )
         self.assertTrue(path.exists(dataset_path))

--- a/foreman/data_refinery_foreman/foreman/test_end_to_end.py
+++ b/foreman/data_refinery_foreman/foreman/test_end_to_end.py
@@ -1,14 +1,32 @@
+from os import path
 from time import sleep
 from unittest import TestCase
 
 from django.test import tag
 
-from data_refinery_common.models import DownloaderJob, Experiment, ProcessorJob, Sample
+import pyrefinebio
+
+from data_refinery_common.models import (
+    ComputationalResult,
+    ComputationalResultAnnotation,
+    ComputedFile,
+    DownloaderJob,
+    Experiment,
+    ExperimentSampleAssociation,
+    Organism,
+    ProcessorJob,
+    Sample,
+    SampleComputedFileAssociation,
+    SampleResultAssociation,
+)
 from data_refinery_foreman.foreman.management.commands.run_tximport import run_tximport
 from data_refinery_foreman.surveyor.management.commands.surveyor_dispatcher import (
     queue_surveyor_for_accession,
 )
 from data_refinery_foreman.surveyor.management.commands.unsurvey import purge_experiment
+
+SMASHER_SAMPLES = ["GSM1487313", "SRR332914"]
+SMASHER_EXPERIMENTS = ["GSE1487313", "SRP332914"]
 
 MICROARRAY_ACCESSION_CODES = [
     "E-TABM-496",  # 39 samples of SACCHAROMYCES_CEREVISIAE microarray data
@@ -22,6 +40,8 @@ RNA_SEQ_ACCESSION_CODES = [
 ]
 
 EXPERIMENT_ACCESSION_CODES = MICROARRAY_ACCESSION_CODES + RNA_SEQ_ACCESSION_CODES
+
+TEST_DATA_BUCKET = "data-refinery-test-assets"
 
 
 def wait_for_job(job) -> bool:
@@ -44,6 +64,92 @@ def wait_for_job(job) -> bool:
             return False
 
     return False
+
+
+def prepare_computed_files():
+    # MICROARRAY TECH
+    experiment = Experiment()
+    experiment.accession_code = "GSE1487313"
+    experiment.num_processed_samples = 1
+    experiment.save()
+
+    result = ComputationalResult()
+    result.save()
+
+    gallus_gallus = Organism.get_object_for_name("GALLUS_GALLUS", taxonomy_id=1001)
+
+    sample = Sample()
+    sample.accession_code = "GSM1487313"
+    sample.title = "GSM1487313"
+    sample.organism = gallus_gallus
+    sample.technology = "MICROARRAY"
+    sample.is_processed = True
+    sample.save()
+
+    sra = SampleResultAssociation()
+    sra.sample = sample
+    sra.result = result
+    sra.save()
+
+    esa = ExperimentSampleAssociation()
+    esa.experiment = experiment
+    esa.sample = sample
+    esa.save()
+
+    computed_file = ComputedFile()
+    computed_file.filename = "GSM1487313_liver.PCL"
+    computed_file.result = result
+    computed_file.size_in_bytes = 123
+    computed_file.is_smashable = True
+    computed_file.s3_key = "GSM1487313_liver.PCL"
+    computed_file.s3_bucket = TEST_DATA_BUCKET
+    computed_file.save()
+
+    assoc = SampleComputedFileAssociation()
+    assoc.sample = sample
+    assoc.computed_file = computed_file
+    assoc.save()
+
+    # RNASEQ TECH
+    experiment2 = Experiment()
+    experiment2.accession_code = "SRP332914"
+    experiment2.num_processed_samples = 1
+    experiment2.save()
+
+    result2 = ComputationalResult()
+    result2.save()
+
+    sample2 = Sample()
+    sample2.accession_code = "SRR332914"
+    sample2.title = "SRR332914"
+    sample2.organism = gallus_gallus
+    sample2.technology = "RNA-SEQ"
+    sample2.is_processed = True
+    sample2.save()
+
+    sra2 = SampleResultAssociation()
+    sra2.sample = sample2
+    sra2.result = result2
+    sra2.save()
+
+    esa2 = ExperimentSampleAssociation()
+    esa2.experiment = experiment2
+    esa2.sample = sample2
+    esa2.save()
+
+    computed_file2 = ComputedFile()
+    computed_file2.filename = "SRP149598_gene_lengthScaledTPM.tsv"
+    computed_file2.result = result2
+    computed_file2.size_in_bytes = 234
+    computed_file2.is_smashable = True
+    computed_file2.s3_key = "SRP149598_gene_lengthScaledTPM.tsv"
+    computed_file2.s3_bucket = TEST_DATA_BUCKET
+    computed_file2.save()
+
+    assoc2 = SampleComputedFileAssociation()
+    assoc2.sample = sample2
+    assoc2.computed_file = computed_file2
+    assoc2.save()
 
 
 # Use unittest TestCase instead of django TestCase to avoid the test
@@ -70,6 +176,22 @@ class EndToEndTestCase(TestCase):
       * Creating a Quantpendium for SACCHAROMYCES_CEREVISIAE.
       * Downloading a dataset aggregated by species.
     """
+
+    @tag("end_to_end")
+    def test_smasher_job(self):
+        for accession_code in SMASHER_EXPERIMENTS:
+            purge_experiment(accession_code)
+
+        prepare_computed_files()
+        pyrefinebio.create_token(agree_to_terms=True, save_token=False)
+
+        dataset_path = "end_to_end_test_dataset"
+        pyrefinebio.download_dataset(
+            dataset_path,
+            "test@endtoend.com",
+            dataset_dict={"GSE1487313": ["GSM1487313"], "SRP332914": ["SRR332914"]},
+        )
+        self.assertTrue(path.exists(dataset_path))
 
     @tag("end_to_end")
     def test_all_the_things(self):
@@ -113,7 +235,7 @@ class EndToEndTestCase(TestCase):
         for survey_job in survey_jobs:
             self.assertTrue(wait_for_job(survey_job))
 
-        self.assertEqual(Sample.objects.count(), 155)
+        self.assertEqual(Sample.objects.exclude(accession_code in SMASHER_SAMPLES).count(), 155)
 
         samples = []
         for accession_code in EXPERIMENT_ACCESSION_CODES:
@@ -157,7 +279,9 @@ class EndToEndTestCase(TestCase):
             self.assertTrue(wait_for_job(processor_job))
 
         # Because SRR1583739 fails, the 26 samples from SRP047410 won't be processed
-        self.assertEqual(Sample.processed_objects.count(), 129)
+        self.assertEqual(
+            Sample.processed_objects.exclude(accession_code in SMASHER_SAMPLES).count(), 129
+        )
 
         print("Finally, need to run tximport to finish an experiment with one bad sample.")
         tximport_jobs = run_tximport(dispatch_jobs=False)
@@ -166,4 +290,6 @@ class EndToEndTestCase(TestCase):
         self.assertTrue(wait_for_job(tximport_jobs[0]))
 
         # This is the full total of jobs minus one.
-        self.assertEqual(Sample.processed_objects.count(), 154)
+        self.assertEqual(
+            Sample.processed_objects.exclude(accession_code in SMASHER_SAMPLES).count(), 154
+        )

--- a/foreman/requirements.in
+++ b/foreman/requirements.in
@@ -9,3 +9,4 @@ raven
 vcrpy
 django-computedfields
 pyrefinebio
+tblib

--- a/foreman/requirements.in
+++ b/foreman/requirements.in
@@ -8,3 +8,4 @@ python-dateutil
 raven
 vcrpy
 django-computedfields
+pyrefinebio

--- a/foreman/requirements.txt
+++ b/foreman/requirements.txt
@@ -26,6 +26,7 @@ requests==2.24.0          # via -r requirements.in, geoparse, pyrefinebio
 retrying==1.3.3           # via -r requirements.in
 six==1.15.0               # via python-dateutil, retrying, vcrpy
 sqlparse==0.3.1           # via django
+tblib==1.7.0              # via -r requirements.in
 tqdm==4.48.0              # via geoparse
 typing-extensions==3.7.4.2  # via importlib-metadata, yarl
 urllib3==1.25.10          # via requests

--- a/foreman/requirements.txt
+++ b/foreman/requirements.txt
@@ -6,26 +6,30 @@
 #
 certifi==2020.6.20        # via requests
 chardet==3.0.4            # via requests
+click==8.0.1              # via pyrefinebio
 coverage==5.2.1           # via -r requirements.in
 django-computedfields==0.1.3  # via -r requirements.in
 django==2.2.13            # via -r requirements.in
 geoparse==2.0.3           # via -r requirements.in
 idna==2.10                # via requests, yarl
+importlib-metadata==4.5.0  # via click
 multidict==4.7.6          # via yarl
 numpy==1.18.5             # via geoparse, pandas
 pandas==1.0.5             # via geoparse
 psycopg2-binary==2.8.5    # via -r requirements.in
-python-dateutil==2.8.1    # via -r requirements.in, pandas
+pyrefinebio==0.3.1        # via -r requirements.in
+python-dateutil==2.8.1    # via -r requirements.in, pandas, pyrefinebio
 pytz==2020.1              # via django, pandas
-pyyaml==5.3.1             # via vcrpy
+pyyaml==5.3.1             # via pyrefinebio, vcrpy
 raven==6.10.0             # via -r requirements.in
-requests==2.24.0          # via -r requirements.in, geoparse
+requests==2.24.0          # via -r requirements.in, geoparse, pyrefinebio
 retrying==1.3.3           # via -r requirements.in
 six==1.15.0               # via python-dateutil, retrying, vcrpy
 sqlparse==0.3.1           # via django
 tqdm==4.48.0              # via geoparse
-typing-extensions==3.7.4.2  # via yarl
+typing-extensions==3.7.4.2  # via importlib-metadata, yarl
 urllib3==1.25.10          # via requests
 vcrpy==4.0.2              # via -r requirements.in
 wrapt==1.12.1             # via vcrpy
 yarl==1.5.0               # via vcrpy
+zipp==3.4.1               # via importlib-metadata

--- a/foreman/run_end_to_end_tests.sh
+++ b/foreman/run_end_to_end_tests.sh
@@ -36,5 +36,6 @@ docker run -t \
        --env RUNNING_IN_CLOUD=False \
        --env DATABASE_HOST="$DATABASE_PUBLIC_HOST" \
        --env JOB_DEFINITION_PREFIX="$USER_$STAGE_" \
+       --env REFINEBIO_BASE_URL="http://$API_HOST/v1/" \
        --volume "$volume_directory":/home/user/data_store \
        ccdlstaging/dr_foreman python3 manage.py test --no-input --testrunner='data_refinery_foreman.test_runner.NoDbTestRunner' data_refinery_foreman.foreman.test_end_to_end

--- a/foreman/run_end_to_end_tests.sh
+++ b/foreman/run_end_to_end_tests.sh
@@ -38,4 +38,4 @@ docker run -t \
        --env JOB_DEFINITION_PREFIX="$USER_$STAGE_" \
        --env REFINEBIO_BASE_URL="http://$API_HOST/v1/" \
        --volume "$volume_directory":/home/user/data_store \
-       ccdlstaging/dr_foreman python3 manage.py test --no-input --testrunner='data_refinery_foreman.test_runner.NoDbTestRunner' data_refinery_foreman.foreman.test_end_to_end
+       ccdlstaging/dr_foreman python3 manage.py test --no-input --parallel=2 --testrunner='data_refinery_foreman.test_runner.NoDbTestRunner' data_refinery_foreman.foreman.test_end_to_end

--- a/infrastructure/permissions.tf
+++ b/infrastructure/permissions.tf
@@ -138,6 +138,20 @@ resource "aws_iam_role_policy_attachment" "foreman_s3" {
   policy_arn = aws_iam_policy.s3_access_policy.arn
 }
 
+resource "aws_iam_policy" "ses_access_policy" {
+  name = "data-refinery-ses-access-policy-${var.user}-${var.stage}"
+  description = "Allows sending email through SES"
+
+  policy = local.ses_access_policy
+
+  tags = var.default_tags
+}
+
+resource "aws_iam_role_policy_attachment" "worker_ses" {
+  role = aws_iam_role.data_refinery_worker.name
+  policy_arn = aws_iam_policy.ses_access_policy.arn
+}
+
 resource "aws_iam_policy" "cloudwatch_policy" {
   name = "data-refinery-cloudwatch-policy-${var.user}-${var.stage}"
   description = "Allows Cloudwatch Permissions."

--- a/infrastructure/policies.tf
+++ b/infrastructure/policies.tf
@@ -126,6 +126,22 @@ EOF
 }
 EOF
 
+  ses_access_policy = <<EOF
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Action":[
+              "SES:SendEmail",
+              "SES:SendRawEmail"
+            ],
+            "Resource": "arn:aws:ses:${var.region}:${data.aws_caller_identity.current.account_id}:identity/refine.bio"
+        }
+    ]
+}
+EOF
+
   ecs_instance_role_policy = <<EOF
 {
     "Version": "2012-10-17",

--- a/infrastructure/variables.tf
+++ b/infrastructure/variables.tf
@@ -299,7 +299,7 @@ output "environment_variables" {
     },
     {
       name = "API_HOST"
-      value = aws_instance.api_server_1.public_ip
+      value = aws_eip.data_refinery_api_ip.public_ip
     },
     {
       name = "ELASTICSEARCH_HOST"

--- a/infrastructure/variables.tf
+++ b/infrastructure/variables.tf
@@ -298,6 +298,10 @@ output "environment_variables" {
       value = var.database_timeout
     },
     {
+      name = "API_HOST"
+      value = aws_instance.api_server_1.public_ip
+    },
+    {
       name = "ELASTICSEARCH_HOST"
       value = aws_elasticsearch_domain.es.endpoint
     },

--- a/workers/batch-job-templates/smasher.tpl.json
+++ b/workers/batch-job-templates/smasher.tpl.json
@@ -39,6 +39,7 @@
             {"name": "RUNNING_IN_CLOUD", "value": "${{RUNNING_IN_CLOUD}}"},
             {"name": "USE_S3", "value": "${{USE_S3}}"},
             {"name": "S3_BUCKET_NAME", "value": "${{S3_BUCKET_NAME}}"},
+            {"name": "S3_RESULTS_BUCKET_NAME", "value": "${{S3_RESULTS_BUCKET_NAME}}"},
             {"name": "LOCAL_ROOT_DIR", "value": "${{LOCAL_ROOT_DIR}}"},
             {"name": "MAX_JOBS_PER_NODE", "value": "${{MAX_JOBS_PER_NODE}}"},
             {"name": "MAX_DOWNLOADER_JOBS_PER_NODE", "value": "${{MAX_DOWNLOADER_JOBS_PER_NODE}}"},


### PR DESCRIPTION
## Issue Number

https://github.com/AlexsLemonade/refinebio/issues/2762

## Purpose/Implementation Notes

This end to end test creates database objects that reference files that exist in the test assets bucket and uses them to smash up a dataset.

It uses the python client to create the dataset through the API! This was actually easier than any other option!

## Types of changes

- New feature (non-breaking change which adds functionality)

## Functional tests

The tests pass when I run them against a dev stack.

## Checklist

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules
