### PR TITLE
Fix a couple small issues with the new send_job function.

### DIFF
--- a/DEBUGGING.md
+++ b/DEBUGGING.md
@@ -88,7 +88,7 @@ from data_refinery_common.models.jobs.downloader_job import DownloaderJob
 from django.utils import timezone
 from datetime import datetime
 
-JOB_CREATED_AT_CUTOFF = datetime(2019, 9, 19, tzinfo=timezone.utc)
+JOB_CREATED_AT_CUTOFF = datetime(2021, 6, 23, tzinfo=timezone.utc)
 
 ProcessorJob.failed_objects.filter(created_at__gt=JOB_CREATED_AT_CUTOFF).exclude(
     pipeline_applied="JANITOR"

--- a/foreman/data_refinery_foreman/foreman/job_control.py
+++ b/foreman/data_refinery_foreman/foreman/job_control.py
@@ -43,9 +43,10 @@ DBCLEAN_TIME = datetime.timedelta(hours=6)
 
 
 def send_janitor_jobs():
-    """Dispatch a Janitor job for each compute environment.
+    """Dispatch a Janitor job for each job queue.
 
-    For now that's just one, but this will eventually need to loop.
+    TODO: make this dispatch janitor jobs for all job queues.
+    https://github.com/AlexsLemonade/refinebio/issues/2789
     """
     new_job = ProcessorJob(num_retries=0, pipeline_applied="JANITOR", ram_amount=2048)
     new_job.save()

--- a/foreman/data_refinery_foreman/foreman/utils.py
+++ b/foreman/data_refinery_foreman/foreman/utils.py
@@ -26,7 +26,7 @@ DESCRIBE_JOBS_PAGE_SIZE = 100
 
 # Setting this to a recent date will prevent the Foreman from queuing/requeuing
 # jobs created before this cutoff.
-JOB_CREATED_AT_CUTOFF = datetime.datetime(2019, 9, 19, tzinfo=timezone.utc)
+JOB_CREATED_AT_CUTOFF = datetime.datetime(2021, 6, 23, tzinfo=timezone.utc)
 
 
 def handle_repeated_failure(job) -> None:


### PR DESCRIPTION
## Issue Number

#2601 

## Purpose/Implementation Notes

If the job queues were full we were logging exceptions because `batch_job_queue` was `None`. We also were dispatching Janitor tests incorrectly because we were appending ram_amount onto the job name when it's not necessary and therefore incorrect.

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

I'm running end to end tests with this change now to make sure I didn't break the message queue.

## Checklist

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules
