### PR TITLE
Fix test_tximport.R path

### DIFF
--- a/workers/tests/processors/test_salmon.py
+++ b/workers/tests/processors/test_salmon.py
@@ -473,7 +473,7 @@ class SalmonTestCase(TestCase):
         cmd_tokens = [
             "/usr/bin/Rscript",
             "--vanilla",
-            "/home/user/data_refinery_workers/processors/test_tximport.R",
+            "/home/user/tests/processors/test_tximport.R",
             "--txi_out",
             rds_file_path,
             "--gene2txmap",


### PR DESCRIPTION
## Issue Number

N/A

## Purpose/Implementation Notes

This fix was on another PR that was cancelled, this is a PR just for this change.
It just corrects the path of `test_tximport.R` in `test_salmon.py`.

## Methods

n/a

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

n/a

## Checklist

- [X] Lint and unit tests pass locally with my changes

## Screenshots

n/a
