### PR TITLE
Results needs to be public so that people can download their datasets.

### DIFF
--- a/infrastructure/disk.tf
+++ b/infrastructure/disk.tf
@@ -49,13 +49,6 @@ resource "aws_s3_bucket" "data_refinery_results_bucket" {
   }
 }
 
-resource "aws_s3_bucket_public_access_block" "data_refinery_results_bucket" {
-  bucket = aws_s3_bucket.data_refinery_results_bucket.id
-
-  block_public_acls   = true
-  block_public_policy = true
-}
-
 resource "aws_s3_bucket" "data_refinery_transcriptome_index_bucket" {
   bucket = "data-refinery-s3-transcriptome-index-${var.user}-${var.stage}"
   acl = "public-read"


### PR DESCRIPTION
## Issue Number

#2257 
#2955 

## Purpose/Implementation Notes

Perhaps we should be using the download URL for these as well, but we're not and blocking public ACL from these buckets breaks the smasher.

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

