### PR TITLE
Add initial implementation of sample metadata to the sample view

### DIFF
--- a/api/data_refinery_api/views/sample.py
+++ b/api/data_refinery_api/views/sample.py
@@ -94,6 +94,8 @@ class DetailedSampleSerializer(serializers.ModelSerializer):
             "last_modified",
             "original_files",
             "computed_files",
+            "contributed_metadata",
+            "contributed_keywords",
             "experiment_accession_codes",
         )
         read_only_fields = fields
@@ -125,7 +127,7 @@ class DetailedSampleSerializer(serializers.ModelSerializer):
     ),
 )
 class SampleListView(generics.ListAPIView):
-    """ Returns detailed information about Samples """
+    """Returns detailed information about Samples"""
 
     model = Sample
     serializer_class = DetailedSampleSerializer
@@ -254,7 +256,7 @@ class SampleListView(generics.ListAPIView):
 
 
 class SampleDetailView(generics.RetrieveAPIView):
-    """ Retrieve the details for a Sample given its accession code """
+    """Retrieve the details for a Sample given its accession code"""
 
     lookup_field = "accession_code"
     queryset = Sample.public_objects.all()

--- a/common/data_refinery_common/models/sample.py
+++ b/common/data_refinery_common/models/sample.py
@@ -81,7 +81,7 @@ class Sample(models.Model):
     last_modified = models.DateTimeField(default=timezone.now)
 
     def save(self, *args, **kwargs):
-        """ On save, update timestamps """
+        """On save, update timestamps"""
         current_time = timezone.now()
         if not self.id:
             self.created_at = current_time
@@ -147,11 +147,11 @@ class Sample(models.Model):
         return downloader_jobs
 
     def get_result_files(self):
-        """ Get all of the ComputedFile objects associated with this Sample """
+        """Get all of the ComputedFile objects associated with this Sample"""
         return self.computed_files.all()
 
     def get_most_recent_smashable_result_file(self):
-        """ Get the most recent of the ComputedFile objects associated with this Sample """
+        """Get the most recent of the ComputedFile objects associated with this Sample"""
         try:
             if settings.RUNNING_IN_CLOUD:
                 latest_computed_file = self.computed_files.filter(
@@ -159,7 +159,7 @@ class Sample(models.Model):
                 ).latest()
             else:
                 latest_computed_file = self.computed_files.filter(
-                    is_public=True, is_smashable=True,
+                    is_public=True, is_smashable=True
                 ).latest()
 
             return latest_computed_file
@@ -168,9 +168,9 @@ class Sample(models.Model):
             return None
 
     def get_most_recent_quant_sf_file(self):
-        """ Returns the latest quant.sf file that was generated for this sample.
+        """Returns the latest quant.sf file that was generated for this sample.
         Note: We don't associate that file to the computed_files of this sample, that's
-        why we have to go through the computational results. """
+        why we have to go through the computational results."""
         return (
             ComputedFile.objects.filter(
                 result__in=self.results.all(),
@@ -184,7 +184,7 @@ class Sample(models.Model):
 
     @property
     def pretty_platform(self):
-        """ Turns
+        """Turns
 
         [HT_HG-U133_Plus_PM] Affymetrix HT HG-U133+ PM Array Plate
 
@@ -202,3 +202,32 @@ class Sample(models.Model):
     @property
     def experiment_accession_codes(self):
         return [e.accession_code for e in self.experiments.all()]
+
+    @property
+    def contributed_metadata(self):
+        out = {}
+        for attrib in self.attributes.all():
+            val = {"value": attrib.get_value()}
+
+            if attrib.unit is not None:
+                val["unit"] = attrib.unit.human_readable_name
+            if attrib.probability is not None:
+                val["confidence"] = attrib.probability
+
+            try:
+                out[attrib.source.source_name][attrib.name.human_readable_name] = val
+            except KeyError:
+                out[attrib.source.source_name] = {attrib.name.human_readable_name: val}
+
+        return out
+
+    @property
+    def contributed_keywords(self):
+        out = {}
+        for kw in self.keywords.all():
+            try:
+                out[kw.source.source_name].append(kw.name.human_readable_name)
+            except KeyError:
+                out[kw.source.source_name] = [kw.name.human_readable_name]
+
+        return out


### PR DESCRIPTION
## Issue Number

Closes https://github.com/AlexsLemonade/refinebio/issues/2892

## Purpose/Implementation Notes

Adds two new `@property` methods to render a sample's attributes and keywords and adds those properties to the Sample view.

We might want to think about tweaking the schema of these dicts or making them only render on the sample detail view.

## Types of changes

What types of changes does your code introduce?

<!-- Remove any which your PR isn't -->
- New feature (non-breaking change which adds functionality)

## Functional tests

I ran the API locally and made sure the new output was there.

## Checklist

_Put an `x` in the boxes that apply._

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules
