### PR TITLE
Give API permission to generate S3 presigned URLs for results

### DIFF
--- a/infrastructure/permissions.tf
+++ b/infrastructure/permissions.tf
@@ -163,6 +163,12 @@ resource "aws_iam_role_policy_attachment" "foreman_s3" {
   policy_arn = aws_iam_policy.s3_access_policy.arn
 }
 
+# The API needs access to S3 to be able to generate presigned URLs.
+resource "aws_iam_role_policy_attachment" "api_s3" {
+  role = aws_iam_role.data_refinery_api.name
+  policy_arn = aws_iam_policy.s3_access_policy.arn
+}
+
 resource "aws_iam_policy" "ses_access_policy" {
   name = "data-refinery-ses-access-policy-${var.user}-${var.stage}"
   description = "Allows sending email through SES"


### PR DESCRIPTION
## Issue Number

https://github.com/AlexsLemonade/refinebio/pull/2959

## Purpose/Implementation Notes

The API didn't have permission for the result files, so it wasn't able to create presigned URLs for them. Thank god for end to end tests!

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

I'm running end to end tests locally to verify this, but I couldn't download before this change and I could after so I think it'll work!

## Checklist

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules
