### PR TITLE
Put secrets in AWS Secrets Manager

### DIFF
--- a/.github/scripts/remote_deploy.sh
+++ b/.github/scripts/remote_deploy.sh
@@ -102,3 +102,10 @@ run_on_deploy_box "source env_vars && echo -e '######\nStarting new deploy for $
 run_on_deploy_box "sudo ./.github/scripts/fix_ca_certs.sh >> /var/log/deploy_$CI_TAG.log 2>&1"
 run_on_deploy_box "source env_vars && ./.github/scripts/run_terraform.sh >> /var/log/deploy_$CI_TAG.log 2>&1"
 run_on_deploy_box "source env_vars && echo -e '######\nDeploying $CI_TAG finished!\n######' >> /var/log/deploy_$CI_TAG.log 2>&1"
+
+./.github/scripts/slackpost_deploy.sh robots deploybot
+
+if [[ "$branch" == "dev" ]]; then
+    run_on_deploy_box "source env_vars && ./foreman/run_end_to_end_tests.sh"
+    ./.github/scripts/slackpost_end_to_end.sh robots deploybot
+fi

--- a/.github/scripts/slackpost_end_to_end.sh
+++ b/.github/scripts/slackpost_end_to_end.sh
@@ -23,17 +23,7 @@ then
         exit 1
 fi
 
-# ------------
-master_check=$(git branch --contains "tags/$CI_TAG" | grep '^  master$' || true)
-dev_check=$(git branch --contains "tags/$CI_TAG" | grep '^  dev$' || true)
-
-if [[ -n $master_check ]]; then
-    CI_BRANCH=master
-elif [[ -n $dev_check ]]; then
-    CI_BRANCH=dev
-fi
-
-text="New deployment! Woo! $CI_USERNAME: $CI_BRANCH $CI_TAG"
+text="The end-to-end tests passed in the staging stack!!!"
 
 escapedText=$(echo "$text" | sed 's/"/\"/g' | sed "s/'/\'/g" )
 

--- a/.github/workflows/config.yml
+++ b/.github/workflows/config.yml
@@ -384,20 +384,6 @@ jobs:
       - name: Push built docker images
         run: ./.github/scripts/push_docker_images.sh
 
-  determine_branch:
-    # As far as I can tell, this is the only way to use the output of
-    # a script in a github conditional.
-    if: startsWith(github.ref, 'refs/tags/v')
-    runs-on: ubuntu-latest
-    outputs:
-      branch: ${{ steps.set_branch.outputs.branch }}
-    steps:
-      - id: set_branch
-        name: Set the $CI_TAG environment variable
-        run: |
-          source scripts/common.sh
-          echo "::set-output name=branch::$(get_master_or_dev ${GITHUB_REF#refs/tags/})"
-
   deploy:
     if: startsWith(github.ref, 'refs/tags/v') && ! endsWith(github.ref, '-hotfix')
     runs-on: ubuntu-latest
@@ -412,7 +398,6 @@ jobs:
       ENGAGEMENT_WEBHOOK: ${{ secrets.ENGAGEMENT_WEBHOOK }}
       CI_USERNAME: ${{ github.actor }}
     needs:
-      - determine_branch
       - syntax_test
       - test_affy_agilent
       - test_api
@@ -441,17 +426,6 @@ jobs:
       - name: Deploy
         run: ./.github/scripts/remote_deploy.sh
 
-      - name: Notify the slack channel
-        run: ./.github/scripts/slackpost_deploy.sh robots deploybot
-
-      - name: Run End to End tests
-        if: ${{needs.determine_branch.outputs.branch == 'dev'}}
-        run: ./foreman/run_end_to_end_tests.sh
-
-      - name: Notify the slack channel
-        if: ${{needs.determine_branch.outputs.branch == 'dev'}}
-        run: ./.github/scripts/slackpost_end_to_end.sh robots deploybot
-
       - name: Cleanup deploy
         run: ./.github/scripts/post_deploy_cleanup.sh
 
@@ -468,8 +442,6 @@ jobs:
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       ENGAGEMENT_WEBHOOK: ${{ secrets.ENGAGEMENT_WEBHOOK }}
       CI_USERNAME: ${{ github.actor }}
-    needs:
-      - determine_branch
     steps:
       - uses: actions/checkout@v2
         with:
@@ -493,17 +465,6 @@ jobs:
 
       - name: Deploy
         run: ./.github/scripts/remote_deploy.sh
-
-      - name: Notify the slack channel
-        run: ./.github/scripts/slackpost_deploy.sh robots deploybot
-
-      - name: Run End to End tests
-        if: ${{needs.determine_branch.outputs.branch == 'dev'}}
-        run: ./foreman/run_end_to_end_tests.sh
-
-      - name: Notify the slack channel
-        if: ${{needs.determine_branch.outputs.branch == 'dev'}}
-        run: ./.github/scripts/slackpost_end_to_end.sh robots deploybot
 
       - name: Cleanup deploy
         run: ./.github/scripts/post_deploy_cleanup.sh

--- a/api/data_refinery_api/settings.py
+++ b/api/data_refinery_api/settings.py
@@ -187,10 +187,15 @@ SWAGGER_SETTINGS = {
 # /usr/local/lib/python3.6/site-packages/raven/conf/remote.py:91:
 # UserWarning: Transport selection via DSN is deprecated. You should
 # explicitly pass the transport class to Client() instead.
-raven_dsn = get_env_variable_gracefully("RAVEN_DSN_API", False)
-if raven_dsn != "not set":
+RAVEN_DSN = get_env_variable_gracefully("RAVEN_DSN_API", None)
+
+# AWS Secrets manager will not let us store an empty string.
+if RAVEN_DSN == "None":
+    RAVEN_DSN = None
+
+if RAVEN_DSN != "not set":
     RAVEN_CONFIG = {
-        "dsn": raven_dsn,
+        "dsn": RAVEN_DSN,
         # Only send 5% of errors for the API, since we aren't going to
         # be interested in any single one.
         "sampleRate": 0.25,

--- a/common/data_refinery_common/logging.py
+++ b/common/data_refinery_common/logging.py
@@ -1,6 +1,8 @@
 import logging
 import sys
 
+from django.conf import settings
+
 import daiquiri
 
 from data_refinery_common.utils import get_env_variable_gracefully, get_instance_id
@@ -45,11 +47,7 @@ def get_and_configure_logger(name: str) -> logging.Logger:
     logger.logger.addHandler(handler)
 
     # This is the Sentry handler
-    if "data_refinery_api" in name:
-        raven_dsn = get_env_variable_gracefully("RAVEN_DSN_API", False)
-    else:
-        raven_dsn = get_env_variable_gracefully("RAVEN_DSN", False)
-    if raven_dsn:
+    if settings.RAVEN_DSN:
         from raven.contrib.django.handlers import SentryHandler
 
         handler = SentryHandler()

--- a/common/data_refinery_common/settings.py
+++ b/common/data_refinery_common/settings.py
@@ -135,6 +135,26 @@ CACHES = {
     }
 }
 
+# Setting the RAVEN_CONFIG when RAVEN_DSN isn't set will cause the
+# following warning:
+# /usr/local/lib/python3.6/site-packages/raven/conf/remote.py:91:
+# UserWarning: Transport selection via DSN is deprecated. You should
+# explicitly pass the transport class to Client() instead.
+RAVEN_DSN = get_env_variable_gracefully("RAVEN_DSN", None)
+
+# AWS Secrets manager will not let us store an empty string.
+if RAVEN_DSN == "None":
+    RAVEN_DSN = None
+
+if RAVEN_DSN != "not set":
+    RAVEN_CONFIG = {"dsn": RAVEN_DSN}
+else:
+    # Preven raven from logging about how it's not configured...
+    import logging
+
+    raven_logger = logging.getLogger("raven.contrib.django.client.DjangoClient")
+    raven_logger.setLevel(logging.CRITICAL)
+
 MAX_JOBS_PER_NODE = int(get_env_variable("MAX_JOBS_PER_NODE"))
 MAX_DOWNLOADER_JOBS_PER_NODE = int(get_env_variable("MAX_DOWNLOADER_JOBS_PER_NODE"))
 

--- a/foreman/batch-job-templates/surveyor.tpl.json
+++ b/foreman/batch-job-templates/surveyor.tpl.json
@@ -6,6 +6,7 @@
         "job_id": ""
     },
     "containerProperties": {
+        "executionRoleArn": "${{BATCH_EXECUTION_ROLE_ARN}}",
         "image": "${{DOCKERHUB_REPO}}/${{FOREMAN_DOCKER_IMAGE}}",
         "vcpus": 1,
         "memory": ${{RAM}},
@@ -24,16 +25,12 @@
             }
         ],
         "environment": [
-            {"name": "DJANGO_SECRET_KEY", "value": "${{DJANGO_SECRET_KEY}}"},
             {"name": "DJANGO_DEBUG", "value": "${{DJANGO_DEBUG}}"},
             {"name": "DATABASE_NAME", "value": "${{DATABASE_NAME}}"},
             {"name": "DATABASE_USER", "value": "${{DATABASE_USER}}"},
-            {"name": "DATABASE_PASSWORD", "value": "${{DATABASE_PASSWORD}}"},
             {"name": "DATABASE_HOST", "value": "${{DATABASE_HOST}}"},
             {"name": "DATABASE_PORT", "value": "${{DATABASE_PORT}}"},
             {"name": "DATABASE_TIMEOUT", "value": "${{DATABASE_TIMEOUT}}"},
-            {"name": "RAVEN_DSN", "value": "${{RAVEN_DSN}}"},
-            {"name": "RAVEN_DSN_API", "value": "${{RAVEN_DSN_API}}"},
             {"name": "RUNNING_IN_CLOUD", "value": "${{RUNNING_IN_CLOUD}}"},
             {"name": "USE_S3", "value": "${{USE_S3}}"},
             {"name": "S3_BUCKET_NAME", "value": "${{S3_BUCKET_NAME}}"},
@@ -50,6 +47,12 @@
              "value": "${{REFINEBIO_JOB_QUEUE_ALL_NAMES}}"},
             {"name": "JOB_DEFINITION_PREFIX", "value": "${{USER}}_${{STAGE}}_"},
             {"name": "LOG_LEVEL", "value": "${{LOG_LEVEL}}"}
+        ],
+        "secrets": [
+            {"name": "DJANGO_SECRET_KEY", "valueFrom": "${{DJANGO_SECRET_KEY_ARN}}"},
+            {"name": "DATABASE_PASSWORD", "valueFrom": "${{DATABASE_PASSWORD_ARN}}"},
+            {"name": "RAVEN_DSN", "valueFrom": "${{RAVEN_DSN_ARN}}"},
+            {"name": "RAVEN_DSN_API", "valueFrom": "${{RAVEN_DSN_API_ARN}}"}
         ],
         "mountPoints": [
             {

--- a/foreman/data_refinery_foreman/settings.py
+++ b/foreman/data_refinery_foreman/settings.py
@@ -148,9 +148,14 @@ CACHES = {
 # /usr/local/lib/python3.6/site-packages/raven/conf/remote.py:91:
 # UserWarning: Transport selection via DSN is deprecated. You should
 # explicitly pass the transport class to Client() instead.
-raven_dsn = get_env_variable_gracefully("RAVEN_DSN", False)
-if raven_dsn:
-    RAVEN_CONFIG = {"dsn": raven_dsn}
+RAVEN_DSN = get_env_variable_gracefully("RAVEN_DSN", None)
+
+# AWS Secrets manager will not let us store an empty string.
+if RAVEN_DSN == "None":
+    RAVEN_DSN = None
+
+if RAVEN_DSN:
+    RAVEN_CONFIG = {"dsn": RAVEN_DSN}
 else:
     # Preven raven from logging about how it's not configured...
     import logging

--- a/foreman/run_end_to_end_tests.sh
+++ b/foreman/run_end_to_end_tests.sh
@@ -37,5 +37,7 @@ docker run -t \
        --env DATABASE_HOST="$DATABASE_PUBLIC_HOST" \
        --env JOB_DEFINITION_PREFIX="$USER_$STAGE_" \
        --env REFINEBIO_BASE_URL="http://$API_HOST/v1/" \
+       --env DJANGO_SECRET_KEY="TEST_KEY_FOR_DEV" \
+       --env DATABASE_PASSWORD="TEST_PASSWORD_FOR_DEV" \
        --volume "$volume_directory":/home/user/data_store \
        ccdlstaging/dr_foreman python3 manage.py test --no-input --parallel=2 --testrunner='data_refinery_foreman.test_runner.NoDbTestRunner' data_refinery_foreman.foreman.test_end_to_end

--- a/infrastructure/permissions.tf
+++ b/infrastructure/permissions.tf
@@ -74,6 +74,31 @@ EOF
   tags = var.default_tags
 }
 
+resource "aws_iam_role" "data_refinery_batch_execution" {
+  name = "data-refinery-batch-execution-role-${var.user}-${var.stage}"
+
+  # Policy text found at:
+  # http://docs.aws.amazon.com/AmazonECS/latest/developerguide/instance_IAM_role.html
+  # "Service": ["ec2.amazonaws.com", "ecs-tasks.amazonaws.com", "batch.amazonaws.com"]
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "",
+      "Effect": "Allow",
+      "Principal": {
+        "Service": "ecs-tasks.amazonaws.com"
+      },
+      "Action": "sts:AssumeRole"
+    }
+  ]
+}
+EOF
+
+  tags = var.default_tags
+}
+
 resource "aws_iam_role" "data_refinery_spot_fleet" {
   name = "data-refinery-spot-fleet-${var.user}-${var.stage}"
 
@@ -150,6 +175,20 @@ resource "aws_iam_policy" "ses_access_policy" {
 resource "aws_iam_role_policy_attachment" "worker_ses" {
   role = aws_iam_role.data_refinery_worker.name
   policy_arn = aws_iam_policy.ses_access_policy.arn
+}
+
+resource "aws_iam_policy" "batch_execution_policy" {
+  name = "data-refinery-batch-execution-policy-${var.user}-${var.stage}"
+  description = "Allows accessing secrets and other common ECS tasks"
+
+  policy = local.batch_execution_policy
+
+  tags = var.default_tags
+}
+
+resource "aws_iam_role_policy_attachment" "batch_execution" {
+  role = aws_iam_role.data_refinery_batch_execution.name
+  policy_arn = aws_iam_policy.batch_execution_policy.arn
 }
 
 resource "aws_iam_policy" "cloudwatch_policy" {

--- a/infrastructure/policies.tf
+++ b/infrastructure/policies.tf
@@ -180,4 +180,37 @@ EOF
     ]
 }
 EOF
+
+  batch_execution_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "ecr:GetAuthorizationToken",
+        "ecr:BatchCheckLayerAvailability",
+        "ecr:GetDownloadUrlForLayer",
+        "ecr:BatchGetImage",
+        "logs:CreateLogStream",
+        "logs:PutLogEvents"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "secretsmanager:GetSecretValue"
+      ],
+      "Resource": [
+        "${aws_secretsmanager_secret.django_secret_key.arn}",
+        "${aws_secretsmanager_secret.database_password.arn}",
+        "${aws_secretsmanager_secret.raven_dsn.arn}",
+        "${aws_secretsmanager_secret.raven_dsn_api.arn}"
+      ]
+    }
+  ]
+}
+EOF
+
 }

--- a/infrastructure/secrets.tf
+++ b/infrastructure/secrets.tf
@@ -1,0 +1,36 @@
+
+resource "aws_secretsmanager_secret" "django_secret_key" {
+  name_prefix = "data-refinery-${var.user}-${var.stage}-django-secret-key"
+}
+
+resource "aws_secretsmanager_secret_version" "django_secret_key" {
+  secret_id = aws_secretsmanager_secret.django_secret_key.id
+  secret_string = var.django_secret_key
+}
+
+resource "aws_secretsmanager_secret" "database_password" {
+  name_prefix = "data-refinery-${var.user}-${var.stage}-database-password"
+}
+
+resource "aws_secretsmanager_secret_version" "database_password" {
+  secret_id = aws_secretsmanager_secret.database_password.id
+  secret_string = var.database_password
+}
+
+resource "aws_secretsmanager_secret" "raven_dsn" {
+  name_prefix = "data-refinery-${var.user}-${var.stage}-raven-dsn"
+}
+
+resource "aws_secretsmanager_secret_version" "raven_dsn" {
+  secret_id = aws_secretsmanager_secret.raven_dsn.id
+  secret_string = var.raven_dsn
+}
+
+resource "aws_secretsmanager_secret" "raven_dsn_api" {
+  name_prefix = "data-refinery-${var.user}-${var.stage}-raven-dsn-api"
+}
+
+resource "aws_secretsmanager_secret_version" "raven_dsn_api" {
+  secret_id = aws_secretsmanager_secret.raven_dsn_api.id
+  secret_string = var.raven_dsn_api
+}

--- a/infrastructure/variables.tf
+++ b/infrastructure/variables.tf
@@ -160,12 +160,14 @@ variable "spot_fleet_capacity" {
   default = "0"
 }
 
+# AWS Secrets manager won't allow these to be empty, so we make them
+# "None" and check for that string in the settings,
 variable "raven_dsn" {
-  default = ""
+  default = "None"
 }
 
 variable "raven_dsn_api" {
-  default = ""
+  default = "None"
 }
 
 # API
@@ -260,6 +262,10 @@ output "environment_variables" {
       value = var.django_secret_key
     },
     {
+      name = "DJANGO_SECRET_KEY_ARN"
+      value = aws_secretsmanager_secret.django_secret_key.arn
+    },
+    {
       name = "DATABASE_NAME"
       value = aws_db_instance.postgres_db.name
     },
@@ -284,6 +290,10 @@ output "environment_variables" {
     {
       name = "DATABASE_PASSWORD"
       value = var.database_password
+    },
+    {
+      name = "DATABASE_PASSWORD_ARN"
+      value = aws_secretsmanager_secret.database_password.arn
     },
     {
       name = "DATABASE_PORT"
@@ -328,6 +338,18 @@ output "environment_variables" {
     {
       name = "RAVEN_DSN_API"
       value = var.raven_dsn_api
+    },
+    {
+      name = "RAVEN_DSN_ARN"
+      value = aws_secretsmanager_secret.raven_dsn.arn
+    },
+    {
+      name = "RAVEN_DSN_API_ARN"
+      value = aws_secretsmanager_secret.raven_dsn_api.arn
+    },
+    {
+      name = "BATCH_EXECUTION_ROLE_ARN"
+      value = aws_iam_role.data_refinery_batch_execution.arn
     },
     {
       name = "S3_BUCKET_NAME"

--- a/workers/batch-job-templates/affymetrix.tpl.json
+++ b/workers/batch-job-templates/affymetrix.tpl.json
@@ -6,6 +6,7 @@
         "job_id": ""
     },
     "containerProperties": {
+        "executionRoleArn": "${{BATCH_EXECUTION_ROLE_ARN}}",
         "image": "${{DOCKERHUB_REPO}}/${{AFFYMETRIX_DOCKER_IMAGE}}",
         "vcpus": 1,
         "memory": ${{RAM}},
@@ -26,16 +27,12 @@
         ],
         "jobRoleArn": "${{WORKER_ROLE_ARN}}",
         "environment": [
-            {"name": "DJANGO_SECRET_KEY", "value": "${{DJANGO_SECRET_KEY}}"},
             {"name": "DJANGO_DEBUG", "value": "${{DJANGO_DEBUG}}"},
             {"name": "DATABASE_NAME", "value": "${{DATABASE_NAME}}"},
             {"name": "DATABASE_USER", "value": "${{DATABASE_USER}}"},
-            {"name": "DATABASE_PASSWORD", "value": "${{DATABASE_PASSWORD}}"},
             {"name": "DATABASE_HOST", "value": "${{DATABASE_HOST}}"},
             {"name": "DATABASE_PORT", "value": "${{DATABASE_PORT}}"},
             {"name": "DATABASE_TIMEOUT", "value": "${{DATABASE_TIMEOUT}}"},
-            {"name": "RAVEN_DSN", "value": "${{RAVEN_DSN}}"},
-            {"name": "RAVEN_DSN_API", "value": "${{RAVEN_DSN_API}}"},
             {"name": "RUNNING_IN_CLOUD", "value": "${{RUNNING_IN_CLOUD}}"},
             {"name": "USE_S3", "value": "${{USE_S3}}"},
             {"name": "S3_BUCKET_NAME", "value": "${{S3_BUCKET_NAME}}"},
@@ -52,6 +49,12 @@
              "value": "${{REFINEBIO_JOB_QUEUE_ALL_NAMES}}"},
             {"name": "JOB_DEFINITION_PREFIX", "value": "${{USER}}_${{STAGE}}_"},
             {"name": "LOG_LEVEL", "value": "${{LOG_LEVEL}}"}
+        ],
+        "secrets": [
+            {"name": "DJANGO_SECRET_KEY", "valueFrom": "${{DJANGO_SECRET_KEY_ARN}}"},
+            {"name": "DATABASE_PASSWORD", "valueFrom": "${{DATABASE_PASSWORD_ARN}}"},
+            {"name": "RAVEN_DSN", "valueFrom": "${{RAVEN_DSN_ARN}}"},
+            {"name": "RAVEN_DSN_API", "valueFrom": "${{RAVEN_DSN_API_ARN}}"}
         ],
         "mountPoints": [
             {

--- a/workers/batch-job-templates/create_compendia.tpl.json
+++ b/workers/batch-job-templates/create_compendia.tpl.json
@@ -6,6 +6,7 @@
         "job_id": ""
     },
     "containerProperties": {
+        "executionRoleArn": "${{BATCH_EXECUTION_ROLE_ARN}}",
         "image": "${{DOCKERHUB_REPO}}/${{COMPENDIA_DOCKER_IMAGE}}",
         "vcpus": 1,
         "memory": 4000,
@@ -26,16 +27,12 @@
         ],
         "jobRoleArn": "${{WORKER_ROLE_ARN}}",
         "environment": [
-            {"name": "DJANGO_SECRET_KEY", "value": "${{DJANGO_SECRET_KEY}}"},
             {"name": "DJANGO_DEBUG", "value": "${{DJANGO_DEBUG}}"},
             {"name": "DATABASE_NAME", "value": "${{DATABASE_NAME}}"},
             {"name": "DATABASE_USER", "value": "${{DATABASE_USER}}"},
-            {"name": "DATABASE_PASSWORD", "value": "${{DATABASE_PASSWORD}}"},
             {"name": "DATABASE_HOST", "value": "${{DATABASE_HOST}}"},
             {"name": "DATABASE_PORT", "value": "${{DATABASE_PORT}}"},
             {"name": "DATABASE_TIMEOUT", "value": "${{DATABASE_TIMEOUT}}"},
-            {"name": "RAVEN_DSN", "value": "${{RAVEN_DSN}}"},
-            {"name": "RAVEN_DSN_API", "value": "${{RAVEN_DSN_API}}"},
             {"name": "RUNNING_IN_CLOUD", "value": "${{RUNNING_IN_CLOUD}}"},
             {"name": "USE_S3", "value": "${{USE_S3}}"},
             {"name": "S3_BUCKET_NAME", "value": "${{S3_BUCKET_NAME}}"},
@@ -53,6 +50,12 @@
              "value": "${{REFINEBIO_JOB_QUEUE_ALL_NAMES}}"},
             {"name": "JOB_DEFINITION_PREFIX", "value": "${{USER}}_${{STAGE}}_"},
             {"name": "LOG_LEVEL", "value": "${{LOG_LEVEL}}"}
+        ],
+        "secrets": [
+            {"name": "DJANGO_SECRET_KEY", "valueFrom": "${{DJANGO_SECRET_KEY_ARN}}"},
+            {"name": "DATABASE_PASSWORD", "valueFrom": "${{DATABASE_PASSWORD_ARN}}"},
+            {"name": "RAVEN_DSN", "valueFrom": "${{RAVEN_DSN_ARN}}"},
+            {"name": "RAVEN_DSN_API", "valueFrom": "${{RAVEN_DSN_API_ARN}}"}
         ],
         "mountPoints": [
             {

--- a/workers/batch-job-templates/create_qn_target.tpl.json
+++ b/workers/batch-job-templates/create_qn_target.tpl.json
@@ -6,6 +6,7 @@
         "job_id": ""
     },
     "containerProperties": {
+        "executionRoleArn": "${{BATCH_EXECUTION_ROLE_ARN}}",
         "image": "${{DOCKERHUB_REPO}}/${{SMASHER_DOCKER_IMAGE}}",
         "vcpus": 1,
         "memory": 13072,
@@ -26,16 +27,12 @@
         ],
         "jobRoleArn": "${{WORKER_ROLE_ARN}}",
         "environment": [
-            {"name": "DJANGO_SECRET_KEY", "value": "${{DJANGO_SECRET_KEY}}"},
             {"name": "DJANGO_DEBUG", "value": "${{DJANGO_DEBUG}}"},
             {"name": "DATABASE_NAME", "value": "${{DATABASE_NAME}}"},
             {"name": "DATABASE_USER", "value": "${{DATABASE_USER}}"},
-            {"name": "DATABASE_PASSWORD", "value": "${{DATABASE_PASSWORD}}"},
             {"name": "DATABASE_HOST", "value": "${{DATABASE_HOST}}"},
             {"name": "DATABASE_PORT", "value": "${{DATABASE_PORT}}"},
             {"name": "DATABASE_TIMEOUT", "value": "${{DATABASE_TIMEOUT}}"},
-            {"name": "RAVEN_DSN", "value": "${{RAVEN_DSN}}"},
-            {"name": "RAVEN_DSN_API", "value": "${{RAVEN_DSN_API}}"},
             {"name": "RUNNING_IN_CLOUD", "value": "${{RUNNING_IN_CLOUD}}"},
             {"name": "USE_S3", "value": "${{USE_S3}}"},
             {"name": "S3_BUCKET_NAME", "value": "${{S3_BUCKET_NAME}}"},
@@ -52,6 +49,12 @@
              "value": "${{REFINEBIO_JOB_QUEUE_ALL_NAMES}}"},
             {"name": "JOB_DEFINITION_PREFIX", "value": "${{USER}}_${{STAGE}}_"},
             {"name": "LOG_LEVEL", "value": "${{LOG_LEVEL}}"}
+        ],
+        "secrets": [
+            {"name": "DJANGO_SECRET_KEY", "valueFrom": "${{DJANGO_SECRET_KEY_ARN}}"},
+            {"name": "DATABASE_PASSWORD", "valueFrom": "${{DATABASE_PASSWORD_ARN}}"},
+            {"name": "RAVEN_DSN", "valueFrom": "${{RAVEN_DSN_ARN}}"},
+            {"name": "RAVEN_DSN_API", "valueFrom": "${{RAVEN_DSN_API_ARN}}"}
         ],
         "mountPoints": [
             {

--- a/workers/batch-job-templates/create_quantpendia.tpl.json
+++ b/workers/batch-job-templates/create_quantpendia.tpl.json
@@ -6,6 +6,7 @@
         "job_id": ""
     },
     "containerProperties": {
+        "executionRoleArn": "${{BATCH_EXECUTION_ROLE_ARN}}",
         "image": "${{DOCKERHUB_REPO}}/${{COMPENDIA_DOCKER_IMAGE}}",
         "vcpus": 1,
         "memory": ${{RAM}},
@@ -26,16 +27,12 @@
         ],
         "jobRoleArn": "${{WORKER_ROLE_ARN}}",
         "environment": [
-            {"name": "DJANGO_SECRET_KEY", "value": "${{DJANGO_SECRET_KEY}}"},
             {"name": "DJANGO_DEBUG", "value": "${{DJANGO_DEBUG}}"},
             {"name": "DATABASE_NAME", "value": "${{DATABASE_NAME}}"},
             {"name": "DATABASE_USER", "value": "${{DATABASE_USER}}"},
-            {"name": "DATABASE_PASSWORD", "value": "${{DATABASE_PASSWORD}}"},
             {"name": "DATABASE_HOST", "value": "${{DATABASE_HOST}}"},
             {"name": "DATABASE_PORT", "value": "${{DATABASE_PORT}}"},
             {"name": "DATABASE_TIMEOUT", "value": "${{DATABASE_TIMEOUT}}"},
-            {"name": "RAVEN_DSN", "value": "${{RAVEN_DSN}}"},
-            {"name": "RAVEN_DSN_API", "value": "${{RAVEN_DSN_API}}"},
             {"name": "RUNNING_IN_CLOUD", "value": "${{RUNNING_IN_CLOUD}}"},
             {"name": "USE_S3", "value": "${{USE_S3}}"},
             {"name": "S3_BUCKET_NAME", "value": "${{S3_BUCKET_NAME}}"},
@@ -52,6 +49,12 @@
              "value": "${{REFINEBIO_JOB_QUEUE_ALL_NAMES}}"},
             {"name": "JOB_DEFINITION_PREFIX", "value": "${{USER}}_${{STAGE}}_"},
             {"name": "LOG_LEVEL", "value": "${{LOG_LEVEL}}"}
+        ],
+        "secrets": [
+            {"name": "DJANGO_SECRET_KEY", "valueFrom": "${{DJANGO_SECRET_KEY_ARN}}"},
+            {"name": "DATABASE_PASSWORD", "valueFrom": "${{DATABASE_PASSWORD_ARN}}"},
+            {"name": "RAVEN_DSN", "valueFrom": "${{RAVEN_DSN_ARN}}"},
+            {"name": "RAVEN_DSN_API", "valueFrom": "${{RAVEN_DSN_API_ARN}}"}
         ],
         "mountPoints": [
             {

--- a/workers/batch-job-templates/downloader.tpl.json
+++ b/workers/batch-job-templates/downloader.tpl.json
@@ -6,6 +6,7 @@
         "job_id": ""
     },
     "containerProperties": {
+        "executionRoleArn": "${{BATCH_EXECUTION_ROLE_ARN}}",
         "image": "${{DOCKERHUB_REPO}}/${{DOWNLOADERS_DOCKER_IMAGE}}",
         "vcpus": 1,
         "memory": ${{RAM}},
@@ -26,16 +27,12 @@
         ],
         "jobRoleArn": "${{WORKER_ROLE_ARN}}",
         "environment": [
-            {"name": "DJANGO_SECRET_KEY", "value": "${{DJANGO_SECRET_KEY}}"},
             {"name": "DJANGO_DEBUG", "value": "${{DJANGO_DEBUG}}"},
             {"name": "DATABASE_NAME", "value": "${{DATABASE_NAME}}"},
             {"name": "DATABASE_USER", "value": "${{DATABASE_USER}}"},
-            {"name": "DATABASE_PASSWORD", "value": "${{DATABASE_PASSWORD}}"},
             {"name": "DATABASE_HOST", "value": "${{DATABASE_HOST}}"},
             {"name": "DATABASE_PORT", "value": "${{DATABASE_PORT}}"},
             {"name": "DATABASE_TIMEOUT", "value": "${{DATABASE_TIMEOUT}}"},
-            {"name": "RAVEN_DSN", "value": "${{RAVEN_DSN}}"},
-            {"name": "RAVEN_DSN_API", "value": "${{RAVEN_DSN_API}}"},
             {"name": "RUNNING_IN_CLOUD", "value": "${{RUNNING_IN_CLOUD}}"},
             {"name": "USE_S3", "value": "${{USE_S3}}"},
             {"name": "S3_BUCKET_NAME", "value": "${{S3_BUCKET_NAME}}"},
@@ -52,6 +49,12 @@
              "value": "${{REFINEBIO_JOB_QUEUE_ALL_NAMES}}"},
             {"name": "JOB_DEFINITION_PREFIX", "value": "${{USER}}_${{STAGE}}_"},
             {"name": "LOG_LEVEL", "value": "${{LOG_LEVEL}}"}
+        ],
+        "secrets": [
+            {"name": "DJANGO_SECRET_KEY", "valueFrom": "${{DJANGO_SECRET_KEY_ARN}}"},
+            {"name": "DATABASE_PASSWORD", "valueFrom": "${{DATABASE_PASSWORD_ARN}}"},
+            {"name": "RAVEN_DSN", "valueFrom": "${{RAVEN_DSN_ARN}}"},
+            {"name": "RAVEN_DSN_API", "valueFrom": "${{RAVEN_DSN_API_ARN}}"}
         ],
         "mountPoints": [
             {

--- a/workers/batch-job-templates/illumina.tpl.json
+++ b/workers/batch-job-templates/illumina.tpl.json
@@ -6,6 +6,7 @@
         "job_id": ""
     },
     "containerProperties": {
+        "executionRoleArn": "${{BATCH_EXECUTION_ROLE_ARN}}",
         "image": "${{DOCKERHUB_REPO}}/${{ILLUMINA_DOCKER_IMAGE}}",
         "vcpus": 1,
         "memory": ${{RAM}},
@@ -26,16 +27,12 @@
         ],
         "jobRoleArn": "${{WORKER_ROLE_ARN}}",
         "environment": [
-            {"name": "DJANGO_SECRET_KEY", "value": "${{DJANGO_SECRET_KEY}}"},
             {"name": "DJANGO_DEBUG", "value": "${{DJANGO_DEBUG}}"},
             {"name": "DATABASE_NAME", "value": "${{DATABASE_NAME}}"},
             {"name": "DATABASE_USER", "value": "${{DATABASE_USER}}"},
-            {"name": "DATABASE_PASSWORD", "value": "${{DATABASE_PASSWORD}}"},
             {"name": "DATABASE_HOST", "value": "${{DATABASE_HOST}}"},
             {"name": "DATABASE_PORT", "value": "${{DATABASE_PORT}}"},
             {"name": "DATABASE_TIMEOUT", "value": "${{DATABASE_TIMEOUT}}"},
-            {"name": "RAVEN_DSN", "value": "${{RAVEN_DSN}}"},
-            {"name": "RAVEN_DSN_API", "value": "${{RAVEN_DSN_API}}"},
             {"name": "RUNNING_IN_CLOUD", "value": "${{RUNNING_IN_CLOUD}}"},
             {"name": "USE_S3", "value": "${{USE_S3}}"},
             {"name": "S3_BUCKET_NAME", "value": "${{S3_BUCKET_NAME}}"},
@@ -52,6 +49,12 @@
              "value": "${{REFINEBIO_JOB_QUEUE_ALL_NAMES}}"},
             {"name": "JOB_DEFINITION_PREFIX", "value": "${{USER}}_${{STAGE}}_"},
             {"name": "LOG_LEVEL", "value": "${{LOG_LEVEL}}"}
+        ],
+        "secrets": [
+            {"name": "DJANGO_SECRET_KEY", "valueFrom": "${{DJANGO_SECRET_KEY_ARN}}"},
+            {"name": "DATABASE_PASSWORD", "valueFrom": "${{DATABASE_PASSWORD_ARN}}"},
+            {"name": "RAVEN_DSN", "valueFrom": "${{RAVEN_DSN_ARN}}"},
+            {"name": "RAVEN_DSN_API", "valueFrom": "${{RAVEN_DSN_API_ARN}}"}
         ],
         "mountPoints": [
             {

--- a/workers/batch-job-templates/janitor.tpl.json
+++ b/workers/batch-job-templates/janitor.tpl.json
@@ -6,6 +6,7 @@
         "job_id": ""
     },
     "containerProperties": {
+        "executionRoleArn": "${{BATCH_EXECUTION_ROLE_ARN}}",
         "image": "${{DOCKERHUB_REPO}}/${{SMASHER_DOCKER_IMAGE}}",
         "vcpus": 1,
         "memory": 256,
@@ -26,16 +27,12 @@
         ],
         "jobRoleArn": "${{WORKER_ROLE_ARN}}",
         "environment": [
-            {"name": "DJANGO_SECRET_KEY", "value": "${{DJANGO_SECRET_KEY}}"},
             {"name": "DJANGO_DEBUG", "value": "${{DJANGO_DEBUG}}"},
             {"name": "DATABASE_NAME", "value": "${{DATABASE_NAME}}"},
             {"name": "DATABASE_USER", "value": "${{DATABASE_USER}}"},
-            {"name": "DATABASE_PASSWORD", "value": "${{DATABASE_PASSWORD}}"},
             {"name": "DATABASE_HOST", "value": "${{DATABASE_HOST}}"},
             {"name": "DATABASE_PORT", "value": "${{DATABASE_PORT}}"},
             {"name": "DATABASE_TIMEOUT", "value": "${{DATABASE_TIMEOUT}}"},
-            {"name": "RAVEN_DSN", "value": "${{RAVEN_DSN}}"},
-            {"name": "RAVEN_DSN_API", "value": "${{RAVEN_DSN_API}}"},
             {"name": "RUNNING_IN_CLOUD", "value": "${{RUNNING_IN_CLOUD}}"},
             {"name": "USE_S3", "value": "${{USE_S3}}"},
             {"name": "S3_BUCKET_NAME", "value": "${{S3_BUCKET_NAME}}"},
@@ -52,6 +49,12 @@
              "value": "${{REFINEBIO_JOB_QUEUE_ALL_NAMES}}"},
             {"name": "JOB_DEFINITION_PREFIX", "value": "${{USER}}_${{STAGE}}_"},
             {"name": "LOG_LEVEL", "value": "${{LOG_LEVEL}}"}
+        ],
+        "secrets": [
+            {"name": "DJANGO_SECRET_KEY", "valueFrom": "${{DJANGO_SECRET_KEY_ARN}}"},
+            {"name": "DATABASE_PASSWORD", "valueFrom": "${{DATABASE_PASSWORD_ARN}}"},
+            {"name": "RAVEN_DSN", "valueFrom": "${{RAVEN_DSN_ARN}}"},
+            {"name": "RAVEN_DSN_API", "valueFrom": "${{RAVEN_DSN_API_ARN}}"}
         ],
         "mountPoints": [
             {

--- a/workers/batch-job-templates/no_op.tpl.json
+++ b/workers/batch-job-templates/no_op.tpl.json
@@ -6,6 +6,7 @@
         "job_id": ""
     },
     "containerProperties": {
+        "executionRoleArn": "${{BATCH_EXECUTION_ROLE_ARN}}",
         "image": "${{DOCKERHUB_REPO}}/${{NO_OP_DOCKER_IMAGE}}",
         "vcpus": 1,
         "memory": ${{RAM}},
@@ -21,21 +22,17 @@
                 "host": {
                     "sourcePath": "${{VOLUME_DIR}}"
                 },
-                "name": "data_store"
+                 "name": "data_store"
             }
         ],
         "jobRoleArn": "${{WORKER_ROLE_ARN}}",
         "environment": [
-            {"name": "DJANGO_SECRET_KEY", "value": "${{DJANGO_SECRET_KEY}}"},
             {"name": "DJANGO_DEBUG", "value": "${{DJANGO_DEBUG}}"},
             {"name": "DATABASE_NAME", "value": "${{DATABASE_NAME}}"},
             {"name": "DATABASE_USER", "value": "${{DATABASE_USER}}"},
-            {"name": "DATABASE_PASSWORD", "value": "${{DATABASE_PASSWORD}}"},
             {"name": "DATABASE_HOST", "value": "${{DATABASE_HOST}}"},
             {"name": "DATABASE_PORT", "value": "${{DATABASE_PORT}}"},
             {"name": "DATABASE_TIMEOUT", "value": "${{DATABASE_TIMEOUT}}"},
-            {"name": "RAVEN_DSN", "value": "${{RAVEN_DSN}}"},
-            {"name": "RAVEN_DSN_API", "value": "${{RAVEN_DSN_API}}"},
             {"name": "RUNNING_IN_CLOUD", "value": "${{RUNNING_IN_CLOUD}}"},
             {"name": "USE_S3", "value": "${{USE_S3}}"},
             {"name": "S3_BUCKET_NAME", "value": "${{S3_BUCKET_NAME}}"},
@@ -52,6 +49,12 @@
              "value": "${{REFINEBIO_JOB_QUEUE_ALL_NAMES}}"},
             {"name": "JOB_DEFINITION_PREFIX", "value": "${{USER}}_${{STAGE}}_"},
             {"name": "LOG_LEVEL", "value": "${{LOG_LEVEL}}"}
+        ],
+        "secrets": [
+            {"name": "DJANGO_SECRET_KEY", "valueFrom": "${{DJANGO_SECRET_KEY_ARN}}"},
+            {"name": "DATABASE_PASSWORD", "valueFrom": "${{DATABASE_PASSWORD_ARN}}"},
+            {"name": "RAVEN_DSN", "valueFrom": "${{RAVEN_DSN_ARN}}"},
+            {"name": "RAVEN_DSN_API", "valueFrom": "${{RAVEN_DSN_API_ARN}}"}
         ],
         "mountPoints": [
             {

--- a/workers/batch-job-templates/qn_dispatcher.tpl.json
+++ b/workers/batch-job-templates/qn_dispatcher.tpl.json
@@ -6,6 +6,7 @@
         "job_id": ""
     },
     "containerProperties": {
+        "executionRoleArn": "${{BATCH_EXECUTION_ROLE_ARN}}",
         "image": "${{DOCKERHUB_REPO}}/${{SMASHER_DOCKER_IMAGE}}",
         "vcpus": 1,
         "memory": 4096,
@@ -26,16 +27,12 @@
         ],
         "jobRoleArn": "${{WORKER_ROLE_ARN}}",
         "environment": [
-            {"name": "DJANGO_SECRET_KEY", "value": "${{DJANGO_SECRET_KEY}}"},
             {"name": "DJANGO_DEBUG", "value": "${{DJANGO_DEBUG}}"},
             {"name": "DATABASE_NAME", "value": "${{DATABASE_NAME}}"},
             {"name": "DATABASE_USER", "value": "${{DATABASE_USER}}"},
-            {"name": "DATABASE_PASSWORD", "value": "${{DATABASE_PASSWORD}}"},
             {"name": "DATABASE_HOST", "value": "${{DATABASE_HOST}}"},
             {"name": "DATABASE_PORT", "value": "${{DATABASE_PORT}}"},
             {"name": "DATABASE_TIMEOUT", "value": "${{DATABASE_TIMEOUT}}"},
-            {"name": "RAVEN_DSN", "value": "${{RAVEN_DSN}}"},
-            {"name": "RAVEN_DSN_API", "value": "${{RAVEN_DSN_API}}"},
             {"name": "RUNNING_IN_CLOUD", "value": "${{RUNNING_IN_CLOUD}}"},
             {"name": "USE_S3", "value": "${{USE_S3}}"},
             {"name": "S3_BUCKET_NAME", "value": "${{S3_BUCKET_NAME}}"},
@@ -52,6 +49,12 @@
              "value": "${{REFINEBIO_JOB_QUEUE_ALL_NAMES}}"},
             {"name": "JOB_DEFINITION_PREFIX", "value": "${{USER}}_${{STAGE}}_"},
             {"name": "LOG_LEVEL", "value": "${{LOG_LEVEL}}"}
+        ],
+        "secrets": [
+            {"name": "DJANGO_SECRET_KEY", "valueFrom": "${{DJANGO_SECRET_KEY_ARN}}"},
+            {"name": "DATABASE_PASSWORD", "valueFrom": "${{DATABASE_PASSWORD_ARN}}"},
+            {"name": "RAVEN_DSN", "valueFrom": "${{RAVEN_DSN_ARN}}"},
+            {"name": "RAVEN_DSN_API", "valueFrom": "${{RAVEN_DSN_API_ARN}}"}
         ],
         "mountPoints": [
             {

--- a/workers/batch-job-templates/qn_reference.tpl.json
+++ b/workers/batch-job-templates/qn_reference.tpl.json
@@ -6,6 +6,7 @@
         "job_id": ""
     },
     "containerProperties": {
+        "executionRoleArn": "${{BATCH_EXECUTION_ROLE_ARN}}",
         "image": "${{DOCKERHUB_REPO}}/${{SMASHER_DOCKER_IMAGE}}",
         "vcpus": 1,
         "memory": ${{RAM}},
@@ -26,16 +27,12 @@
         ],
         "jobRoleArn": "${{WORKER_ROLE_ARN}}",
         "environment": [
-            {"name": "DJANGO_SECRET_KEY", "value": "${{DJANGO_SECRET_KEY}}"},
             {"name": "DJANGO_DEBUG", "value": "${{DJANGO_DEBUG}}"},
             {"name": "DATABASE_NAME", "value": "${{DATABASE_NAME}}"},
             {"name": "DATABASE_USER", "value": "${{DATABASE_USER}}"},
-            {"name": "DATABASE_PASSWORD", "value": "${{DATABASE_PASSWORD}}"},
             {"name": "DATABASE_HOST", "value": "${{DATABASE_HOST}}"},
             {"name": "DATABASE_PORT", "value": "${{DATABASE_PORT}}"},
             {"name": "DATABASE_TIMEOUT", "value": "${{DATABASE_TIMEOUT}}"},
-            {"name": "RAVEN_DSN", "value": "${{RAVEN_DSN}}"},
-            {"name": "RAVEN_DSN_API", "value": "${{RAVEN_DSN_API}}"},
             {"name": "RUNNING_IN_CLOUD", "value": "${{RUNNING_IN_CLOUD}}"},
             {"name": "USE_S3", "value": "${{USE_S3}}"},
             {"name": "S3_BUCKET_NAME", "value": "${{S3_BUCKET_NAME}}"},
@@ -53,6 +50,12 @@
              "value": "${{REFINEBIO_JOB_QUEUE_ALL_NAMES}}"},
             {"name": "JOB_DEFINITION_PREFIX", "value": "${{USER}}_${{STAGE}}_"},
             {"name": "LOG_LEVEL", "value": "${{LOG_LEVEL}}"}
+        ],
+        "secrets": [
+            {"name": "DJANGO_SECRET_KEY", "valueFrom": "${{DJANGO_SECRET_KEY_ARN}}"},
+            {"name": "DATABASE_PASSWORD", "valueFrom": "${{DATABASE_PASSWORD_ARN}}"},
+            {"name": "RAVEN_DSN", "valueFrom": "${{RAVEN_DSN_ARN}}"},
+            {"name": "RAVEN_DSN_API", "valueFrom": "${{RAVEN_DSN_API_ARN}}"}
         ],
         "mountPoints": [
             {

--- a/workers/batch-job-templates/salmon.tpl.json
+++ b/workers/batch-job-templates/salmon.tpl.json
@@ -6,6 +6,7 @@
         "job_id": ""
     },
     "containerProperties": {
+        "executionRoleArn": "${{BATCH_EXECUTION_ROLE_ARN}}",
         "image": "${{DOCKERHUB_REPO}}/${{SALMON_DOCKER_IMAGE}}",
         "vcpus": 1,
         "memory": ${{RAM}},
@@ -26,16 +27,12 @@
         ],
         "jobRoleArn": "${{WORKER_ROLE_ARN}}",
         "environment": [
-            {"name": "DJANGO_SECRET_KEY", "value": "${{DJANGO_SECRET_KEY}}"},
             {"name": "DJANGO_DEBUG", "value": "${{DJANGO_DEBUG}}"},
             {"name": "DATABASE_NAME", "value": "${{DATABASE_NAME}}"},
             {"name": "DATABASE_USER", "value": "${{DATABASE_USER}}"},
-            {"name": "DATABASE_PASSWORD", "value": "${{DATABASE_PASSWORD}}"},
             {"name": "DATABASE_HOST", "value": "${{DATABASE_HOST}}"},
             {"name": "DATABASE_PORT", "value": "${{DATABASE_PORT}}"},
             {"name": "DATABASE_TIMEOUT", "value": "${{DATABASE_TIMEOUT}}"},
-            {"name": "RAVEN_DSN", "value": "${{RAVEN_DSN}}"},
-            {"name": "RAVEN_DSN_API", "value": "${{RAVEN_DSN_API}}"},
             {"name": "RUNNING_IN_CLOUD", "value": "${{RUNNING_IN_CLOUD}}"},
             {"name": "USE_S3", "value": "${{USE_S3}}"},
             {"name": "S3_BUCKET_NAME", "value": "${{S3_BUCKET_NAME}}"},
@@ -52,6 +49,12 @@
              "value": "${{REFINEBIO_JOB_QUEUE_ALL_NAMES}}"},
             {"name": "JOB_DEFINITION_PREFIX", "value": "${{USER}}_${{STAGE}}_"},
             {"name": "LOG_LEVEL", "value": "${{LOG_LEVEL}}"}
+        ],
+        "secrets": [
+            {"name": "DJANGO_SECRET_KEY", "valueFrom": "${{DJANGO_SECRET_KEY_ARN}}"},
+            {"name": "DATABASE_PASSWORD", "valueFrom": "${{DATABASE_PASSWORD_ARN}}"},
+            {"name": "RAVEN_DSN", "valueFrom": "${{RAVEN_DSN_ARN}}"},
+            {"name": "RAVEN_DSN_API", "valueFrom": "${{RAVEN_DSN_API_ARN}}"}
         ],
         "mountPoints": [
             {

--- a/workers/batch-job-templates/smasher.tpl.json
+++ b/workers/batch-job-templates/smasher.tpl.json
@@ -6,6 +6,7 @@
         "job_id": ""
     },
     "containerProperties": {
+        "executionRoleArn": "${{BATCH_EXECUTION_ROLE_ARN}}",
         "image": "${{DOCKERHUB_REPO}}/${{SMASHER_DOCKER_IMAGE}}",
         "vcpus": 1,
         "memory": 28000 ,
@@ -26,16 +27,12 @@
         ],
         "jobRoleArn": "${{WORKER_ROLE_ARN}}",
         "environment": [
-            {"name": "DJANGO_SECRET_KEY", "value": "${{DJANGO_SECRET_KEY}}"},
             {"name": "DJANGO_DEBUG", "value": "${{DJANGO_DEBUG}}"},
             {"name": "DATABASE_NAME", "value": "${{DATABASE_NAME}}"},
             {"name": "DATABASE_USER", "value": "${{DATABASE_USER}}"},
-            {"name": "DATABASE_PASSWORD", "value": "${{DATABASE_PASSWORD}}"},
             {"name": "DATABASE_HOST", "value": "${{DATABASE_HOST}}"},
             {"name": "DATABASE_PORT", "value": "${{DATABASE_PORT}}"},
             {"name": "DATABASE_TIMEOUT", "value": "${{DATABASE_TIMEOUT}}"},
-            {"name": "RAVEN_DSN", "value": "${{RAVEN_DSN}}"},
-            {"name": "RAVEN_DSN_API", "value": "${{RAVEN_DSN_API}}"},
             {"name": "RUNNING_IN_CLOUD", "value": "${{RUNNING_IN_CLOUD}}"},
             {"name": "USE_S3", "value": "${{USE_S3}}"},
             {"name": "S3_BUCKET_NAME", "value": "${{S3_BUCKET_NAME}}"},
@@ -53,6 +50,12 @@
              "value": "${{REFINEBIO_JOB_QUEUE_ALL_NAMES}}"},
             {"name": "JOB_DEFINITION_PREFIX", "value": "${{USER}}_${{STAGE}}_"},
             {"name": "LOG_LEVEL", "value": "${{LOG_LEVEL}}"}
+        ],
+        "secrets": [
+            {"name": "DJANGO_SECRET_KEY", "valueFrom": "${{DJANGO_SECRET_KEY_ARN}}"},
+            {"name": "DATABASE_PASSWORD", "valueFrom": "${{DATABASE_PASSWORD_ARN}}"},
+            {"name": "RAVEN_DSN", "valueFrom": "${{RAVEN_DSN_ARN}}"},
+            {"name": "RAVEN_DSN_API", "valueFrom": "${{RAVEN_DSN_API_ARN}}"}
         ],
         "mountPoints": [
             {

--- a/workers/batch-job-templates/transcriptome.tpl.json
+++ b/workers/batch-job-templates/transcriptome.tpl.json
@@ -6,6 +6,7 @@
         "job_id": ""
     },
     "containerProperties": {
+        "executionRoleArn": "${{BATCH_EXECUTION_ROLE_ARN}}",
         "image": "${{DOCKERHUB_REPO}}/${{TRANSCRIPTOME_DOCKER_IMAGE}}",
         "vcpus": 1,
         "memory": ${{RAM}},
@@ -26,16 +27,12 @@
         ],
         "jobRoleArn": "${{WORKER_ROLE_ARN}}",
         "environment": [
-            {"name": "DJANGO_SECRET_KEY", "value": "${{DJANGO_SECRET_KEY}}"},
             {"name": "DJANGO_DEBUG", "value": "${{DJANGO_DEBUG}}"},
             {"name": "DATABASE_NAME", "value": "${{DATABASE_NAME}}"},
             {"name": "DATABASE_USER", "value": "${{DATABASE_USER}}"},
-            {"name": "DATABASE_PASSWORD", "value": "${{DATABASE_PASSWORD}}"},
             {"name": "DATABASE_HOST", "value": "${{DATABASE_HOST}}"},
             {"name": "DATABASE_PORT", "value": "${{DATABASE_PORT}}"},
             {"name": "DATABASE_TIMEOUT", "value": "${{DATABASE_TIMEOUT}}"},
-            {"name": "RAVEN_DSN", "value": "${{RAVEN_DSN}}"},
-            {"name": "RAVEN_DSN_API", "value": "${{RAVEN_DSN_API}}"},
             {"name": "RUNNING_IN_CLOUD", "value": "${{RUNNING_IN_CLOUD}}"},
             {"name": "USE_S3", "value": "${{USE_S3}}"},
             {"name": "S3_BUCKET_NAME", "value": "${{S3_BUCKET_NAME}}"},
@@ -53,6 +50,12 @@
              "value": "${{REFINEBIO_JOB_QUEUE_ALL_NAMES}}"},
             {"name": "JOB_DEFINITION_PREFIX", "value": "${{USER}}_${{STAGE}}_"},
             {"name": "LOG_LEVEL", "value": "${{LOG_LEVEL}}"}
+        ],
+        "secrets": [
+            {"name": "DJANGO_SECRET_KEY", "valueFrom": "${{DJANGO_SECRET_KEY_ARN}}"},
+            {"name": "DATABASE_PASSWORD", "valueFrom": "${{DATABASE_PASSWORD_ARN}}"},
+            {"name": "RAVEN_DSN", "valueFrom": "${{RAVEN_DSN_ARN}}"},
+            {"name": "RAVEN_DSN_API", "valueFrom": "${{RAVEN_DSN_API_ARN}}"}
         ],
         "mountPoints": [
             {

--- a/workers/batch-job-templates/tximport.tpl.json
+++ b/workers/batch-job-templates/tximport.tpl.json
@@ -6,6 +6,7 @@
         "job_id": ""
     },
     "containerProperties": {
+        "executionRoleArn": "${{BATCH_EXECUTION_ROLE_ARN}}",
         "image": "${{DOCKERHUB_REPO}}/${{SALMON_DOCKER_IMAGE}}",
         "vcpus": 1,
         "memory": 32768,
@@ -26,16 +27,12 @@
         ],
         "jobRoleArn": "${{WORKER_ROLE_ARN}}",
         "environment": [
-            {"name": "DJANGO_SECRET_KEY", "value": "${{DJANGO_SECRET_KEY}}"},
             {"name": "DJANGO_DEBUG", "value": "${{DJANGO_DEBUG}}"},
             {"name": "DATABASE_NAME", "value": "${{DATABASE_NAME}}"},
             {"name": "DATABASE_USER", "value": "${{DATABASE_USER}}"},
-            {"name": "DATABASE_PASSWORD", "value": "${{DATABASE_PASSWORD}}"},
             {"name": "DATABASE_HOST", "value": "${{DATABASE_HOST}}"},
             {"name": "DATABASE_PORT", "value": "${{DATABASE_PORT}}"},
             {"name": "DATABASE_TIMEOUT", "value": "${{DATABASE_TIMEOUT}}"},
-            {"name": "RAVEN_DSN", "value": "${{RAVEN_DSN}}"},
-            {"name": "RAVEN_DSN_API", "value": "${{RAVEN_DSN_API}}"},
             {"name": "RUNNING_IN_CLOUD", "value": "${{RUNNING_IN_CLOUD}}"},
             {"name": "USE_S3", "value": "${{USE_S3}}"},
             {"name": "S3_BUCKET_NAME", "value": "${{S3_BUCKET_NAME}}"},
@@ -52,6 +49,12 @@
              "value": "${{REFINEBIO_JOB_QUEUE_ALL_NAMES}}"},
             {"name": "JOB_DEFINITION_PREFIX", "value": "${{USER}}_${{STAGE}}_"},
             {"name": "LOG_LEVEL", "value": "${{LOG_LEVEL}}"}
+        ],
+        "secrets": [
+            {"name": "DJANGO_SECRET_KEY", "valueFrom": "${{DJANGO_SECRET_KEY_ARN}}"},
+            {"name": "DATABASE_PASSWORD", "valueFrom": "${{DATABASE_PASSWORD_ARN}}"},
+            {"name": "RAVEN_DSN", "valueFrom": "${{RAVEN_DSN_ARN}}"},
+            {"name": "RAVEN_DSN_API", "valueFrom": "${{RAVEN_DSN_API_ARN}}"}
         ],
         "mountPoints": [
             {

--- a/workers/data_refinery_workers/settings.py
+++ b/workers/data_refinery_workers/settings.py
@@ -134,9 +134,14 @@ STATIC_URL = "/static/"
 # /usr/local/lib/python3.6/site-packages/raven/conf/remote.py:91:
 # UserWarning: Transport selection via DSN is deprecated. You should
 # explicitly pass the transport class to Client() instead.
-raven_dsn = get_env_variable_gracefully("RAVEN_DSN", False)
-if raven_dsn:
-    RAVEN_CONFIG = {"dsn": raven_dsn}
+RAVEN_DSN = get_env_variable_gracefully("RAVEN_DSN", None)
+
+# AWS Secrets manager will not let us store an empty string.
+if RAVEN_DSN == "None":
+    RAVEN_DSN = None
+
+if RAVEN_DSN:
+    RAVEN_CONFIG = {"dsn": RAVEN_DSN}
 else:
     # Preven raven from logging about how it's not configured...
     import logging


### PR DESCRIPTION
## Issue Number

#2584 

## Purpose/Implementation Notes

The secrets for the Batch jobs have been visible through the Batch UI. This makes them nice and safe in AWS Secrets Manager.

I also tried to fix some of the staging end to end test running in github actions. It's still untested though because it won't be tested until a deploy.

## Types of changes

- New feature (non-breaking change which adds functionality)

## Functional tests

I can run the end to end tests on my dev stack!

## Checklist

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules
