### PR TITLE
Disable job filler because it's running too many jobs and add job timeout

### DIFF
--- a/foreman/batch-job-templates/surveyor.tpl.json
+++ b/foreman/batch-job-templates/surveyor.tpl.json
@@ -1,5 +1,6 @@
 {
     "jobDefinitionName": "${{USER}}_${{STAGE}}_SURVEYOR_${{RAM}}",
+    "timeout": {"attemptDurationSeconds": 10800},
     "type": "container",
     "parameters": {
         "job_name": "",

--- a/infrastructure/foreman-configuration/foreman-server-instance-user-data.tpl.sh
+++ b/infrastructure/foreman-configuration/foreman-server-instance-user-data.tpl.sh
@@ -94,19 +94,21 @@ set daemon 900
 
 service monit restart
 
-docker run \
-       --env-file /home/ubuntu/environment \
-       -e DATABASE_HOST="${database_host}" \
-       -e DATABASE_NAME="${database_name}" \
-       -e DATABASE_USER="${database_user}" \
-       -e DATABASE_PASSWORD="${database_password}" \
-       -v /tmp:/tmp \
-       --log-driver=awslogs \
-       --log-opt awslogs-region="${region}" \
-       --log-opt awslogs-group="${log_group}" \
-       --log-opt awslogs-stream="log-stream-foreman-${user}-${stage}" \
-       --name=job_filler \
-       -it -d "${dockerhub_repo}/${foreman_docker_image}" python3 manage.py create_missing_processor_jobs
+# This seems to be repeatedly requeuing the same jobs at the moment.
+# https://github.com/AlexsLemonade/refinebio/issues/2823
+# docker run \
+#        --env-file /home/ubuntu/environment \
+#        -e DATABASE_HOST="${database_host}" \
+#        -e DATABASE_NAME="${database_name}" \
+#        -e DATABASE_USER="${database_user}" \
+#        -e DATABASE_PASSWORD="${database_password}" \
+#        -v /tmp:/tmp \
+#        --log-driver=awslogs \
+#        --log-opt awslogs-region="${region}" \
+#        --log-opt awslogs-group="${log_group}" \
+#        --log-opt awslogs-stream="log-stream-foreman-${user}-${stage}" \
+#        --name=job_filler \
+#        -it -d "${dockerhub_repo}/${foreman_docker_image}" python3 manage.py create_missing_processor_jobs
 
 # Delete the cloudinit and syslog in production.
 export STAGE=${stage}

--- a/workers/batch-job-templates/affy_to_pcl.tpl.json
+++ b/workers/batch-job-templates/affy_to_pcl.tpl.json
@@ -1,5 +1,6 @@
 {
     "jobDefinitionName": "${{USER}}_${{STAGE}}_AFFY_TO_PCL_${{RAM}}",
+    "timeout": {"attemptDurationSeconds": 10800},
     "type": "container",
     "parameters": {
         "job_name": "",

--- a/workers/batch-job-templates/create_compendia.tpl.json
+++ b/workers/batch-job-templates/create_compendia.tpl.json
@@ -1,5 +1,6 @@
 {
     "jobDefinitionName": "${{USER}}_${{STAGE}}_CREATE_COMPENDIA",
+    "timeout": {"attemptDurationSeconds": 10800},
     "type": "container",
     "parameters": {
         "job_name": "",

--- a/workers/batch-job-templates/create_qn_target.tpl.json
+++ b/workers/batch-job-templates/create_qn_target.tpl.json
@@ -1,5 +1,6 @@
 {
     "jobDefinitionName": "${{USER}}_${{STAGE}}_CREATE_QN_TARGET",
+    "timeout": {"attemptDurationSeconds": 10800},
     "type": "container",
     "parameters": {
         "job_name": "",

--- a/workers/batch-job-templates/create_quantpendia.tpl.json
+++ b/workers/batch-job-templates/create_quantpendia.tpl.json
@@ -1,5 +1,6 @@
 {
     "jobDefinitionName": "${{USER}}_${{STAGE}}_CREATE_QUANTPENDIA",
+    "timeout": {"attemptDurationSeconds": 10800},
     "type": "container",
     "parameters": {
         "job_name": "",

--- a/workers/batch-job-templates/downloader.tpl.json
+++ b/workers/batch-job-templates/downloader.tpl.json
@@ -1,5 +1,6 @@
 {
     "jobDefinitionName": "${{USER}}_${{STAGE}}_DOWNLOADER_${{RAM}}",
+    "timeout": {"attemptDurationSeconds": 10800},
     "type": "container",
     "parameters": {
         "job_name": "",

--- a/workers/batch-job-templates/illumina.tpl.json
+++ b/workers/batch-job-templates/illumina.tpl.json
@@ -1,5 +1,6 @@
 {
     "jobDefinitionName": "${{USER}}_${{STAGE}}_ILLUMINA_${{RAM}}",
+    "timeout": {"attemptDurationSeconds": 10800},
     "type": "container",
     "parameters": {
         "job_name": "",

--- a/workers/batch-job-templates/janitor.tpl.json
+++ b/workers/batch-job-templates/janitor.tpl.json
@@ -1,5 +1,6 @@
 {
     "jobDefinitionName": "${{USER}}_${{STAGE}}_JANITOR",
+    "timeout": {"attemptDurationSeconds": 10800},
     "type": "container",
     "parameters": {
         "job_name": "",

--- a/workers/batch-job-templates/no_op.tpl.json
+++ b/workers/batch-job-templates/no_op.tpl.json
@@ -1,5 +1,6 @@
 {
     "jobDefinitionName": "${{USER}}_${{STAGE}}_NO_OP_${{RAM}}",
+    "timeout": {"attemptDurationSeconds": 10800},
     "type": "container",
     "parameters": {
         "job_name": "",

--- a/workers/batch-job-templates/qn_dispatcher.tpl.json
+++ b/workers/batch-job-templates/qn_dispatcher.tpl.json
@@ -1,5 +1,6 @@
 {
     "jobDefinitionName": "${{USER}}_${{STAGE}}_QN_DISPATCHER",
+    "timeout": {"attemptDurationSeconds": 10800},
     "type": "container",
     "parameters": {
         "job_name": "",

--- a/workers/batch-job-templates/qn_reference.tpl.json
+++ b/workers/batch-job-templates/qn_reference.tpl.json
@@ -1,5 +1,6 @@
 {
     "jobDefinitionName": "${{USER}}_${{STAGE}}_QN_REFERENCE_${{RAM}}",
+    "timeout": {"attemptDurationSeconds": 10800},
     "type": "container",
     "parameters": {
         "job_name": "",

--- a/workers/batch-job-templates/salmon.tpl.json
+++ b/workers/batch-job-templates/salmon.tpl.json
@@ -1,5 +1,6 @@
 {
     "jobDefinitionName": "${{USER}}_${{STAGE}}_SALMON_${{RAM}}",
+    "timeout": {"attemptDurationSeconds": 10800},
     "type": "container",
     "parameters": {
         "job_name": "",

--- a/workers/batch-job-templates/smasher.tpl.json
+++ b/workers/batch-job-templates/smasher.tpl.json
@@ -1,5 +1,6 @@
 {
     "jobDefinitionName": "${{USER}}_${{STAGE}}_SMASHER",
+    "timeout": {"attemptDurationSeconds": 10800},
     "type": "container",
     "parameters": {
         "job_name": "",

--- a/workers/batch-job-templates/transcriptome_index.tpl.json
+++ b/workers/batch-job-templates/transcriptome_index.tpl.json
@@ -1,5 +1,6 @@
 {
     "jobDefinitionName": "${{USER}}_${{STAGE}}_TRANSCRIPTOME_INDEX_${{RAM}}",
+    "timeout": {"attemptDurationSeconds": 10800},
     "type": "container",
     "parameters": {
         "job_name": "",

--- a/workers/batch-job-templates/tximport.tpl.json
+++ b/workers/batch-job-templates/tximport.tpl.json
@@ -1,5 +1,6 @@
 {
     "jobDefinitionName": "${{USER}}_${{STAGE}}_TXIMPORT",
+    "timeout": {"attemptDurationSeconds": 10800},
     "type": "container",
     "parameters": {
         "job_name": "",


### PR DESCRIPTION
## Issue Number

https://github.com/AlexsLemonade/refinebio/issues/2823

## Purpose/Implementation Notes

Not sure what the right thing to do with this is yet, but we need to disable it.

I've stopped the docker container in prod so it's not running.

This is also going to add job timeouts because we shouldn't ever spend more than 3 hours running a job but I saw some jobs today that had been hung since `4:34:00` (and terminating them manually through the console didn't seem to work, I terminated the instance to force them all to end).

## Types of changes

- Ops-ing

## Functional tests

I've spun up a dev stack to make sure the job timeouts don't break job definitions.