### PR TITLE
Add psycopg2 package dependencies.

### DIFF
--- a/common/dockerfiles/Dockerfile.migrations
+++ b/common/dockerfiles/Dockerfile.migrations
@@ -3,6 +3,11 @@ FROM python:3.8.5-slim-buster
 RUN groupadd user && useradd --create-home --home-dir /home/user -g user user
 WORKDIR /home/user
 
+RUN apt-get update -qq && \
+    apt-get install -y \
+    gcc \
+    libpq-dev
+
 # Needed for migration 0006
 COPY config/ config
 

--- a/foreman/dockerfiles/Dockerfile.foreman
+++ b/foreman/dockerfiles/Dockerfile.foreman
@@ -8,6 +8,8 @@ RUN apt-get -y install apt-fast
 
 RUN apt-fast update -qq && \
     apt-fast install -y \
+    gcc \
+    libpq-dev \
     python3 \
     python3-pip
 


### PR DESCRIPTION
## Purpose/Implementation Notes

The
```
#18 7.045   Preparing metadata (setup.py): started
#18 7.168   Preparing metadata (setup.py): finished with status 'error'
#18 7.168   ERROR: Command errored out with exit status 1:
#18 7.168    command: /usr/bin/python3 -c 'import io, os, sys, setuptools, tokenize; sys.argv[0] = '"'"'/tmp/pip-install-9po9zfhg/psycopg2-binary_557e3f35b68149979eba67a9404b7463/setup.py'"'"'; __file__='"'"'/tmp/pip-install-9po9zfhg/psycopg2-binary_557e3f35b68149979eba67a9404b7463/setup.py'"'"';f = getattr(tokenize, '"'"'open'"'"', open)(__file__) if os.path.exists(__file__) else io.StringIO('"'"'from setuptools import setup; setup()'"'"');code = f.read().replace('"'"'\r\n'"'"', '"'"'\n'"'"');f.close();exec(compile(code, __file__, '"'"'exec'"'"'))' egg_info --egg-base /tmp/pip-pip-egg-info-_xroqrlo
#18 7.168        cwd: /tmp/pip-install-9po9zfhg/psycopg2-binary_557e3f35b68149979eba67a9404b7463/
#18 7.168   Complete output (23 lines):
#18 7.168   running egg_info
#18 7.168   creating /tmp/pip-pip-egg-info-_xroqrlo/psycopg2_binary.egg-info
#18 7.168   writing /tmp/pip-pip-egg-info-_xroqrlo/psycopg2_binary.egg-info/PKG-INFO
#18 7.168   writing dependency_links to /tmp/pip-pip-egg-info-_xroqrlo/psycopg2_binary.egg-info/dependency_links.txt
#18 7.168   writing top-level names to /tmp/pip-pip-egg-info-_xroqrlo/psycopg2_binary.egg-info/top_level.txt
#18 7.168   writing manifest file '/tmp/pip-pip-egg-info-_xroqrlo/psycopg2_binary.egg-info/SOURCES.txt'
#18 7.168
#18 7.168   Error: pg_config executable not found.
#18 7.168
#18 7.168   pg_config is required to build psycopg2 from source.  Please add the directory
#18 7.168   containing pg_config to the $PATH or specify the full executable path with the
#18 7.168   option:
#18 7.168
#18 7.168       python setup.py build_ext --pg-config /path/to/pg_config build ...
#18 7.168
#18 7.168   or with the pg_config option in 'setup.cfg'.
#18 7.168
#18 7.168   If you prefer to avoid building psycopg2 from source, please install the PyPI
#18 7.168   'psycopg2-binary' package instead.
#18 7.168
#18 7.168   For further information please check the 'doc/src/install.rst' file (also at
#18 7.168   <https://www.psycopg.org/docs/install.html>).
#18 7.168
#18 7.168   ----------------------------------------
#18 7.168 WARNING: Discarding https://files.pythonhosted.org/packages/fc/51/0f2c6aec5c59e5640f507b59567f63b9d73a9317898810b4db311da32dfc/psycopg2-binary-2.8.6.tar.gz#sha256=11b9c0ebce097180129e422379b824ae21c8f2a6596b159c7659e2e5a00e1aa0 (from https://pypi.org/simple/psycopg2-binary/) (requires-python:>=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*). Command errored out with exit status 1: python setup.py egg_info Check the logs for full command output.
#18 7.169 ERROR: Could not find a version that satisfies the requirement psycopg2-binary==2.8.6 (from versions: 2.7.4, 2.7.5, 2.7.6, 2.7.6.1, 2.7.7, 2.8, 2.8.1, 2.8.2, 2.8.3, 2.8.4, 2.8.5, 2.8.6, 2.9, 2.9.1, 2.9.2, 2.9.3)
#18 7.169 ERROR: No matching distribution found for psycopg2-binary==2.8.6`

```
error started popping up on ARM. This is an alternative to fixing the error with `--platform=linux/amd64` (less performant).

## Types of changes
- Bugfix (non-breaking change which fixes an issue)

## Checklist
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules
