### PR TITLE
Set image platform to "linux/amd64".

### DIFF
--- a/common/dockerfiles/Dockerfile.common_tests
+++ b/common/dockerfiles/Dockerfile.common_tests
@@ -1,4 +1,4 @@
-FROM ubuntu:18.04
+FROM --platform=linux/amd64 ubuntu:18.04
 
 RUN apt-get update -qq
 RUN apt-get install -y software-properties-common


### PR DESCRIPTION
## Purpose/Implementation Notes
Some of R packages aren't available for arm64 (broken package dependencies). Setting amd64 platform image fixes the problem in a "best effort" fashion.

## Types of changes
- Bugfix (non-breaking change which fixes an issue)

## Checklist
- [x] Lint and unit tests pass locally with my changes