### PR TITLE
Fix typo in container registry domain

### DIFF
--- a/scripts/prepare_image.sh
+++ b/scripts/prepare_image.sh
@@ -104,7 +104,7 @@ else
 
         if test "$GITHUB_ACTIONS"; then
             # docker needs repositories to be lowercase
-            CACHE_REPO="$(echo "ghrc.io/$GITHUB_REPOSITORY" | tr '[:upper:]' '[:lower:]')"
+            CACHE_REPO="$(echo "ghcr.io/$GITHUB_REPOSITORY" | tr '[:upper:]' '[:lower:]')"
             CACHED_PACKAGE="$CACHE_REPO/dr_$image"
             CACHE="--build-arg BUILDKIT_INLINE_CACHE=1 --cache-from $CACHED_PACKAGE"
         fi


### PR DESCRIPTION
Hi `AlexsLemonade/refinebio`!

This is not an automatic, 🤖-generated PR, as you can check in my [GitHub profile](https://github.com/p-), I work for GitHub and I am part of the [GitHub Security Lab](https://securitylab.github.com/).

While performing a code search for container registry domains we noticed that this repo contains a misspelled domain name.

If a malicious actor were in control of that misspelled domain, they could potentially perform an attack on the software supply chain of this project and/or steal the credentials used to connect to the container registry (depending on how the misspelled domain name of the container registry is used).
Please fix this typo and check your documentation for similar typos.