### PR TITLE
add filename to filter for computed files

### DIFF
--- a/api/data_refinery_api/views/computed_file.py
+++ b/api/data_refinery_api/views/computed_file.py
@@ -139,6 +139,7 @@ class ComputedFileListView(generics.ListAPIView):
         "created_at",
         "last_modified",
         "result__id",
+        "filename",
     )
     ordering_fields = (
         "id",


### PR DESCRIPTION
## Issue Number

N/A

## Purpose/Implementation Notes

Adding the ability to filter `ComputedFiles` by `filename` to support: https://github.com/AlexsLemonade/refinebio-py/issues/79

## Types of changes

- New feature (non-breaking change which adds functionality)

## Functional tests

N/A

## Checklist

- [X] Lint and unit tests pass locally with my changes

## Screenshots

N/A
