### PR TITLE
Fix transcriptome index file downloading/deletion

### DIFF
--- a/workers/data_refinery_workers/downloaders/transcriptome_index.py
+++ b/workers/data_refinery_workers/downloaders/transcriptome_index.py
@@ -109,8 +109,8 @@ def download_transcriptome(job_id: int) -> None:
             source_filename=long_original_file.source_filename,
             source_url=long_original_file.source_url,
             is_downloaded=True,
-            absolute_file_path=long_dl_file_path,
-            filename=long_original_file.source_filename,
+            absolute_file_path=short_dl_file_path,
+            filename=long_original_file.filename,
             has_raw=True,
         )
         short_original_file.calculate_size()


### PR DESCRIPTION
## Issue Number

N/A trying to get staging end to end tests to pass

## Purpose/Implementation Notes

Most of the short original file's properties should be the same, but the absolute file path should not.

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

It's a bit late to start spinning up a dev stack, but I'll test this on one tomorrow.

## Checklist

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules
