### PR TITLE
Install certbot via snap instead of apt.

### DIFF
--- a/infrastructure/api-configuration/api-server-instance-user-data.tpl.sh
+++ b/infrastructure/api-configuration/api-server-instance-user-data.tpl.sh
@@ -27,8 +27,9 @@ if [[ "${stage}" == "staging" || "${stage}" == "prod" ]]; then
     # Create and install SSL Certificate for the API.
     # Only necessary on staging and prod.
     # We cannot use ACM for this because *.bio is not a Top Level Domain that Route53 supports.
-    apt-get install -y software-properties-common
-    add-apt-repository ppa:certbot/certbot
+    snap install core
+    snap refresh core
+    snap install --classic certbot
     apt-get update
     apt-get install -y python-certbot-nginx
 


### PR DESCRIPTION
## Issue Number

N/A Certbot failed to install last night so we had no HTTPS

## Purpose/Implementation Notes

This is the new recommended way to install certbot. I did this on the prod server last night, so I think it'll work but I can't really test without at least hitting staging.