### PR TITLE
Cycle instances to change SSH keys

### DIFF
--- a/infrastructure/deploy.sh
+++ b/infrastructure/deploy.sh
@@ -174,6 +174,11 @@ fi
 # Temporary taint to cylce AWS credentials:
 terraform taint aws_iam_access_key.data_refinery_user_client_key || true
 
+# And to update the authorized_key files on the instances:
+terraform taint aws_instance.pg_bouncer
+terraform taint aws_instance.api_server_1
+terraform taint aws_instance.foreman_server_1
+
 # Terraform doesn't manage these well, so they need to be tainted if
 # they exist to ensure they won't require manual intervention.
 terraform taint module.batch.aws_launch_template.data_refinery_launch_template || true


### PR DESCRIPTION
## Issue Number

#2830 

## Purpose/Implementation Notes

Taint instances because updating the keypair won't cylce instances, despite not updating authorized_keys.
