### PR TITLE
Fix aws events log group ARN.

### DIFF
--- a/infrastructure/disk.tf
+++ b/infrastructure/disk.tf
@@ -154,13 +154,7 @@ PATTERN
 resource "aws_cloudwatch_event_target" "compendia_object_metrics_target" {
   rule = aws_cloudwatch_event_rule.compendia_object_metrics.name
   target_id = "compendia-object-logs-target-${var.user}-${var.stage}"
-  arn = substr(
-    aws_cloudwatch_log_group.compendia_object_metrics_log_group.arn,
-    0,
-    length(
-      aws_cloudwatch_log_group.compendia_object_metrics_log_group.arn,
-    ) - 2,
-  )
+  arn = aws_cloudwatch_log_group.compendia_object_metrics_log_group.arn
 }
 
 resource "aws_s3_bucket" "data_refinery_cert_bucket" {


### PR DESCRIPTION
## Issue Number

N/A discovered while pulling some stats

## Purpose/Implementation Notes

We discovered that a CloudTrail event was failing because of a ResourceNotFoundException. This event was trying to create a log stream inside of `"logGroupName": "/aws/events/data-refinery-compendia-log-group-circleci-pr",`, which seems to be missing the last two characters.

I think this may have been necessary in an older terraform/AWS provider version. The last log event that worked was around June 20th which is around the time we upgraded.

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

I've deployed a dev stack to make sure it's not broken, but this will really get tested in staging.

## Checklist

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules
