### PR TITLE
Add script to run full pipeline locally

### DIFF
--- a/README.md
+++ b/README.md
@@ -447,26 +447,26 @@ See the [Ensembl Transcriptome Index section](#ensembl-transcriptome-indices) fo
 
 Downloader Jobs will be queued automatically when `Surveyor Jobs`
 discover new samples. However, if you just want to queue a `Downloader Job`
-yourself rather than having the Surveyor do it for you, you can use the `./workers/tester.sh`
+yourself rather than having the Surveyor do it for you, you can use the `./workers/run_job.sh`
 script:
 ```bash
-./workers/tester.sh run_downloader_job --job-name=<EXTERNAL_SOURCE> --job-id=<JOB_ID>
+./workers/run_job.sh run_downloader_job --job-name=<EXTERNAL_SOURCE> --job-id=<JOB_ID>
 ```
 
 For example:
 ```bash
-./workers/tester.sh run_downloader_job --job-name=SRA --job-id=12345
+./workers/run_job.sh run_downloader_job --job-name=SRA --job-id=12345
 ```
 
 or
 
 ```bash
-./workers/tester.sh run_downloader_job --job-name=ARRAY_EXPRESS --job-id=1
+./workers/run_job.sh run_downloader_job --job-name=ARRAY_EXPRESS --job-id=1
 ```
 
 Or for more information run:
 ```bash
-./workers/tester.sh -h
+./workers/run_job.sh -h
 ```
 
 ### Processor Jobs
@@ -476,35 +476,35 @@ However, if you just want to run a `Processor Job` without yourself without havi
 a `Downloader Job` do it for you, the following command will do so:
 
 ```bash
-./workers/tester.sh -i <IMAGE_NAME> run_processor_job --job-name=<JOB_NAME> --job-id=<JOB_ID>
+./workers/run_job.sh -i <IMAGE_NAME> run_processor_job --job-name=<JOB_NAME> --job-id=<JOB_ID>
 ```
 
 For example
 ```bash
-./workers/tester.sh -i affymetrix run_processor_job --job-name=AFFY_TO_PCL --job-id=54321
+./workers/run_job.sh -i affymetrix run_processor_job --job-name=AFFY_TO_PCL --job-id=54321
 ```
 
 or
 
 ```bash
-./workers/tester.sh -i no_op run_processor_job --job-name=NO_OP --job-id=1
+./workers/run_job.sh -i no_op run_processor_job --job-name=NO_OP --job-id=1
 ```
 
 or
 
 ```bash
-./workers/tester.sh -i salmon run_processor_job --job-name=SALMON --job-id=1
+./workers/run_job.sh -i salmon run_processor_job --job-name=SALMON --job-id=1
 ```
 
 or
 
 ```bash
-./workers/tester.sh -i transcriptome run_processor_job --job-name=TRANSCRIPTOME_INDEX_LONG --job-id=1
+./workers/run_job.sh -i transcriptome run_processor_job --job-name=TRANSCRIPTOME_INDEX_LONG --job-id=1
 ```
 
 Or for more information run:
 ```bash
-./workers/tester.sh -h
+./workers/run_job.sh -h
 ```
 
 ### Creating Quantile Normalization Reference Targets

--- a/api/data_refinery_api/views/dataset.py
+++ b/api/data_refinery_api/views/dataset.py
@@ -14,7 +14,7 @@ from drf_yasg import openapi
 from drf_yasg.utils import swagger_auto_schema
 
 from data_refinery_api.exceptions import BadRequest, InvalidData
-from data_refinery_common.job_lookup import ProcessorPipeline
+from data_refinery_common.enums import ProcessorPipeline
 from data_refinery_common.logging import get_and_configure_logger
 from data_refinery_common.message_queue import send_job
 from data_refinery_common.models import (

--- a/common/data_refinery_common/enums.py
+++ b/common/data_refinery_common/enums.py
@@ -1,0 +1,138 @@
+from enum import Enum, unique
+
+
+@unique
+class PipelineEnum(Enum):
+    """Hardcoded pipeline names."""
+
+    AGILENT_TWOCOLOR = "Agilent Two Color"
+    ARRAY_EXPRESS = "Array Express"
+    ILLUMINA = "Illumina"
+    NO_OP = "No Op"
+    SALMON = "Salmon"
+    SMASHER = "Smasher"
+    TXIMPORT = "Tximport"
+    TX_INDEX = "Transcriptome Index"
+    QN_REFERENCE = "Quantile Normalization Reference"
+    JANITOR = "Janitor"
+    CREATE_COMPENDIA = "Compendia"
+    CREATE_QUANTPENDIA = "Quantpendia"
+
+
+@unique
+class ProcessorEnum(Enum):
+    """Hardcoded processor info in each pipeline."""
+
+    # One processor in "Agilent Two Color" pipeline
+    AGILENT_TWOCOLOR = {
+        "name": "Agilent SCAN TwoColor",
+        "docker_img": "not_available_yet",
+        "yml_file": "agilent_twocolor.yml",
+    }
+
+    # One processor in "Array Express" pipeline
+    AFFYMETRIX_SCAN = {
+        "name": "Affymetrix SCAN",
+        "docker_img": "dr_affymetrix",
+        "yml_file": "affymetrix.yml",
+    }
+
+    # One processor in "Illumina" pipeline
+    ILLUMINA_SCAN = {
+        "name": "Illumina SCAN",
+        "docker_img": "dr_illumina",
+        "yml_file": "illumina.yml",
+    }
+
+    # One processor in "No Op" pipeline
+    SUBMITTER_PROCESSED = {
+        "name": "Submitter-processed",
+        "docker_img": "dr_no_op",
+        "yml_file": "no_op.yml",
+    }
+
+    # Three processors in "Salmon" pipeline
+    SALMON_QUANT = {
+        "name": "Salmon Quant",
+        "docker_img": "dr_salmon",
+        "yml_file": "salmon_quant.yml",
+    }
+    SALMONTOOLS = {"name": "Salmontools", "docker_img": "dr_salmon", "yml_file": "salmontools.yml"}
+    TXIMPORT = {"name": "Tximport", "docker_img": "dr_salmon", "yml_file": "tximport.yml"}
+
+    # One processor in "Smasher" pipeline
+    SMASHER = {"name": "Smasher", "docker_img": "dr_smasher", "yml_file": "smasher.yml"}
+
+    # One processor in "Transcriptome Index" pipeline
+    TX_INDEX = {
+        "name": "Transcriptome Index",
+        "docker_img": "dr_transcriptome",
+        "yml_file": "transcriptome_index.yml",
+    }
+
+    QN_REFERENCE = {
+        "name": "Quantile Normalization Reference",
+        "docker_img": "dr_smasher",
+        "yml_file": "qn.yml",
+    }
+
+    CREATE_COMPENDIA = {
+        "name": "Compendia Creation",
+        "docker_img": "dr_compendia",
+        "yml_file": "compendia.yml",
+    }
+
+    CREATE_QUANTPENDIA = {
+        "name": "Quantpendia Creation",
+        "docker_img": "dr_compendia",
+        "yml_file": "compendia.yml",
+    }
+
+    @classmethod
+    def has_key(cls, key):
+        """Class method that tells whether a certain key exists."""
+        return key in cls.__members__
+
+
+class ProcessorPipeline(Enum):
+    """An enumeration of supported processors"""
+
+    AFFY_TO_PCL = "AFFY_TO_PCL"
+    AGILENT_ONECOLOR_TO_PCL = "AGILENT_ONECOLOR_TO_PCL"  # Currently unsupported
+    AGILENT_TWOCOLOR_TO_PCL = "AGILENT_TWOCOLOR_TO_PCL"
+    SALMON = "SALMON"
+    TXIMPORT = "TXIMPORT"
+    ILLUMINA_TO_PCL = "ILLUMINA_TO_PCL"
+    TRANSCRIPTOME_INDEX_LONG = "TRANSCRIPTOME_INDEX_LONG"
+    TRANSCRIPTOME_INDEX_SHORT = "TRANSCRIPTOME_INDEX_SHORT"
+    SMASHER = "SMASHER"
+    NO_OP = "NO_OP"
+    QN_REFERENCE = "QN_REFERENCE"
+    JANITOR = "JANITOR"
+    NONE = "NONE"
+    CREATE_COMPENDIA = "CREATE_COMPENDIA"
+    CREATE_QUANTPENDIA = "CREATE_QUANTPENDIA"
+
+
+SMASHER_JOB_TYPES = [
+    ProcessorPipeline.SMASHER,
+    ProcessorPipeline.QN_REFERENCE,
+    ProcessorPipeline.CREATE_COMPENDIA,
+    ProcessorPipeline.CREATE_QUANTPENDIA,
+]
+
+
+class Downloaders(Enum):
+    """An enumeration of downloaders for downloader_task."""
+
+    ARRAY_EXPRESS = "ARRAY_EXPRESS"
+    SRA = "SRA"
+    TRANSCRIPTOME_INDEX = "TRANSCRIPTOME_INDEX"
+    GEO = "GEO"
+    NONE = "NONE"
+
+
+class SurveyJobTypes(Enum):
+    """An enumeration of downloaders for downloader_task."""
+
+    SURVEYOR = "SURVEYOR"

--- a/common/data_refinery_common/job_lookup.py
+++ b/common/data_refinery_common/job_lookup.py
@@ -1,132 +1,11 @@
 import re
-from enum import Enum, unique
 
 from data_refinery_common import utils
+from data_refinery_common.enums import Downloaders, ProcessorPipeline
 from data_refinery_common.logging import get_and_configure_logger
 from data_refinery_common.models import ProcessorJob, Sample
 
 logger = get_and_configure_logger(__name__)
-
-
-@unique
-class PipelineEnum(Enum):
-    """Hardcoded pipeline names."""
-
-    AGILENT_TWOCOLOR = "Agilent Two Color"
-    ARRAY_EXPRESS = "Array Express"
-    ILLUMINA = "Illumina"
-    NO_OP = "No Op"
-    SALMON = "Salmon"
-    SMASHER = "Smasher"
-    TXIMPORT = "Tximport"
-    TX_INDEX = "Transcriptome Index"
-    QN_REFERENCE = "Quantile Normalization Reference"
-    JANITOR = "Janitor"
-    CREATE_COMPENDIA = "Compendia"
-    CREATE_QUANTPENDIA = "Quantpendia"
-
-
-@unique
-class ProcessorEnum(Enum):
-    """Hardcoded processor info in each pipeline."""
-
-    # One processor in "Agilent Two Color" pipeline
-    AGILENT_TWOCOLOR = {
-        "name": "Agilent SCAN TwoColor",
-        "docker_img": "not_available_yet",
-        "yml_file": "agilent_twocolor.yml",
-    }
-
-    # One processor in "Array Express" pipeline
-    AFFYMETRIX_SCAN = {
-        "name": "Affymetrix SCAN",
-        "docker_img": "dr_affymetrix",
-        "yml_file": "affymetrix.yml",
-    }
-
-    # One processor in "Illumina" pipeline
-    ILLUMINA_SCAN = {
-        "name": "Illumina SCAN",
-        "docker_img": "dr_illumina",
-        "yml_file": "illumina.yml",
-    }
-
-    # One processor in "No Op" pipeline
-    SUBMITTER_PROCESSED = {
-        "name": "Submitter-processed",
-        "docker_img": "dr_no_op",
-        "yml_file": "no_op.yml",
-    }
-
-    # Three processors in "Salmon" pipeline
-    SALMON_QUANT = {
-        "name": "Salmon Quant",
-        "docker_img": "dr_salmon",
-        "yml_file": "salmon_quant.yml",
-    }
-    SALMONTOOLS = {"name": "Salmontools", "docker_img": "dr_salmon", "yml_file": "salmontools.yml"}
-    TXIMPORT = {"name": "Tximport", "docker_img": "dr_salmon", "yml_file": "tximport.yml"}
-
-    # One processor in "Smasher" pipeline
-    SMASHER = {"name": "Smasher", "docker_img": "dr_smasher", "yml_file": "smasher.yml"}
-
-    # One processor in "Transcriptome Index" pipeline
-    TX_INDEX = {
-        "name": "Transcriptome Index",
-        "docker_img": "dr_transcriptome",
-        "yml_file": "transcriptome_index.yml",
-    }
-
-    QN_REFERENCE = {
-        "name": "Quantile Normalization Reference",
-        "docker_img": "dr_smasher",
-        "yml_file": "qn.yml",
-    }
-
-    CREATE_COMPENDIA = {
-        "name": "Compendia Creation",
-        "docker_img": "dr_compendia",
-        "yml_file": "compendia.yml",
-    }
-
-    CREATE_QUANTPENDIA = {
-        "name": "Quantpendia Creation",
-        "docker_img": "dr_compendia",
-        "yml_file": "compendia.yml",
-    }
-
-    @classmethod
-    def has_key(cls, key):
-        """Class method that tells whether a certain key exists."""
-        return key in cls.__members__
-
-
-class ProcessorPipeline(Enum):
-    """An enumeration of supported processors"""
-
-    AFFY_TO_PCL = "AFFY_TO_PCL"
-    AGILENT_ONECOLOR_TO_PCL = "AGILENT_ONECOLOR_TO_PCL"  # Currently unsupported
-    AGILENT_TWOCOLOR_TO_PCL = "AGILENT_TWOCOLOR_TO_PCL"
-    SALMON = "SALMON"
-    TXIMPORT = "TXIMPORT"
-    ILLUMINA_TO_PCL = "ILLUMINA_TO_PCL"
-    TRANSCRIPTOME_INDEX_LONG = "TRANSCRIPTOME_INDEX_LONG"
-    TRANSCRIPTOME_INDEX_SHORT = "TRANSCRIPTOME_INDEX_SHORT"
-    SMASHER = "SMASHER"
-    NO_OP = "NO_OP"
-    QN_REFERENCE = "QN_REFERENCE"
-    JANITOR = "JANITOR"
-    NONE = "NONE"
-    CREATE_COMPENDIA = "CREATE_COMPENDIA"
-    CREATE_QUANTPENDIA = "CREATE_QUANTPENDIA"
-
-
-SMASHER_JOB_TYPES = [
-    ProcessorPipeline.SMASHER,
-    ProcessorPipeline.QN_REFERENCE,
-    ProcessorPipeline.CREATE_COMPENDIA,
-    ProcessorPipeline.CREATE_QUANTPENDIA,
-]
 
 
 def does_processor_job_have_samples(job: ProcessorJob):
@@ -135,22 +14,6 @@ def does_processor_job_have_samples(job: ProcessorJob):
         or job.pipeline_applied == ProcessorPipeline.JANITOR.value
         or job.pipeline_applied == ProcessorPipeline.QN_REFERENCE.value
     )
-
-
-class Downloaders(Enum):
-    """An enumeration of downloaders for downloader_task."""
-
-    ARRAY_EXPRESS = "ARRAY_EXPRESS"
-    SRA = "SRA"
-    TRANSCRIPTOME_INDEX = "TRANSCRIPTOME_INDEX"
-    GEO = "GEO"
-    NONE = "NONE"
-
-
-class SurveyJobTypes(Enum):
-    """An enumeration of downloaders for downloader_task."""
-
-    SURVEYOR = "SURVEYOR"
 
 
 def is_file_rnaseq(filename: str) -> bool:

--- a/common/data_refinery_common/job_management.py
+++ b/common/data_refinery_common/job_management.py
@@ -1,8 +1,8 @@
 from typing import List
 
-from data_refinery_common import job_lookup
+from data_refinery_common.enums import Downloaders, ProcessorPipeline
 from data_refinery_common.job_lookup import (
-    ProcessorPipeline,
+    determine_downloader_task,
     determine_processor_pipeline,
     determine_ram_amount,
 )
@@ -72,9 +72,9 @@ def create_downloader_job(
     if not original_downloader_job:
         sample_object = list(undownloaded_files)[0].samples.first()
         if sample_object:
-            downloader_task = job_lookup.determine_downloader_task(sample_object)
+            downloader_task = determine_downloader_task(sample_object)
 
-            if downloader_task == job_lookup.Downloaders.NONE:
+            if downloader_task == Downloaders.NONE:
                 logger.warn(
                     (
                         "No valid downloader task found for sample, which is weird"

--- a/common/data_refinery_common/message_queue.py
+++ b/common/data_refinery_common/message_queue.py
@@ -280,13 +280,17 @@ def is_job_processor(job_type):
 
 
 def send_job(job_type: Enum, job, is_dispatch=False) -> bool:
+    # There's no Batch to dispatch jobs to locally, so don't even try.
+    if not settings.RUNNING_IN_CLOUD:
+        return False
+
     job_name = get_job_name(job_type, job.id)
     is_processor = is_job_processor(job_type)
 
     if settings.AUTO_DISPATCH_BATCH_JOBS:
         # We only want to dispatch processor jobs directly.
         # Everything else will be handled by the Foreman, which will increment the retry counter.
-        should_dispatch = is_processor or is_dispatch or (not settings.RUNNING_IN_CLOUD)
+        should_dispatch = is_processor or is_dispatch
     else:
         should_dispatch = is_dispatch  # only dispatch when specifically requested to
 
@@ -334,8 +338,5 @@ def send_job(job_type: Enum, job, is_dispatch=False) -> bool:
                 reason=str(e),
             )
             raise
-    else:
-        job.num_retries = job.num_retries - 1
-        job.save()
 
     return True

--- a/common/data_refinery_common/message_queue.py
+++ b/common/data_refinery_common/message_queue.py
@@ -11,7 +11,7 @@ from django.utils import timezone
 
 import boto3
 
-from data_refinery_common.job_lookup import (
+from data_refinery_common.enums import (
     SMASHER_JOB_TYPES,
     Downloaders,
     ProcessorPipeline,

--- a/common/data_refinery_common/models/jobs/downloader_job.py
+++ b/common/data_refinery_common/models/jobs/downloader_job.py
@@ -36,7 +36,7 @@ class DownloaderJob(models.Model):
 
     # This field contains a string which corresponds to a valid
     # Downloader Task. Valid values are enumerated in:
-    # data_refinery_common.job_lookup.Downloaders
+    # data_refinery_common.enums.Downloaders
     downloader_task = models.CharField(max_length=256)
     accession_code = models.CharField(max_length=256, blank=True, null=True)
     no_retry = models.BooleanField(default=False)

--- a/common/data_refinery_common/models/original_file.py
+++ b/common/data_refinery_common/models/original_file.py
@@ -5,6 +5,7 @@ from django.db import models
 from django.utils import timezone
 
 from data_refinery_common.constants import CURRENT_SALMON_VERSION, SYSTEM_VERSION
+from data_refinery_common.enums import ProcessorPipeline
 from data_refinery_common.logging import get_and_configure_logger
 from data_refinery_common.models.managers import PublicObjectsManager
 from data_refinery_common.utils import FileUtils, calculate_file_size, calculate_sha1
@@ -127,18 +128,25 @@ class OriginalFile(models.Model):
         self.save()
 
     def has_blocking_jobs(self, own_processor_id=None) -> bool:
+        # Ignore transcriptome jobs because they always queue two jobs
+        # for the same file.
+        transcriptome_job_types = [
+            ProcessorPipeline.TRANSCRIPTOME_INDEX_LONG.value,
+            ProcessorPipeline.TRANSCRIPTOME_INDEX_SHORT.value,
+        ]
+
         # If the file has a processor job that should not have been
         # retried, then it still shouldn't be retried.
         # Exclude the ones that were aborted.
         no_retry_processor_jobs = self.processor_jobs.filter(
             no_retry=True, worker_version=SYSTEM_VERSION
-        ).exclude(abort=True)
+        ).exclude(abort=True, pipeline_applied__in=transcriptome_job_types)
 
         # If the file has a processor job that hasn't even started
         # yet, then it doesn't need another.
         incomplete_processor_jobs = self.processor_jobs.filter(
             end_time__isnull=True, success__isnull=True, retried=False
-        )
+        ).exclude(pipeline_applied__in=transcriptome_job_types)
 
         if own_processor_id:
             incomplete_processor_jobs = incomplete_processor_jobs.exclude(id=own_processor_id)

--- a/common/data_refinery_common/rna_seq.py
+++ b/common/data_refinery_common/rna_seq.py
@@ -2,7 +2,7 @@ from typing import List
 
 from django.db.models import OuterRef, Subquery
 
-from data_refinery_common.job_lookup import ProcessorEnum
+from data_refinery_common.enums import ProcessorEnum
 from data_refinery_common.logging import get_and_configure_logger
 from data_refinery_common.models import ComputationalResult, Experiment
 from data_refinery_common.utils import get_env_variable

--- a/foreman/data_refinery_foreman/foreman/downloader_job_manager.py
+++ b/foreman/data_refinery_foreman/foreman/downloader_job_manager.py
@@ -1,7 +1,7 @@
 from typing import List
 
 import data_refinery_foreman.foreman.utils as utils
-from data_refinery_common.job_lookup import Downloaders
+from data_refinery_common.enums import Downloaders
 from data_refinery_common.logging import get_and_configure_logger
 from data_refinery_common.message_queue import get_capacity_for_downloader_jobs, send_job
 from data_refinery_common.models import DownloaderJob

--- a/foreman/data_refinery_foreman/foreman/job_control.py
+++ b/foreman/data_refinery_foreman/foreman/job_control.py
@@ -4,7 +4,7 @@ import time
 from django.conf import settings
 from django.utils import timezone
 
-from data_refinery_common.job_lookup import ProcessorPipeline
+from data_refinery_common.enums import ProcessorPipeline
 from data_refinery_common.logging import get_and_configure_logger
 from data_refinery_common.message_queue import send_job
 from data_refinery_common.models import ComputedFile, ProcessorJob

--- a/foreman/data_refinery_foreman/foreman/job_requeuing.py
+++ b/foreman/data_refinery_foreman/foreman/job_requeuing.py
@@ -1,4 +1,4 @@
-from data_refinery_common.job_lookup import Downloaders, ProcessorPipeline, SurveyJobTypes
+from data_refinery_common.enums import Downloaders, ProcessorPipeline, SurveyJobTypes
 from data_refinery_common.logging import get_and_configure_logger
 from data_refinery_common.message_queue import send_job
 from data_refinery_common.models import (

--- a/foreman/data_refinery_foreman/foreman/management/commands/create_compendia.py
+++ b/foreman/data_refinery_foreman/foreman/management/commands/create_compendia.py
@@ -4,7 +4,7 @@ from django.core.management.base import BaseCommand
 from django.db.models.aggregates import Count
 from django.db.models.expressions import Q
 
-from data_refinery_common.job_lookup import ProcessorPipeline
+from data_refinery_common.enums import ProcessorPipeline
 from data_refinery_common.logging import get_and_configure_logger
 from data_refinery_common.message_queue import send_job
 from data_refinery_common.models import (

--- a/foreman/data_refinery_foreman/foreman/management/commands/create_quantpendia.py
+++ b/foreman/data_refinery_foreman/foreman/management/commands/create_quantpendia.py
@@ -3,7 +3,7 @@ import time
 
 from django.core.management.base import BaseCommand
 
-from data_refinery_common.job_lookup import ProcessorPipeline
+from data_refinery_common.enums import ProcessorPipeline
 from data_refinery_common.logging import get_and_configure_logger
 from data_refinery_common.message_queue import send_job
 from data_refinery_common.models import (

--- a/foreman/data_refinery_foreman/foreman/management/commands/get_job_to_be_run.py
+++ b/foreman/data_refinery_foreman/foreman/management/commands/get_job_to_be_run.py
@@ -1,0 +1,61 @@
+import json
+
+from django.core.management.base import BaseCommand
+
+from data_refinery_common.models import DownloaderJob, ProcessorJob
+
+
+class Command(BaseCommand):
+    def handle(self, *args, **options):
+        """Outputs a JSON dict of a job that need to be run.
+
+        The most recently created unstarted ProcessorJob will be prioritized.
+
+        If there are no unstarted ProcessorJobs, then the most
+        recently created unstarted DownloaderJob will be prioritized.
+
+        The dict will have two top level keys: downloader_jobs and processor_jobs.
+        The JSON output will be a dict containing the following keys:
+        * job_name
+        * job_id
+        * image_name
+        * job_type
+        """
+        processor_jobs_to_run = [
+            "AFFY_TO_PCL",
+            "SALMON",
+            "TXIMPORT",
+            "ILLUMINA_TO_PCL",
+            "TRANSCRIPTOME_INDEX_LONG",
+            "TRANSCRIPTOME_INDEX_SHORT",
+            "NO_OP",
+        ]
+        processor_job = (
+            ProcessorJob.objects.filter(
+                start_time=None, success=None, pipeline_applied__in=processor_jobs_to_run
+            )
+            .order_by("-id")
+            .first()
+        )
+        if processor_job:
+            job_dict = {
+                "job_id": processor_job.id,
+                "job_type": "ProcessorJob",
+                "job_name": processor_job.pipeline_applied,
+            }
+            print(json.dumps(job_dict))
+            return
+
+        downloader_job = (
+            DownloaderJob.objects.filter(start_time=None, success=None).order_by("-id").first()
+        )
+        if downloader_job:
+            job_dict = {
+                "job_id": downloader_job.id,
+                "job_type": "DownloaderJob",
+                "job_name": downloader_job.downloader_task,
+            }
+            print(json.dumps(job_dict))
+            return
+
+        print("{}")

--- a/foreman/data_refinery_foreman/foreman/management/commands/get_job_to_be_run.py
+++ b/foreman/data_refinery_foreman/foreman/management/commands/get_job_to_be_run.py
@@ -14,7 +14,6 @@ class Command(BaseCommand):
         If there are no unstarted ProcessorJobs, then the most
         recently created unstarted DownloaderJob will be prioritized.
 
-        The dict will have two top level keys: downloader_jobs and processor_jobs.
         The JSON output will be a dict containing the following keys:
         * job_name
         * job_id

--- a/foreman/data_refinery_foreman/foreman/management/commands/organism_shepherd.py
+++ b/foreman/data_refinery_foreman/foreman/management/commands/organism_shepherd.py
@@ -10,7 +10,7 @@ from typing import Dict, List
 
 from django.core.management.base import BaseCommand
 
-from data_refinery_common.job_lookup import Downloaders, ProcessorPipeline
+from data_refinery_common.enums import Downloaders, ProcessorPipeline
 from data_refinery_common.logging import get_and_configure_logger
 from data_refinery_common.message_queue import get_capacity_for_jobs, send_job
 from data_refinery_common.models import (

--- a/foreman/data_refinery_foreman/foreman/management/commands/rerun_salmon_old_samples.py
+++ b/foreman/data_refinery_foreman/foreman/management/commands/rerun_salmon_old_samples.py
@@ -8,7 +8,7 @@ from django.core.management.base import BaseCommand
 from django.db.models import Count
 from django.db.models.expressions import Q
 
-from data_refinery_common.job_lookup import ProcessorEnum, ProcessorPipeline
+from data_refinery_common.enums import ProcessorEnum, ProcessorPipeline
 from data_refinery_common.job_management import create_downloader_job
 from data_refinery_common.logging import get_and_configure_logger
 from data_refinery_common.models import Experiment, ProcessorJob

--- a/foreman/data_refinery_foreman/foreman/management/commands/run_tximport.py
+++ b/foreman/data_refinery_foreman/foreman/management/commands/run_tximport.py
@@ -11,7 +11,7 @@ from typing import List
 from django.core.management.base import BaseCommand
 from django.db.models import Count
 
-from data_refinery_common.job_lookup import ProcessorPipeline
+from data_refinery_common.enums import ProcessorPipeline
 from data_refinery_common.logging import get_and_configure_logger
 from data_refinery_common.message_queue import send_job
 from data_refinery_common.models import (

--- a/foreman/data_refinery_foreman/foreman/management/commands/test_organism_shepherd.py
+++ b/foreman/data_refinery_foreman/foreman/management/commands/test_organism_shepherd.py
@@ -4,7 +4,7 @@ from django.core.management import call_command
 from django.test import TransactionTestCase
 from django.utils import timezone
 
-from data_refinery_common.job_lookup import ProcessorPipeline
+from data_refinery_common.enums import ProcessorPipeline
 from data_refinery_common.models import (
     DownloaderJob,
     DownloaderJobOriginalFileAssociation,

--- a/foreman/data_refinery_foreman/foreman/management/commands/test_rerun_salmon_old_samples.py
+++ b/foreman/data_refinery_foreman/foreman/management/commands/test_rerun_salmon_old_samples.py
@@ -3,16 +3,13 @@ from typing import Dict, List
 
 from django.test import TestCase
 
-from data_refinery_common.job_lookup import ProcessorPipeline
+from data_refinery_common.enums import ProcessorPipeline
 from data_refinery_common.models import (
     ComputationalResult,
     ComputationalResultAnnotation,
     ComputedFile,
     DownloaderJob,
-    DownloaderJobOriginalFileAssociation,
     Experiment,
-    ExperimentOrganismAssociation,
-    ExperimentResultAssociation,
     ExperimentSampleAssociation,
     Organism,
     OrganismIndex,
@@ -247,7 +244,8 @@ class RerunSalmonTestCase(TestCase):
         setup_experiment(["AA001", "AA002"], [])
         update_salmon_all_experiments()
 
-        # Verify that no jobs were created, because all samples had been processed with the latest version
+        # Verify that no jobs were created, because all samples had
+        # been processed with the latest version
         dl_jobs = DownloaderJob.objects.all()
         self.assertEqual(dl_jobs.count(), 0)
 

--- a/foreman/data_refinery_foreman/foreman/management/commands/test_run_tximport.py
+++ b/foreman/data_refinery_foreman/foreman/management/commands/test_run_tximport.py
@@ -4,7 +4,7 @@ from unittest.mock import patch
 
 from django.test import TestCase
 
-from data_refinery_common.job_lookup import ProcessorPipeline
+from data_refinery_common.enums import ProcessorPipeline
 from data_refinery_common.models import (
     ComputationalResult,
     ComputationalResultAnnotation,

--- a/foreman/data_refinery_foreman/foreman/processor_job_manager.py
+++ b/foreman/data_refinery_foreman/foreman/processor_job_manager.py
@@ -1,7 +1,7 @@
 from typing import List
 
 import data_refinery_foreman.foreman.utils as utils
-from data_refinery_common.job_lookup import ProcessorPipeline
+from data_refinery_common.enums import ProcessorPipeline
 from data_refinery_common.logging import get_and_configure_logger
 from data_refinery_common.message_queue import get_capacity_for_jobs, send_job
 from data_refinery_common.models import ProcessorJob

--- a/foreman/data_refinery_foreman/foreman/survey_job_manager.py
+++ b/foreman/data_refinery_foreman/foreman/survey_job_manager.py
@@ -1,7 +1,7 @@
 from typing import List
 
 import data_refinery_foreman.foreman.utils as utils
-from data_refinery_common.job_lookup import SurveyJobTypes
+from data_refinery_common.enums import SurveyJobTypes
 from data_refinery_common.logging import get_and_configure_logger
 from data_refinery_common.message_queue import get_capacity_for_jobs, send_job
 from data_refinery_common.models import SurveyJob

--- a/foreman/data_refinery_foreman/surveyor/array_express.py
+++ b/foreman/data_refinery_foreman/surveyor/array_express.py
@@ -2,7 +2,7 @@ from typing import Dict, List
 
 from django.utils.dateparse import parse_date
 
-from data_refinery_common.job_lookup import Downloaders
+from data_refinery_common.enums import Downloaders
 from data_refinery_common.logging import get_and_configure_logger
 from data_refinery_common.models import (
     Experiment,

--- a/foreman/data_refinery_foreman/surveyor/external_source.py
+++ b/foreman/data_refinery_foreman/surveyor/external_source.py
@@ -1,7 +1,9 @@
 import abc
 from typing import List
 
-from data_refinery_common import job_lookup, logging
+from data_refinery_common import logging
+from data_refinery_common.enums import Downloaders
+from data_refinery_common.job_lookup import determine_downloader_task
 from data_refinery_common.message_queue import send_job
 from data_refinery_common.models import (
     DownloaderJob,
@@ -67,9 +69,9 @@ class ExternalSourceSurveyor:
                 continue
 
             sample_object = original_file.samples.first()
-            downloader_task = job_lookup.determine_downloader_task(sample_object)
+            downloader_task = determine_downloader_task(sample_object)
 
-            if downloader_task == job_lookup.Downloaders.NONE:
+            if downloader_task == Downloaders.NONE:
                 logger.info(
                     "No valid downloader task found for sample.",
                     sample=sample_object.id,
@@ -109,7 +111,7 @@ class ExternalSourceSurveyor:
         # Transcriptome is a special case because there's no sample_object.
         # It's alright to re-process transcriptome indices.
         if is_transcriptome:
-            downloader_task = job_lookup.Downloaders.TRANSCRIPTOME_INDEX
+            downloader_task = Downloaders.TRANSCRIPTOME_INDEX
         else:
             source_urls = [original_file.source_url for original_file in original_files]
             # There is already a downloader job associated with this file.
@@ -123,9 +125,9 @@ class ExternalSourceSurveyor:
                 return False
 
             sample_object = original_files[0].samples.first()
-            downloader_task = job_lookup.determine_downloader_task(sample_object)
+            downloader_task = determine_downloader_task(sample_object)
 
-        if downloader_task == job_lookup.Downloaders.NONE:
+        if downloader_task == Downloaders.NONE:
             logger.info(
                 "No valid downloader task found for sample.",
                 sample=sample_object.id,

--- a/foreman/data_refinery_foreman/surveyor/geo.py
+++ b/foreman/data_refinery_foreman/surveyor/geo.py
@@ -5,7 +5,7 @@ from typing import Dict, List
 import dateutil.parser
 import GEOparse
 
-from data_refinery_common.job_lookup import Downloaders
+from data_refinery_common.enums import Downloaders
 from data_refinery_common.logging import get_and_configure_logger
 from data_refinery_common.models import (
     Experiment,

--- a/foreman/data_refinery_foreman/surveyor/management/commands/dispatch_qn_jobs.py
+++ b/foreman/data_refinery_foreman/surveyor/management/commands/dispatch_qn_jobs.py
@@ -1,7 +1,7 @@
 from django.core.management.base import BaseCommand
 from django.db.models import Count
 
-from data_refinery_common.job_lookup import ProcessorPipeline
+from data_refinery_common.enums import ProcessorPipeline
 from data_refinery_common.logging import get_and_configure_logger
 from data_refinery_common.message_queue import send_job
 from data_refinery_common.models import (

--- a/foreman/data_refinery_foreman/surveyor/sra.py
+++ b/foreman/data_refinery_foreman/surveyor/sra.py
@@ -5,7 +5,7 @@ from typing import Dict, List
 
 from django.utils.dateparse import parse_date
 
-from data_refinery_common.job_lookup import Downloaders
+from data_refinery_common.enums import Downloaders
 from data_refinery_common.logging import get_and_configure_logger
 from data_refinery_common.models import (
     Experiment,

--- a/foreman/data_refinery_foreman/surveyor/test_transcriptome_index.py
+++ b/foreman/data_refinery_foreman/surveyor/test_transcriptome_index.py
@@ -5,7 +5,7 @@ from django.test import TestCase
 
 import vcr
 
-from data_refinery_common.job_lookup import Downloaders
+from data_refinery_common.enums import Downloaders
 from data_refinery_common.models import DownloaderJob, Organism, SurveyJob, SurveyJobKeyValue
 from data_refinery_foreman.surveyor.transcriptome_index import TranscriptomeIndexSurveyor
 

--- a/foreman/data_refinery_foreman/surveyor/transcriptome_index.py
+++ b/foreman/data_refinery_foreman/surveyor/transcriptome_index.py
@@ -1,11 +1,10 @@
 import csv
 import re
-import shutil
 import urllib
 from abc import ABC
 from typing import Dict, List
 
-from data_refinery_common.job_lookup import Downloaders
+from data_refinery_common.enums import Downloaders
 from data_refinery_common.logging import get_and_configure_logger
 from data_refinery_common.models import Organism, OriginalFile, SurveyJobKeyValue
 from data_refinery_foreman.surveyor import utils

--- a/scripts/reinit_database.sh
+++ b/scripts/reinit_database.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+# Reintializes the database so there's no data or migrations run against it.
+
+
+# This script should always run as if it were being called from
+# the directory it lives in.
+script_directory="$(perl -e 'use File::Basename;
+ use Cwd "abs_path";
+ print dirname(abs_path(@ARGV[0]));' -- "$0")"
+cd "$script_directory" || exit
+
+# Clear it out.
+docker rm -f drdb
+echo "sudo is required to delete the existing postgres volume because Docker."
+sudo rm -r ../volumes_postgres
+
+# Get it goin' again.
+./run_postgres.sh
+sleep 10
+./install_db_docker.sh
+./update_models.sh

--- a/scripts/run_full_pipeline.py
+++ b/scripts/run_full_pipeline.py
@@ -22,8 +22,7 @@ def parse_args():
 
 def get_job_to_run():
     completed_command = subprocess.run(
-        ["./foreman/run_surveyor.sh", "get_job_to_be_run"],
-        stdout=subprocess.PIPE,  # capture_output=True
+        ["./foreman/run_surveyor.sh", "get_job_to_be_run"], stdout=subprocess.PIPE,
     )
 
     # The JSON output is on the last line of the output, but it has a
@@ -56,30 +55,22 @@ def run_job(job):
         elif job_name == "NO_OP":
             image_name = "no_op"
 
-    completed_command = subprocess.check_call(
+    subprocess.check_call(
         [
             "./workers/run_job.sh",
             "-i",
             image_name,
             subcommand,
             f"--job-name={job_name}",
-            # job_name,
             f"--job-id={job_id}",
-            # str(job_id),
         ]
     )
 
-    if completed_command != 0:
-        print(f"{job_name} Job with id {job_id} failed!")
-
 
 def survey_accession(accession_code):
-    completed_command = subprocess.check_call(
+    subprocess.check_call(
         ["./foreman/run_surveyor.sh", "survey_all", "--accession", accession_code]
     )
-
-    if completed_command != 0:
-        print(f"The Survey Job failed!")
 
 
 def run_full_pipeline(accession_code):

--- a/scripts/run_full_pipeline.py
+++ b/scripts/run_full_pipeline.py
@@ -1,0 +1,99 @@
+import argparse
+import json
+import subprocess
+
+
+def parse_args():
+    description = """This script can be used to run the full pipeline.
+    This includes surveyor jobs queuing downloader jobs, which in turn should queue processor jobs.
+    This includes Microarray experiments, RNA-Seq experiments, and transcriptome indices.
+    This script must be run from the top level directory of the refinebio repository.!"""
+    parser = argparse.ArgumentParser(description=description)
+
+    accession_help_text = """Specify the accession_code of the experiment to survey.
+    If creating a Transcriptome Index an organism name like 'Homo
+    Sapiens' should be supplied if the organism is in the main
+    division of Ensembl. If the organism is in any other division it
+    should be specified like 'Arabidopsis thaliana, EnsemblPlants'."""
+    parser.add_argument("accession_code", help=accession_help_text)
+
+    return parser.parse_args()
+
+
+def get_job_to_run():
+    completed_command = subprocess.run(
+        ["./foreman/run_surveyor.sh", "get_job_to_be_run"],
+        stdout=subprocess.PIPE,  # capture_output=True
+    )
+
+    # The JSON output is on the last line of the output, but it has a
+    # newline as well.
+    last_line = completed_command.stdout.decode("utf-8").split("\n")[-2].strip()
+    if completed_command.returncode == 0:
+        return json.loads(last_line)
+
+
+def run_job(job):
+    job_name = job["job_name"]
+    job_id = job["job_id"]
+    print(f"Running {job_name} Job with id {job_id}!")
+
+    image_name = ""
+    if job["job_type"] == "DownloaderJob":
+        subcommand = "run_downloader_job"
+        image_name = "downloaders"
+    else:
+        subcommand = "run_processor_job"
+
+        if job_name == "AFFY_TO_PCL":
+            image_name = "affymetrix"
+        elif job_name == "SALMON":
+            image_name = "salmon"
+        elif job_name == "ILLUMINA_TO_PCL":
+            image_name == "illumina"
+        elif job_name in ["TRANSCRIPTOME_INDEX_LONG", "TRANSCRIPTOME_INDEX_SHORT"]:
+            image_name = "transcriptome"
+        elif job_name == "NO_OP":
+            image_name = "no_op"
+
+    completed_command = subprocess.check_call(
+        [
+            "./workers/run_job.sh",
+            "-i",
+            image_name,
+            subcommand,
+            f"--job-name={job_name}",
+            # job_name,
+            f"--job-id={job_id}",
+            # str(job_id),
+        ]
+    )
+
+    if completed_command != 0:
+        print(f"{job_name} Job with id {job_id} failed!")
+
+
+def survey_accession(accession_code):
+    completed_command = subprocess.check_call(
+        ["./foreman/run_surveyor.sh", "survey_all", "--accession", accession_code]
+    )
+
+    if completed_command != 0:
+        print(f"The Survey Job failed!")
+
+
+def run_full_pipeline(accession_code):
+    survey_accession(accession_code)
+
+    job_to_run = get_job_to_run()
+
+    while job_to_run:
+        run_job(job_to_run)
+
+        job_to_run = get_job_to_run()
+
+
+if __name__ == "__main__":
+    args = parse_args()
+
+    run_full_pipeline(args.accession_code)

--- a/workers/data_refinery_workers/downloaders/management/commands/run_downloader_job.py
+++ b/workers/data_refinery_workers/downloaders/management/commands/run_downloader_job.py
@@ -2,7 +2,7 @@ import sys
 
 from django.core.management.base import BaseCommand
 
-from data_refinery_common.job_lookup import Downloaders
+from data_refinery_common.enums import Downloaders
 from data_refinery_common.logging import get_and_configure_logger
 from data_refinery_workers.downloaders.array_express import download_array_express
 from data_refinery_workers.downloaders.geo import download_geo
@@ -17,7 +17,7 @@ class Command(BaseCommand):
         parser.add_argument(
             "--job-name",
             type=str,
-            help=("The downloader job's name. Must be enumerated in job_lookup."),
+            help=("The downloader job's name. Must be enumerated in data_refinery_common.enums."),
         )
         parser.add_argument("--job-id", type=int, help=("The downloader job's ID."))
 

--- a/workers/data_refinery_workers/downloaders/transcriptome_index.py
+++ b/workers/data_refinery_workers/downloaders/transcriptome_index.py
@@ -3,7 +3,7 @@ import shutil
 import urllib.request
 from contextlib import closing
 
-from data_refinery_common.job_lookup import ProcessorPipeline
+from data_refinery_common.enums import ProcessorPipeline
 from data_refinery_common.logging import get_and_configure_logger
 from data_refinery_common.message_queue import send_job
 from data_refinery_common.models import (

--- a/workers/data_refinery_workers/processors/agilent_twocolor.py
+++ b/workers/data_refinery_workers/processors/agilent_twocolor.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, unicode_literals
-
 import os
 import warnings
 from typing import Dict
@@ -9,7 +7,7 @@ from django.utils import timezone
 import rpy2.robjects as ro
 from rpy2.rinterface import RRuntimeError
 
-from data_refinery_common.job_lookup import PipelineEnum
+from data_refinery_common.enums import PipelineEnum
 from data_refinery_common.logging import get_and_configure_logger
 from data_refinery_common.models import (
     ComputationalResult,
@@ -34,7 +32,8 @@ def _prepare_files(job_context: Dict) -> Dict:
     """
     original_file = job_context["original_files"][0]
     job_context["input_file_path"] = original_file.absolute_file_path
-    # Turns /home/user/data_store/E-GEOD-8607/raw/foo.txt into /home/user/data_store/E-GEOD-8607/processed/foo.cel
+    # Turns /home/user/data_store/E-GEOD-8607/raw/foo.txt
+    # into /home/user/data_store/E-GEOD-8607/processed/foo.cel
     pre_part = original_file.absolute_file_path.split("/")[:-2]
     end_part = original_file.absolute_file_path.split("/")[-1]
 
@@ -80,8 +79,12 @@ def _run_scan_twocolor(job_context: Dict) -> Dict:
         # There is a bug in Bioconductor that causes this, but it happens
         # _after_ our output file is made and written to disk so..
         # we can ignore it!
-        # See it for yourself here: https://github.com/Miserlou/SCAN.UPC/blob/master/R/TwoColor.R#L122
-        bugstring = 'Error in sampleNames(expressionSet) = sampleNames : \n  could not find function "sampleNames<-"\n'
+        # See it for yourself here:
+        # https://github.com/Miserlou/SCAN.UPC/blob/master/R/TwoColor.R#L122
+        bugstring = (
+            "Error in sampleNames(expressionSet) = sampleNames : \n  "
+            'could not find function "sampleNames<-"\n'
+        )
         if str(e) == bugstring:
             job_context["time_end"] = timezone.now()
             job_context["success"] = True

--- a/workers/data_refinery_workers/processors/array_express.py
+++ b/workers/data_refinery_workers/processors/array_express.py
@@ -8,7 +8,7 @@ from django.utils import timezone
 import rpy2.robjects as ro
 from rpy2.rinterface import RRuntimeError
 
-from data_refinery_common.job_lookup import PipelineEnum
+from data_refinery_common.enums import PipelineEnum
 from data_refinery_common.logging import get_and_configure_logger
 from data_refinery_common.models import (
     ComputationalResult,

--- a/workers/data_refinery_workers/processors/create_compendia.py
+++ b/workers/data_refinery_workers/processors/create_compendia.py
@@ -13,7 +13,7 @@ import pandas as pd
 import psutil
 from fancyimpute import IterativeSVD
 
-from data_refinery_common.job_lookup import PipelineEnum
+from data_refinery_common.enums import PipelineEnum
 from data_refinery_common.logging import get_and_configure_logger
 from data_refinery_common.models import (
     CompendiumResult,

--- a/workers/data_refinery_workers/processors/create_quantpendia.py
+++ b/workers/data_refinery_workers/processors/create_quantpendia.py
@@ -9,7 +9,7 @@ from django.utils import timezone
 
 import psutil
 
-from data_refinery_common.job_lookup import PipelineEnum
+from data_refinery_common.enums import PipelineEnum
 from data_refinery_common.logging import get_and_configure_logger
 from data_refinery_common.models import (
     CompendiumResult,

--- a/workers/data_refinery_workers/processors/illumina.py
+++ b/workers/data_refinery_workers/processors/illumina.py
@@ -10,7 +10,7 @@ from django.utils import timezone
 import numpy as np
 import pandas as pd
 
-from data_refinery_common.job_lookup import PipelineEnum, ProcessorPipeline
+from data_refinery_common.enums import PipelineEnum, ProcessorPipeline
 from data_refinery_common.logging import get_and_configure_logger
 from data_refinery_common.message_queue import send_job
 from data_refinery_common.models import (

--- a/workers/data_refinery_workers/processors/janitor.py
+++ b/workers/data_refinery_workers/processors/janitor.py
@@ -3,7 +3,7 @@ import shutil
 
 import boto3
 
-from data_refinery_common.job_lookup import PipelineEnum
+from data_refinery_common.enums import PipelineEnum
 from data_refinery_common.logging import get_and_configure_logger
 from data_refinery_common.models import Pipeline, ProcessorJob, Sample
 from data_refinery_common.utils import get_env_variable

--- a/workers/data_refinery_workers/processors/management/commands/qn_dispatcher.py
+++ b/workers/data_refinery_workers/processors/management/commands/qn_dispatcher.py
@@ -1,7 +1,7 @@
 from django.core.management.base import BaseCommand
 from django.db.models import Count
 
-from data_refinery_common.job_lookup import ProcessorPipeline
+from data_refinery_common.enums import ProcessorPipeline
 from data_refinery_common.logging import get_and_configure_logger
 from data_refinery_common.message_queue import send_job
 from data_refinery_common.models import (

--- a/workers/data_refinery_workers/processors/management/commands/run_processor_job.py
+++ b/workers/data_refinery_workers/processors/management/commands/run_processor_job.py
@@ -2,7 +2,7 @@ import sys
 
 from django.core.management.base import BaseCommand
 
-from data_refinery_common.job_lookup import ProcessorPipeline
+from data_refinery_common.enums import ProcessorPipeline
 from data_refinery_common.logging import get_and_configure_logger
 
 logger = get_and_configure_logger(__name__)
@@ -14,7 +14,7 @@ class Command(BaseCommand):
         parser.add_argument(
             "--job-name",
             type=str,
-            help=("The processor job's name. Must be enumerated in job_lookup."),
+            help=("The processor job's name. Must be enumerated in data_refinery_common.enums."),
         )
         parser.add_argument("--job-id", type=int, help=("The processor job's ID."))
 

--- a/workers/data_refinery_workers/processors/no_op.py
+++ b/workers/data_refinery_workers/processors/no_op.py
@@ -3,7 +3,7 @@ import os
 import subprocess
 from typing import Dict
 
-from data_refinery_common.job_lookup import PipelineEnum
+from data_refinery_common.enums import PipelineEnum
 from data_refinery_common.logging import get_and_configure_logger
 from data_refinery_common.models import (
     ComputationalResult,

--- a/workers/data_refinery_workers/processors/qn_reference.py
+++ b/workers/data_refinery_workers/processors/qn_reference.py
@@ -6,7 +6,7 @@ from django.utils import timezone
 
 import pandas as pd
 
-from data_refinery_common.job_lookup import PipelineEnum
+from data_refinery_common.enums import PipelineEnum
 from data_refinery_common.logging import get_and_configure_logger
 from data_refinery_common.models import (
     ComputationalResult,

--- a/workers/data_refinery_workers/processors/salmon.py
+++ b/workers/data_refinery_workers/processors/salmon.py
@@ -16,7 +16,7 @@ import pandas as pd
 import untangle
 from botocore.client import Config
 
-from data_refinery_common.job_lookup import PipelineEnum
+from data_refinery_common.enums import PipelineEnum
 from data_refinery_common.logging import get_and_configure_logger
 from data_refinery_common.models import (
     ComputationalResult,

--- a/workers/data_refinery_workers/processors/smasher.py
+++ b/workers/data_refinery_workers/processors/smasher.py
@@ -19,7 +19,7 @@ import requests
 from botocore.exceptions import ClientError
 from sklearn import preprocessing
 
-from data_refinery_common.job_lookup import PipelineEnum
+from data_refinery_common.enums import PipelineEnum
 from data_refinery_common.logging import get_and_configure_logger
 from data_refinery_common.models import ComputedFile, Pipeline
 from data_refinery_common.utils import calculate_file_size, calculate_sha1, get_env_variable

--- a/workers/data_refinery_workers/processors/test_compendia.py
+++ b/workers/data_refinery_workers/processors/test_compendia.py
@@ -2,7 +2,7 @@ import os
 
 from django.test import TransactionTestCase, tag
 
-from data_refinery_common.job_lookup import ProcessorPipeline
+from data_refinery_common.enums import ProcessorPipeline
 from data_refinery_common.models import (
     ComputationalResult,
     ComputationalResultAnnotation,
@@ -11,15 +11,11 @@ from data_refinery_common.models import (
     Experiment,
     ExperimentSampleAssociation,
     Organism,
-    OriginalFile,
     ProcessorJob,
     ProcessorJobDatasetAssociation,
-    ProcessorJobOriginalFileAssociation,
     Sample,
-    SampleAnnotation,
     SampleComputedFileAssociation,
     SampleResultAssociation,
-    SurveyJob,
 )
 from data_refinery_workers.processors import create_compendia
 

--- a/workers/data_refinery_workers/processors/test_create_quantpendia.py
+++ b/workers/data_refinery_workers/processors/test_create_quantpendia.py
@@ -2,7 +2,7 @@ import os
 
 from django.test import TransactionTestCase, tag
 
-from data_refinery_common.job_lookup import ProcessorPipeline
+from data_refinery_common.enums import ProcessorPipeline
 from data_refinery_common.models import (
     ComputationalResult,
     ComputedFile,

--- a/workers/data_refinery_workers/processors/test_salmon.py
+++ b/workers/data_refinery_workers/processors/test_salmon.py
@@ -10,7 +10,7 @@ from django.test import TestCase, tag
 import numpy
 import scipy.stats
 
-from data_refinery_common.job_lookup import ProcessorEnum
+from data_refinery_common.enums import ProcessorEnum
 from data_refinery_common.models import (
     ComputationalResult,
     ComputationalResultAnnotation,

--- a/workers/data_refinery_workers/processors/transcriptome_index.py
+++ b/workers/data_refinery_workers/processors/transcriptome_index.py
@@ -7,7 +7,7 @@ from typing import Dict
 
 from django.utils import timezone
 
-from data_refinery_common.job_lookup import PipelineEnum
+from data_refinery_common.enums import PipelineEnum
 from data_refinery_common.logging import get_and_configure_logger
 from data_refinery_common.models import (
     ComputationalResult,

--- a/workers/data_refinery_workers/processors/tximport.py
+++ b/workers/data_refinery_workers/processors/tximport.py
@@ -4,7 +4,7 @@ from typing import Dict
 import boto3
 from botocore.client import Config
 
-from data_refinery_common.job_lookup import PipelineEnum
+from data_refinery_common.enums import PipelineEnum
 from data_refinery_common.logging import get_and_configure_logger
 from data_refinery_common.models import Pipeline
 from data_refinery_common.utils import get_env_variable

--- a/workers/data_refinery_workers/processors/utils.py
+++ b/workers/data_refinery_workers/processors/utils.py
@@ -14,7 +14,7 @@ from django.utils import timezone
 
 import yaml
 
-from data_refinery_common.job_lookup import SMASHER_JOB_TYPES, ProcessorEnum, ProcessorPipeline
+from data_refinery_common.enums import SMASHER_JOB_TYPES, ProcessorEnum, ProcessorPipeline
 from data_refinery_common.job_management import create_downloader_job
 from data_refinery_common.logging import get_and_configure_logger
 from data_refinery_common.models import Processor, ProcessorJob, Sample

--- a/workers/run_job.sh
+++ b/workers/run_job.sh
@@ -40,8 +40,8 @@ while getopts "hi:" opt; do
             echo "     AGILENT_TWOCOLOR_TO_PCL is a special case because it requires the 'affymetrix' image."
             echo ""
             echo "Examples:"
-            echo "    ./workers/tester.sh run_downloader_job --job-name=SRA --job-id=12345"
-            echo "    ./workers/tester.sh -i affymetrix run_processor_job --job-name=AGILENT_TWOCOLOR_TO_PCL --job-id=54321"
+            echo "    ./workers/run_job.sh run_downloader_job --job-name=SRA --job-id=12345"
+            echo "    ./workers/run_job.sh -i affymetrix run_processor_job --job-name=AGILENT_TWOCOLOR_TO_PCL --job-id=54321"
             exit 0
             ;;
         \?)
@@ -81,15 +81,16 @@ fi
 
 volume_directory="$script_directory/volume"
 
+if [ ! -d "$volume_directory" ]; then
+    mkdir "$volume_directory"
+    chmod -R a+rwX "$volume_directory"
+fi
+
 source scripts/common.sh
 DB_HOST_IP=$(get_docker_db_ip_address)
 
-AWS_ACCESS_KEY_ID="$(~/bin/aws configure get default.aws_access_key_id)"
-AWS_SECRET_ACCESS_KEY="$(~/bin/aws configure get default.aws_secret_access_key)"
-export AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY
-
 docker run \
-	   -it \
+       -it \
        --add-host=database:"$DB_HOST_IP" \
        --env-file workers/environments/local \
        --env AWS_ACCESS_KEY_ID \


### PR DESCRIPTION
## Issue Number

https://github.com/AlexsLemonade/refinebio/issues/2775

## Purpose/Implementation Notes

This adds a python script that invokes bash scripts to run surveyor, downloader, and processor jobs for a given experiment accession (or organism/Ensembl division in the case of transcriptome indices).

I also ended up doing some refactoring because the transcriptome jobs were failing because of an issue in `needs_processing`. Fixing that issue ended up creating a cyclical import issue. The right way to fix it seemed to split the `job_lookup` namespace because it was really doing two things.

## Types of changes

- New feature (non-breaking change which adds functionality)

## Functional tests

I've run transcriptome and no_op smoothly and I'm running others still.

## Checklist

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules
