### PR TITLE
E2E tests: Download the quant file using the smasher

### DIFF
--- a/foreman/data_refinery_foreman/foreman/test_end_to_end.py
+++ b/foreman/data_refinery_foreman/foreman/test_end_to_end.py
@@ -351,7 +351,7 @@ class FullFlowEndToEndTestCase(TestCase):
         ref_TPM = squish_duplicates(pd.DataFrame({"reference": ref["TPM"]}))
         ref_NumReads = squish_duplicates(pd.DataFrame({"reference": ref["NumReads"]}))
 
-        with zipfile.Zipfile(dataset_path) as zf:
+        with zipfile.ZipFile(dataset_path) as zf:
             with zf.open("SRP094706/SRR5085168_quant.sf", "r") as out_file:
                 out = pd.read_csv(out_file, delimiter="\t", index_col=0)
         out_TPM = squish_duplicates(pd.DataFrame({"actual": out["TPM"]}))

--- a/foreman/data_refinery_foreman/foreman/test_end_to_end.py
+++ b/foreman/data_refinery_foreman/foreman/test_end_to_end.py
@@ -1,3 +1,4 @@
+import zipfile
 from datetime import timedelta
 from os import path
 from time import sleep
@@ -325,22 +326,34 @@ class FullFlowEndToEndTestCase(TestCase):
             "R64-1-1",
         )
 
-        # The `quant.sf` file is not directly associated with the sample, so we
-        # need to find it this way
-        quant_result = sample.results.get(processor__name="Salmon Quant")
-        quant_file = quant_result.computedfile_set.get(filename="quant.sf")
-        output_filename = quant_file.sync_from_s3(force=True)
+        # We are now going to download the `quant.sf` file by making a
+        # quant-only smasher job. We need to do this because the results bucket
+        # was locked down, so we can't access it without agreeing to the terms
+        # first.
+        pyrefinebio.create_token(agree_to_terms=True, save_token=False)
 
-        ref_filename = "/home/user/data_store/reference/SRR5085168_quant.sf"
+        dataset_path = "end_to_end_quant_dataset.zip"
+        pyrefinebio.download_dataset(
+            dataset_path,
+            "testendtoend@example.com",
+            dataset_dict={"SRP094706": ["SRR5085168"]},
+            quant_sf_only=True,
+            aggregation="EXPERIMENT",
+            timeout=timedelta(minutes=15),
+        )
+        self.assertTrue(path.exists(dataset_path))
 
         def squish_duplicates(data: pd.DataFrame) -> pd.DataFrame:
             return data.groupby(data.index, sort=False).mean()
 
+        ref_filename = "/home/user/data_store/reference/SRR5085168_quant.sf"
         ref = pd.read_csv(ref_filename, delimiter="\t", index_col=0)
         ref_TPM = squish_duplicates(pd.DataFrame({"reference": ref["TPM"]}))
         ref_NumReads = squish_duplicates(pd.DataFrame({"reference": ref["NumReads"]}))
 
-        out = pd.read_csv(output_filename, delimiter="\t", index_col=0)
+        with zipfile.Zipfile(dataset_path) as zf:
+            with zf.open("SRP094706/SRR5085168_quant.sf", "r") as out_file:
+                out = pd.read_csv(out_file, delimiter="\t", index_col=0)
         out_TPM = squish_duplicates(pd.DataFrame({"actual": out["TPM"]}))
         out_NumReads = squish_duplicates(pd.DataFrame({"actual": out["NumReads"]}))
 

--- a/foreman/requirements.in
+++ b/foreman/requirements.in
@@ -6,7 +6,7 @@ coverage
 GEOparse>=2.0.3
 python-dateutil
 raven
-pyrefinebio>=0.3.2
+pyrefinebio>=0.4.2
 tblib
 djangorestframework>=3.11.2
 # Can't go above 6.X without upgrading elasticsearch

--- a/foreman/requirements.txt
+++ b/foreman/requirements.txt
@@ -24,7 +24,7 @@ multidict==5.1.0          # via yarl
 numpy==1.19.5             # via -r requirements.in, geoparse, pandas, scipy
 pandas==1.1.5             # via geoparse
 psycopg2-binary==2.8.6    # via -r requirements.in
-pyrefinebio==0.3.2        # via -r requirements.in
+pyrefinebio==0.4.2        # via -r requirements.in
 python-dateutil==2.8.1    # via -r requirements.in, elasticsearch-dsl, pandas, pyrefinebio
 pytz==2021.1              # via django, pandas
 pyyaml==5.4.1             # via -r requirements.in, pyrefinebio, vcrpy


### PR DESCRIPTION
## Issue Number

Came up while deploying

## Purpose/Implementation Notes

Because we locked down the S3 buckets, `.sync_from_s3()` no longer works inside the end-to-end tests. Because we were only trying to grab a quant file, the easiest solution is to use the smasher to download the quant file.

## Types of changes

What types of changes does your code introduce?

<!-- Remove any which your PR isn't -->
- Bugfix (non-breaking change which fixes an issue)

## Functional tests

I spun up a devstack and verified that the tests pass.

## Checklist

_Put an `x` in the boxes that apply._

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules

## Screenshots

Please attach any screenshots that illustrate these changes.
