### PR TITLE
Update pyrefinebio version to fix end to end tests

### DIFF
--- a/foreman/requirements.in
+++ b/foreman/requirements.in
@@ -6,7 +6,7 @@ coverage
 GEOparse>=2.0.3
 python-dateutil
 raven
-pyrefinebio>=0.4.2
+pyrefinebio>=0.4.3
 tblib
 djangorestframework>=3.11.2
 # Can't go above 6.X without upgrading elasticsearch

--- a/foreman/requirements.txt
+++ b/foreman/requirements.txt
@@ -24,8 +24,9 @@ multidict==5.1.0          # via yarl
 numpy==1.19.5             # via -r requirements.in, geoparse, pandas, scipy
 pandas==1.1.5             # via geoparse
 psycopg2-binary==2.8.6    # via -r requirements.in
-pyrefinebio==0.4.2        # via -r requirements.in
+pyrefinebio==0.4.3        # via -r requirements.in
 python-dateutil==2.8.1    # via -r requirements.in, elasticsearch-dsl, pandas, pyrefinebio
+pytimeparse==1.1.8        # via pyrefinebio
 pytz==2021.1              # via django, pandas
 pyyaml==5.4.1             # via -r requirements.in, pyrefinebio, vcrpy
 raven==6.10.0             # via -r requirements.in


### PR DESCRIPTION
## Issue Number

https://github.com/AlexsLemonade/refinebio-py/pull/64

## Purpose/Implementation Notes

This should fix the end to end test because it changes to the exception we're expecting.

The end to end test is already expecting a ServerError, which this switches to.

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

N/A This should really only affect the end to end tests.

## Checklist

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules
