### PR TITLE
Poll the smasher end to end test so it doesn't fail when the API isn't up yet.

### DIFF
--- a/foreman/data_refinery_foreman/foreman/test_end_to_end.py
+++ b/foreman/data_refinery_foreman/foreman/test_end_to_end.py
@@ -171,15 +171,14 @@ class SmasherEndToEndTestCase(TestCase):
         prepare_computed_files()
 
         # The API sometimes takes a bit to come back up.
-        stop = False
         start_time = timezone.now()
-        while not stop:
+        while True:
             try:
                 pyrefinebio.create_token(agree_to_terms=True, save_token=False)
-                stop = True
+                break
             except pyrefinebio.ServerError:
                 if timezone.now() - start_time > timedelta(minutes=15):
-                    stop = True
+                    break
                 else:
                     sleep(30)
 

--- a/foreman/data_refinery_foreman/foreman/test_end_to_end.py
+++ b/foreman/data_refinery_foreman/foreman/test_end_to_end.py
@@ -178,7 +178,7 @@ class SmasherEndToEndTestCase(TestCase):
                 break
             except pyrefinebio.ServerError:
                 if timezone.now() - start_time > timedelta(minutes=15):
-                    break
+                    raise AssertionError("Server not up after 15 minutes")
                 else:
                     sleep(30)
 


### PR DESCRIPTION
## Issue Number

N/A Will and I noticed this in the end to end tests

## Purpose/Implementation Notes

The end to end tests run right after the deploy, so sometimes the API isn't yet up by the time we're trying to use it to download a dataset.

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

I ran an end-to-end test against a dev stack, it worked! I tried to have the API down, but I couldn't get it quick enough. I guess staging will be the final test.

## Checklist

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules
