### PR TITLE
Migrate deprecated `set-output` command

### DIFF
--- a/.github/workflows/config.yml
+++ b/.github/workflows/config.yml
@@ -478,7 +478,7 @@ jobs:
         name: Set the $CI_TAG environment variable
         run: |
           source scripts/common.sh
-          echo "::set-output name=branch::$(get_master_or_dev ${GITHUB_REF#refs/tags/})"
+          echo "branch=$(get_master_or_dev ${GITHUB_REF#refs/tags/})" >> $GITHUB_OUTPUT
 
   deploy:
     if: startsWith(github.ref, 'refs/tags/v') && ! endsWith(github.ref, '-hotfix')


### PR DESCRIPTION
## Issue Number

NA

## Purpose/Implementation Notes

Change the variable setting way based on 

> The set-output command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/


## Methods
NA

## Types of changes

<!-- Remove any which your PR isn't -->
- Bugfix (non-breaking change which fixes an issue)

## Functional tests

NA

## Checklist

- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules
