### PR TITLE
Reduce the number of queries on the stats page

### DIFF
--- a/api/data_refinery_api/views/stats.py
+++ b/api/data_refinery_api/views/stats.py
@@ -192,7 +192,7 @@ class Stats(APIView):
                 in_=openapi.IN_QUERY,
                 type=openapi.TYPE_STRING,
                 description="Specify a range from which to calculate the possible options",
-                enum=("day", "week", "month", "year",),
+                enum=("day", "week", "month", "year"),
             )
         ]
     )
@@ -336,12 +336,16 @@ class Stats(APIView):
                     created_at__gt=JOB_CREATED_AT_CUTOFF,
                 ),
             ),
-        )
-        # via https://stackoverflow.com/questions/32520655/get-average-of-difference-of-datetime-fields-in-django
-        result["average_time"] = (
-            jobs.filter(start_filter)
-            .filter(start_time__isnull=False, end_time__isnull=False, success=True)
-            .aggregate(average_time=Avg(F("end_time") - F("start_time")))["average_time"]
+            # via https://stackoverflow.com/questions/32520655/get-average-of-difference-of-datetime-fields-in-django
+            average_time=Avg(
+                F("end_time") - F("start_time"),
+                filter=Q(
+                    start_time__isnull=False,
+                    end_time__isnull=False,
+                    success=True,
+                    created_at__gt=JOB_CREATED_AT_CUTOFF,
+                ),
+            ),
         )
 
         if not result["average_time"]:
@@ -395,7 +399,7 @@ class FailedDownloaderJobStats(APIView):
                 in_=openapi.IN_QUERY,
                 type=openapi.TYPE_STRING,
                 description="Specify a range from which to calculate the possible options",
-                enum=("day", "week", "month", "year",),
+                enum=("day", "week", "month", "year"),
             )
         ]
     )
@@ -429,7 +433,7 @@ class FailedProcessorJobStats(APIView):
                 in_=openapi.IN_QUERY,
                 type=openapi.TYPE_STRING,
                 description="Specify a range from which to calculate the possible options",
-                enum=("day", "week", "month", "year",),
+                enum=("day", "week", "month", "year"),
             )
         ]
     )


### PR DESCRIPTION
## Issue Number

https://github.com/AlexsLemonade/refinebio/issues/2371

## Purpose/Implementation Notes

This PR reduces the number of queries we execute as part of the stats endpoint by computing the average time at the same time as the other summary statistics.

This brings the total number of queries we execute on the job tables down to 2. I spent lots of time researching and brainstorming ways to do everything in 1 query, but it turns out that SQL and Django need multiple queries if you want to group by a field for some data and not for other data. I tried to get around this by grouping by `start` (the truncated start time that we use in the timelines) and then computing the other summary stats by iterating through this list, but this ended up being just as slow as the current two queries we have.

I think this is about as much progress as can be made on the dashboard while we are not processing, because right now the dashboard does not time out, so some inefficient queries seem to be hiding behind the fact that we are not processing.

One option we have that could _potentially_ speed up the query is to add things to the index for each kind of jobs, but my understanding is that we would need every field we filter on to be in the index in order to take advantage of the index.

A last thing that we could try is to [manually vacuum](https://www.postgresql.org/docs/current/sql-vacuum.html) some of the worst tables, like the processor jobs, downloader jobs, and samples. I have a feeling that these tables are pretty fragmented because we delete things from it so often when unsurveying experiments. A full vacuum requires writing out a new database file and copying everything over while the database is fully locked, though, so I am not sure about the RDS costs associated with that or what the downtime would be.

## Types of changes

What types of changes does your code introduce?

<!-- Remove any which your PR isn't -->
- Bugfix (non-breaking change which fixes an issue)

## Functional tests

I ran all of my changes on the API server inside a REPL session and timed the execution using `timeit` to verify that this is indeed faster than the current endpoint while returning the same output.

## Checklist

_Put an `x` in the boxes that apply._

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules
