### PR TITLE
Set compendia results back to public, remove ks-check as an option

### DIFF
--- a/workers/data_refinery_workers/processors/create_compendia.py
+++ b/workers/data_refinery_workers/processors/create_compendia.py
@@ -502,7 +502,7 @@ def _quantile_normalize(job_context: Dict) -> Dict:
 
     # Perform the Quantile Normalization
     job_context["organism"] = Organism.get_object_for_name(job_context["organism_name"])
-    job_context = smashing_utils.quantile_normalize(job_context, ks_check=False)
+    job_context = smashing_utils.quantile_normalize(job_context)
 
     log_state("end quantile normalize", job_context["job"].id, quantile_start)
 
@@ -521,8 +521,6 @@ def _create_result_objects(job_context: Dict) -> Dict:
     result = ComputationalResult()
     result.commands.append(" ".join(job_context["formatted_command"]))
     result.is_ccdl = True
-    # Temporary until we re-enable the QN test step.
-    result.is_public = False
     result.time_start = job_context["time_start"]
     result.time_end = job_context["time_end"]
     try:

--- a/workers/data_refinery_workers/processors/smashing_utils.py
+++ b/workers/data_refinery_workers/processors/smashing_utils.py
@@ -559,7 +559,7 @@ def _test_qn(merged_matrix):
     return result
 
 
-def quantile_normalize(job_context: Dict, ks_check=True, ks_stat=0.001) -> Dict:
+def quantile_normalize(job_context: Dict, ks_stat=0.001) -> Dict:
     """
     Apply quantile normalization.
     """
@@ -601,7 +601,7 @@ def quantile_normalize(job_context: Dict, ks_check=True, ks_stat=0.001) -> Dict:
             # We're unsure of how strigent to be about
             # the pvalue just yet, so we're extra lax
             # rather than failing tons of tests. This may need tuning.
-            if ks_check and (statistic > ks_stat or pvalue < 0.8):
+            if statistic > ks_stat or pvalue < 0.8:
                 job_context["ks_warning"] = (
                     "Failed Kolmogorov Smirnov test! Stat: "
                     + str(statistic)


### PR DESCRIPTION
## Issue Number

https://github.com/AlexsLemonade/refinebio/issues/2092

## Purpose/Implementation Notes

Pretty straightforward. We'll see how this works on smaller, then larger compendia.

This option shouldn't be needed any more, so I've just removed it entirely.

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

Unit tests will cover it some, but then I'll test in prod for scale.

## Checklist

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules
