### PR TITLE
Remove temporary parameter group. Stop logging checkpoints.

### DIFF
--- a/infrastructure/instances.tf
+++ b/infrastructure/instances.tf
@@ -55,23 +55,9 @@ resource "aws_db_parameter_group" "postgres_parameters" {
     value = "60000" # 60000ms = 60s
   }
 
-  tags = var.default_tags
-}
-
-# Temporary. This will go away once we can delete things.
-resource "aws_db_parameter_group" "postgres_parameter_group" {
-  name = "postgres-parameter-group-${var.user}-${var.stage}"
-  description = "Postgres Parameters ${var.user} ${var.stage}"
-  family = "postgres11"
-
   parameter {
-    name = "deadlock_timeout"
-    value = "60000" # 60000ms = 60s
-  }
-
-  parameter {
-    name = "statement_timeout"
-    value = "60000" # 60000ms = 60s
+    name = "log_checkpoints"
+    value = false
   }
 
   tags = var.default_tags


### PR DESCRIPTION
## Issue Number

Remakes #2658

## Purpose/Implementation Notes

See #2658. It got impossible to merge dev in after git-crypt was removed. Yeah it sat around that long. Ooops.

## Functional tests

I ran a deploy with this on top of what's in dev.