### PR TITLE
reduce db queries

### DIFF
--- a/api/data_refinery_api/views/sample.py
+++ b/api/data_refinery_api/views/sample.py
@@ -177,13 +177,19 @@ class SampleListView(generics.ListAPIView):
             raise InvalidFilters(invalid_filters=invalid_filters)
 
         queryset = (
-            Sample.public_objects.prefetch_related("organism")
+            Sample.public_objects.select_related("organism")
+            .prefetch_related("experiments")
             .prefetch_related(
-                Prefetch("results", queryset=ComputationalResult.objects.order_by("time_start"))
+                Prefetch(
+                    "results",
+                    queryset=ComputationalResult.objects.select_related("processor")
+                    .select_related("organism_index")
+                    .order_by("time_start"),
+                )
             )
-            .prefetch_related("results__processor")
-            .prefetch_related("results__computationalresultannotation_set")
-            .prefetch_related("results__computedfile_set")
+            .prefetch_related("sampleannotation_set")
+            .prefetch_related("original_files")
+            .prefetch_related("computed_files")
             .filter(**self.get_query_params_filters())
         )
 


### PR DESCRIPTION
## Issue Number

#2655 

## Purpose/Implementation Notes

* restructures the sample list api `pre_fetches` to reduce association db queries
* uses select related appropriately for `organisms`
* nests the prefetch for `ComputationalResults` relationships inside of the `Prefetch` obect

I think more optimizations can be had here but I need to see how this performs with a much larger dataset. I think we need to strike a balance of not overloading the db queries or the amount of joining that needs to happen in python. 

## Methods

n/a

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

went from 81 db queries to 7

## Checklist

- [x] Lint and unit tests pass locally with my changes

## Screenshots

n/a

<details>

```

       │ File: log.txt
───────┼────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
   1   │
   2   │ Rebuilding the ccdlstaging/dr_api_local image.
   3   │ Performing system checks...
   4   │
   5   │ System check identified no issues (0 silenced).
   6   │ (0.006) SELECT t.oid, typarray FROM pg_type t JOIN pg_namespace ns ON typnamespace = ns.oid WHERE typname = 'hstore'; args=None
   7   │ (0.001) SELECT typarray FROM pg_type WHERE typname = 'citext'; args=None
   8   │ (0.006)
   9   │             SELECT c.relname,
  10   │             CASE WHEN FALSE THEN 'p' WHEN c.relkind IN ('m', 'v') THEN 'v' ELSE 't' END
  11   │             FROM pg_catalog.pg_class c
  12   │             LEFT JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace
  13   │             WHERE c.relkind IN ('f', 'm', 'p', 'r', 'v')
  14   │                 AND n.nspname NOT IN ('pg_catalog', 'pg_toast')
  15   │                 AND pg_catalog.pg_table_is_visible(c.oid)
  16   │         ; args=None
  17   │ (0.003) SELECT "django_migrations"."id", "django_migrations"."app", "django_migrations"."name", "django_migrations"."applied" FROM "django_migrations"; args=()
  18   │ August 11, 2021 - 15:11:57
  19   │ Django version 3.2.4, using settings 'data_refinery_api.settings'
  20   │ Starting development server at http://0.0.0.0:8000/
  21   │ Quit the server with CONTROL-C.
  22   │ (0.003) SELECT "cache_key", "value", "expires" FROM "cache_table" WHERE "cache_key" IN (':1:throttle_anon_172.17.0.1'); args=[':1:throttle_anon_172.17.0.1']
  23   │ (0.003) DELETE FROM "cache_table" WHERE "cache_key" IN (':1:throttle_anon_172.17.0.1'); args=[':1:throttle_anon_172.17.0.1']
  24   │ (0.001) SELECT COUNT(*) FROM "cache_table"; args=None
  25   │ (0.001) SELECT "cache_key", "expires" FROM "cache_table" WHERE "cache_key" = ':1:throttle_anon_172.17.0.1'; args=[':1:throttle_anon_172.17.0.1']
  26   │ (0.002) INSERT INTO "cache_table" ("cache_key", "value", "expires") VALUES (':1:throttle_anon_172.17.0.1', 'gAWVDQAAAAAAAABdlEdB2ET6L1up22Eu', '2021-08-11T15:11:58'::timestamp); args=[':1:throttle_anon_172.17.0.1', 'gAWVDQAAAAAAAABdlEdB2ET6L1up22Eu', date
       │ time.datetime(2021, 8, 11, 15, 11, 58)]
  27   │ (0.000) SELECT "cache_key", "value", "expires" FROM "cache_table" WHERE "cache_key" IN (':1:throttle_user_172.17.0.1'); args=[':1:throttle_user_172.17.0.1']
  28   │ (0.001) DELETE FROM "cache_table" WHERE "cache_key" IN (':1:throttle_user_172.17.0.1'); args=[':1:throttle_user_172.17.0.1']
  29   │ (0.000) SELECT COUNT(*) FROM "cache_table"; args=None
  30   │ (0.001) SELECT "cache_key", "expires" FROM "cache_table" WHERE "cache_key" = ':1:throttle_user_172.17.0.1'; args=[':1:throttle_user_172.17.0.1']
  31   │ (0.000) INSERT INTO "cache_table" ("cache_key", "value", "expires") VALUES (':1:throttle_user_172.17.0.1', 'gAWVDQAAAAAAAABdlEdB2ET6L1xBgGEu', '2021-08-11T15:11:58'::timestamp); args=[':1:throttle_user_172.17.0.1', 'gAWVDQAAAAAAAABdlEdB2ET6L1xBgGEu', date
       │ time.datetime(2021, 8, 11, 15, 11, 58)]
  32   │ (0.006) SELECT COUNT(*) AS "__count" FROM "samples" WHERE "samples"."is_public"; args=()
  33   │ (0.009) SELECT "samples"."id", "samples"."accession_code", "samples"."title", "samples"."organism_id", "samples"."source_database", "samples"."source_archive_url", "samples"."source_filename", "samples"."source_absolute_file_path", "samples"."has_raw", "s
       │ amples"."platform_accession_code", "samples"."platform_name", "samples"."technology", "samples"."manufacturer", "samples"."protocol_info", "samples"."sex", "samples"."age", "samples"."specimen_part", "samples"."genotype", "samples"."disease", "samples"."d
       │ isease_stage", "samples"."cell_line", "samples"."treatment", "samples"."race", "samples"."subject", "samples"."compound", "samples"."time", "samples"."is_processed", "samples"."is_blacklisted", "samples"."is_public", "samples"."created_at", "samples"."las
       │ t_modified", "organisms"."id", "organisms"."name", "organisms"."taxonomy_id", "organisms"."is_scientific_name", "organisms"."created_at", "organisms"."last_modified", "organisms"."qn_target_id", "organisms"."has_compendia", "organisms"."has_quantfile_comp
       │ endia" FROM "samples" LEFT OUTER JOIN "organisms" ON ("samples"."organism_id" = "organisms"."id") WHERE "samples"."is_public" ORDER BY "samples"."is_processed" DESC LIMIT 25; args=()
  34   │ (0.009) SELECT ("experiment_sample_associations"."sample_id") AS "_prefetch_related_val_sample_id", "experiments"."id", "experiments"."accession_code", "experiments"."alternate_accession_code", "experiments"."source_database", "experiments"."source_url",
       │ "experiments"."title", "experiments"."description", "experiments"."protocol_description", "experiments"."technology", "experiments"."submitter_institution", "experiments"."has_publication", "experiments"."publication_title", "experiments"."publication_doi
       │ ", "experiments"."publication_authors", "experiments"."pubmed_id", "experiments"."source_first_published", "experiments"."source_last_modified", "experiments"."num_total_samples", "experiments"."num_processed_samples", "experiments"."num_downloadable_samp
       │ les", "experiments"."sample_keywords", "experiments"."sample_metadata_fields", "experiments"."platform_names", "experiments"."platform_accession_codes", "experiments"."is_public", "experiments"."created_at", "experiments"."last_modified" FROM "experiments
       │ " INNER JOIN "experiment_sample_associations" ON ("experiments"."id" = "experiment_sample_associations"."experiment_id") WHERE "experiment_sample_associations"."sample_id" IN (3, 1, 6, 7, 4, 8, 2, 5, 10, 9, 330, 163, 478, 102, 101, 162, 161, 404, 104, 249
       │ , 165, 331, 11, 248, 247); args=(3, 1, 6, 7, 4, 8, 2, 5, 10, 9, 330, 163, 478, 102, 101, 162, 161, 404, 104, 249, 165, 331, 11, 248, 247)
  35   │ (0.013) SELECT ("sample_result_associations"."sample_id") AS "_prefetch_related_val_sample_id", "computational_results"."id", "computational_results"."commands", "computational_results"."processor_id", "computational_results"."organism_index_id", "computa
       │ tional_results"."is_ccdl", "computational_results"."time_start", "computational_results"."time_end", "computational_results"."is_public", "computational_results"."created_at", "computational_results"."last_modified", "processors"."id", "processors"."name"
       │ , "processors"."version", "processors"."docker_image", "processors"."environment", "organism_index"."id", "organism_index"."organism_id", "organism_index"."result_id", "organism_index"."index_type", "organism_index"."database_name", "organism_index"."rele
       │ ase_version", "organism_index"."assembly_name", "organism_index"."salmon_version", "organism_index"."absolute_directory_path", "organism_index"."is_public", "organism_index"."created_at", "organism_index"."last_modified" FROM "computational_results" INNER
       │  JOIN "sample_result_associations" ON ("computational_results"."id" = "sample_result_associations"."result_id") LEFT OUTER JOIN "processors" ON ("computational_results"."processor_id" = "processors"."id") LEFT OUTER JOIN "organism_index" ON ("computationa
       │ l_results"."organism_index_id" = "organism_index"."id") WHERE "sample_result_associations"."sample_id" IN (3, 1, 6, 7, 4, 8, 2, 5, 10, 9, 330, 163, 478, 102, 101, 162, 161, 404, 104, 249, 165, 331, 11, 248, 247) ORDER BY "computational_results"."time_star
       │ t" ASC; args=(3, 1, 6, 7, 4, 8, 2, 5, 10, 9, 330, 163, 478, 102, 101, 162, 161, 404, 104, 249, 165, 331, 11, 248, 247)
  36   │ (0.004) SELECT "sample_annotations"."id", "sample_annotations"."sample_id", "sample_annotations"."data", "sample_annotations"."is_ccdl", "sample_annotations"."is_public", "sample_annotations"."created_at", "sample_annotations"."last_modified" FROM "sample
       │ _annotations" WHERE "sample_annotations"."sample_id" IN (3, 1, 6, 7, 4, 8, 2, 5, 10, 9, 330, 163, 478, 102, 101, 162, 161, 404, 104, 249, 165, 331, 11, 248, 247); args=(3, 1, 6, 7, 4, 8, 2, 5, 10, 9, 330, 163, 478, 102, 101, 162, 161, 404, 104, 249, 165,
       │ 331, 11, 248, 247)
  37   │ (0.007) SELECT ("original_file_sample_associations"."sample_id") AS "_prefetch_related_val_sample_id", "original_files"."id", "original_files"."filename", "original_files"."absolute_file_path", "original_files"."size_in_bytes", "original_files"."sha1", "o
       │ riginal_files"."md5", "original_files"."expected_md5", "original_files"."expected_size_in_bytes", "original_files"."s3_bucket", "original_files"."s3_key", "original_files"."source_url", "original_files"."is_archive", "original_files"."source_filename", "o
       │ riginal_files"."has_raw", "original_files"."is_downloaded", "original_files"."is_public", "original_files"."created_at", "original_files"."last_modified" FROM "original_files" INNER JOIN "original_file_sample_associations" ON ("original_files"."id" = "ori
       │ ginal_file_sample_associations"."original_file_id") WHERE "original_file_sample_associations"."sample_id" IN (3, 1, 6, 7, 4, 8, 2, 5, 10, 9, 330, 163, 478, 102, 101, 162, 161, 404, 104, 249, 165, 331, 11, 248, 247); args=(3, 1, 6, 7, 4, 8, 2, 5, 10, 9, 33
       │ 0, 163, 478, 102, 101, 162, 161, 404, 104, 249, 165, 331, 11, 248, 247)
  38   │ (0.009) SELECT ("sample_computed_file_associations"."sample_id") AS "_prefetch_related_val_sample_id", "computed_files"."id", "computed_files"."filename", "computed_files"."absolute_file_path", "computed_files"."size_in_bytes", "computed_files"."sha1", "c
       │ omputed_files"."result_id", "computed_files"."is_smashable", "computed_files"."is_qc", "computed_files"."is_qn_target", "computed_files"."quant_sf_only", "computed_files"."is_compendia", "computed_files"."svd_algorithm", "computed_files"."compendia_organi
       │ sm_id", "computed_files"."compendia_version", "computed_files"."s3_bucket", "computed_files"."s3_key", "computed_files"."is_public", "computed_files"."created_at", "computed_files"."last_modified" FROM "computed_files" INNER JOIN "sample_computed_file_ass
       │ ociations" ON ("computed_files"."id" = "sample_computed_file_associations"."computed_file_id") WHERE "sample_computed_file_associations"."sample_id" IN (3, 1, 6, 7, 4, 8, 2, 5, 10, 9, 330, 163, 478, 102, 101, 162, 161, 404, 104, 249, 165, 331, 11, 248, 24
       │ 7); args=(3, 1, 6, 7, 4, 8, 2, 5, 10, 9, 330, 163, 478, 102, 101, 162, 161, 404, 104, 249, 165, 331, 11, 248, 247)
```
</details>