### PR TITLE
Refactor `script_directory` setting logic for sh scripts

### DIFF
--- a/api/run_tests.sh
+++ b/api/run_tests.sh
@@ -4,9 +4,7 @@
 
 # This script should always run as if it were being called from
 # the directory it lives in.
-script_directory="$(perl -e 'use File::Basename;
- use Cwd "abs_path";
- print dirname(abs_path(@ARGV[0]));' -- "$0")"
+script_directory="$(cd "$(dirname "$0")" || exit; pwd)"
 cd "$script_directory" || exit
 
 # However in order to give Docker access to all the code we have to

--- a/api/serve.sh
+++ b/api/serve.sh
@@ -4,9 +4,7 @@
 
 # This script should always run as if it were being called from
 # the directory it lives in.
-script_directory="$(perl -e 'use File::Basename;
- use Cwd "abs_path";
- print dirname(abs_path(@ARGV[0]));' -- "$0")"
+script_directory="$(cd "$(dirname "$0")" || exit; pwd)"
 cd "$script_directory" || exit
 
 # However in order to give Docker access to all the code we have to

--- a/api/serve_production.sh
+++ b/api/serve_production.sh
@@ -4,9 +4,7 @@
 
 # This script should always run as if it were being called from
 # the directory it lives in.
-script_directory="$(perl -e 'use File::Basename;
- use Cwd "abs_path";
- print dirname(abs_path(@ARGV[0]));' -- "$0")"
+script_directory="$(cd "$(dirname "$0")" || exit; pwd)"
 cd "$script_directory" || exit
 
 # However in order to give Docker access to all the code we have to

--- a/common/run_tests.sh
+++ b/common/run_tests.sh
@@ -4,9 +4,7 @@
 
 # This script should always run as if it were being called from
 # the directory it lives in.
-script_directory="$(perl -e 'use File::Basename;
- use Cwd "abs_path";
- print dirname(abs_path(@ARGV[0]));' -- "$0")"
+script_directory="$(cd "$(dirname "$0")" || exit; pwd)"
 cd "$script_directory" || exit
 
 # However in order to give Docker access to all the code we have to

--- a/config/externally_supplied_metadata/metasra/translate.sh
+++ b/config/externally_supplied_metadata/metasra/translate.sh
@@ -11,9 +11,7 @@ PROCESSED_ACCESSIONS_FILE="$(basename -s .tab "$ACCESSIONS_FILE").processed.tab"
 
 # This script should always run as if it were being called from
 # the directory it lives in.
-script_directory="$(perl -e 'use File::Basename;
- use Cwd "abs_path";
- print dirname(abs_path(@ARGV[0]));' -- "$0")"
+script_directory="$(cd "$(dirname "$0")" || exit; pwd)"
 cd "$script_directory" || exit
 
 if ! [ -e "$JSON_FILE" ]; then

--- a/foreman/run_end_to_end_tests.sh
+++ b/foreman/run_end_to_end_tests.sh
@@ -4,9 +4,7 @@
 
 # This script should always run as if it were being called from
 # the directory it lives in.
-script_directory="$(perl -e 'use File::Basename;
- use Cwd "abs_path";
- print dirname(abs_path(@ARGV[0]));' -- "$0")"
+script_directory="$(cd "$(dirname "$0")" || exit; pwd)"
 cd "$script_directory" || exit
 
 # Set up the data volume directory if it does not already exist.

--- a/foreman/run_management_command.sh
+++ b/foreman/run_management_command.sh
@@ -4,9 +4,7 @@
 
 # This script should always run as if it were being called from
 # the directory it lives in.
-script_directory="$(perl -e 'use File::Basename;
- use Cwd "abs_path";
- print dirname(abs_path(@ARGV[0]));' -- "$0")"
+script_directory="$(cd "$(dirname "$0")" || exit; pwd)"
 cd "$script_directory" || exit
 
 # However in order to give Docker access to all the code we have to

--- a/foreman/run_tests.sh
+++ b/foreman/run_tests.sh
@@ -4,9 +4,7 @@
 
 # This script should always run as if it were being called from
 # the directory it lives in.
-script_directory="$(perl -e 'use File::Basename;
- use Cwd "abs_path";
- print dirname(abs_path(@ARGV[0]));' -- "$0")"
+script_directory="$(cd "$(dirname "$0")" || exit; pwd)"
 cd "$script_directory" || exit
 
 # Set up the data volume directory if it does not already exist.

--- a/foreman/test_survey.sh
+++ b/foreman/test_survey.sh
@@ -48,9 +48,7 @@ fi
 
 # This script should always run as if it were being called from
 # the directory it lives in.
-script_directory="$(perl -e 'use File::Basename;
- use Cwd "abs_path";
- print dirname(abs_path(@ARGV[0]));' -- "$0")"
+script_directory="$(cd "$(dirname "$0")" || exit; pwd)"
 cd "$script_directory" || exit
 
 # Set up the data volume directory if it does not already exist.

--- a/infrastructure/deploy.sh
+++ b/infrastructure/deploy.sh
@@ -2,9 +2,7 @@
 
 # This script should always run as if it were being called from
 # the directory it lives in.
-script_directory="$(perl -e 'use File::Basename;
- use Cwd "abs_path";
- print dirname(abs_path(@ARGV[0]));' -- "$0")"
+script_directory="$(cd "$(dirname "$0")" || exit; pwd)"
 cd "$script_directory" || exit
 
 print_description() {

--- a/infrastructure/destroy_terraform.sh
+++ b/infrastructure/destroy_terraform.sh
@@ -2,9 +2,7 @@
 
 # This script should always run as if it were being called from
 # the directory it lives in.
-script_directory="$(perl -e 'use File::Basename;
- use Cwd "abs_path";
- print dirname(abs_path(@ARGV[0]));' -- "$0")"
+script_directory="$(cd "$(dirname "$0")" || exit; pwd)"
 cd "$script_directory" || exit
 
 print_description() {

--- a/scripts/create_virtualenv.sh
+++ b/scripts/create_virtualenv.sh
@@ -2,9 +2,7 @@
 
 # This script should always run as if it were being called from
 # the directory it lives in.
-script_directory="$(perl -e 'use File::Basename;
- use Cwd "abs_path";
- print dirname(abs_path(@ARGV[0]));' -- "$0")"
+script_directory="$(cd "$(dirname "$0")" || exit; pwd)"
 cd "$script_directory" || exit
 
 # However in order to give virtualenv access to all the code we have to

--- a/scripts/format_batch_with_env.sh
+++ b/scripts/format_batch_with_env.sh
@@ -105,9 +105,7 @@ fi
 
 # This script should always run from the context of the directory of
 # the project it is building.
-script_directory="$(perl -e 'use File::Basename;
- use Cwd "abs_path";
- print dirname(abs_path(@ARGV[0]));' -- "$0")"
+script_directory="$(cd "$(dirname "$0")" || exit; pwd)"
 
 project_directory="$script_directory/.."
 

--- a/scripts/install_all.sh
+++ b/scripts/install_all.sh
@@ -8,9 +8,7 @@ TERRAFORM_VERSION="0.13.5"
 
 # This script should always run as if it were being called from
 # the directory it lives in.
-script_directory="$(perl -e 'use File::Basename;
- use Cwd "abs_path";
- print dirname(abs_path(@ARGV[0]));' -- "$0")"
+script_directory="$(cd "$(dirname "$0")" || exit; pwd)"
 cd "$script_directory" || exit
 
 print_description() {

--- a/scripts/kill_all_jobs.sh
+++ b/scripts/kill_all_jobs.sh
@@ -2,9 +2,7 @@
 
 # This script should always run as if it were being called from
 # the directory it lives in.
-script_directory="$(perl -e 'use File::Basename;
- use Cwd "abs_path";
- print dirname(abs_path(@ARGV[0]));' -- "$0")"
+script_directory="$(cd "$(dirname "$0")" || exit; pwd)"
 cd "$script_directory" || exit
 
 while read -r row; do

--- a/scripts/make_migrations.sh
+++ b/scripts/make_migrations.sh
@@ -8,9 +8,7 @@ set -e
 
 # This script should always run as if it were being called from
 # the directory it lives in.
-script_directory="$(perl -e 'use File::Basename;
- use Cwd "abs_path";
- print dirname(abs_path(@ARGV[0]));' -- "$0")"
+script_directory="$(cd "$(dirname "$0")" || exit; pwd)"
 cd "$script_directory" || exit
 
 ./prepare_image.sh -i migrations -s common

--- a/scripts/prepare_image.sh
+++ b/scripts/prepare_image.sh
@@ -2,9 +2,7 @@
 
 # This script should always run as if it were being called from
 # the directory it lives in.
-script_directory="$(perl -e 'use File::Basename;
- use Cwd "abs_path";
- print dirname(abs_path(@ARGV[0]));' -- "$0")"
+script_directory="$(cd "$(dirname "$0")" || exit; pwd)"
 cd "$script_directory" || exit
 
 # Import the functions in common.sh

--- a/scripts/rebuild_es_index.sh
+++ b/scripts/rebuild_es_index.sh
@@ -2,9 +2,7 @@
 
 # This script should always run as if it were being called from
 # the directory it lives in.
-script_directory="$(perl -e 'use File::Basename;
- use Cwd "abs_path";
- print dirname(abs_path(@ARGV[0]));' -- "$0")"
+script_directory="$(cd "$(dirname "$0")" || exit; pwd)"
 cd "$script_directory" || exit
 
 ./run_manage.sh -i api_local -s api search_index --rebuild -f

--- a/scripts/reinit_database.sh
+++ b/scripts/reinit_database.sh
@@ -5,9 +5,7 @@
 
 # This script should always run as if it were being called from
 # the directory it lives in.
-script_directory="$(perl -e 'use File::Basename;
- use Cwd "abs_path";
- print dirname(abs_path(@ARGV[0]));' -- "$0")"
+script_directory="$(cd "$(dirname "$0")" || exit; pwd)"
 cd "$script_directory" || exit
 
 # Clear it out.

--- a/scripts/run_all_tests.sh
+++ b/scripts/run_all_tests.sh
@@ -7,9 +7,7 @@ set -e
 
 # This script should always run as if it were being called from
 # the directory it lives in.
-script_directory="$(perl -e 'use File::Basename;
- use Cwd "abs_path";
- print dirname(abs_path(@ARGV[0]));' -- "$0")"
+script_directory="$(cd "$(dirname "$0")" || exit; pwd)"
 cd "$script_directory" || exit
 
 # Get access to all of the refinebio project

--- a/scripts/run_manage.sh
+++ b/scripts/run_manage.sh
@@ -6,9 +6,7 @@
 
 # This script should always run as if it were being called from
 # the directory it lives in.
-script_directory="$(perl -e 'use File::Basename;
- use Cwd "abs_path";
- print dirname(abs_path(@ARGV[0]));' -- "$0")"
+script_directory="$(cd "$(dirname "$0")" || exit; pwd)"
 cd "$script_directory" || exit
 
 # Import the functions in common.sh

--- a/scripts/run_postgres.sh
+++ b/scripts/run_postgres.sh
@@ -2,9 +2,7 @@
 
 # This script should always run as if it were being called from
 # the directory it lives in.
-script_directory="$(perl -e 'use File::Basename;
- use Cwd "abs_path";
- print dirname(abs_path(@ARGV[0]));' -- "$0")"
+script_directory="$(cd "$(dirname "$0")" || exit; pwd)"
 cd "$script_directory" || exit
 
 # Get access to all of refinebio

--- a/scripts/run_shell.sh
+++ b/scripts/run_shell.sh
@@ -12,9 +12,7 @@ set -e
 
 # This script should always run as if it were being called from
 # the directory it lives in.
-script_directory="$(perl -e 'use File::Basename;
- use Cwd "abs_path";
- print dirname(abs_path(@ARGV[0]));' -- "$0")"
+script_directory="$(cd "$(dirname "$0")" || exit; pwd)"
 cd "$script_directory" || exit
 
 # Import functions in common.sh

--- a/scripts/update_models.sh
+++ b/scripts/update_models.sh
@@ -6,9 +6,7 @@ set -e
 
 # This script should always run as if it were being called from
 # the directory it lives in.
-script_directory="$(perl -e 'use File::Basename;
- use Cwd "abs_path";
- print dirname(abs_path(@ARGV[0]));' -- "$0")"
+script_directory="$(cd "$(dirname "$0")" || exit; pwd)"
 cd "$script_directory" || exit
 
 # Get access to all of refinebio

--- a/scripts/update_my_docker_images.sh
+++ b/scripts/update_my_docker_images.sh
@@ -8,9 +8,7 @@ set -e
 
 # This script should always run as if it were being called from
 # the directory it lives in.
-script_directory="$(perl -e 'use File::Basename;
- use Cwd "abs_path";
- print dirname(abs_path(@ARGV[0]));' -- "$0")"
+script_directory="$(cd "$(dirname "$0")" || exit; pwd)"
 cd "$script_directory" || exit
 
 # Get access to all of refinebio

--- a/workers/run_command.sh
+++ b/workers/run_command.sh
@@ -26,9 +26,7 @@ fi
 
 # This script should always run as if it were being called from
 # the directory it lives in.
-script_directory="$(perl -e 'use File::Basename;
- use Cwd "abs_path";
- print dirname(abs_path(@ARGV[0]));' -- "$0")"
+script_directory="$(cd "$(dirname "$0")" || exit; pwd)"
 cd "$script_directory" || exit
 
 # However in order to give Docker access to all the code we have to

--- a/workers/run_janitor.sh
+++ b/workers/run_janitor.sh
@@ -1,9 +1,7 @@
 #!/bin/sh
 
 # the directory it lives in.
-script_directory="$(perl -e 'use File::Basename;
- use Cwd "abs_path";
- print dirname(abs_path(@ARGV[0]));' -- "$0")"
+script_directory="$(cd "$(dirname "$0")" || exit; pwd)"
 cd "$script_directory" || exit
 
 # However in order to give Docker access to all the code we have to

--- a/workers/run_job.sh
+++ b/workers/run_job.sh
@@ -61,9 +61,7 @@ fi
 
 # This script should always run as if it were being called from
 # the directory it lives in.
-script_directory="$(perl -e 'use File::Basename;
- use Cwd "abs_path";
- print dirname(abs_path(@ARGV[0]));' -- "$0")"
+script_directory="$(cd "$(dirname "$0")" || exit; pwd)"
 cd "$script_directory" || exit
 
 # However in order to give Docker access to all the code we have to

--- a/workers/run_tests.sh
+++ b/workers/run_tests.sh
@@ -44,9 +44,7 @@ done
 
 # This script should always run as if it were being called from
 # the directory it lives in.
-script_directory="$(perl -e 'use File::Basename;
- use Cwd "abs_path";
- print dirname(abs_path(@ARGV[0]));' -- "$0")"
+script_directory="$(cd "$(dirname "$0")" || exit; pwd)"
 cd "$script_directory" || exit
 
 # However in order to give Docker access to all the code we have to


### PR DESCRIPTION
## Issue Number

#3108 

## Purpose/Implementation Notes

Stacked on #3106 

The refine.bio .sh scripts have an identical piece of code making sure it runs from the `scripts` directory. It involves running perl code using File::Basename and Cwd modules:

```
script_directory="$(perl -e 'use File::Basename;
use Cwd "abs_path";
print dirname(abs_path(@ARGV[0]));' -- "$0")"
```

This PR changes it to an equal bash code eliminating the perl dependency.

## Methods
N/A

## Types of changes
N/A

## Checklist
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

