### PR TITLE
Harden end to end tests

### DIFF
--- a/foreman/requirements.in
+++ b/foreman/requirements.in
@@ -6,7 +6,7 @@ coverage
 GEOparse>=2.0.3
 python-dateutil
 raven
-pyrefinebio>=0.4.3
+pyrefinebio>=0.4.6
 tblib
 djangorestframework>=3.11.2
 # Can't go above 6.X without upgrading elasticsearch

--- a/foreman/requirements.txt
+++ b/foreman/requirements.txt
@@ -4,42 +4,123 @@
 #
 #    pip-compile requirements.in
 #
-asgiref==3.3.4            # via django
-certifi==2021.5.30        # via requests
-chardet==4.0.0            # via requests
-click==8.0.1              # via pyrefinebio
-coverage==5.5             # via -r requirements.in
-django-computedfields==0.1.5  # via -r requirements.in
-django-elasticsearch-dsl-drf==0.22.1  # via -r requirements.in
-django-elasticsearch-dsl==6.5.0  # via -r requirements.in, django-elasticsearch-dsl-drf
-django-nine==0.2.4        # via django-elasticsearch-dsl-drf
-django==3.2.4             # via -r requirements.in, django-nine, djangorestframework
-djangorestframework==3.12.4  # via -r requirements.in, django-elasticsearch-dsl-drf
-elasticsearch-dsl==6.4.0  # via -r requirements.in, django-elasticsearch-dsl, django-elasticsearch-dsl-drf
-elasticsearch==6.8.2      # via django-elasticsearch-dsl-drf, elasticsearch-dsl
-geoparse==2.0.3           # via -r requirements.in
-idna==2.10                # via requests, yarl
-importlib-metadata==4.5.0  # via click
-multidict==5.1.0          # via yarl
-numpy==1.19.5             # via -r requirements.in, geoparse, pandas, scipy
-pandas==1.1.5             # via geoparse
-psycopg2-binary==2.8.6    # via -r requirements.in
-pyrefinebio==0.4.3        # via -r requirements.in
-python-dateutil==2.8.1    # via -r requirements.in, elasticsearch-dsl, pandas, pyrefinebio
-pytimeparse==1.1.8        # via pyrefinebio
-pytz==2021.1              # via django, pandas
-pyyaml==5.4.1             # via -r requirements.in, pyrefinebio, vcrpy
-raven==6.10.0             # via -r requirements.in
-requests==2.25.1          # via -r requirements.in, geoparse, pyrefinebio
-retrying==1.3.3           # via -r requirements.in
-scipy==1.5.4              # via -r requirements.in
-six==1.16.0               # via django-elasticsearch-dsl, django-elasticsearch-dsl-drf, elasticsearch-dsl, python-dateutil, retrying, vcrpy
-sqlparse==0.4.1           # via django
-tblib==1.7.0              # via -r requirements.in
-tqdm==4.61.1              # via geoparse
-typing-extensions==3.10.0.0  # via asgiref, importlib-metadata, yarl
-urllib3==1.26.5           # via elasticsearch, requests
-vcrpy==4.1.1              # via -r requirements.in
-wrapt==1.12.1             # via vcrpy
-yarl==1.6.3               # via vcrpy
-zipp==3.4.1               # via importlib-metadata
+asgiref==3.3.4
+    # via django
+certifi==2021.5.30
+    # via requests
+chardet==4.0.0
+    # via requests
+click==8.0.1
+    # via pyrefinebio
+coverage==5.5
+    # via -r requirements.in
+django-computedfields==0.1.5
+    # via -r requirements.in
+django-elasticsearch-dsl-drf==0.22.1
+    # via -r requirements.in
+django-elasticsearch-dsl==6.5.0
+    # via
+    #   -r requirements.in
+    #   django-elasticsearch-dsl-drf
+django-nine==0.2.4
+    # via django-elasticsearch-dsl-drf
+django==3.2.4
+    # via
+    #   -r requirements.in
+    #   django-nine
+    #   djangorestframework
+djangorestframework==3.12.4
+    # via
+    #   -r requirements.in
+    #   django-elasticsearch-dsl-drf
+elasticsearch-dsl==6.4.0
+    # via
+    #   -r requirements.in
+    #   django-elasticsearch-dsl
+    #   django-elasticsearch-dsl-drf
+elasticsearch==6.8.2
+    # via
+    #   django-elasticsearch-dsl-drf
+    #   elasticsearch-dsl
+geoparse==2.0.3
+    # via -r requirements.in
+idna==2.10
+    # via
+    #   requests
+    #   yarl
+importlib-metadata==4.5.0
+    # via click
+iso8601==0.1.16
+    # via pyrefinebio
+multidict==5.1.0
+    # via yarl
+numpy==1.19.5
+    # via
+    #   -r requirements.in
+    #   geoparse
+    #   pandas
+    #   scipy
+pandas==1.1.5
+    # via geoparse
+psycopg2-binary==2.8.6
+    # via -r requirements.in
+pyrefinebio==0.4.6
+    # via -r requirements.in
+python-dateutil==2.8.1
+    # via
+    #   -r requirements.in
+    #   elasticsearch-dsl
+    #   pandas
+pytimeparse==1.1.8
+    # via pyrefinebio
+pytz==2021.1
+    # via
+    #   django
+    #   pandas
+pyyaml==5.4.1
+    # via
+    #   -r requirements.in
+    #   pyrefinebio
+    #   vcrpy
+raven==6.10.0
+    # via -r requirements.in
+requests==2.25.1
+    # via
+    #   -r requirements.in
+    #   geoparse
+    #   pyrefinebio
+retrying==1.3.3
+    # via -r requirements.in
+scipy==1.5.4
+    # via -r requirements.in
+six==1.16.0
+    # via
+    #   django-elasticsearch-dsl
+    #   django-elasticsearch-dsl-drf
+    #   elasticsearch-dsl
+    #   python-dateutil
+    #   retrying
+    #   vcrpy
+sqlparse==0.4.1
+    # via django
+tblib==1.7.0
+    # via -r requirements.in
+tqdm==4.61.1
+    # via geoparse
+typing-extensions==3.10.0.0
+    # via
+    #   asgiref
+    #   importlib-metadata
+    #   yarl
+urllib3==1.26.5
+    # via
+    #   elasticsearch
+    #   requests
+vcrpy==4.1.1
+    # via -r requirements.in
+wrapt==1.12.1
+    # via vcrpy
+yarl==1.6.3
+    # via vcrpy
+zipp==3.4.1
+    # via importlib-metadata


### PR DESCRIPTION
## Issue Number

https://github.com/AlexsLemonade/refinebio-py/pull/67

## Purpose/Implementation Notes

The end to end tests sometimes failed because the API wasn't returning a JSON body in the error responsed. This updates version of pyrefinebio, which should handle this error correctly now.
