### PR TITLE
Add stop jobs command so I don't have to go into the database as much.

### DIFF
--- a/common/data_refinery_common/message_queue.py
+++ b/common/data_refinery_common/message_queue.py
@@ -11,12 +11,7 @@ from django.utils import timezone
 
 import boto3
 
-from data_refinery_common.enums import (
-    SMASHER_JOB_TYPES,
-    Downloaders,
-    ProcessorPipeline,
-    SurveyJobTypes,
-)
+from data_refinery_common.enums import Downloaders, ProcessorPipeline, SurveyJobTypes
 from data_refinery_common.logging import get_and_configure_logger
 from data_refinery_common.utils import get_env_variable
 
@@ -298,8 +293,6 @@ def send_job(job_type: Enum, job, is_dispatch=False) -> bool:
         should_dispatch = is_dispatch  # only dispatch when specifically requested to
 
     if should_dispatch:
-        batch = boto3.client("batch", region_name=AWS_REGION)
-
         job_name = JOB_DEFINITION_PREFIX + job_name
 
         # Smasher, tximport, and janitor jobs  don't have RAM tiers.
@@ -343,3 +336,10 @@ def send_job(job_type: Enum, job, is_dispatch=False) -> bool:
             raise
 
     return True
+
+
+def terminate_job(job, reason=None):
+    if not reason:
+        reason = "The job was terminated by data_refinery_common.message_queue.terminate_job()."
+
+    batch.terminate_job(jobId=job.batch_job_id, reason=reason)

--- a/foreman/data_refinery_foreman/foreman/management/commands/stop_jobs.py
+++ b/foreman/data_refinery_foreman/foreman/management/commands/stop_jobs.py
@@ -1,0 +1,78 @@
+from django.core.management.base import BaseCommand
+
+from data_refinery_common.message_queue import terminate_job
+from data_refinery_common.models import DownloaderJob, ProcessorJob, SurveyJob
+
+PROCESSOR = "PROCESSOR"
+DOWNLOADER = "DOWNLOADER"
+SURVEYOR = "SURVEYOR"
+
+
+def stop_job(job_id, job_class, reason):
+    job = job_class.objects.get(pk=job_id)
+
+    if job.success is not None:
+        # The job already completed, this would just further confuse things.
+        return
+
+    job.no_retry = True
+    job.success = False
+    job.failure_reason = reason
+    job.save()
+
+    terminate_job(job, reason)
+
+
+def stop_jobs(job_ids, job_type, reason):
+    if job_type == PROCESSOR:
+        job_class = ProcessorJob
+    elif job_type == DOWNLOADER:
+        job_class = DownloaderJob
+    elif job_type == SURVEYOR:
+        job_class = SurveyJob
+    else:
+        print("Invalid job-type supplied!")
+        exit(1)
+
+    for job_id in job_ids.strip().split(","):
+        stop_job(job_id, job_class, reason)
+
+
+class Command(BaseCommand):
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "job-ids", type=str, help=("Comma separated job IDs that need to be stopped."),
+        )
+
+        parser.add_argument(
+            "--job-type",
+            type=str,
+            default=PROCESSOR,
+            choices=[PROCESSOR, DOWNLOADER, SURVEYOR],
+            help=(
+                f"The type of job to be stopped, either {PROCESSOR}, {DOWNLOADER}, or {SURVEYOR}."
+            ),
+        )
+
+        parser.add_argument(
+            "--reason",
+            type=str,
+            default=(
+                "The job was terminated by"
+                " data_refinery_foreman.foreman.management.commands.stop_job"
+            ),
+            help=(
+                "A reason to be used as the job's failure_reason and to be provided to"
+                " AWS Batch as the reason for the job termination."
+            ),
+        )
+
+    def handle(self, *args, **options):
+        """This command stops the job from running and marks it as no retry.
+
+        Defaults to stopping processor jobs,
+
+        If a comma-separated --accesion-codes parameter is supplied
+        only eligible experiments in that list will be run instead.
+        """
+        stop_jobs(options["job-ids"], options["job_type"], options["reason"])

--- a/infrastructure/permissions.tf
+++ b/infrastructure/permissions.tf
@@ -239,6 +239,15 @@ resource "aws_iam_policy" "batch_write_policy" {
   tags = var.default_tags
 }
 
+resource "aws_iam_policy" "batch_terminate_policy" {
+  name = "data-refinery-batch-terminate-policy-${var.user}-${var.stage}"
+  description = "Allows Batch Terminate Permissions."
+
+  policy = local.batch_terminate_policy
+
+  tags = var.default_tags
+}
+
 resource "aws_iam_role_policy_attachment" "worker_batch_read" {
   role = aws_iam_role.data_refinery_worker.name
   policy_arn = aws_iam_policy.batch_read_policy.arn
@@ -257,6 +266,11 @@ resource "aws_iam_role_policy_attachment" "foreman_batch_read" {
 resource "aws_iam_role_policy_attachment" "foreman_batch_write" {
   role = aws_iam_role.data_refinery_foreman.name
   policy_arn = aws_iam_policy.batch_write_policy.arn
+}
+
+resource "aws_iam_role_policy_attachment" "foreman_batch_terminate" {
+  role = aws_iam_role.data_refinery_foreman.name
+  policy_arn = aws_iam_policy.batch_terminate_policy.arn
 }
 
 resource "aws_iam_role_policy_attachment" "api_batch_read" {

--- a/infrastructure/policies.tf
+++ b/infrastructure/policies.tf
@@ -126,6 +126,23 @@ EOF
 }
 EOF
 
+  batch_terminate_policy = <<EOF
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Action": [
+                "batch:TerminateJob"
+            ],
+            "Resource": [
+              "arn:aws:batch:${var.region}:${data.aws_caller_identity.current.account_id}:*"
+            ]
+        }
+    ]
+}
+EOF
+
   ses_access_policy = <<EOF
 {
     "Version": "2012-10-17",


### PR DESCRIPTION
## Issue Number

N/A This came up while I was running compendia

## Purpose/Implementation Notes

Stopping a compendia job I don't want to run any more is annoying because it gets retried. This is a better way of doing it.

## Types of changes

- New feature (non-breaking change which adds functionality)

## Functional tests

I've tested this on a dev stack

## Checklist

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules
