### PR TITLE
Add a separate `downloadable_organism_names` field to the experiment doc

### DIFF
--- a/api/data_refinery_api/test/test_search.py
+++ b/api/data_refinery_api/test/test_search.py
@@ -164,9 +164,12 @@ class ESTestCases(APITestCase):
         self.assertEqual(response.json()["facets"]["technology"]["microarray"], 1)
         self.assertEqual(response.json()["facets"]["technology"]["rna-seq"], 0)
         self.assertEqual(
-            list(response.json()["facets"]["organism_names"].keys()), [ECOLI_STRAIN_NAME]
+            list(response.json()["facets"]["downloadable_organism_names"].keys()),
+            [ECOLI_STRAIN_NAME],
         )
-        self.assertEqual(response.json()["facets"]["organism_names"][ECOLI_STRAIN_NAME], 1)
+        self.assertEqual(
+            response.json()["facets"]["downloadable_organism_names"][ECOLI_STRAIN_NAME], 1
+        )
 
         # Basic Search
         response = self.client.get(

--- a/api/data_refinery_api/views/experiment_document.py
+++ b/api/data_refinery_api/views/experiment_document.py
@@ -282,7 +282,8 @@ class ExperimentDocumentView(DocumentViewSet):
         "accession_code": "accession_code",
         "alternate_accession_code": "alternate_accession_code",
         "platform": "platform_accession_codes",
-        "organism": "downloadable_organism_names.raw",
+        "organism": "organism_names.raw",
+        "downloadable_organism": "downloadable_organism_names.raw",
         "num_processed_samples": {
             "field": "num_processed_samples",
             "lookups": [LOOKUP_FILTER_RANGE, LOOKUP_QUERY_IN, LOOKUP_QUERY_GT],

--- a/api/data_refinery_api/views/experiment_document.py
+++ b/api/data_refinery_api/views/experiment_document.py
@@ -141,6 +141,7 @@ class ExperimentDocumentSerializer(DocumentSerializer):
             "platform_names",
             "platform_accession_codes",
             "organism_names",
+            "downloadable_organism_names",
             "pubmed_id",
             "num_total_samples",
             "num_processed_samples",
@@ -236,7 +237,7 @@ requests.post(host + '/v1/search/', json.dumps(search), headers=headers)
     ),
 )
 class ExperimentDocumentView(DocumentViewSet):
-    """ ElasticSearch powered experiment search. """
+    """ElasticSearch powered experiment search."""
 
     document = ExperimentDocument
     serializer_class = ExperimentDocumentSerializer
@@ -281,7 +282,7 @@ class ExperimentDocumentView(DocumentViewSet):
         "accession_code": "accession_code",
         "alternate_accession_code": "alternate_accession_code",
         "platform": "platform_accession_codes",
-        "organism": "organism_names.raw",
+        "organism": "downloadable_organism_names.raw",
         "num_processed_samples": {
             "field": "num_processed_samples",
             "lookups": [LOOKUP_FILTER_RANGE, LOOKUP_QUERY_IN, LOOKUP_QUERY_GT],
@@ -321,8 +322,8 @@ class ExperimentDocumentView(DocumentViewSet):
             "facet": TermsFacet,
             "enabled": True,  # These are enabled by default, which is more expensive but more simple.
         },
-        "organism_names": {
-            "field": "organism_names.raw",
+        "downloadable_organism_names": {
+            "field": "downloadable_organism_names.raw",
             "facet": TermsFacet,
             "enabled": True,
             "options": {"size": 999999},

--- a/common/data_refinery_common/models/documents.py
+++ b/common/data_refinery_common/models/documents.py
@@ -35,8 +35,8 @@ standard_keyword = analyzer("standard_keyword", tokenizer="keyword", filter=[],)
 
 @experiment_index.doc_type
 class ExperimentDocument(Document):
-    """ Our Experiment ElasticSearch Document, which
-    corresponds to our Experiment model. """
+    """Our Experiment ElasticSearch Document, which
+    corresponds to our Experiment model."""
 
     # Keyword Fields
     title = fields.TextField(
@@ -55,6 +55,9 @@ class ExperimentDocument(Document):
         analyzer=html_strip_no_stop, fielddata=True, fields={"raw": fields.KeywordField()}
     )
     organism_names = fields.TextField(
+        analyzer=html_strip_no_ngram, fielddata=True, fields={"raw": fields.KeywordField()}
+    )
+    downloadable_organism_names = fields.TextField(
         analyzer=html_strip_no_ngram, fielddata=True, fields={"raw": fields.KeywordField()}
     )
     platform_names = fields.TextField(
@@ -93,5 +96,5 @@ class ExperimentDocument(Document):
         ]
 
     def get_queryset(self):
-        """ Override default queryset """
+        """Override default queryset"""
         return super(ExperimentDocument, self).get_queryset().order_by("id")

--- a/common/data_refinery_common/models/experiment.py
+++ b/common/data_refinery_common/models/experiment.py
@@ -8,7 +8,7 @@ from data_refinery_common.models.managers import ProcessedPublicObjectsManager, 
 
 
 class Experiment(models.Model):
-    """ An Experiment or Study """
+    """An Experiment or Study"""
 
     class Meta:
         db_table = "experiments"
@@ -66,7 +66,7 @@ class Experiment(models.Model):
     last_modified = models.DateTimeField(default=timezone.now)
 
     def save(self, *args, **kwargs):
-        """ On save, update timestamps """
+        """On save, update timestamps"""
         current_time = timezone.now()
         if not self.id:
             self.created_at = current_time
@@ -81,7 +81,7 @@ class Experiment(models.Model):
         return super(Experiment, self).save(*args, **kwargs)
 
     def update_num_samples(self):
-        """ Update our cache values """
+        """Update our cache values"""
         aggregates = self.samples.aggregate(
             num_total_samples=Count("id"),
             num_processed_samples=Count("id", filter=Q(is_processed=True)),
@@ -95,7 +95,7 @@ class Experiment(models.Model):
         self.save()
 
     def to_metadata_dict(self):
-        """ Render this Experiment as a dict """
+        """Render this Experiment as a dict"""
 
         metadata = {}
         metadata["title"] = self.title
@@ -128,7 +128,7 @@ class Experiment(models.Model):
         return metadata
 
     def get_sample_keywords(self):
-        """ Get the human-readable name of all of the keywords that are defined
+        """Get the human-readable name of all of the keywords that are defined
         on at least one sample
         """
         keywords = set()
@@ -139,7 +139,7 @@ class Experiment(models.Model):
         return list(keywords)
 
     def get_sample_metadata_fields(self):
-        """ Get all metadata fields that are non-empty for at least one sample in the experiment.
+        """Get all metadata fields that are non-empty for at least one sample in the experiment.
         See https://github.com/AlexsLemonade/refinebio-frontend/issues/211 for why this is needed.
         """
         fields = []
@@ -178,28 +178,25 @@ class Experiment(models.Model):
         self.platform_accession_codes = self.get_platform_accession_codes()
 
     def get_sample_technologies(self):
-        """ Get a list of unique technologies for all of the associated samples
-        """
+        """Get a list of unique technologies for all of the associated samples"""
         return list(set([sample.technology for sample in self.samples.all()]))
 
     def get_platform_names(self):
-        """ Get a list of unique platforms for all of the associated samples
-        """
+        """Get a list of unique platforms for all of the associated samples"""
         return list(set([sample.platform_name for sample in self.samples.all()]))
 
     def get_platform_accession_codes(self):
-        """ Get a list of unique platforms for all of the associated samples
-        """
+        """Get a list of unique platforms for all of the associated samples"""
         return list(set([sample.platform_accession_code for sample in self.samples.all()]))
 
     @property
     def platforms(self):
-        """ Returns a list of related pipelines """
+        """Returns a list of related pipelines"""
         return list(set([sample.platform_name for sample in self.samples.all()]))
 
     @property
     def pretty_platforms(self):
-        """ Returns a prettified list of related pipelines """
+        """Returns a prettified list of related pipelines"""
         return list(set([sample.pretty_platform for sample in self.samples.all()]))
 
     @property
@@ -209,13 +206,21 @@ class Experiment(models.Model):
         )
 
     @property
-    def organism_names(self):
-        """ Get a list of unique organism names that has at least one downloadable sample """
+    def downloadable_organism_names(self):
+        """Get a list of unique organism names that has at least one downloadable sample"""
         result = (
             self.samples.filter(is_processed=True, organism__qn_target__isnull=False)
             .values_list("organism__name", flat=True)
             .distinct()
         )
+
+        return list(result)
+
+    @property
+    def organism_names(self):
+        """Get a list of unique organism names"""
+        result = self.samples.values_list("organism__name", flat=True).distinct()
+
         return list(result)
 
     @property


### PR DESCRIPTION
## Issue Number

Fixes #2840

## Purpose/Implementation Notes

This PR moves the old behavior to a field called `downloadable_organism_names` field and makes `organism_names` return all of the organism names. I wired up the filters to point to `downloadable_organism_names`, but the frontend takes the data from `organism_names` to populate the UI, so this makes the new behavior consistent with the experiment detail view.

I need to file a tiny frontend PR to go along with this one that just changes the facet name.

## Types of changes

What types of changes does your code introduce?

<!-- Remove any which your PR isn't -->
- Bugfix (non-breaking change which fixes an issue)

## Functional tests

I ran the API locally alongside the frontend changes and made sure everything looks right.

## Checklist

_Put an `x` in the boxes that apply._

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules

## Screenshots

![image](https://user-images.githubusercontent.com/13942258/125502483-0ccf59f9-8051-44ad-a1b0-fd8ade9cd7f6.png)
