### PR TITLE
Removes checks from deploy.sh for unused env var

### DIFF
--- a/.github/scripts/remote_deploy.sh
+++ b/.github/scripts/remote_deploy.sh
@@ -105,7 +105,10 @@ run_on_deploy_box "sudo touch /var/log/deploy_$CI_TAG.log"
 run_on_deploy_box "sudo chown ubuntu:ubuntu /var/log/deploy_$CI_TAG.log"
 run_on_deploy_box "source env_vars && echo -e '######\nStarting new deploy for $CI_TAG\n######' >> /var/log/deploy_$CI_TAG.log 2>&1"
 run_on_deploy_box "sudo ./.github/scripts/fix_ca_certs.sh >> /var/log/deploy_$CI_TAG.log 2>&1"
+
+# This should never be logged to Github Actions in case it exposes any secrets as terraform output.
 run_on_deploy_box "source env_vars && ./.github/scripts/run_terraform.sh >> /var/log/deploy_$CI_TAG.log 2>&1"
+
 run_on_deploy_box "source env_vars && echo -e '######\nDeploying $CI_TAG finished!\n######' >> /var/log/deploy_$CI_TAG.log 2>&1"
 
 ./.github/scripts/slackpost_deploy.sh robots deploybot

--- a/infrastructure/deploy.sh
+++ b/infrastructure/deploy.sh
@@ -202,12 +202,7 @@ if terraform output | grep -q 'No outputs found'; then
     # Until terraform plan supports -var-file the plan is wrong.
     # terraform plan
 
-    if [[ -n "$GITHUB_ACTIONS" ]]; then
-        # Make sure we can't expose secrets in circleci
-        terraform apply -var-file="environments/$env.tfvars" -auto-approve > /dev/null
-    else
-        terraform apply -var-file="environments/$env.tfvars" -auto-approve
-    fi
+    terraform apply -var-file="environments/$env.tfvars" -auto-approve
 fi
 
 # We have to do this once before the initial deploy..
@@ -225,12 +220,7 @@ if [[ -z $ran_init_build ]]; then
     # Until terraform plan supports -var-file the plan is wrong.
     # terraform plan
 
-    if [[ -n "$GITHUB_ACTIONS" ]]; then
-        # Make sure we can't expose secrets in circleci
-        terraform apply -var-file="environments/$env.tfvars" -auto-approve > /dev/null
-    else
-        terraform apply -var-file="environments/$env.tfvars" -auto-approve
-    fi
+    terraform apply -var-file="environments/$env.tfvars" -auto-approve
 fi
 
 # Make sure that prod_env is empty since we are only appending to it.
@@ -334,12 +324,7 @@ terraform taint aws_instance.foreman_server_1
 # echo "Removing ingress.."
 # rm ci_ingress.tf
 
-if [[ -n "$GITHUB_ACTIONS" ]]; then
-    # Make sure we can't expose secrets in circleci
-    terraform apply -var-file="environments/$env.tfvars" -auto-approve > /dev/null
-else
-    terraform apply -var-file="environments/$env.tfvars" -auto-approve
-fi
+terraform apply -var-file="environments/$env.tfvars" -auto-approve
 
 # We try to avoid rebuilding the API server because we can only run certbot
 # 5 times a week. Therefore we pull the newest image and restart the API


### PR DESCRIPTION
## Issue Number

N/A came up during the deploy tour

## Purpose/Implementation Notes

We have determined these checks don't do anything because the GITHUB_ACTIONS env var isn't passed through to the deploy box. I did leave the check for it in `scripts/prepare_image.sh` because that is invoked withing github actions during the tests.

## Types of changes

- Remove dead code

## Functional tests

This will be checked partially by unit tests, but when this goes into a staging deploy I will double check its outputs to make sure there's nothing that shouldn't be there.

## Checklist

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules
