### PR TITLE
Tweaks params for compendia compute env

### DIFF
--- a/infrastructure/batch/compute.tf
+++ b/infrastructure/batch/compute.tf
@@ -112,10 +112,9 @@ resource "aws_batch_compute_environment" "data_refinery_compendia" {
     # Compendia are long running, so we don't want to use spot instances.
     type = local.on_demand_environment_type
     allocation_strategy = local.on_demand_allocation_strategy
-    spot_iam_fleet_role = var.data_refinery_spot_fleet_role.arn
     bid_percentage = 100
 
-    max_vcpus = 32
+    max_vcpus = 64
     min_vcpus = 0
     # standard launch template
     launch_template {

--- a/workers/batch-job-templates/create_compendia.tpl.json
+++ b/workers/batch-job-templates/create_compendia.tpl.json
@@ -10,7 +10,7 @@
         "executionRoleArn": "${{BATCH_EXECUTION_ROLE_ARN}}",
         "image": "${{DOCKERHUB_REPO}}/${{COMPENDIA_DOCKER_IMAGE}}",
         "vcpus": 1,
-        "memory": 4000,
+        "memory": ${{RAM}},
         "command": [
             "python3",
             "manage.py",

--- a/workers/batch-job-templates/create_quantpendia.tpl.json
+++ b/workers/batch-job-templates/create_quantpendia.tpl.json
@@ -10,7 +10,7 @@
         "executionRoleArn": "${{BATCH_EXECUTION_ROLE_ARN}}",
         "image": "${{DOCKERHUB_REPO}}/${{COMPENDIA_DOCKER_IMAGE}}",
         "vcpus": 1,
-        "memory": 4000,
+        "memory": ${{RAM}},
         "command": [
             "python3",
             "manage.py",


### PR DESCRIPTION
## Issue Number

#2929 

## Purpose/Implementation Notes

I think that one instance of that size was more vCPUs then our max, so it never came up and the jobs got stuck at runnable.

Also fixes RAM amounts for *pendia jobs.

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

I'm going to test in staging because there's enough human/mouse data there already.

## Checklist

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream module
