### PR TITLE
Bump the timeouts for compendia to 10 days.

### DIFF
--- a/workers/batch-job-templates/create_compendia.tpl.json
+++ b/workers/batch-job-templates/create_compendia.tpl.json
@@ -1,6 +1,6 @@
 {
     "jobDefinitionName": "${{USER}}_${{STAGE}}_CREATE_COMPENDIA_${{RAM}}",
-    "timeout": {"attemptDurationSeconds": 10800},
+    "timeout": {"attemptDurationSeconds": 864000},
     "type": "container",
     "parameters": {
         "job_name": "",

--- a/workers/batch-job-templates/create_quantpendia.tpl.json
+++ b/workers/batch-job-templates/create_quantpendia.tpl.json
@@ -1,6 +1,6 @@
 {
     "jobDefinitionName": "${{USER}}_${{STAGE}}_CREATE_QUANTPENDIA_${{RAM}}",
-    "timeout": {"attemptDurationSeconds": 10800},
+    "timeout": {"attemptDurationSeconds": 864000},
     "type": "container",
     "parameters": {
         "job_name": "",


### PR DESCRIPTION
## Issue Number

#2931 

## Purpose/Implementation Notes

The timeout was set for 3 hours. The compendia take more like 5 days I think. This sets it to 10 days, just so that if it takes longer than I thought it won't be wasted, but if it goes past 5 days I'll be checking on it daily to make sure it's not hung.

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

N/A