### PR TITLE
Add isQueued field to all three job endpoints.

### DIFF
--- a/api/data_refinery_api/test/test_api_general.py
+++ b/api/data_refinery_api/test/test_api_general.py
@@ -256,19 +256,19 @@ class APITestCases(APITestCase):
 
         response = self.client.get(reverse("survey_jobs", kwargs={"version": API_VERSION}))
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertFalse(response.data["results"][0]["isQueued"])
+        self.assertFalse(response.data["results"][0]["is_queued"])
         cache.clear()
 
         response = self.client.get(
             reverse("survey_jobs", kwargs={"version": API_VERSION}) + "1/"  # change back
         )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertFalse(response.data["isQueued"])
+        self.assertFalse(response.data["is_queued"])
         cache.clear()
 
         response = self.client.get(reverse("downloader_jobs", kwargs={"version": API_VERSION}))
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertFalse(response.data["results"][0]["isQueued"])
+        self.assertFalse(response.data["results"][0]["is_queued"])
         cache.clear()
 
         # Don't know the best way to deal with this, but since the
@@ -280,19 +280,19 @@ class APITestCases(APITestCase):
             reverse("downloader_jobs", kwargs={"version": API_VERSION}) + "1/"  # change back
         )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertFalse(response.data["isQueued"])
+        self.assertFalse(response.data["is_queued"])
         cache.clear()
 
         response = self.client.get(reverse("processor_jobs", kwargs={"version": API_VERSION}))
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertFalse(response.data["results"][0]["isQueued"])
+        self.assertFalse(response.data["results"][0]["is_queued"])
         cache.clear()
 
         response = self.client.get(
             reverse("processor_jobs", kwargs={"version": API_VERSION}) + "1/"
         )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertFalse(response.data["isQueued"])
+        self.assertFalse(response.data["is_queued"])
         cache.clear()
 
         response = self.client.get(reverse("stats", kwargs={"version": API_VERSION}))

--- a/api/data_refinery_api/test/test_api_general.py
+++ b/api/data_refinery_api/test/test_api_general.py
@@ -1,26 +1,18 @@
 import json
-from unittest.mock import Mock, patch
 
 from django.core.cache import cache
-from django.core.exceptions import TooManyFieldsSent
-from django.core.management import call_command
-from django.http import HttpResponseForbidden, HttpResponseServerError
 from django.urls import reverse
 from rest_framework import status
 from rest_framework.test import APITestCase
 
-from data_refinery_api.views import DatasetView, ExperimentListView
 from data_refinery_common.models import (
     ComputationalResult,
     ComputationalResultAnnotation,
-    ComputedFile,
     Contribution,
-    Dataset,
     DownloaderJob,
     DownloaderJobOriginalFileAssociation,
     Experiment,
     ExperimentAnnotation,
-    ExperimentOrganismAssociation,
     ExperimentSampleAssociation,
     OntologyTerm,
     Organism,
@@ -34,8 +26,8 @@ from data_refinery_common.models import (
     SampleAnnotation,
     SampleKeyword,
     SampleResultAssociation,
+    SurveyJob,
 )
-from data_refinery_common.models.documents import ExperimentDocument
 from data_refinery_common.utils import get_env_variable
 
 API_VERSION = "v1"
@@ -71,7 +63,11 @@ class APITestCases(APITestCase):
         experiment_annotation.experiment = experiment
         experiment_annotation.save()
 
-        # Create 26 test organisms numbered 0-25 for pagination test, so there should be 29 organisms total (with the 3 others below)
+        SurveyJob().save()
+
+        # Create 26 test organisms numbered 0-25 for pagination test,
+        # so there should be 29 organisms total (with the 3 others
+        # below)
         for i in range(26):
             Organism(name=("TEST_ORGANISM_{}".format(i)), taxonomy_id=(1234 + i)).save()
 
@@ -260,30 +256,43 @@ class APITestCases(APITestCase):
 
         response = self.client.get(reverse("survey_jobs", kwargs={"version": API_VERSION}))
         self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertFalse(response.data["results"][0]["isQueued"])
+        cache.clear()
+
+        response = self.client.get(
+            reverse("survey_jobs", kwargs={"version": API_VERSION}) + "1/"  # change back
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertFalse(response.data["isQueued"])
         cache.clear()
 
         response = self.client.get(reverse("downloader_jobs", kwargs={"version": API_VERSION}))
         self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertFalse(response.data["results"][0]["isQueued"])
         cache.clear()
 
-        # Don't know the best way to deal with this, but since the other tests in different files
-        # create objects which are then deleted, the new objects from these tests will have different
-        # IDs. In this case, since this file is ran first, the IDs are 1, but this may be a problem
-        # in the future.
+        # Don't know the best way to deal with this, but since the
+        # other tests in different files create objects which are then
+        # deleted, the new objects from these tests will have
+        # different IDs. In this case, since this file is ran first,
+        # the IDs are 1, but this may be a problem in the future.
         response = self.client.get(
             reverse("downloader_jobs", kwargs={"version": API_VERSION}) + "1/"  # change back
         )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertFalse(response.data["isQueued"])
         cache.clear()
 
         response = self.client.get(reverse("processor_jobs", kwargs={"version": API_VERSION}))
         self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertFalse(response.data["results"][0]["isQueued"])
         cache.clear()
 
         response = self.client.get(
             reverse("processor_jobs", kwargs={"version": API_VERSION}) + "1/"
         )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertFalse(response.data["isQueued"])
         cache.clear()
 
         response = self.client.get(reverse("stats", kwargs={"version": API_VERSION}))
@@ -332,7 +341,8 @@ class APITestCases(APITestCase):
         self.assertListEqual(response.json()["details"], ["foo"])
 
         # Tenth call since reset_cache() should be throttled, three have happened.
-        for i in range(8):
+        # Make more than necessary to ensure we get the throttle.
+        for i in range(15):
             response = self.client.get(
                 reverse("transcriptome_indices", kwargs={"version": API_VERSION})
             )
@@ -424,7 +434,9 @@ class APITestCases(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(len(response.json()["results"]), 25)
 
-        # First organism on second page should be TEST_ORGANISM_25, and since 29 organisms have been created, there should be 4 on the 2nd page
+        # First organism on second page should be TEST_ORGANISM_25,
+        # and since 29 organisms have been created, there should be 4
+        # on the 2nd page
         response = self.client.get(
             reverse("organisms", kwargs={"version": API_VERSION}), {"offset": 25}
         )

--- a/api/data_refinery_api/test/test_api_general.py
+++ b/api/data_refinery_api/test/test_api_general.py
@@ -343,9 +343,7 @@ class APITestCases(APITestCase):
         # Tenth call since reset_cache() should be throttled, three have happened.
         # Make more than necessary to ensure we get the throttle.
         for i in range(15):
-            response = self.client.get(
-                reverse("transcriptome_indices", kwargs={"version": API_VERSION})
-            )
+            response = self.client.get(reverse("survey_jobs", kwargs={"version": API_VERSION}))
         self.assertEqual(response.status_code, status.HTTP_429_TOO_MANY_REQUESTS)
 
     def test_experiment_multiple_accessions(self):

--- a/api/data_refinery_api/views/jobs/downloader_job.py
+++ b/api/data_refinery_api/views/jobs/downloader_job.py
@@ -5,6 +5,7 @@
 from django.utils.decorators import method_decorator
 from rest_framework import filters, generics, serializers
 
+import boto3
 from django_filters.rest_framework import DjangoFilterBackend
 from drf_yasg import openapi
 from drf_yasg.utils import swagger_auto_schema
@@ -12,6 +13,16 @@ from drf_yasg.utils import swagger_auto_schema
 from data_refinery_api.exceptions import InvalidFilters
 from data_refinery_api.utils import check_filters
 from data_refinery_common.models import DownloaderJob
+from data_refinery_common.utils import get_env_variable
+
+AWS_REGION = get_env_variable(
+    "AWS_REGION", "us-east-1"
+)  # Default to us-east-1 if the region variable can't be found
+
+# Job definitons are AWS objects so they have to be namespaced for our stack.
+JOB_DEFINITION_PREFIX = get_env_variable("JOB_DEFINITION_PREFIX", "")
+
+batch = boto3.client("batch", region_name=AWS_REGION)
 
 
 class DownloaderJobSerializer(serializers.ModelSerializer):
@@ -65,6 +76,24 @@ class DownloaderJobListView(generics.ListAPIView):
     ordering_fields = ("id", "created_at")
     ordering = ("-id",)
 
+    def list(self, request, *args, **kwargs):
+        response = super(DownloaderJobListView, self).list(request, args, kwargs)
+
+        results = response.data["results"]
+        batch_job_ids = [job["batch_job_id"] for job in results if job.get("batch_job_id", None)]
+        running_job_ids = set()
+        if batch_job_ids:
+            described_jobs = batch.describe_jobs(jobs=batch_job_ids)
+            for job in described_jobs["jobs"]:
+                if job["status"] in ["SUBMITTED", "PENDING", "RUNNABLE", "STARTING", "RUNNING"]:
+                    running_job_ids.add(job["jobId"])
+
+        for result in results:
+            batch_job_id = result.get("batch_job_id", None)
+            result["isQueued"] = bool(batch_job_id and batch_job_id in running_job_ids)
+
+        return response
+
     def get_queryset(self):
         invalid_filters = check_filters(self, ["sample_accession_code"])
 
@@ -89,3 +118,20 @@ class DownloaderJobDetailView(generics.RetrieveAPIView):
     model = DownloaderJob
     queryset = DownloaderJob.objects.all()
     serializer_class = DownloaderJobSerializer
+
+    def get(self, request, *args, **kwargs):
+        response = super(DownloaderJobDetailView, self).get(request, args, kwargs)
+
+        if "batch_job_id" in response.data and response.data["batch_job_id"]:
+            described_jobs = batch.describe_jobs(jobs=[response.data["batch_job_id"]])
+            response.data["isQueued"] = described_jobs["jobs"][0] in [
+                "SUBMITTED",
+                "PENDING",
+                "RUNNABLE",
+                "STARTING",
+                "RUNNING",
+            ]
+        else:
+            response.data["isQueued"] = False
+
+        return response

--- a/api/data_refinery_api/views/jobs/downloader_job.py
+++ b/api/data_refinery_api/views/jobs/downloader_job.py
@@ -34,6 +34,7 @@ class DownloaderJobSerializer(serializers.ModelSerializer):
         fields = (
             "id",
             "downloader_task",
+            "ram_amount",
             "num_retries",
             "retried",
             "was_recreated",

--- a/api/data_refinery_api/views/jobs/downloader_job.py
+++ b/api/data_refinery_api/views/jobs/downloader_job.py
@@ -90,7 +90,7 @@ class DownloaderJobListView(generics.ListAPIView):
 
         for result in results:
             batch_job_id = result.get("batch_job_id", None)
-            result["isQueued"] = bool(batch_job_id and batch_job_id in running_job_ids)
+            result["is_queued"] = bool(batch_job_id and batch_job_id in running_job_ids)
 
         return response
 
@@ -124,7 +124,7 @@ class DownloaderJobDetailView(generics.RetrieveAPIView):
 
         if "batch_job_id" in response.data and response.data["batch_job_id"]:
             described_jobs = batch.describe_jobs(jobs=[response.data["batch_job_id"]])
-            response.data["isQueued"] = described_jobs["jobs"][0] in [
+            response.data["is_queued"] = described_jobs["jobs"][0] in [
                 "SUBMITTED",
                 "PENDING",
                 "RUNNABLE",
@@ -132,6 +132,6 @@ class DownloaderJobDetailView(generics.RetrieveAPIView):
                 "RUNNING",
             ]
         else:
-            response.data["isQueued"] = False
+            response.data["is_queued"] = False
 
         return response

--- a/api/data_refinery_api/views/jobs/downloader_job.py
+++ b/api/data_refinery_api/views/jobs/downloader_job.py
@@ -12,8 +12,11 @@ from drf_yasg.utils import swagger_auto_schema
 
 from data_refinery_api.exceptions import InvalidFilters
 from data_refinery_api.utils import check_filters
+from data_refinery_common.logging import get_and_configure_logger
 from data_refinery_common.models import DownloaderJob
 from data_refinery_common.utils import get_env_variable
+
+logger = get_and_configure_logger(__name__)
 
 AWS_REGION = get_env_variable(
     "AWS_REGION", "us-east-1"
@@ -83,10 +86,13 @@ class DownloaderJobListView(generics.ListAPIView):
         batch_job_ids = [job["batch_job_id"] for job in results if job.get("batch_job_id", None)]
         running_job_ids = set()
         if batch_job_ids:
-            described_jobs = batch.describe_jobs(jobs=batch_job_ids)
-            for job in described_jobs["jobs"]:
-                if job["status"] in ["SUBMITTED", "PENDING", "RUNNABLE", "STARTING", "RUNNING"]:
-                    running_job_ids.add(job["jobId"])
+            try:
+                described_jobs = batch.describe_jobs(jobs=batch_job_ids)
+                for job in described_jobs["jobs"]:
+                    if job["status"] in ["SUBMITTED", "PENDING", "RUNNABLE", "STARTING", "RUNNING"]:
+                        running_job_ids.add(job["jobId"])
+            except Exception as e:
+                logger.exception(f"Failure to query about batch_job_ids.")
 
         for result in results:
             batch_job_id = result.get("batch_job_id", None)
@@ -123,14 +129,20 @@ class DownloaderJobDetailView(generics.RetrieveAPIView):
         response = super(DownloaderJobDetailView, self).get(request, args, kwargs)
 
         if "batch_job_id" in response.data and response.data["batch_job_id"]:
-            described_jobs = batch.describe_jobs(jobs=[response.data["batch_job_id"]])
-            response.data["is_queued"] = described_jobs["jobs"][0] in [
-                "SUBMITTED",
-                "PENDING",
-                "RUNNABLE",
-                "STARTING",
-                "RUNNING",
-            ]
+            try:
+                described_jobs = batch.describe_jobs(jobs=[response.data["batch_job_id"]])
+                response.data["is_queued"] = described_jobs["jobs"][0]["status"] in [
+                    "SUBMITTED",
+                    "PENDING",
+                    "RUNNABLE",
+                    "STARTING",
+                    "RUNNING",
+                ]
+            except Exception as e:
+                logger.exception(
+                    f"Failure to query about batch_job_id.",
+                    batch_job_id=response.data["batch_job_id"],
+                )
         else:
             response.data["is_queued"] = False
 

--- a/api/data_refinery_api/views/jobs/downloader_job.py
+++ b/api/data_refinery_api/views/jobs/downloader_job.py
@@ -40,6 +40,7 @@ class DownloaderJobSerializer(serializers.ModelSerializer):
             "worker_id",
             "worker_version",
             "batch_job_id",
+            "batch_job_queue",
             "failure_reason",
             "success",
             "original_files",

--- a/api/data_refinery_api/views/jobs/processor_job.py
+++ b/api/data_refinery_api/views/jobs/processor_job.py
@@ -93,7 +93,7 @@ class ProcessorJobListView(generics.ListAPIView):
 
         for result in results:
             batch_job_id = result.get("batch_job_id", None)
-            result["isQueued"] = bool(batch_job_id and batch_job_id in running_job_ids)
+            result["is_queued"] = bool(batch_job_id and batch_job_id in running_job_ids)
 
         return response
 
@@ -127,7 +127,7 @@ class ProcessorJobDetailView(generics.RetrieveAPIView):
 
         if "batch_job_id" in response.data and response.data["batch_job_id"]:
             described_jobs = batch.describe_jobs(jobs=[response.data["batch_job_id"]])
-            response.data["isQueued"] = described_jobs["jobs"][0] in [
+            response.data["is_queued"] = described_jobs["jobs"][0] in [
                 "SUBMITTED",
                 "PENDING",
                 "RUNNABLE",
@@ -135,6 +135,6 @@ class ProcessorJobDetailView(generics.RetrieveAPIView):
                 "RUNNING",
             ]
         else:
-            response.data["isQueued"] = False
+            response.data["is_queued"] = False
 
         return response

--- a/api/data_refinery_api/views/jobs/processor_job.py
+++ b/api/data_refinery_api/views/jobs/processor_job.py
@@ -12,8 +12,11 @@ from drf_yasg.utils import swagger_auto_schema
 
 from data_refinery_api.exceptions import InvalidFilters
 from data_refinery_api.utils import check_filters
+from data_refinery_common.logging import get_and_configure_logger
 from data_refinery_common.models import ProcessorJob
 from data_refinery_common.utils import get_env_variable
+
+logger = get_and_configure_logger(__name__)
 
 AWS_REGION = get_env_variable(
     "AWS_REGION", "us-east-1"
@@ -86,10 +89,13 @@ class ProcessorJobListView(generics.ListAPIView):
         batch_job_ids = [job["batch_job_id"] for job in results if job.get("batch_job_id", None)]
         running_job_ids = set()
         if batch_job_ids:
-            described_jobs = batch.describe_jobs(jobs=batch_job_ids)
-            for job in described_jobs["jobs"]:
-                if job["status"] in ["SUBMITTED", "PENDING", "RUNNABLE", "STARTING", "RUNNING"]:
-                    running_job_ids.add(job["jobId"])
+            try:
+                described_jobs = batch.describe_jobs(jobs=batch_job_ids)
+                for job in described_jobs["jobs"]:
+                    if job["status"] in ["SUBMITTED", "PENDING", "RUNNABLE", "STARTING", "RUNNING"]:
+                        running_job_ids.add(job["jobId"])
+            except Exception as e:
+                logger.exception(f"Failure to query about batch_job_ids.")
 
         for result in results:
             batch_job_id = result.get("batch_job_id", None)
@@ -126,14 +132,20 @@ class ProcessorJobDetailView(generics.RetrieveAPIView):
         response = super(ProcessorJobDetailView, self).get(request, args, kwargs)
 
         if "batch_job_id" in response.data and response.data["batch_job_id"]:
-            described_jobs = batch.describe_jobs(jobs=[response.data["batch_job_id"]])
-            response.data["is_queued"] = described_jobs["jobs"][0] in [
-                "SUBMITTED",
-                "PENDING",
-                "RUNNABLE",
-                "STARTING",
-                "RUNNING",
-            ]
+            try:
+                described_jobs = batch.describe_jobs(jobs=[response.data["batch_job_id"]])
+                response.data["is_queued"] = described_jobs["jobs"][0]["status"] in [
+                    "SUBMITTED",
+                    "PENDING",
+                    "RUNNABLE",
+                    "STARTING",
+                    "RUNNING",
+                ]
+            except Exception as e:
+                logger.exception(
+                    f"Failure to query about batch_job_id.",
+                    batch_job_id=response.data["batch_job_id"],
+                )
         else:
             response.data["is_queued"] = False
 

--- a/api/data_refinery_api/views/jobs/survey_job.py
+++ b/api/data_refinery_api/views/jobs/survey_job.py
@@ -4,11 +4,22 @@
 
 from rest_framework import filters, generics, serializers
 
+import boto3
 from django_filters.rest_framework import DjangoFilterBackend
 
 from data_refinery_api.exceptions import InvalidFilters
 from data_refinery_api.utils import check_filters
 from data_refinery_common.models import SurveyJob
+from data_refinery_common.utils import get_env_variable
+
+AWS_REGION = get_env_variable(
+    "AWS_REGION", "us-east-1"
+)  # Default to us-east-1 if the region variable can't be found
+
+# Job definitons are AWS objects so they have to be namespaced for our stack.
+JOB_DEFINITION_PREFIX = get_env_variable("JOB_DEFINITION_PREFIX", "")
+
+batch = boto3.client("batch", region_name=AWS_REGION)
 
 
 class SurveyJobSerializer(serializers.ModelSerializer):
@@ -42,6 +53,24 @@ class SurveyJobListView(generics.ListAPIView):
     ordering_fields = ("id", "created_at")
     ordering = ("-id",)
 
+    def list(self, request, *args, **kwargs):
+        response = super(SurveyJobListView, self).list(request, args, kwargs)
+
+        results = response.data["results"]
+        batch_job_ids = [job["batch_job_id"] for job in results if job.get("batch_job_id", None)]
+        running_job_ids = set()
+        if batch_job_ids:
+            described_jobs = batch.describe_jobs(jobs=batch_job_ids)
+            for job in described_jobs["jobs"]:
+                if job["status"] in ["SUBMITTED", "PENDING", "RUNNABLE", "STARTING", "RUNNING"]:
+                    running_job_ids.add(job["jobId"])
+
+        for result in results:
+            batch_job_id = result.get("batch_job_id", None)
+            result["isQueued"] = bool(batch_job_id and batch_job_id in running_job_ids)
+
+        return response
+
     def get_queryset(self):
         invalid_filters = check_filters(self)
 
@@ -58,3 +87,20 @@ class SurveyJobDetailView(generics.RetrieveAPIView):
     model = SurveyJob
     queryset = SurveyJob.objects.all()
     serializer_class = SurveyJobSerializer
+
+    def get(self, request, *args, **kwargs):
+        response = super(SurveyJobDetailView, self).get(request, args, kwargs)
+
+        if "batch_job_id" in response.data and response.data["batch_job_id"]:
+            described_jobs = batch.describe_jobs(jobs=[response.data["batch_job_id"]])
+            response.data["isQueued"] = described_jobs["jobs"][0] in [
+                "SUBMITTED",
+                "PENDING",
+                "RUNNABLE",
+                "STARTING",
+                "RUNNING",
+            ]
+        else:
+            response.data["isQueued"] = False
+
+        return response

--- a/api/data_refinery_api/views/jobs/survey_job.py
+++ b/api/data_refinery_api/views/jobs/survey_job.py
@@ -9,8 +9,11 @@ from django_filters.rest_framework import DjangoFilterBackend
 
 from data_refinery_api.exceptions import InvalidFilters
 from data_refinery_api.utils import check_filters
+from data_refinery_common.logging import get_and_configure_logger
 from data_refinery_common.models import SurveyJob
 from data_refinery_common.utils import get_env_variable
+
+logger = get_and_configure_logger(__name__)
 
 AWS_REGION = get_env_variable(
     "AWS_REGION", "us-east-1"
@@ -60,10 +63,13 @@ class SurveyJobListView(generics.ListAPIView):
         batch_job_ids = [job["batch_job_id"] for job in results if job.get("batch_job_id", None)]
         running_job_ids = set()
         if batch_job_ids:
-            described_jobs = batch.describe_jobs(jobs=batch_job_ids)
-            for job in described_jobs["jobs"]:
-                if job["status"] in ["SUBMITTED", "PENDING", "RUNNABLE", "STARTING", "RUNNING"]:
-                    running_job_ids.add(job["jobId"])
+            try:
+                described_jobs = batch.describe_jobs(jobs=batch_job_ids)
+                for job in described_jobs["jobs"]:
+                    if job["status"] in ["SUBMITTED", "PENDING", "RUNNABLE", "STARTING", "RUNNING"]:
+                        running_job_ids.add(job["jobId"])
+            except Exception as e:
+                logger.exception(f"Failure to query about batch_job_ids.")
 
         for result in results:
             batch_job_id = result.get("batch_job_id", None)
@@ -92,14 +98,20 @@ class SurveyJobDetailView(generics.RetrieveAPIView):
         response = super(SurveyJobDetailView, self).get(request, args, kwargs)
 
         if "batch_job_id" in response.data and response.data["batch_job_id"]:
-            described_jobs = batch.describe_jobs(jobs=[response.data["batch_job_id"]])
-            response.data["is_queued"] = described_jobs["jobs"][0] in [
-                "SUBMITTED",
-                "PENDING",
-                "RUNNABLE",
-                "STARTING",
-                "RUNNING",
-            ]
+            try:
+                described_jobs = batch.describe_jobs(jobs=[response.data["batch_job_id"]])
+                response.data["is_queued"] = described_jobs["jobs"][0]["status"] in [
+                    "SUBMITTED",
+                    "PENDING",
+                    "RUNNABLE",
+                    "STARTING",
+                    "RUNNING",
+                ]
+            except Exception as e:
+                logger.exception(
+                    f"Failure to query about batch_job_id.",
+                    batch_job_id=response.data["batch_job_id"],
+                )
         else:
             response.data["is_queued"] = False
 

--- a/api/data_refinery_api/views/jobs/survey_job.py
+++ b/api/data_refinery_api/views/jobs/survey_job.py
@@ -32,6 +32,8 @@ class SurveyJobSerializer(serializers.ModelSerializer):
             "id",
             "source_type",
             "success",
+            "batch_job_id",
+            "batch_job_queue",
             "start_time",
             "end_time",
             "created_at",

--- a/api/data_refinery_api/views/jobs/survey_job.py
+++ b/api/data_refinery_api/views/jobs/survey_job.py
@@ -67,7 +67,7 @@ class SurveyJobListView(generics.ListAPIView):
 
         for result in results:
             batch_job_id = result.get("batch_job_id", None)
-            result["isQueued"] = bool(batch_job_id and batch_job_id in running_job_ids)
+            result["is_queued"] = bool(batch_job_id and batch_job_id in running_job_ids)
 
         return response
 
@@ -93,7 +93,7 @@ class SurveyJobDetailView(generics.RetrieveAPIView):
 
         if "batch_job_id" in response.data and response.data["batch_job_id"]:
             described_jobs = batch.describe_jobs(jobs=[response.data["batch_job_id"]])
-            response.data["isQueued"] = described_jobs["jobs"][0] in [
+            response.data["is_queued"] = described_jobs["jobs"][0] in [
                 "SUBMITTED",
                 "PENDING",
                 "RUNNABLE",
@@ -101,6 +101,6 @@ class SurveyJobDetailView(generics.RetrieveAPIView):
                 "RUNNING",
             ]
         else:
-            response.data["isQueued"] = False
+            response.data["is_queued"] = False
 
         return response

--- a/api/data_refinery_api/views/jobs/survey_job.py
+++ b/api/data_refinery_api/views/jobs/survey_job.py
@@ -34,6 +34,7 @@ class SurveyJobSerializer(serializers.ModelSerializer):
             "success",
             "batch_job_id",
             "batch_job_queue",
+            "ram_amount",
             "start_time",
             "end_time",
             "created_at",


### PR DESCRIPTION
## Issue Number

https://github.com/AlexsLemonade/refinebio-frontend/issues/950
https://github.com/AlexsLemonade/refinebio/issues/2812
https://github.com/AlexsLemonade/refinebio/issues/2791

## Purpose/Implementation Notes

This removes `nomad` as a parameter to the job endpoints and instead just adds a `is_queued` to all job objects. This field isn't filterable because it isn't added until after the job has been retrieved.

I've also tried to address https://github.com/AlexsLemonade/refinebio/issues/2791 by just making a few more API calls to make sure a bad timing window won't prevent the 429 from being triggered.

## Types of changes

- Bugfix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)

## Functional tests

I've updated unit tests to test this. I've also run the unit tests a bunch of times to see if I can still trigger the 429. I saw it a couple times before I added my change to that test but not since.

## Checklist

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules
