### PR TITLE
Give postgres settings more work_mem, send logs to cloudwatch

### DIFF
--- a/infrastructure/instances.tf
+++ b/infrastructure/instances.tf
@@ -93,7 +93,7 @@ resource "aws_db_instance" "postgres_db" {
   skip_final_snapshot = var.stage == "prod" ? false : true
   final_snapshot_identifier = var.stage == "prod" ? "data-refinery-prod-snapshot" : "none"
 
-  enabled_cloudwatch_logs_exports = ["postgres", "update"]
+  enabled_cloudwatch_logs_exports = ["postgresql", "upgrade"]
 
   vpc_security_group_ids = [aws_security_group.data_refinery_db.id]
   multi_az = true


### PR DESCRIPTION
## Issue Number

#2874 

## Purpose/Implementation Notes

The database ran out of space today. Probably not due to data issues. Seems likely it may be related to autovacuum not working, but we also discovered that our working memory is too low.

We ran some manual vacuums to get things running smoother for the short-term. The work_mem will probably help too but we need to address #2874 for a more robust fix.

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

I've run a dev deploy to make sure the terraform is valid.

## Checklist

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream module