### PR TITLE
Add boto3 installation to deploybox instance data.

### DIFF
--- a/infrastructure/deploy_box_instance_data.sh
+++ b/infrastructure/deploy_box_instance_data.sh
@@ -65,6 +65,8 @@ apt-get install -y \
         unzip \
         postgresql-client
 
+pip3 install boto3
+
 usermod -aG docker ubuntu
 
 touch /var/log/docker_update.log


### PR DESCRIPTION
## Issue Number

#2601

## Purpose/Implementation Notes

There was an issue with the deploy because boto3 wasn't installed. I installed it on the box using the command I added to this script.
