### PR TITLE
Make remove dead computed files less noisy

### DIFF
--- a/common/data_refinery_common/models/computed_file.py
+++ b/common/data_refinery_common/models/computed_file.py
@@ -250,15 +250,16 @@ class ComputedFile(models.Model):
         if not settings.RUNNING_IN_CLOUD and not force:
             return False
 
-        try:
-            S3.delete_object(Bucket=self.s3_bucket, Key=self.s3_key)
-        except Exception:
-            logger.exception(
-                "Failed to delete S3 object for Computed File.",
-                computed_file=self.id,
-                s3_object=self.s3_key,
-            )
-            return False
+        if self.s3_bucket and self.s3_key:
+            try:
+                S3.delete_object(Bucket=self.s3_bucket, Key=self.s3_key)
+            except Exception:
+                logger.exception(
+                    "Failed to delete S3 object for Computed File.",
+                    computed_file=self.id,
+                    s3_object=self.s3_key,
+                )
+                return False
 
         self.s3_key = None
         self.s3_bucket = None

--- a/common/data_refinery_common/models/computed_file.py
+++ b/common/data_refinery_common/models/computed_file.py
@@ -261,9 +261,11 @@ class ComputedFile(models.Model):
                 )
                 return False
 
-        self.s3_key = None
-        self.s3_bucket = None
-        self.save()
+        if self.s3_bucket or self.s3_key:
+            self.s3_key = None
+            self.s3_bucket = None
+            self.save()
+
         return True
 
     def get_synced_file_path(self, force=False, path=None):


### PR DESCRIPTION
## Issue Number

#2935 

## Purpose/Implementation Notes

I saw this exception a whole lot, which was to be expected since the whole reason we're deleting these files is that these fields are null.

It worked well and cleaned up the files though. There were no samples that needed be requeued, but that's not surprising to me since we've tested `retry_samples --computed-files-not-uploaded` in staging before.

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

N/A, I'll test again on staging but there's nothing left to be done so we won't even be able to hit this branch point. I think this is low risk though.

## Checklist

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules
