### PR TITLE
Fix deploy script ordering to populate batch-job-templates sooner

### DIFF
--- a/infrastructure/deploy_box_instance_data.sh
+++ b/infrastructure/deploy_box_instance_data.sh
@@ -65,7 +65,7 @@ apt-get install -y \
         unzip \
         postgresql-client
 
-pip3 install boto3
+pip3 install boto3 awscli
 
 usermod -aG docker ubuntu
 


### PR DESCRIPTION
## Issue Number

#2601 

## Purpose/Implementation Notes

This moves some code around because the batch-job-templates dir was missing when we went to enumerate the jobs to deregister them.

 Add another python dep to the deploybox
