### PR TITLE
Apparently a lifecycle on ACM certs can help with deploys.

### DIFF
--- a/infrastructure/networking.tf
+++ b/infrastructure/networking.tf
@@ -217,6 +217,10 @@ resource "aws_acm_certificate" "ssl-cert" {
       Environment = "data-refinery-circleci-${var.stage}"
     }
   )
+
+  lifecycle {
+    create_before_destroy = true
+  }
 }
 
 resource "aws_acm_certificate_validation" "ssl-cert" {


### PR DESCRIPTION
## Issue Number

#2912 failed

## Purpose/Implementation Notes

It failed with
```
Error: error deleting ACM Certificate (arn:aws:acm:us-east-1:589864003899:certificate/aa11bfaf-4c2c-460f-a8ce-2464816ae6f4): ResourceInUseException: Certificate arn:aws:acm:us-east-1:589864003899:certificate/aa11bfaf-4c2c-460f-a8ce-2464816ae6f4 in account 589864003899 is in use.
```

I pushed a hotfix to see if the extra time would make it work, but it seems to be stalled at the same destroy as last time.

https://github.com/hashicorp/terraform-provider-aws/issues/4537 suggests this might fix it.
