### PR TITLE
Add some changes to API startup for debugging certbot challenge

### DIFF
--- a/infrastructure/api-configuration/api-server-instance-user-data.tpl.sh
+++ b/infrastructure/api-configuration/api-server-instance-user-data.tpl.sh
@@ -26,55 +26,55 @@ service nginx restart
 if [[ "${stage}" == "staging" || "${stage}" == "prod" ]]; then
     # Check here for the cert in S3, if present install, if not run certbot.
     if [[ $(aws s3 ls "${data_refinery_cert_bucket}" | wc -l) == "0" ]]; then
-	# Create and install SSL Certificate for the API.
-	# Only necessary on staging and prod.
-	# We cannot use ACM for this because *.bio is not a Top Level Domain that Route53 supports.
-	snap install core
-	snap refresh core
-	snap install --classic certbot
-	apt-get update
-	apt-get install -y python-certbot-nginx
+        # Create and install SSL Certificate for the API.
+        # Only necessary on staging and prod.
+        # We cannot use ACM for this because *.bio is not a Top Level Domain that Route53 supports.
+        snap install core
+        snap refresh core
+        snap install --classic certbot
+        apt-get update
+        apt-get install -y python-certbot-nginx
 
-	# Temporary to see what this outputs
-	curl 'http://api.refine.bio'
+        # Temporary to see what this outputs
+        curl 'http://api.refine.bio'
         # The certbot challenge cannot be completed until the aws_lb_target_group_attachment resources are created.
         sleep 300
-	# Temporary to see what this outputs
-	curl 'http://api.refine.bio'
+        # Temporary to see what this outputs
+        curl 'http://api.refine.bio'
 
-	# g3w4k4t5n3s7p7v8@alexslemonade.slack.com is the email address we
-	# have configured to forward mail to the #teamcontact channel in
-	# slack. Certbot will use it for "important account
-	# notifications".
-	# In the future, if we ever hit the 5-deploy-a-week limit, changing one of these lines to:
-	# certbot --nginx -d api.staging.refine.bio -d api2.staging.refine.bio -n --agree-tos --redirect -m g3w4k4t5n3s7p7v8@alexslemonade.slack.com
-	# will circumvent certbot's limit because the 5-a-week limit only applies to the
-	# "same set of domains", so by changing that set we get to use the 20-a-week limit.
-	if [[ "${stage}" == "staging" ]]; then
+        # g3w4k4t5n3s7p7v8@alexslemonade.slack.com is the email address we
+        # have configured to forward mail to the #teamcontact channel in
+        # slack. Certbot will use it for "important account
+        # notifications".
+        # In the future, if we ever hit the 5-deploy-a-week limit, changing one of these lines to:
+        # certbot --nginx -d api.staging.refine.bio -d api2.staging.refine.bio -n --agree-tos --redirect -m g3w4k4t5n3s7p7v8@alexslemonade.slack.com
+        # will circumvent certbot's limit because the 5-a-week limit only applies to the
+        # "same set of domains", so by changing that set we get to use the 20-a-week limit.
+        if [[ "${stage}" == "staging" ]]; then
             certbot --nginx -d api.staging.refine.bio -n --agree-tos --redirect -m g3w4k4t5n3s7p7v8@alexslemonade.slack.com
-	elif [[ "${stage}" == "prod" ]]; then
+        elif [[ "${stage}" == "prod" ]]; then
             certbot --nginx -d api.refine.bio -n --agree-tos --redirect -m g3w4k4t5n3s7p7v8@alexslemonade.slack.com
-	fi
+        fi
 
-	# Add the nginx.conf file that certbot setup to the zip dir.
-	cp /etc/nginx/nginx.conf /etc/letsencrypt/
+        # Add the nginx.conf file that certbot setup to the zip dir.
+        cp /etc/nginx/nginx.conf /etc/letsencrypt/
 
-	cd /etc/letsencrypt/ || exit
-	sudo zip -r ../letsencryptdir.zip "../$(basename "$PWD")"
+        cd /etc/letsencrypt/ || exit
+        sudo zip -r ../letsencryptdir.zip "../$(basename "$PWD")"
 
-	# And then cleanup the extra copy.
-	rm /etc/letsencrypt/nginx.conf
+        # And then cleanup the extra copy.
+        rm /etc/letsencrypt/nginx.conf
 
-	cd - || exit
-	mv /etc/letsencryptdir.zip .
-	aws s3 cp letsencryptdir.zip "s3://${data_refinery_cert_bucket}/"
-	rm letsencryptdir.zip
+        cd - || exit
+        mv /etc/letsencryptdir.zip .
+        aws s3 cp letsencryptdir.zip "s3://${data_refinery_cert_bucket}/"
+        rm letsencryptdir.zip
     else
-	zip_filename=$(aws s3 ls "${data_refinery_cert_bucket}" | head -1 | awk '{print $4}')
-	aws s3 cp "s3://${data_refinery_cert_bucket}/$zip_filename" letsencryptdir.zip
-	unzip letsencryptdir.zip -d /etc/
-	mv /etc/letsencrypt/nginx.conf /etc/nginx/
-	service nginx restart
+        zip_filename=$(aws s3 ls "${data_refinery_cert_bucket}" | head -1 | awk '{print $4}')
+        aws s3 cp "s3://${data_refinery_cert_bucket}/$zip_filename" letsencryptdir.zip
+        unzip letsencryptdir.zip -d /etc/
+        mv /etc/letsencrypt/nginx.conf /etc/nginx/
+        service nginx restart
     fi
 fi
 

--- a/infrastructure/api-configuration/api-server-instance-user-data.tpl.sh
+++ b/infrastructure/api-configuration/api-server-instance-user-data.tpl.sh
@@ -35,8 +35,12 @@ if [[ "${stage}" == "staging" || "${stage}" == "prod" ]]; then
 	apt-get update
 	apt-get install -y python-certbot-nginx
 
+	# Temporary to see what this outputs
+	curl 'http://api.refine.bio'
         # The certbot challenge cannot be completed until the aws_lb_target_group_attachment resources are created.
-        sleep 180
+        sleep 300
+	# Temporary to see what this outputs
+	curl 'http://api.refine.bio'
 
 	# g3w4k4t5n3s7p7v8@alexslemonade.slack.com is the email address we
 	# have configured to forward mail to the #teamcontact channel in


### PR DESCRIPTION
## Issue Number

#2975 

## Purpose/Implementation Notes

See if curling ourselves can be a better test for the API server coming up. If the output changes before the target group attachment comes up, then I can use that output to poll until it does. In some cases it might be faster, but it'll also prevent us from ever running into that timing issue again.

## Types of changes

- Temporary debugging
