### PR TITLE
Trying only switching to fancySVD.

### DIFF
--- a/workers/data_refinery_workers/processors/compendia.yml
+++ b/workers/data_refinery_workers/processors/compendia.yml
@@ -14,4 +14,4 @@ python:
   - data-refinery-common
   - pandas
   - numpy
-  - fancyimpute
+  - fancySVD

--- a/workers/data_refinery_workers/processors/create_compendia.py
+++ b/workers/data_refinery_workers/processors/create_compendia.py
@@ -11,7 +11,7 @@ from django.utils import timezone
 import numpy as np
 import pandas as pd
 import psutil
-from fancyimpute import IterativeSVD
+from fancySVD import IterativeSVD
 
 from data_refinery_common.enums import PipelineEnum
 from data_refinery_common.logging import get_and_configure_logger

--- a/workers/dockerfiles/Dockerfile.compendia
+++ b/workers/dockerfiles/Dockerfile.compendia
@@ -79,17 +79,7 @@ ENV LANG C.UTF-8
 RUN pip3 install --upgrade pip
 
 # Smasher-specific requirements
-RUN pip3 install numpy scipy matplotlib pandas==0.25.3 scikit-learn sympy nose rpy2===2.9.5 tzlocal
-# End smasher-specific
-
-# Some combination of pip and setuptools versions makes this bug appear:
-# https://github.com/pypa/setuptools/issues/1694
-# Upgrading setuptools fixes it though!
-RUN pip3 install --upgrade setuptools
-
-# Impute-specific requirements
-# We need to freeze the tensorflow version for fancyimpute
-RUN pip3 install tensorflow==2.4.1 fancyimpute==0.5.5
+RUN pip3 install numpy scipy matplotlib pandas==0.25.3 scikit-learn sympy nose rpy2===2.9.5 tzlocal fancySVD
 # End smasher-specific
 
 COPY config/ config/


### PR DESCRIPTION
## Issue Number

https://github.com/AlexsLemonade/fancySVD/pull/1

## Purpose/Implementation Notes

The tests broke because of a new fancyimpute version makes the delicate dependency balancing act we were doing fall apart. Therefore I've created a fancySVD package that doesn't need many dependencies. This is much easier to install and I think is maybe even working.

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

`./workers/run_tests.sh data_refinery_workers.processors.test_imports.ImportTestCase.test_compendia_imports` worked locally!

## Checklist

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules
