### PR TITLE
Remove SSH key from AMI template

### DIFF
--- a/ami/instance.tf
+++ b/ami/instance.tf
@@ -30,7 +30,6 @@ resource "aws_instance" "ubuntu-ami-template-instance" {
 
   subnet_id = data.aws_subnet.ccdl_dev_subnet.id
   associate_public_ip_address = true
-  key_name = "data-refinery-key-circleci-prod"
   vpc_security_group_ids = [aws_security_group.ami_template_instance.id]
 
   tags = {


### PR DESCRIPTION
## Issue Number

#2832 

## Purpose/Implementation Notes

After cycling the instances, the old key was still there because it was baked into the AMI. This removes it. 

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

I've already updated the AMIs and tested it on staging. (Once the AMIs were updated, I just reran the deploy since they're outside the deploy process.)
