### PR TITLE
Refactor Docker image build scripts

### DIFF
--- a/.github/scripts/cleanup_instance.sh
+++ b/.github/scripts/cleanup_instance.sh
@@ -13,7 +13,14 @@ sudo apt-get remove -y '^ghc-8.*'
 sudo apt-get remove -y '^dotnet-.*'
 sudo apt-get remove -y '^llvm-.*'
 sudo apt-get remove -y 'php.*'
-sudo apt-get remove -y azure-cli google-cloud-sdk hhvm google-chrome-stable firefox powershell mono-devel
+sudo apt-get remove -y \
+    azure-cli \
+    firefox \
+    google-chrome-stable \
+    google-cloud-sdk \
+    hhvm \
+    mono-devel \
+    powershell
 sudo apt-get autoremove -y
 sudo apt-get clean
 

--- a/.github/scripts/filter_tests.sh
+++ b/.github/scripts/filter_tests.sh
@@ -1,14 +1,14 @@
 #!/bin/bash
 
-# Exit on failure
+# Exit on failure.
 set -e
 
 git log --format=oneline -n 1 "$GITHUB_SHA"
 if [[ $(git log --format=oneline -n 1 "$GITHUB_SHA") = *"noslow"* ]]; then
-	echo "Skipping slow tests..";
+	echo "Skipping slow tests..."
 	./workers/run_tests.sh --exclude-tag=slow "$@"
 else
-	echo "Running all tests..";
+	echo "Running all tests..."
 	./workers/run_tests.sh "$@"
 fi
 

--- a/.github/scripts/post_deploy_cleanup.sh
+++ b/.github/scripts/post_deploy_cleanup.sh
@@ -8,4 +8,5 @@
 ssh -o StrictHostKeyChecking=no \
     -o ServerAliveInterval=15 \
     -i infrastructure/data-refinery-key.pem \
-    ubuntu@"${DEPLOY_IP_ADDRESS}" "cd refinebio && git clean -f"
+    "ubuntu@${DEPLOY_IP_ADDRESS}" \
+    "cd refinebio && git clean -f"

--- a/.github/scripts/pull_docker_images.sh
+++ b/.github/scripts/pull_docker_images.sh
@@ -10,6 +10,6 @@ fi
 
 for image in $IMAGES; do
     PACKAGE="$REPO/dr_$image"
-    # Only pull the package if it already exists
+    # Only pull the package if it already exists.
     (docker pull "$PACKAGE" && docker tag "$PACKAGE" "ccdlstaging/dr_$image") || true
 done

--- a/.github/scripts/remote_deploy.sh
+++ b/.github/scripts/remote_deploy.sh
@@ -72,8 +72,8 @@ run_on_deploy_box "source env_vars && echo -e '######\nBuilding new images for $
 run_on_deploy_box "source env_vars && ./.github/scripts/update_docker_img.sh 2>&1 | tee -a /var/log/docker_update_$CI_TAG.log"
 run_on_deploy_box "source env_vars && echo -e '######\nFinished building new images for $CI_TAG\n######' 2>&1 | tee -a /var/log/docker_update_$CI_TAG.log"
 
-# Load docker_img_exists function and $ALL_CCDL_IMAGES
-source scripts/common.sh
+# Load docker_img_exists function and $ALL_IMAGES.
+. scripts/common.sh
 
 if [[ "$MASTER_OR_DEV" == "master" ]]; then
     DOCKERHUB_REPO=ccdl
@@ -89,7 +89,7 @@ fi
 # https://github.com/AlexsLemonade/refinebio/issues/784
 # Since it's not clear how that happened, the safest thing is to add
 # an explicit check that the Docker images were successfully updated.
-for IMAGE in $ALL_CCDL_IMAGES; do
+for IMAGE in $ALL_IMAGES; do
     image_name="$DOCKERHUB_REPO/dr_$IMAGE"
     if ! docker_img_exists "$image_name" "$CI_TAG"; then
         echo "Docker image $image_name:$CI_TAG doesn't exist after running update_docker_img.sh!"

--- a/.github/scripts/remote_deploy.sh
+++ b/.github/scripts/remote_deploy.sh
@@ -18,11 +18,10 @@
 #     - AWS_ACCESS_KEY_ID -- The AWS key id to use when interacting with AWS.
 #     - AWS_SECRET_ACCESS_KEY -- The AWS secret key to use when interacting with AWS.
 
-
-echo "$INSTANCE_SSH_KEY" > infrastructure/data-refinery-key.pem
+echo "$INSTANCE_SSH_KEY" >infrastructure/data-refinery-key.pem
 chmod 600 infrastructure/data-refinery-key.pem
 
-run_on_deploy_box () {
+run_on_deploy_box() {
     # shellcheck disable=SC2029
     ssh -o StrictHostKeyChecking=no \
         -o ServerAliveInterval=15 \
@@ -32,7 +31,7 @@ run_on_deploy_box () {
 
 # Create file containing local env vars that are needed for deploy.
 rm -f env_vars
-cat >> env_vars <<EOF
+cat >>env_vars <<EOF
 export CI_TAG='$CI_TAG'
 export DOCKER_ID='$DOCKER_ID'
 export DOCKER_PASSWD='$DOCKER_PASSWD'
@@ -80,7 +79,7 @@ if [[ "$MASTER_OR_DEV" == "master" ]]; then
 elif [[ "$MASTER_OR_DEV" == "dev" ]]; then
     DOCKERHUB_REPO=ccdlstaging
 else
-    echo "Why in the world was remote_deploy.sh called from a branch other than dev or master?!?!?"
+    echo "Why in the world was remote_deploy.sh called from a branch other than dev or master?!"
     exit 1
 fi
 

--- a/.github/scripts/run_terraform.sh
+++ b/.github/scripts/run_terraform.sh
@@ -1,16 +1,14 @@
 #!/bin/bash -e
 
-# Import Hashicorps' Key.
+# Import Hashicorps' key.
 curl https://keybase.io/hashicorp/pgp_keys.asc | gpg --import
 
-
-# Install terraform and nomad
+# Install Terraform.
 cd
 TERRAFORM_VERSION=0.13.5
 wget -N https://releases.hashicorp.com/terraform/$TERRAFORM_VERSION/terraform_${TERRAFORM_VERSION}_linux_amd64.zip
 wget -N https://releases.hashicorp.com/terraform/$TERRAFORM_VERSION/terraform_${TERRAFORM_VERSION}_SHA256SUMS
 wget -N https://releases.hashicorp.com/terraform/$TERRAFORM_VERSION/terraform_${TERRAFORM_VERSION}_SHA256SUMS.sig
-
 
 # Verify the signature file is untampered.
 gpg_ok=$(gpg --verify terraform_${TERRAFORM_VERSION}_SHA256SUMS.sig terraform_${TERRAFORM_VERSION}_SHA256SUMS |& grep Good)
@@ -32,9 +30,9 @@ sudo mv terraform /usr/local/bin/
 cd ~/refinebio/infrastructure
 
 # Circle won't set the branch name for us, so do it ourselves.
-source ~/refinebio/scripts/common.sh
-branch=$(get_master_or_dev "$CI_TAG")
+. ~/refinebio/scripts/common.sh
 
+branch=$(get_master_or_dev "$CI_TAG")
 if [[ $branch == "master" ]]; then
     ENVIRONMENT=prod
     BATCH_USE_ON_DEMAND_INSTANCES="false"
@@ -42,7 +40,7 @@ elif [[ $branch == "dev" ]]; then
     ENVIRONMENT=staging
     BATCH_USE_ON_DEMAND_INSTANCES="true"
 else
-    echo "Why in the world was run_terraform.sh called from a branch other than dev or master?!?!?"
+    echo "Why in the world was run_terraform.sh called from a branch other than dev or master?!"
     exit 1
 fi
 

--- a/.github/scripts/slackpost_deploy.sh
+++ b/.github/scripts/slackpost_deploy.sh
@@ -1,26 +1,23 @@
 #!/bin/bash
 
-if [[ $ENGAGEMENTBOT_WEBHOOK == "" ]]
-then
+if [[ $ENGAGEMENTBOT_WEBHOOK == "" ]]; then
     echo "No webhook url. Set ENGAGEMENTBOT_WEBHOOK in the environment variables if you want to be notified of deploys on slack"
     exit 0
 fi
 
 # ------------
 channel=$1
-if [[ $channel == "" ]]
-then
-        echo "No channel specified"
-        exit 1
+if [[ $channel == "" ]]; then
+    echo "No channel specified"
+    exit 1
 fi
 
 # ------------
 shift
 username=$1
-if [[ $username == "" ]]
-then
-        echo "No username specified"
-        exit 1
+if [[ $username == "" ]]; then
+    echo "No username specified"
+    exit 1
 fi
 
 # ------------
@@ -35,7 +32,7 @@ fi
 
 text="New deployment! Woo! $CI_USERNAME: $CI_BRANCH $CI_TAG"
 
-escapedText=$(echo "$text" | sed 's/"/\"/g' | sed "s/'/\'/g" )
+escapedText=$(echo "$text" | sed 's/"/\"/g' | sed "s/'/\'/g")
 
 json="{\"channel\": \"$channel\", \"username\":\"$username\", \"icon_emoji\":\":tada:\", \"attachments\":[{\"color\":\"danger\" , \"text\": \"$escapedText\"}]}"
 

--- a/.github/scripts/slackpost_end_to_end.sh
+++ b/.github/scripts/slackpost_end_to_end.sh
@@ -1,31 +1,28 @@
 #!/bin/bash
 
-if [[ $ENGAGEMENTBOT_WEBHOOK == "" ]]
-then
+if [[ $ENGAGEMENTBOT_WEBHOOK == "" ]]; then
     echo "No webhook url. Set ENGAGEMENTBOT_WEBHOOK in the environment variables if you want to be notified of deploys on slack"
     exit 0
 fi
 
 # ------------
 channel=$1
-if [[ $channel == "" ]]
-then
-        echo "No channel specified"
-        exit 1
+if [[ $channel == "" ]]; then
+    echo "No channel specified"
+    exit 1
 fi
 
 # ------------
 shift
 username=$1
-if [[ $username == "" ]]
-then
-        echo "No username specified"
-        exit 1
+if [[ $username == "" ]]; then
+    echo "No username specified"
+    exit 1
 fi
 
 text="The end-to-end tests passed in the staging stack!!!"
 
-escapedText=$(echo "$text" | sed 's/"/\"/g' | sed "s/'/\'/g" )
+escapedText=$(echo "$text" | sed 's/"/\"/g' | sed "s/'/\'/g")
 
 json="{\"channel\": \"$channel\", \"username\":\"$username\", \"icon_emoji\":\":tada:\", \"attachments\":[{\"color\":\"danger\" , \"text\": \"$escapedText\"}]}"
 

--- a/.github/scripts/update_docker_img.sh
+++ b/.github/scripts/update_docker_img.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-# Load docker_img_exists function and $WORKER_IMAGES
+# Load docker_img_exists function and $WORKER_IMAGES.
 . ~/refinebio/scripts/common.sh
 
 # Github won't set the branch name for us, so do it ourselves.
@@ -16,7 +16,7 @@ else
     exit 1
 fi
 
-echo "$CI_TAG" > ~/refinebio/common/version
+echo "$CI_TAG" >~/refinebio/common/version
 
 # Create ~/refinebio/common/dist/data-refinery-common-*.tar.gz, which is
 # required by the workers and data_refinery_foreman images.
@@ -36,9 +36,10 @@ for IMAGE in $WORKER_IMAGES; do
         echo "Building docker image: $image_name:$CI_TAG"
         # Build and push image. We use the CI_TAG as the system version.
         docker build \
-               -t "$image_name:$CI_TAG" \
-               -f "workers/dockerfiles/Dockerfile.$IMAGE" \
-               --build-arg SYSTEM_VERSION="$CI_TAG" .
+            --build-arg SYSTEM_VERSION="$CI_TAG" \
+            --file "workers/dockerfiles/Dockerfile.$IMAGE" \
+            --tag "$image_name:$CI_TAG" \
+            .
         docker push "$image_name:$CI_TAG"
         # Update latest version.
         docker tag "$image_name:$CI_TAG" "$image_name:latest"
@@ -56,10 +57,10 @@ if docker_img_exists "$FOREMAN_DOCKER_IMAGE" "$CI_TAG"; then
 else
     # Build and push image. We use the CI_TAG as the system version.
     docker build \
-           --build-arg SYSTEM_VERSION="$CI_TAG" \
-           --file foreman/dockerfiles/Dockerfile.foreman \
-           --tag "$FOREMAN_DOCKER_IMAGE:$CI_TAG" \
-           .
+        --build-arg SYSTEM_VERSION="$CI_TAG" \
+        --file foreman/dockerfiles/Dockerfile.foreman \
+        --tag "$FOREMAN_DOCKER_IMAGE:$CI_TAG" \
+        .
     docker push "$FOREMAN_DOCKER_IMAGE:$CI_TAG"
     # Update latest version.
     docker tag "$FOREMAN_DOCKER_IMAGE:$CI_TAG" "$FOREMAN_DOCKER_IMAGE:latest"
@@ -73,10 +74,10 @@ if docker_img_exists "$API_DOCKER_IMAGE" "$CI_TAG"; then
 else
     # Build and push image. We use the CI_TAG as the system version.
     docker build \
-           --build-arg SYSTEM_VERSION="$CI_TAG" \
-           --file api/dockerfiles/Dockerfile.api_production \
-           --tag "$API_DOCKER_IMAGE:$CI_TAG" \
-           .
+        --build-arg SYSTEM_VERSION="$CI_TAG" \
+        --file api/dockerfiles/Dockerfile.api_production \
+        --tag "$API_DOCKER_IMAGE:$CI_TAG" \
+        .
     docker push "$API_DOCKER_IMAGE:$CI_TAG"
     # Update latest version.
     docker tag "$API_DOCKER_IMAGE:$CI_TAG" "$API_DOCKER_IMAGE:latest"

--- a/.github/scripts/update_docker_img.sh
+++ b/.github/scripts/update_docker_img.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 set -e
 
-# Load docker_img_exists function and $CCDL_WORKER_IMAGES
-source ~/refinebio/scripts/common.sh
+# Load docker_img_exists function and $WORKER_IMAGES
+. ~/refinebio/scripts/common.sh
 
 # Github won't set the branch name for us, so do it ourselves.
 branch=$(get_master_or_dev "$CI_TAG")
@@ -12,7 +12,7 @@ if [[ "$branch" == "master" ]]; then
 elif [[ "$branch" == "dev" ]]; then
     DOCKERHUB_REPO=ccdlstaging
 else
-    echo "Why in the world was update_docker_img.sh called from a branch other than dev or master?!?!?"
+    echo "Why in the world was update_docker_img.sh called from a branch other than dev or master!?"
     exit 1
 fi
 
@@ -20,15 +20,15 @@ echo "$CI_TAG" > ~/refinebio/common/version
 
 # Create ~/refinebio/common/dist/data-refinery-common-*.tar.gz, which is
 # required by the workers and data_refinery_foreman images.
-## Remove old common distributions if they exist
+## Remove old common distributions if they exist.
 rm -f ~/refinebio/common/dist/*
 cd ~/refinebio/common && python3 setup.py sdist
 
-# Log into DockerHub
+# Log into DockerHub.
 docker login -u "$DOCKER_ID" -p "$DOCKER_PASSWD"
 
 cd ~/refinebio
-for IMAGE in $CCDL_WORKER_IMAGES; do
+for IMAGE in $WORKER_IMAGES; do
     image_name="$DOCKERHUB_REPO/dr_$IMAGE"
     if docker_img_exists "$image_name" "$CI_TAG"; then
         echo "Docker image exists, skipping: $image_name:$CI_TAG"
@@ -40,43 +40,45 @@ for IMAGE in $CCDL_WORKER_IMAGES; do
                -f "workers/dockerfiles/Dockerfile.$IMAGE" \
                --build-arg SYSTEM_VERSION="$CI_TAG" .
         docker push "$image_name:$CI_TAG"
-        # Update latest version
+        # Update latest version.
         docker tag "$image_name:$CI_TAG" "$image_name:latest"
         docker push "$image_name:latest"
 
-        # Save some space when we're through
+        # Save some space when we're through.
         docker rmi "$image_name:$CI_TAG"
     fi
 done
 
-# Build and push foreman image
+# Build and push foreman image.
 FOREMAN_DOCKER_IMAGE="$DOCKERHUB_REPO/dr_foreman"
 if docker_img_exists "$FOREMAN_DOCKER_IMAGE" "$CI_TAG"; then
     echo "Docker image exists, skipping: $FOREMAN_DOCKER_IMAGE:$CI_TAG"
 else
     # Build and push image. We use the CI_TAG as the system version.
     docker build \
-           -t "$FOREMAN_DOCKER_IMAGE:$CI_TAG" \
-           -f foreman/dockerfiles/Dockerfile.foreman \
-           --build-arg SYSTEM_VERSION="$CI_TAG" .
+           --build-arg SYSTEM_VERSION="$CI_TAG" \
+           --file foreman/dockerfiles/Dockerfile.foreman \
+           --tag "$FOREMAN_DOCKER_IMAGE:$CI_TAG" \
+           .
     docker push "$FOREMAN_DOCKER_IMAGE:$CI_TAG"
-    # Update latest version
+    # Update latest version.
     docker tag "$FOREMAN_DOCKER_IMAGE:$CI_TAG" "$FOREMAN_DOCKER_IMAGE:latest"
     docker push "$FOREMAN_DOCKER_IMAGE:latest"
 fi
 
-# Build and push API image
+# Build and push API image.
 API_DOCKER_IMAGE="$DOCKERHUB_REPO/dr_api"
 if docker_img_exists "$API_DOCKER_IMAGE" "$CI_TAG"; then
     echo "Docker image exists, skipping: $API_DOCKER_IMAGE:$CI_TAG"
 else
     # Build and push image. We use the CI_TAG as the system version.
     docker build \
-           -t "$API_DOCKER_IMAGE:$CI_TAG" \
-           -f api/dockerfiles/Dockerfile.api_production \
-           --build-arg SYSTEM_VERSION="$CI_TAG" .
+           --build-arg SYSTEM_VERSION="$CI_TAG" \
+           --file api/dockerfiles/Dockerfile.api_production \
+           --tag "$API_DOCKER_IMAGE:$CI_TAG" \
+           .
     docker push "$API_DOCKER_IMAGE:$CI_TAG"
-    # Update latest version
+    # Update latest version.
     docker tag "$API_DOCKER_IMAGE:$CI_TAG" "$API_DOCKER_IMAGE:latest"
     docker push "$API_DOCKER_IMAGE:latest"
 fi

--- a/.github/scripts/upload_test_coverage.sh
+++ b/.github/scripts/upload_test_coverage.sh
@@ -3,14 +3,12 @@
 # Script to upload code coverage
 
 project=$1
-if [[ $project == "" ]]
-then
+if [[ $project == "" ]]; then
     echo "No project specified"
     exit 1
 fi
 
-if [[ $project == "workers" ]]
-then
+if [[ $project == "workers" ]]; then
     # the workers project uses it's own test_volume directory
     test_volume="workers/test_volume"
 else
@@ -19,8 +17,7 @@ fi
 
 coverage_file="${test_volume}/coverage.xml"
 
-if [[ ! -f $coverage_file ]]
-then
+if [[ ! -f $coverage_file ]]; then
     echo "Coverage file wasn't found, were the tests run before?"
     exit 0 # exit this script but don't fail the tests for this.
 fi
@@ -30,7 +27,7 @@ output_file="${test_volume}/${project}_coverage.xml"
 # In the test coverage report, all file paths are relative to each project
 # folder. We need to be relative to the repo's root directory. That's why we
 # append the project folder name to each file path in coverage.xml
-sed "s/filename=\"/filename=\"$project\//g" "$coverage_file" > "$output_file"
+sed "s/filename=\"/filename=\"$project\//g" "$coverage_file" >"$output_file"
 
 # codecov.sh is located at https://codecov.io/bash
 # we downloaded it for convenience

--- a/README.md
+++ b/README.md
@@ -19,46 +19,49 @@ Refine.bio currently has four sub-projects contained within this repo:
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 ## Table of Contents
 
-- [Development](#development)
-  - [Git Workflow](#git-workflow)
-  - [Installation](#installation)
-    - [Automatic](#automatic)
-    - [Linux (Manual)](#linux-manual)
-    - [Mac (Manual)](#mac-manual)
-    - [Virtual Environment](#virtual-environment)
-    - [Services](#services)
-      - [Postgres](#postgres)
-    - [Common Dependecies](#common-dependecies)
-    - [ElasticSearch](#elasticsearch)
-  - [Testing](#testing)
-    - [API](#api)
-    - [Common](#common)
-    - [Foreman](#foreman)
-    - [Workers](#workers)
-  - [Style](#style)
-  - [Gotchas](#gotchas)
-    - [R](#r)
-- [Running Locally](#running-locally)
-  - [API](#api-1)
-  - [Surveyor Jobs](#surveyor-jobs)
-    - [Sequence Read Archive](#sequence-read-archive)
-    - [Ensembl Transcriptome Indices](#ensembl-transcriptome-indices)
-  - [Downloader Jobs](#downloader-jobs)
-  - [Processor Jobs](#processor-jobs)
-  - [Creating Quantile Normalization Reference Targets](#creating-quantile-normalization-reference-targets)
-  - [Creating Compendia](#creating-compendia)
-  - [Running Tximport Early](#running-tximport-early)
-  - [Development Helpers](#development-helpers)
-- [Cloud Deployment](#cloud-deployment)
-  - [Docker Images](#docker-images)
-  - [Terraform](#terraform)
-  - [Running Jobs](#running-jobs)
-  - [Log Consumption](#log-consumption)
-  - [Dumping and Restoring Database Backups](#dumping-and-restoring-database-backups)
-  - [Tearing Down](#tearing-down)
-- [Support](#support)
-- [Meta-README](#meta-readme)
-- [License](#license)
+- [Refine.bio  ](#refinebio--)
+  - [Table of Contents](#table-of-contents)
+  - [Development](#development)
+    - [Git Workflow](#git-workflow)
+    - [Installation](#installation)
+      - [Automatic](#automatic)
+      - [Linux (Manual)](#linux-manual)
+      - [Mac (Manual)](#mac-manual)
+      - [Virtual Environment](#virtual-environment)
+      - [Services](#services)
+        - [Postgres](#postgres)
+      - [Common Dependecies](#common-dependecies)
+      - [ElasticSearch](#elasticsearch)
+    - [Testing](#testing)
+      - [API](#api)
+      - [Common](#common)
+      - [Foreman](#foreman)
+      - [Workers](#workers)
+    - [Style](#style)
+    - [Gotchas](#gotchas)
+      - [R](#r)
+  - [Running Locally](#running-locally)
+    - [API](#api-1)
+    - [Surveyor Jobs](#surveyor-jobs)
+      - [Sequence Read Archive](#sequence-read-archive)
+      - [Ensembl Transcriptome Indices](#ensembl-transcriptome-indices)
+    - [Downloader Jobs](#downloader-jobs)
+    - [Processor Jobs](#processor-jobs)
+    - [Creating Quantile Normalization Reference Targets](#creating-quantile-normalization-reference-targets)
+    - [Creating Compendia](#creating-compendia)
+    - [Running Tximport Early](#running-tximport-early)
+    - [Development Helpers](#development-helpers)
+  - [Cloud Deployment](#cloud-deployment)
+    - [Docker Images](#docker-images)
+    - [Terraform](#terraform)
+    - [AWS Batch](#aws-batch)
+    - [Running Jobs](#running-jobs)
+    - [Log Consumption](#log-consumption)
+    - [Dumping and Restoring Database Backups](#dumping-and-restoring-database-backups)
+    - [Tearing Down](#tearing-down)
+  - [Support](#support)
+  - [Meta-README](#meta-readme)
+  - [License](#license)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
@@ -630,17 +633,17 @@ Please try to keep the `dev` and `master` versions in sync for major and minor v
 
 Refine.bio uses a number of different Docker images to run different pieces of the system.
 By default, refine.bio will pull images from the Dockerhub repo `ccdlstaging`.
-If you would like to use images you have built and pushed to Dockerhub yourself you can pass the `-d` option to the `deploy.sh` script.
+If you would like to use images you have built and pushed to Dockerhub yourself you can pass the `-r` option to the `deploy.sh` script.
 
 To make building and pushing your own images easier, the `scripts/update_my_docker_images.sh` has been provided.
-The `-d` option will allow you to specify which repo you'd like to push to.
+The `-r` option will allow you to specify which repo you'd like to push to.
 If the Dockerhub repo requires you to be logged in, you should do so before running the script using `docker login`.
 The -v option allows you to specify the version, which will both end up on the Docker images you're building as the SYSTEM_VERSION environment variable and also will be the docker tag for the image.
 
 `scripts/update_my_docker_images.sh` will not build the dr_affymetrix image, because this image requires a lot of resources and time to build.
-It can instead be built with `./scripts/prepare_image.sh -i affymetrix -d <YOUR_DOCKERHUB_REPO>`.
+It can instead be built with `./scripts/prepare_image.sh -i affymetrix -r <YOUR_DOCKERHUB_REPO>`.
 WARNING: The affymetrix image installs a lot of data-as-R-packages and needs a lot of disk space to build the image.
-It's not recommended to build the image with less than 60GB of free space on the disk that Docker runs on.
+It's not recommended to build the image with less than 75GB of free space on the disk that Docker runs on.
 
 ### Terraform
 
@@ -667,7 +670,7 @@ The correct way to deploy to the cloud is by running the `deploy.sh` script. Thi
 configuration steps, such as setting environment variables, setting up Batch job specifications, and performing database migrations. It can be used from the `infrastructure` directory like so:
 
 ```bash
-./deploy.sh -u myusername -e dev -r us-east-1 -v v1.0.0 -d my-dockerhub-repo
+./deploy.sh -u myusername -e dev -d us-east-1 -v v1.0.0 -r my-dockerhub-repo
 ```
 
 This will spin up the whole system. It will usually take about 15 minutes, most of which is spent waiting for the Postgres instance to start.
@@ -811,7 +814,7 @@ This can take a long time (>30 minutes)!
 
 ### Tearing Down
 
-A stack that has been spun up via `deploy.sh -u myusername -e dev` can be taken down with `destroy_terraform.sh  -u myusername -e dev -r us-east-1`.
+A stack that has been spun up via `deploy.sh -u myusername -e dev` can be taken down with `destroy_terraform.sh  -u myusername -e dev -d us-east-1`.
 The same username and environment must be passed into `destroy_terraform.sh` as were used to run `deploy.sh` either via the -e and -u options or by specifying `TF_VAR_stage` or `TF_VAR_user` so that the script knows which to take down.
 Note that this will prompt you for confirmation before actually destroying all of your cloud resources.
 

--- a/api/run_tests.sh
+++ b/api/run_tests.sh
@@ -4,27 +4,31 @@
 
 # This script should always run as if it were being called from
 # the directory it lives in.
-script_directory="$(cd "$(dirname "$0")" || exit; pwd)"
+script_directory="$(
+    cd "$(dirname "$0")" || exit
+    pwd
+)"
 cd "$script_directory" || exit
 
-# However in order to give Docker access to all the code we have to
-# move up a level
+# However, in order to give Docker access to all the code we have to
+# move up a level.
 cd ..
 
-# Ensure that postgres is running
+# Ensure that Postgres is running.
 if ! [ "$(docker ps --filter name=drdb -q)" ]; then
     echo "You must start Postgres first with:" >&2
     echo "./scripts/run_postgres.sh" >&2
     exit 1
 fi
-# Ensure that elasticsearch is running
+
+# Ensure that ElasticSearch is running.
 if ! [ "$(docker ps --filter name=dres -q)" ]; then
     echo "You must start elasticsearchfirst with:" >&2
     echo "./scripts/run_es.sh" >&2
     exit 1
 fi
 
-project_root=$(pwd) # "cd .." called above
+project_root=$(pwd) # "cd .." called above.
 volume_directory="$project_root/test_volume"
 if [ ! -d "$volume_directory" ]; then
     mkdir "$volume_directory"
@@ -34,18 +38,23 @@ chmod -R a+rwX "$volume_directory"
 ./scripts/prepare_image.sh -i api_local -s api
 
 . ./scripts/common.sh
+
 DB_HOST_IP=$(get_docker_db_ip_address)
 ES_HOST_IP=$(get_docker_es_ip_address)
 
-# Only run interactively if we are on a TTY
+# Only run interactively if we are on a TTY.
 if [ -t 1 ]; then
-    INTERACTIVE="-i"
+    INTERACTIVE="--interactive"
 fi
 
-docker run -t $INTERACTIVE \
-       --add-host=database:"$DB_HOST_IP" \
-       --add-host=elasticsearch:"$ES_HOST_IP" \
-       --env-file api/environments/test \
-       --platform linux/amd64 \
-       --volume "$volume_directory":/home/user/data_store \
-       ccdlstaging/dr_api_local bash -c "$(run_tests_with_coverage "$@")"
+# shellcheck disable=SC2086
+docker run \
+    --add-host=database:"$DB_HOST_IP" \
+    --add-host=elasticsearch:"$ES_HOST_IP" \
+    --env-file api/environments/test \
+    --platform linux/amd64 \
+    --tty \
+    --volume "$volume_directory":/home/user/data_store \
+    $INTERACTIVE \
+    "$DOCKERHUB_REPO/dr_api_local" \
+    bash -c "$(run_tests_with_coverage "$@")"

--- a/api/serve.sh
+++ b/api/serve.sh
@@ -4,22 +4,29 @@
 
 # This script should always run as if it were being called from
 # the directory it lives in.
-script_directory="$(cd "$(dirname "$0")" || exit; pwd)"
+script_directory="$(
+    cd "$(dirname "$0")" || exit
+    pwd
+)"
 cd "$script_directory" || exit
 
-# However in order to give Docker access to all the code we have to
-# move up a level
+# However, in order to give Docker access to all the code we have to
+# move up a level.
 cd ..
 
 ./scripts/prepare_image.sh -i api_local -s api
 
 . ./scripts/common.sh
+
 DB_HOST_IP=$(get_docker_db_ip_address)
 ES_HOST_IP=$(get_docker_es_ip_address)
 
 docker run \
-       --add-host=database:"$DB_HOST_IP" \
-       --add-host=elasticsearch:"$ES_HOST_IP" \
-       --env-file api/environments/local \
-       -p 8000:8000 \
-       -it ccdlstaging/dr_api_local python3 manage.py runserver 0.0.0.0:8000 "$@"
+    --add-host=database:"$DB_HOST_IP" \
+    --add-host=elasticsearch:"$ES_HOST_IP" \
+    --env-file api/environments/local \
+    --interactive \
+    --publish 8000:8000 \
+    --tty \
+    "$DOCKERHUB_REPO/dr_api_local" \
+    python3 manage.py runserver 0.0.0.0:8000 "$@"

--- a/api/serve_production.sh
+++ b/api/serve_production.sh
@@ -4,24 +4,31 @@
 
 # This script should always run as if it were being called from
 # the directory it lives in.
-script_directory="$(cd "$(dirname "$0")" || exit; pwd)"
+script_directory="$(
+    cd "$(dirname "$0")" || exit
+    pwd
+)"
 cd "$script_directory" || exit
 
-# However in order to give Docker access to all the code we have to
-# move up a level
+# However, in order to give Docker access to all the code we have to
+# move up a level.
 cd ..
 
 ./scripts/prepare_image.sh -i api_production -s api
 
 . ./scripts/common.sh
-DB_HOST_IP=$(get_docker_db_ip_address)
 
+DB_HOST_IP=$(get_docker_db_ip_address)
 STATIC_VOLUMES=/tmp/volumes_static
 
 docker run \
-       --add-host=database:"$DB_HOST_IP" \
-       --env-file api/environments/local \
-       --link drdb:postgres \
-       -v "$STATIC_VOLUMES":/tmp/www/static \
-       -p 8081:8081 \
-       -it -d ccdlstaging/dr_api_production /bin/sh -c "/home/user/collect_and_run_uwsgi.sh"
+    --add-host=database:"$DB_HOST_IP" \
+    --detach \
+    --env-file api/environments/local \
+    --interactive \
+    --link drdb:postgres \
+    --publish 8081:8081 \
+    --tty \
+    --volume "$STATIC_VOLUMES":/tmp/www/static \
+    "$DOCKERHUB_REPO/dr_api_production" \
+    /bin/sh -c "/home/user/collect_and_run_uwsgi.sh"

--- a/common/dockerfiles/Dockerfile.common_tests
+++ b/common/dockerfiles/Dockerfile.common_tests
@@ -1,4 +1,5 @@
-FROM ccdlstaging/dr_base:latest
+ARG DOCKERHUB_REPO
+FROM $DOCKERHUB_REPO/dr_base:latest
 
 # Fail in case of an error at any stage in the pipe.
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]

--- a/common/dockerfiles/Dockerfile.migrations
+++ b/common/dockerfiles/Dockerfile.migrations
@@ -1,4 +1,5 @@
-FROM ccdlstaging/dr_base:latest
+ARG DOCKERHUB_REPO
+FROM $DOCKERHUB_REPO/dr_base:latest
 
 # Fail in case of an error at any stage in the pipe.
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]

--- a/common/run_tests.sh
+++ b/common/run_tests.sh
@@ -1,24 +1,27 @@
 #!/bin/sh -e
 
-# script for executing Django PyUnit Tests within a Docker container.
+# Script for executing Django PyUnit tests within a Docker container.
 
 # This script should always run as if it were being called from
 # the directory it lives in.
-script_directory="$(cd "$(dirname "$0")" || exit; pwd)"
+script_directory="$(
+    cd "$(dirname "$0")" || exit
+    pwd
+)"
 cd "$script_directory" || exit
 
-# However in order to give Docker access to all the code we have to
-# move up a level
+# However, in order to give Docker access to all the code we have to
+# move up a level.
 cd ..
 
-# Ensure that postgres is running
+# Ensure that Postgres is running.
 if ! [ "$(docker ps --filter name=drdb -q)" ]; then
     echo "You must start Postgres first with:" >&2
     echo "./scripts/run_postgres.sh" >&2
     exit 1
 fi
 
-project_root=$(pwd) # "cd .." called above
+project_root=$(pwd) # "cd .." called above.
 volume_directory="$project_root/test_volume"
 if [ ! -d "$volume_directory" ]; then
     mkdir "$volume_directory"
@@ -28,18 +31,23 @@ chmod -R a+rwX "$volume_directory"
 ./scripts/prepare_image.sh -i common_tests -s common
 
 . ./scripts/common.sh
+
 DB_HOST_IP=$(get_docker_db_ip_address)
 ES_HOST_IP=$(get_docker_es_ip_address)
 
-# Only run interactively if we are on a TTY
+# Only run interactively if we are on a TTY.
 if [ -t 1 ]; then
-    INTERACTIVE="-i"
+    INTERACTIVE="--interactive"
 fi
 
-docker run -t $INTERACTIVE \
-       --add-host=database:"$DB_HOST_IP" \
-       --add-host=elasticsearch:"$ES_HOST_IP" \
-       --env-file common/environments/test \
-       --platform linux/amd64 \
-       --volume "$volume_directory":/home/user/data_store \
-        ccdlstaging/dr_common_tests bash -c "$(run_tests_with_coverage "$@")" --parallel
+# shellcheck disable=SC2086
+docker run \
+    --add-host=database:"$DB_HOST_IP" \
+    --add-host=elasticsearch:"$ES_HOST_IP" \
+    --env-file common/environments/test \
+    --platform linux/amd64 \
+    --tty \
+    --volume "$volume_directory":/home/user/data_store \
+    $INTERACTIVE \
+    "$DOCKERHUB_REPO/dr_common_tests" \
+    bash -c "$(run_tests_with_coverage "$@")" --parallel

--- a/foreman/dockerfiles/Dockerfile.foreman
+++ b/foreman/dockerfiles/Dockerfile.foreman
@@ -1,4 +1,5 @@
-FROM ccdlstaging/dr_base:latest
+ARG DOCKERHUB_REPO
+FROM $DOCKERHUB_REPO/dr_base:latest
 
 # Fail in case of an error at any stage in the pipe.
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]

--- a/foreman/run_end_to_end_tests.sh
+++ b/foreman/run_end_to_end_tests.sh
@@ -4,7 +4,10 @@
 
 # This script should always run as if it were being called from
 # the directory it lives in.
-script_directory="$(cd "$(dirname "$0")" || exit; pwd)"
+script_directory="$(
+    cd "$(dirname "$0")" || exit
+    pwd
+)"
 cd "$script_directory" || exit
 
 # Set up the data volume directory if it does not already exist.
@@ -25,30 +28,27 @@ if [ ! -e "$reference_file_dir/$quant_file" ]; then
     mkdir -p "$reference_file_dir"
     echo "Downloading quant file for Transcriptome Index validation tests."
     wget -q -O "$reference_file_dir/$quant_file" \
-            "$test_data_repo/$quant_file"
+        "$test_data_repo/$quant_file"
 fi
 
 # temp for testing locally.
 ../scripts/prepare_image.sh -i foreman -s foreman
 
-
 while read -r row; do
     # Exporting an expansion rather than a variable, which is exactly what we want to do.
     # shellcheck disable=SC2163
     export "${row}"
-done < ../infrastructure/prod_env
+done <../infrastructure/prod_env
 
-
-# Hardcode ccdlstaging because this should only ever be run in staging or
-# locally, and when running locally `prepare_image.sh` makes the forman
-# ccdlstaging/dr_foreman.
-docker run -t \
-    --env-file ../infrastructure/prod_env \
-    --env RUNNING_IN_CLOUD=False \
+docker run \
     --env DATABASE_HOST="$DATABASE_PUBLIC_HOST" \
+    --env DJANGO_SECRET_KEY="TEST_KEY_FOR_DEV" \
     --env JOB_DEFINITION_PREFIX="$USER_$STAGE_" \
     --env REFINEBIO_BASE_URL="http://$API_HOST/v1/" \
-    --env DJANGO_SECRET_KEY="TEST_KEY_FOR_DEV" \
-    --volume "$volume_directory":/home/user/data_store \
+    --env RUNNING_IN_CLOUD=False \
+    --env-file ../infrastructure/prod_env \
     --volume "$HOME/.aws":/home/user/.aws \
-    ccdlstaging/dr_foreman python3 manage.py test --no-input --parallel=2 --testrunner='tests.test_runner.NoDbTestRunner' tests.foreman.test_end_to_end
+    --volume "$volume_directory":/home/user/data_store \
+    --tty \
+    "$DOCKERHUB_REPO/dr_foreman" \
+    python3 manage.py test --no-input --parallel=2 --testrunner='tests.test_runner.NoDbTestRunner' tests.foreman.test_end_to_end

--- a/foreman/run_management_command.sh
+++ b/foreman/run_management_command.sh
@@ -1,13 +1,16 @@
 #!/bin/sh
 
-# Script for running the Data Refinery Surveyor container
+# Script for running the Data Refinery Surveyor container.
 
 # This script should always run as if it were being called from
 # the directory it lives in.
-script_directory="$(cd "$(dirname "$0")" || exit; pwd)"
+script_directory="$(
+    cd "$(dirname "$0")" || exit
+    pwd
+)"
 cd "$script_directory" || exit
 
-# However in order to give Docker access to all the code we have to
+# However, in order to give Docker access to all the code we have to
 # move up a level
 cd ..
 
@@ -21,12 +24,16 @@ chmod -R a+rwX "$volume_directory"
 ./scripts/prepare_image.sh -i foreman -s foreman
 
 . ./scripts/common.sh
+
 DB_HOST_IP=$(get_docker_db_ip_address)
 
-docker run -it \
-       --add-host=database:"$DB_HOST_IP" \
-       --env-file foreman/environments/local \
-       --env AWS_ACCESS_KEY_ID="$AWS_ACCESS_KEY_ID" \
-       --env AWS_SECRET_ACCESS_KEY="$AWS_SECRET_ACCESS_KEY" \
-       --volume "$volume_directory":/home/user/data_store \
-       ccdlstaging/dr_foreman python3 manage.py "$@"
+docker run \
+    --add-host=database:"$DB_HOST_IP" \
+    --env AWS_ACCESS_KEY_ID="$AWS_ACCESS_KEY_ID" \
+    --env AWS_SECRET_ACCESS_KEY="$AWS_SECRET_ACCESS_KEY" \
+    --env-file foreman/environments/local \
+    --interactive \
+    --tty \
+    --volume "$volume_directory":/home/user/data_store \
+    "$DOCKERHUB_REPO/dr_foreman" \
+    python3 manage.py "$@"

--- a/foreman/run_tests.sh
+++ b/foreman/run_tests.sh
@@ -4,7 +4,10 @@
 
 # This script should always run as if it were being called from
 # the directory it lives in.
-script_directory="$(cd "$(dirname "$0")" || exit; pwd)"
+script_directory="$(
+    cd "$(dirname "$0")" || exit
+    pwd
+)"
 cd "$script_directory" || exit
 
 # Set up the data volume directory if it does not already exist.
@@ -18,11 +21,11 @@ if [ ! -d "$volume_directory" ]; then
 fi
 chmod -R a+rwX "$volume_directory"
 
-# However in order to give Docker access to all the code we have to
-# move up a level
+# However, in order to give Docker access to all the code we have to
+# move up a level.
 cd ..
 
-# First ensure postgres is running
+# First ensure Postgres is running.
 if ! [ "$(docker ps --filter name=drdb -q)" ]; then
     echo "You must start Postgres first with:" >&2
     echo "./scripts/run_postgres.sh" >&2
@@ -32,16 +35,21 @@ fi
 ./scripts/prepare_image.sh -i foreman -s foreman
 
 . ./scripts/common.sh
+
 DB_HOST_IP=$(get_docker_db_ip_address)
 
-# Only run interactively if we are on a TTY
+# Only run interactively if we are on a TTY.
 if [ -t 1 ]; then
-    INTERACTIVE="-i"
+    INTERACTIVE="--interactive"
 fi
 
-docker run -t $INTERACTIVE \
-       --add-host=database:"$DB_HOST_IP" \
-       --env-file foreman/environments/test \
-       --platform linux/amd64 \
-       --volume "$volume_directory":/home/user/data_store \
-       ccdlstaging/dr_foreman bash -c "$(run_tests_with_coverage --exclude-tag=manual "$@")"
+# shellcheck disable=SC2086
+docker run \
+    --add-host=database:"$DB_HOST_IP" \
+    --env-file foreman/environments/test \
+    --platform linux/amd64 \
+    --tty \
+    --volume "$volume_directory":/home/user/data_store \
+    $INTERACTIVE \
+    "$DOCKERHUB_REPO/dr_foreman" \
+    bash -c "$(run_tests_with_coverage --exclude-tag=manual "$@")"

--- a/foreman/test_survey.sh
+++ b/foreman/test_survey.sh
@@ -2,7 +2,7 @@
 
 # Script for testing the surveying of an accession manually (e.g. from a dataset request)
 print_options() {
-    cat << EOF
+    cat <<EOF
 There are two required arguments for this script that come from survey_experiment():
 -s specifies which surveyor to use.
 -a specifies which experiment accession should be surveyed.
@@ -48,7 +48,10 @@ fi
 
 # This script should always run as if it were being called from
 # the directory it lives in.
-script_directory="$(cd "$(dirname "$0")" || exit; pwd)"
+script_directory="$(
+    cd "$(dirname "$0")" || exit
+    pwd
+)"
 cd "$script_directory" || exit
 
 # Set up the data volume directory if it does not already exist.
@@ -62,11 +65,11 @@ if [ ! -d "$volume_directory" ]; then
 fi
 chmod -R a+rwX "$volume_directory"
 
-# However in order to give Docker access to all the code we have to
-# move up a level
+# However, in order to give Docker access to all the code we have to
+# move up a level.
 cd ..
 
-# First ensure postgres is running
+# First ensure Postgres is running.
 if ! [ "$(docker ps --filter name=drdb -q)" ]; then
     echo "You must start Postgres first with:" >&2
     echo "./scripts/run_postgres.sh" >&2
@@ -76,12 +79,16 @@ fi
 ./scripts/prepare_image.sh -i foreman -s foreman
 
 . ./scripts/common.sh
+
 DB_HOST_IP=$(get_docker_db_ip_address)
 
 docker run \
-       --add-host=database:"$DB_HOST_IP" \
-       --env-file foreman/environments/test \
-       --volume "$volume_directory":/home/user/data_store \
-       -e SURVEYOR="$SURVEYOR" \
-       -e ACCESSION="$ACCESSION" \
-       -it ccdlstaging/dr_foreman bash -c "python3 manage.py test --tag=manual ."
+    --add-host=database:"$DB_HOST_IP" \
+    --env ACCESSION="$ACCESSION" \
+    --env SURVEYOR="$SURVEYOR" \
+    --env-file foreman/environments/test \
+    --interactive \
+    --tty \
+    --volume "$volume_directory":/home/user/data_store \
+    "$DOCKERHUB_REPO/dr_foreman" \
+    bash -c "python3 manage.py test --tag=manual ."

--- a/infrastructure/api-configuration/api-server-instance-user-data.tpl.sh
+++ b/infrastructure/api-configuration/api-server-instance-user-data.tpl.sh
@@ -15,7 +15,7 @@
 cd /home/ubuntu || exit
 
 # Install and configure Nginx.
-cat <<"EOF" > nginx.conf
+cat <<"EOF" >nginx.conf
 ${nginx_config}
 EOF
 apt-get update -y
@@ -107,7 +107,7 @@ echo "
     size 20k
     daily
     maxage 3
-}" >> /etc/logrotate.conf
+}" >>/etc/logrotate.conf
 echo "
 /tmp/access.log {
     missingok
@@ -116,10 +116,10 @@ echo "
     size 20k
     daily
     maxage 3
-}" >> /etc/logrotate.conf
+}" >>/etc/logrotate.conf
 
 # Install our environment variables
-cat <<"EOF" > environment
+cat <<"EOF" >environment
 ${api_environment}
 EOF
 
@@ -135,36 +135,40 @@ docker pull "${dockerhub_repo}/${api_docker_image}"
 # These database values are created after TF
 # is run, so we have to pass them in programatically
 docker run \
-       --env-file environment \
-       -e DATABASE_HOST="${database_host}" \
-       -e DATABASE_NAME="${database_name}" \
-       -e DATABASE_USER="${database_user}" \
-       -e DATABASE_PASSWORD="${database_password}" \
-       -e ELASTICSEARCH_HOST="${elasticsearch_host}" \
-       -e ELASTICSEARCH_PORT="${elasticsearch_port}" \
-       -v "$STATIC_VOLUMES":/tmp/www/static \
-       --log-driver=awslogs \
-       --log-opt awslogs-region="${region}" \
-       --log-opt awslogs-group="${log_group}" \
-       --log-opt awslogs-stream="${log_stream}" \
-       -p 8081:8081 \
-       --name=dr_api \
-       -it -d "${dockerhub_repo}/${api_docker_image}" /bin/sh -c "/home/user/collect_and_run_uwsgi.sh"
+    --detach \
+    --env DATABASE_HOST="${database_host}" \
+    --env DATABASE_NAME="${database_name}" \
+    --env DATABASE_PASSWORD="${database_password}" \
+    --env DATABASE_USER="${database_user}" \
+    --env ELASTICSEARCH_HOST="${elasticsearch_host}" \
+    --env ELASTICSEARCH_PORT="${elasticsearch_port}" \
+    --env-file environment \
+    --interactive \
+    --log-driver=awslogs \
+    --log-opt awslogs-group="${log_group}" \
+    --log-opt awslogs-region="${region}" \
+    --log-opt awslogs-stream="${log_stream}" \
+    --name=dr_api \
+    --tty \
+    --volume "$STATIC_VOLUMES":/tmp/www/static \
+    -publish 8081:8081 \
+    "${dockerhub_repo}/${api_docker_image}" \
+    /bin/sh -c "/home/user/collect_and_run_uwsgi.sh"
 
 # Nuke and rebuild the search index. It shouldn't take too long.
 sleep 30
-docker exec dr_api python3 manage.py search_index --delete -f;
-docker exec dr_api python3 manage.py search_index --rebuild -f;
-docker exec dr_api python3 manage.py search_index --populate -f;
+docker exec dr_api python3 manage.py search_index --delete -f
+docker exec dr_api python3 manage.py search_index --rebuild -f
+docker exec dr_api python3 manage.py search_index --populate -f
 
 # Let's use this instance to call the populate command every twenty minutes.
-crontab -l > tempcron
+crontab -l >tempcron
 # echo new cron into cron file
 # TODO: stop logging this to api_cron.log once we figure out why it
 # hasn't been working.
-echo -e "SHELL=/bin/bash\nPATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin\n*/20 * * * * docker exec dr_api python3 manage.py update_es_index >> /var/log/api_cron.log 2>&1" >> tempcron
+echo -e "SHELL=/bin/bash\nPATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin\n*/20 * * * * docker exec dr_api python3 manage.py update_es_index >> /var/log/api_cron.log 2>&1" >>tempcron
 # Post a summary of downloads every Monday at 12:00 UTC
-echo -e "SHELL=/bin/bash\nPATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin\n0 12 * * MON docker exec dr_api python3 manage.py post_downloads_summary >> /var/log/api_cron.log 2>&1" >> tempcron
+echo -e "SHELL=/bin/bash\nPATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin\n0 12 * * MON docker exec dr_api python3 manage.py post_downloads_summary >> /var/log/api_cron.log 2>&1" >>tempcron
 # install new cron file
 crontab tempcron
 rm tempcron

--- a/infrastructure/destroy_terraform.sh
+++ b/infrastructure/destroy_terraform.sh
@@ -2,7 +2,10 @@
 
 # This script should always run as if it were being called from
 # the directory it lives in.
-script_directory="$(cd "$(dirname "$0")" || exit; pwd)"
+script_directory="$(
+    cd "$(dirname "$0")" || exit
+    pwd
+)"
 cd "$script_directory" || exit
 
 print_description() {
@@ -10,17 +13,17 @@ print_description() {
 }
 
 print_options() {
-    echo 'This script accepts the following arguments: -e, -u, -r, and -h.'
-    echo 'Neither -e, -u or -r is optional unless TF_VAR_stage, TF_VAR_user,'
+    echo 'This script accepts the following arguments: -e, -u, -d, and -h.'
+    echo 'Neither -e, -u or -d is optional unless TF_VAR_stage, TF_VAR_user,'
     echo 'or TF_VAR_region is set, respectively.'
     echo '-h prints this help message and exits.'
     echo '-e specifies the environment you would like to destroy.'
     echo '-u specifies the username you used to spin up the stack.'
-    echo '-r specifies the region of the stack to destroy.'
+    echo '-d specifies the region of the stack to destroy.'
     echo 'All arguments are needed to determine which stack to destroy.'
 }
 
-while getopts ":e:u:r:h" opt; do
+while getopts ":e:u:d:h" opt; do
     case $opt in
     e)
         export env=$OPTARG
@@ -29,7 +32,7 @@ while getopts ":e:u:r:h" opt; do
     u)
         export TF_VAR_user=$OPTARG
         ;;
-    r)
+    d)
         export TF_VAR_region=$OPTARG
         ;;
     h)
@@ -62,7 +65,7 @@ if [[ -z $TF_VAR_user ]]; then
 fi
 
 if [[ -z $TF_VAR_region ]]; then
-    echo 'Error: must specify region by either providing the -r argument or setting TF_VAR_region.'
+    echo 'Error: must specify region by either providing the -d argument or setting TF_VAR_region.'
     exit 1
 fi
 

--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -5,8 +5,11 @@
 export ALL_IMAGES="smasher compendia illumina affymetrix salmon transcriptome no_op downloaders foreman api"
 # Sometimes we only want to work with the worker images.
 export WORKER_IMAGES="smasher compendia illumina affymetrix salmon transcriptome no_op downloaders"
+
 # Default Docker registry.
-export DOCKERHUB_REPO="ccdlstaging"
+if [ -z "$DOCKERHUB_REPO" ]; then
+    export DOCKERHUB_REPO="ccdlstaging"
+fi
 
 get_docker_db_ip_address() {
     docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' drdb 2>/dev/null

--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -2,16 +2,18 @@
 
 # These are lists of docker images that we use. The actual names end
 # up being <DOCKERHUB_REPO>/dr_<IMAGE_NAME> but this is useful for scripting.
-export ALL_CCDL_IMAGES="smasher compendia illumina affymetrix salmon transcriptome no_op downloaders foreman api"
+export ALL_IMAGES="smasher compendia illumina affymetrix salmon transcriptome no_op downloaders foreman api"
 # Sometimes we only want to work with the worker images.
-export CCDL_WORKER_IMAGES="smasher compendia illumina affymetrix salmon transcriptome no_op downloaders"
+export WORKER_IMAGES="smasher compendia illumina affymetrix salmon transcriptome no_op downloaders"
+# Default Docker registry.
+export DOCKERHUB_REPO="ccdlstaging"
 
-get_docker_db_ip_address () {
-    docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' drdb 2> /dev/null
+get_docker_db_ip_address() {
+    docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' drdb 2>/dev/null
 }
 
-get_docker_es_ip_address () {
-    docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' dres 2> /dev/null
+get_docker_es_ip_address() {
+    docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' dres 2>/dev/null
 }
 
 # `coverage report -m` will always have an exit code of 0 which makes
@@ -19,7 +21,7 @@ get_docker_es_ip_address () {
 # of running the tests as $exit_code, then report the coverage, and
 # then exit with the appropriate code.
 # This is done a function so arguments to the tests can be passed through.
-run_tests_with_coverage () {
+run_tests_with_coverage() {
     COVERAGE="coverage run --source=\".\" manage.py test --settings=tests.settings --no-input $*; exit_code=\$?;"
     SAVE_REPORT="coverage xml -o data_store/coverage.xml;"
     PRINT_REPORT="coverage report -m;"
@@ -33,11 +35,11 @@ run_tests_with_coverage () {
 # https://stackoverflow.com/questions/32113330/check-if-imagetag-combination-already-exists-on-docker-hub
 docker_img_exists() {
     TOKEN=$(curl -s -H "Content-Type: application/json" -X POST \
-                 -d '{"username": "'"${DOCKER_ID}"'", "password": "'"${DOCKER_PASSWD}"'"}' \
-                 https://hub.docker.com/v2/users/login/ | jq -r .token)
+        -d '{"username": "'"${DOCKER_ID}"'", "password": "'"${DOCKER_PASSWD}"'"}' \
+        https://hub.docker.com/v2/users/login/ | jq -r .token)
     EXISTS=$(curl -s -H "Authorization: JWT ${TOKEN}" \
-                  "https://hub.docker.com/v2/repositories/$1/tags/?page_size=10000" \
-                 | jq -r "[.results | .[] | .name == \"$2\"] | any" 2> /dev/null)
+        "https://hub.docker.com/v2/repositories/$1/tags/?page_size=10000" |
+        jq -r "[.results | .[] | .name == \"$2\"] | any" 2>/dev/null)
     test -n "$EXISTS" -a "$EXISTS" = true
 }
 
@@ -57,7 +59,7 @@ get_master_or_dev() {
         # All dev versions should end with '-dev' or '-dev-hotfix' and all master versions should not.
         if [ -n "$master_check" ] && ! echo "$version" | grep -Eq "\-dev(\-hotfix)?$"; then
             echo "master"
-        elif [ -n "$dev_check" ] ; then
+        elif [ -n "$dev_check" ]; then
             echo "dev"
         else
             echo "unknown"

--- a/scripts/format_batch_with_env.sh
+++ b/scripts/format_batch_with_env.sh
@@ -24,34 +24,34 @@ print_options() {
 
 while getopts ":p:e:o:v:h" opt; do
     case $opt in
-        p)
-            export project="$OPTARG"
-            ;;
-        e)
-            export env="$OPTARG"
-            ;;
-        o)
-            export output_dir="$OPTARG"
-            ;;
-        v)
-            export system_version="$OPTARG"
-            ;;
-        h)
-            print_description
-            echo
-            print_options
-            exit 0
-            ;;
-        \?)
-            echo "Invalid option: -$OPTARG" >&2
-            print_options >&2
-            exit 1
-            ;;
-        :)
-            echo "Option -$OPTARG requires an argument." >&2
-            print_options >&2
-            exit 1
-            ;;
+    p)
+        export project="$OPTARG"
+        ;;
+    e)
+        export env="$OPTARG"
+        ;;
+    o)
+        export output_dir="$OPTARG"
+        ;;
+    v)
+        export system_version="$OPTARG"
+        ;;
+    h)
+        print_description
+        echo
+        print_options
+        exit 0
+        ;;
+    \?)
+        echo "Invalid option: -$OPTARG" >&2
+        print_options >&2
+        exit 1
+        ;;
+    :)
+        echo "Option -$OPTARG requires an argument." >&2
+        print_options >&2
+        exit 1
+        ;;
     esac
 done
 
@@ -102,10 +102,12 @@ if [ -z "$COMPENDIA_DOCKER_IMAGE" ]; then
     export COMPENDIA_DOCKER_IMAGE="dr_compendia:$system_version"
 fi
 
-
 # This script should always run from the context of the directory of
 # the project it is building.
-script_directory="$(cd "$(dirname "$0")" || exit; pwd)"
+script_directory="$(
+    cd "$(dirname "$0")" || exit
+    pwd
+)"
 
 project_directory="$script_directory/.."
 
@@ -142,7 +144,7 @@ while read -r line; do
         # shellcheck disable=SC2163
         export "$line"
     fi
-done < "$environment_file"
+done <"$environment_file"
 
 # If output_dir wasn't specified then assume the same folder we're
 # getting the templates from.
@@ -154,7 +156,6 @@ if [ ! -d "$output_dir" ]; then
     mkdir "$output_dir"
 fi
 
-
 # Not quite sure how to deal with this just yet, so punt.
 # export INDEX=0
 
@@ -163,7 +164,7 @@ fi
 if [ "$project" = "workers" ]; then
     # Iterate over all the template files in the directory.
     for template in batch-job-templates/*.tpl.json; do
-	template="$(basename "$template")"
+        template="$(basename "$template")"
         # Strip off the trailing .tpl for once we've formatted it.
         OUTPUT_BASE="$(basename "$template" .tpl.json)"
         FILETYPE=".json"
@@ -173,66 +174,62 @@ if [ "$project" = "workers" ]; then
 
         if [ "$OUTPUT_FILE" = "downloader.json" ]; then
             rams="1024 4096 16384"
-            for r in $rams
-            do
+            for r in $rams; do
                 export RAM_POSTFIX="_$r"
                 export RAM="$r"
                 FILEPATH="$output_dir/downloader$RAM_POSTFIX$FILETYPE"
                 perl -p -e 's/\$\{\{([^}]+)\}\}/defined $ENV{$1} ? $ENV{$1} : $&/eg' \
-                     < "batch-job-templates/$template" \
-                     > "$FILEPATH" \
-                     2> /dev/null
+                    <"batch-job-templates/$template" \
+                    >"$FILEPATH" \
+                    2>/dev/null
                 echo "Made $FILEPATH"
             done
             echo "Made $output_dir/$OUTPUT_FILE"
 
         elif [ "$OUTPUT_FILE" = "create_compendia.json" ]; then
             rams="30000 950000"
-            for r in $rams
-            do
+            for r in $rams; do
                 export RAM_POSTFIX="_$r"
                 export RAM="$r"
                 FILEPATH="$output_dir/$OUTPUT_BASE$RAM_POSTFIX$FILETYPE"
                 perl -p -e 's/\$\{\{([^}]+)\}\}/defined $ENV{$1} ? $ENV{$1} : $&/eg' \
-                     < "batch-job-templates/$template" \
-                     > "$FILEPATH" \
-                     2> /dev/null
+                    <"batch-job-templates/$template" \
+                    >"$FILEPATH" \
+                    2>/dev/null
                 echo "Made $FILEPATH"
             done
             echo "Made $output_dir/$OUTPUT_FILE"
 
         elif [ "$OUTPUT_FILE" = "create_quantpendia.json" ]; then
             rams="30000 131000"
-            for r in $rams
-            do
+            for r in $rams; do
                 export RAM_POSTFIX="_$r"
                 export RAM="$r"
                 FILEPATH="$output_dir/$OUTPUT_BASE$RAM_POSTFIX$FILETYPE"
                 perl -p -e 's/\$\{\{([^}]+)\}\}/defined $ENV{$1} ? $ENV{$1} : $&/eg' \
-                     < "batch-job-templates/$template" \
-                     > "$FILEPATH" \
-                     2> /dev/null
+                    <"batch-job-templates/$template" \
+                    >"$FILEPATH" \
+                    2>/dev/null
                 echo "Made $FILEPATH"
             done
             echo "Made $output_dir/$OUTPUT_FILE"
         # From https://unix.stackexchange.com/a/111517
         elif (echo "$NO_RAM_JOB_FILES" | grep -Fqw "$OUTPUT_FILE"); then
             perl -p -e 's/\$\{\{([^}]+)\}\}/defined $ENV{$1} ? $ENV{$1} : $&/eg' \
-                 < "batch-job-templates/$template" \
-                 > "$output_dir/$OUTPUT_FILE" \
-                 2> /dev/null
+                <"batch-job-templates/$template" \
+                >"$output_dir/$OUTPUT_FILE" \
+                2>/dev/null
             echo "Made $output_dir/$OUTPUT_FILE"
         else
             rams="2048 4096 8192 12288 16384 32768 65536"
-            for r in $rams
-            do
+            for r in $rams; do
                 export RAM_POSTFIX="_$r"
                 export RAM="$r"
                 FILEPATH="$output_dir/$OUTPUT_BASE$RAM_POSTFIX$FILETYPE"
                 perl -p -e 's/\$\{\{([^}]+)\}\}/defined $ENV{$1} ? $ENV{$1} : $&/eg' \
-                     < "batch-job-templates/$template" \
-                     > "$FILEPATH" \
-                     2> /dev/null
+                    <"batch-job-templates/$template" \
+                    >"$FILEPATH" \
+                    2>/dev/null
                 echo "Made $FILEPATH"
             done
         fi
@@ -241,7 +238,7 @@ elif [ "$project" = "surveyor" ]; then
 
     # Iterate over all the template files in the directory.
     for template in batch-job-templates/*.tpl.json; do
-	template="$(basename "$template")"
+        template="$(basename "$template")"
         # Strip off the trailing .tpl for once we've formatted it.
         OUTPUT_BASE="$(basename "$template" .tpl.json)"
         FILETYPE=".json"
@@ -249,21 +246,20 @@ elif [ "$project" = "surveyor" ]; then
 
         if [ "$OUTPUT_FILE" = "surveyor_dispatcher.json" ]; then
             perl -p -e 's/\$\{\{([^}]+)\}\}/defined $ENV{$1} ? $ENV{$1} : $&/eg' \
-                 < "batch-job-templates/$template" \
-                 > "$output_dir/$OUTPUT_FILE" \
-                 2> /dev/null
+                <"batch-job-templates/$template" \
+                >"$output_dir/$OUTPUT_FILE" \
+                2>/dev/null
             echo "Made $output_dir/$OUTPUT_FILE"
         else
             rams="1024 4096 16384"
-            for r in $rams
-            do
+            for r in $rams; do
                 export RAM_POSTFIX="_$r"
                 export RAM="$r"
                 FILEPATH="$output_dir/$OUTPUT_BASE$RAM_POSTFIX$FILETYPE"
                 perl -p -e 's/\$\{\{([^}]+)\}\}/defined $ENV{$1} ? $ENV{$1} : $&/eg' \
-                     < "batch-job-templates/$template" \
-                     > "$FILEPATH" \
-                     2> /dev/null
+                    <"batch-job-templates/$template" \
+                    >"$FILEPATH" \
+                    2>/dev/null
                 echo "Made $FILEPATH"
             done
         fi
@@ -272,12 +268,12 @@ elif [ "$project" = "surveyor" ]; then
 elif [ "$project" = "foreman" ]; then
     # foreman sub-project
     perl -p -e 's/\$\{\{([^}]+)\}\}/defined $ENV{$1} ? $ENV{$1} : $&/eg' \
-         < environment.tpl \
-         > "$output_dir/environment" \
-         2> /dev/null
+        <environment.tpl \
+        >"$output_dir/environment" \
+        2>/dev/null
 elif [ "$project" = "api" ]; then
     perl -p -e 's/\$\{\{([^}]+)\}\}/defined $ENV{$1} ? $ENV{$1} : $&/eg' \
-         < environment.tpl \
-         > "$output_dir/environment" \
-         2> /dev/null
+        <environment.tpl \
+        >"$output_dir/environment" \
+        2>/dev/null
 fi

--- a/scripts/install_all.sh
+++ b/scripts/install_all.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-# Exit on error
+# Exit on error.
 set -e
 
 # Config variables
@@ -8,7 +8,10 @@ TERRAFORM_VERSION="0.13.5"
 
 # This script should always run as if it were being called from
 # the directory it lives in.
-script_directory="$(cd "$(dirname "$0")" || exit; pwd)"
+script_directory="$(
+    cd "$(dirname "$0")" || exit
+    pwd
+)"
 cd "$script_directory" || exit
 
 print_description() {
@@ -37,117 +40,117 @@ confirm() {
     printf "%s [y/N] " "$1"
     read -r confirmation
     if ! [ "$confirmation" = "y" ]; then
-	echo "Confirmation failure" >&2
+        echo "Confirmation failure" >&2
         exit 1
     fi
 }
 
 while getopts "hv" opt; do
     case $opt in
-        h)
-            print_description
-            echo
-            print_usage
-            exit 0
-            ;;
-	v)
-	    OUTPUT="/dev/stdout"
-	    ;;
-        \?)
-            echo "Invalid option: -$OPTARG" >&2
-            print_usage >&2
-            exit 1
-            ;;
+    h)
+        print_description
+        echo
+        print_usage
+        exit 0
+        ;;
+    v)
+        OUTPUT="/dev/stdout"
+        ;;
+    \?)
+        echo "Invalid option: -$OPTARG" >&2
+        print_usage >&2
+        exit 1
+        ;;
     esac
 done
 
 # Unless output was set to stdout by the verbose flag, set it to /dev/null
-# to hide the stdout of package management commands
+# to hide the stdout of package management commands.
 if [ -z "$OUTPUT" ]; then
     OUTPUT="/dev/null"
 fi
 
 if [ -z "$INSTALL_CMD" ]; then
     case "$(uname)" in
-        "Darwin")
-            if ! command -v brew >/dev/null; then
-                confirm "Would you like to install Homebrew?"
-                /usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
-            fi
+    "Darwin")
+        if ! command -v brew >/dev/null; then
+            confirm "Would you like to install Homebrew?"
+            /usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
+        fi
 
-            INSTALL_CMD="brew install"
-            INSTALL_CASK_CMD="brew cask install"
-            BREW=true
-            ;;
-        "Linux")
-            if command -v apt >/dev/null; then
-                sudo apt-get update
-                INSTALL_CMD="sudo apt-get install --assume-yes"
-                APT=true
-            else
-                echo "Your Linux distribution is not officially supported," >&2
-                echo "but it *should* be able to run the required services. You need to manually" >&2
-                echo "install dependencies or give the command to install dependencies with \$INSTALL_CMD." >&2
-                exit 1
-            fi
-            ;;
-        *)
-            echo "$(uname) is an unsupported operating system." >&2
-            echo "You can try to provide a package manager command with \$INSTALL_CMD," >&2
-            echo "but your mileage may vary." >&2
+        INSTALL_CMD="brew install"
+        INSTALL_CASK_CMD="brew cask install"
+        BREW=true
+        ;;
+    "Linux")
+        if command -v apt >/dev/null; then
+            sudo apt-get update
+            INSTALL_CMD="sudo apt-get install --assume-yes"
+            APT=true
+        else
+            echo "Your Linux distribution is not officially supported," >&2
+            echo "but it *should* be able to run the required services. You need to manually" >&2
+            echo "install dependencies or give the command to install dependencies with \$INSTALL_CMD." >&2
             exit 1
-            ;;
+        fi
+        ;;
+    *)
+        echo "$(uname) is an unsupported operating system." >&2
+        echo "You can try to provide a package manager command with \$INSTALL_CMD," >&2
+        echo "but your mileage may vary." >&2
+        exit 1
+        ;;
     esac
 fi
 
-if ! command -v docker > /dev/null; then
+if ! command -v docker >/dev/null; then
     echo "Installing Docker..."
 
-    # On macOS, install docker desktop with Homebrew cask
-    if [ $BREW ]; then
-        $INSTALL_CASK_CMD docker > $OUTPUT
+    # On macOS, install docker desktop with Homebrew cask.
+    if [ "$BREW" ]; then
+        $INSTALL_CASK_CMD docker >"$OUTPUT"
     else
-        $INSTALL_CMD docker.io > $OUTPUT || (echo "You must manually install docker" && exit 1)
+        $INSTALL_CMD docker.io >"$OUTPUT" || (echo "You must manually install Docker" && exit 1)
 
-        echo "Fixing docker permissions..."
+        echo "Fixing Docker permissions..."
         sudo groupadd -f docker
         sudo usermod -aG docker "$USER"
 
-	echo
-	echo "Logout and log back in to apply the permissions changes, then execute this script again."
-	exit 0
+        echo
+        echo "Logout and log back in to apply the permissions changes, then execute this script again."
+        exit 0
     fi
 fi
 
-if ! command -v pip3 > /dev/null && ! [ $BREW ]; then # Don't reinstall python on macOS
-    echo "Installing python and pip..."
-    $INSTALL_CMD python3-pip > $OUTPUT || (echo "You must manually install python and pip" && exit 1)
+if ! command -v pip3 >/dev/null && ! [ "$BREW" ]; then # Don't reinstall python on macOS
+    echo "Installing Python and pip..."
+    $INSTALL_CMD python3-pip >"$OUTPUT" || (echo "You must manually install Python and pip" && exit 1)
 fi
 
-if ! command -v terraform > /dev/null; then
-    echo "Installing terraform..."
-    if [ $BREW ]; then
-        $INSTALL_CMD terraform > $OUTPUT
-    elif [ $APT ] || confirm "Would you like to automatically install Terraform for amd64 linux?"; then
-        $INSTALL_CMD unzip > $OUTPUT
+if ! command -v terraform >/dev/null; then
+    echo "Installing Terraform..."
+    if [ "$BREW" ]; then
+        $INSTALL_CMD terraform >"$OUTPUT"
+    elif [ "$APT" ] || confirm "Would you like to automatically install Terraform for amd64 Linux?"; then
+        $INSTALL_CMD unzip >"$OUTPUT"
         curl -0s "https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip" \
-             > "terraform_${TERRAFORM_VERSION}_linux_amd64.zip"
+            >"terraform_${TERRAFORM_VERSION}_linux_amd64.zip"
         sudo unzip -d /usr/bin "terraform_${TERRAFORM_VERSION}_linux_amd64.zip"
         sudo chmod a+rx /usr/bin/terraform
-	rm "terraform_${TERRAFORM_VERSION}_linux_amd64.zip"
+        rm "terraform_${TERRAFORM_VERSION}_linux_amd64.zip"
     else
         echo "You need to manually install Terraform before continuing..." >&2
         exit 1
     fi
 fi
 
-if ! command -v pre-commit > /dev/null; then
+if ! command -v pre-commit >/dev/null; then
     message="Would you like to automatically install pre-commit? \
 Note: This will install all the required dependencies (black, isort, etc) \
 using an additional ~185MB of disk space."
-    if [ $APT ] || confirm "$message"; then
+    if [ "$APT" ] || confirm "$message"; then
         echo "Installing pre-commit..."
-        $INSTALL_CMD shellcheck > $OUTPUT
+        $INSTALL_CMD shellcheck >"$OUTPUT"
         pip3 install pre-commit
         pre-commit install
     else
@@ -155,32 +158,32 @@ using an additional ~185MB of disk space."
     fi
 fi
 
-if ! command -v jq > /dev/null; then
+if ! command -v jq >/dev/null; then
     echo "Installing jq..."
-    $INSTALL_CMD jq > $OUTPUT || (echo "You must manually install jq" && exit 1)
+    $INSTALL_CMD jq >"$OUTPUT" || (echo "You must manually install jq" && exit 1)
 fi
 
-if ! command -v ip > /dev/null; then
-    if [ $BREW ]; then
-        $INSTALL_CMD iproute2mac > $OUTPUT
+if ! command -v ip >/dev/null; then
+    if [ "$BREW" ]; then
+        $INSTALL_CMD iproute2mac >"$OUTPUT"
     else
-        $INSTALL_CMD iproute2 > $OUTPUT || (echo "You must manually install iproute2" && exit 1)
+        $INSTALL_CMD iproute2 >"$OUTPUT" || (echo "You must manually install iproute2" && exit 1)
     fi
 fi
 
 echo "Starting postgres and installing the database..."
-./run_postgres.sh > $OUTPUT
-./install_db_docker.sh > $OUTPUT
+./run_postgres.sh >"$OUTPUT"
+./install_db_docker.sh >"$OUTPUT"
 
 echo "Starting elasticsearch and building the ES Indexes..."
-./run_es.sh > $OUTPUT
-./rebuild_es_index.sh > $OUTPUT
+./run_es.sh >"$OUTPUT"
+./rebuild_es_index.sh >"$OUTPUT"
 
 echo "Creating virtual environment..."
-./create_virtualenv.sh > $OUTPUT
+./create_virtualenv.sh >"$OUTPUT"
 echo "Run \`source dr_env/bin/activate\` to activate the virtual environment."
 
 echo "Updating common dependencies..."
-# Source the virtual environment first
+# Source the virtual environment first.
 . ../dr_env/bin/activate
-./update_models.sh > $OUTPUT
+./update_models.sh >"$OUTPUT"

--- a/scripts/install_db_docker.sh
+++ b/scripts/install_db_docker.sh
@@ -1,8 +1,45 @@
 #! /bin/sh
 
-docker run -e PGPASSWORD=mysecretpassword --rm --link drdb:postgres postgres:9.6.6 psql -c "create database data_refinery" -h postgres -U postgres
-docker run -e PGPASSWORD=mysecretpassword --rm --link drdb:postgres postgres:9.6.6 psql -c "CREATE ROLE data_refinery_user WITH LOGIN PASSWORD 'data_refinery_password';" -h postgres -U postgres
-docker run -e PGPASSWORD=mysecretpassword --rm --link drdb:postgres postgres:9.6.6 psql -c 'GRANT ALL PRIVILEGES ON DATABASE data_refinery TO data_refinery_user;' -h postgres -U postgres
-docker run -e PGPASSWORD=mysecretpassword --rm --link drdb:postgres postgres:9.6.6 psql -c 'ALTER USER data_refinery_user CREATEDB;' -h postgres -U postgres
-docker run -e PGPASSWORD=mysecretpassword --rm --link drdb:postgres postgres:9.6.6 psql -c 'ALTER ROLE data_refinery_user superuser;' -h postgres -U postgres
-docker run -e PGPASSWORD=mysecretpassword --rm --link drdb:postgres postgres:9.6.6 psql -c 'CREATE EXTENSION IF NOT EXISTS hstore;' -h postgres -U postgres -d data_refinery
+POSTGRES_VERSION="9.6.6"
+
+docker run \
+    --env PGPASSWORD=mysecretpassword \
+    --link drdb:postgres \
+    --rm \
+    "postgres:$POSTGRES_VERSION" \
+    psql -c "create database data_refinery" -h postgres -U postgres
+
+docker run \
+    --env PGPASSWORD=mysecretpassword \
+    --link drdb:postgres \
+    --rm \
+    "postgres:$POSTGRES_VERSION" \
+    psql -c "CREATE ROLE data_refinery_user WITH LOGIN PASSWORD 'data_refinery_password';" -h postgres -U postgres
+
+docker run \
+    --env PGPASSWORD=mysecretpassword \
+    --link drdb:postgres \
+    --rm \
+    "postgres:$POSTGRES_VERSION" \
+    psql -c 'GRANT ALL PRIVILEGES ON DATABASE data_refinery TO data_refinery_user;' -h postgres -U postgres
+
+docker run \
+    --env PGPASSWORD=mysecretpassword \
+    --link drdb:postgres \
+    --rm \
+    "postgres:$POSTGRES_VERSION" \
+    psql -c 'ALTER USER data_refinery_user CREATEDB;' -h postgres -U postgres
+
+docker run \
+    --env PGPASSWORD=mysecretpassword \
+    --link drdb:postgres \
+    --rm \
+    "postgres:$POSTGRES_VERSION" \
+    psql -c 'ALTER ROLE data_refinery_user superuser;' -h postgres -U postgres
+
+docker run \
+    --env PGPASSWORD=mysecretpassword \
+    --link drdb:postgres \
+    --rm \
+    "postgres:$POSTGRES_VERSION" \
+    psql -c 'CREATE EXTENSION IF NOT EXISTS hstore;' -h postgres -U postgres -d data_refinery

--- a/scripts/kill_all_jobs.sh
+++ b/scripts/kill_all_jobs.sh
@@ -2,13 +2,16 @@
 
 # This script should always run as if it were being called from
 # the directory it lives in.
-script_directory="$(cd "$(dirname "$0")" || exit; pwd)"
+script_directory="$(
+    cd "$(dirname "$0")" || exit
+    pwd
+)"
 cd "$script_directory" || exit
 
 while read -r row; do
     # Exporting an expansion rather than a variable, which is exactly what we want to do.
     # shellcheck disable=SC2163
     export "${row}"
-done < ../infrastructure/prod_env
+done <../infrastructure/prod_env
 
 python3 kill_all_jobs.py

--- a/scripts/make_migrations.sh
+++ b/scripts/make_migrations.sh
@@ -3,34 +3,44 @@
 # Script for migrating the database using a Docker container so no
 # virtual environment is needed on the host machine.
 
-# Exit on error
+# Exit on error.
 set -e
 
 # This script should always run as if it were being called from
 # the directory it lives in.
-script_directory="$(cd "$(dirname "$0")" || exit; pwd)"
+script_directory="$(
+    cd "$(dirname "$0")" || exit
+    pwd
+)"
 cd "$script_directory" || exit
 
 ./prepare_image.sh -i migrations -s common
 
 . ./common.sh
+
 DB_HOST_IP=$(get_docker_db_ip_address)
 
 docker run \
-       --volume "$script_directory/../common/data_refinery_common":/home/user/data_refinery_common \
-       --add-host=database:"$DB_HOST_IP" \
-       --env-file ../common/environments/local \
-       --interactive \
-       ccdlstaging/dr_migrations python3 manage.py makemigrations data_refinery_common
+    --add-host=database:"$DB_HOST_IP" \
+    --env-file ../common/environments/local \
+    --interactive \
+    --platform linux/amd64 \
+    --volume "$script_directory/../common/data_refinery_common":/home/user/data_refinery_common \
+    "$DOCKERHUB_REPO/dr_migrations" \
+    python3 manage.py makemigrations data_refinery_common
 
 docker run \
-       --volume "$script_directory/../common/data_refinery_common":/home/user/data_refinery_common \
-       --add-host=database:"$DB_HOST_IP" \
-       --env-file ../common/environments/local \
-       ccdlstaging/dr_migrations python3 manage.py migrate
+    --add-host=database:"$DB_HOST_IP" \
+    --env-file ../common/environments/local \
+    --platform linux/amd64 \
+    --volume "$script_directory/../common/data_refinery_common":/home/user/data_refinery_common \
+    "$DOCKERHUB_REPO/dr_migrations" \
+    python3 manage.py migrate
 
 docker run \
-       --volume "$script_directory/../common/data_refinery_common":/home/user/data_refinery_common \
-       --add-host=database:"$DB_HOST_IP" \
-       --env-file ../common/environments/local \
-       ccdlstaging/dr_migrations python3 manage.py createcachetable
+    --add-host=database:"$DB_HOST_IP" \
+    --env-file ../common/environments/local \
+    --platform linux/amd64 \
+    --volume "$script_directory/../common/data_refinery_common":/home/user/data_refinery_common \
+    "$DOCKERHUB_REPO/dr_migrations" \
+    python3 manage.py createcachetable

--- a/scripts/prepare_image.sh
+++ b/scripts/prepare_image.sh
@@ -2,7 +2,10 @@
 
 # This script should always run as if it were being called from
 # the directory it lives in.
-script_directory="$(cd "$(dirname "$0")" || exit; pwd)"
+script_directory="$(
+    cd "$(dirname "$0")" || exit
+    pwd
+)"
 cd "$script_directory" || exit
 
 # Import the functions in common.sh
@@ -18,64 +21,71 @@ print_description() {
 
 print_options() {
     echo "Options:"
-    echo "    -h           Prints the help message"
+    echo "    -h           Prints the help message."
     echo "    -i IMAGE     The image to be prepared. This must be specified."
     echo "    -s SERVICE   The service to seach for a dockerfile."
-    echo "                 The default option is 'workers'"
-    echo "    -p           Pull the latest version of the image from Dockerhub"
-    echo "    -d REPO      The docker repo to pull images from."
-    echo "                 The default option is 'ccdl'"
+    echo "                 The default option is 'workers'."
+    echo "    -d           Pull the latest version of the image from Dockerhub."
+    echo "    -u           Push the built image to the Dockerhub."
+    echo "    -r REPO      The docker registry to use for pull/push actions."
+    echo "                 The default option is 'ccdlstaging'."
     echo
     echo "Examples:"
     echo "    Build the image ccdl/dr_downloaders:"
-    echo "    ./scripts/prepare_image.sh -i downloaders -d ccdl"
+    echo "    ./scripts/prepare_image.sh -i downloaders -r ccdlstaging"
 }
 
-while getopts "phi:d:s:" opt; do
+while getopts "udhi:b:r:s:" opt; do
     case $opt in
-        i)
-            image=$OPTARG
-            ;;
-        d)
-            dockerhub_repo=$OPTARG
-            ;;
-        p)
-            pull="True"
-            ;;
-        s)
-            service=$OPTARG
-            ;;
-        h)
-            print_description
-            echo
-            print_options
-            exit 0
-            ;;
-        \?)
-            echo "Invalid option: -$OPTARG" >&2
-            print_options >&2
-            exit 1
-            ;;
-        :)
-            echo "Option -$OPTARG requires an argument." >&2
-            print_options >&2
-            exit 1
-            ;;
+    b)
+        DOCKER_BUILDER="$OPTARG"
+        ;;
+    d)
+        PULL="True"
+        ;;
+    i)
+        IMAGE="$OPTARG"
+        ;;
+    r)
+        DOCKERHUB_REPO="$OPTARG"
+        ;;
+
+    s)
+        SERVICE="$OPTARG"
+        ;;
+    u)
+        DOCKER_ACTION="push"
+        ;;
+    h)
+        print_description
+        echo
+        print_options
+        exit 0
+        ;;
+    \?)
+        echo "Invalid option: -$OPTARG" >&2
+        print_options >&2
+        exit 1
+        ;;
+    :)
+        echo "Option -$OPTARG requires an argument." >&2
+        print_options >&2
+        exit 1
+        ;;
     esac
 done
 
-if [ -z "$image" ]; then
+if [ -z "$IMAGE" ]; then
     echo "Error: you must specify an image with -i" >&2
     exit 1
 fi
 
-
-if [ -z "$service" ]; then
-    service="workers"
+if [ -z "$SERVICE" ]; then
+    SERVICE="workers"
 fi
 
-if [ -z "$dockerhub_repo" ]; then
-    dockerhub_repo="ccdlstaging"
+if [ -z "$DOCKERHUB_REPO" ]; then
+    DOCKERHUB_REPO="ccdlstaging"
 fi
 
 # Default to "local" for system version if we're not running in the cloud.
@@ -83,43 +93,61 @@ if [ -z "$SYSTEM_VERSION" ]; then
     SYSTEM_VERSION="local$(date +%s)"
 fi
 
+if [ -z "$DOCKER_ACTION" ]; then
+    DOCKER_ACTION="load"
+fi
+
 # We want to check if a test image has been built for this branch. If
 # it has we should use that rather than building it slowly.
-image_name="$dockerhub_repo/dr_$image"
+DOCKER_IMAGE="$DOCKERHUB_REPO/dr_$IMAGE"
 # shellcheck disable=SC2086
-if [ "$(docker_img_exists $image_name $branch_name)" ] ; then
-    docker pull "$image_name:$branch_name"
-elif [ -n "$pull" ]; then
-    docker pull "$image_name"
+if [ "$(docker_img_exists $IMAGE_NAME $branch_name)" ]; then
+    docker pull "$IMAGE_NAME:$branch_name"
+elif [ -n "$PULL" ]; then
+    docker pull \
+        --platform linux/amd64 \
+        "$DOCKER_IMAGE"
 else
     echo ""
-    echo "Rebuilding the $image_name image."
-    finished=1
+    echo "Rebuilding the $DOCKER_IMAGE image."
+
     attempts=0
+    finished=1
     while [ $finished != 0 ] && [ $attempts -lt 3 ]; do
         if [ $attempts -gt 0 ]; then
-            echo "Failed to build $image_name, trying again."
+            echo "Failed to build $DOCKER_IMAGE, trying again."
         fi
 
-
+        CURRENT_IMAGE="$DOCKER_IMAGE:$SYSTEM_VERSION"
+        LATEST_IMAGE="$DOCKER_IMAGE:latest"
         if test "$GITHUB_ACTIONS"; then
-            # docker needs repositories to be lowercase
-            CACHE_REPO="$(echo "ghrc.io/$GITHUB_REPOSITORY" | tr '[:upper:]' '[:lower:]')"
-            CACHED_PACKAGE="$CACHE_REPO/dr_$image"
-            CACHE="--build-arg BUILDKIT_INLINE_CACHE=1 --cache-from $CACHED_PACKAGE"
+            # Docker needs repositories to be lowercase.
+            CACHE_REPO="$(echo "ghrc.io/$GITHUB_REPOSITORY" |
+                tr '[:upper:]' '[:lower:]')"
+            LATEST_IMAGE="$CACHE_REPO/dr_$IMAGE"
         fi
 
-        docker build \
-               -t "$image_name" \
-               -f "$service/dockerfiles/Dockerfile.$image" \
-               --build-arg SYSTEM_VERSION="$SYSTEM_VERSION" \
-               $CACHE .
+        if test "$DOCKER_BUILDER"; then
+            docker buildx use "$DOCKER_BUILDER"
+        fi
+
+        DOCKER_BUILDKIT=1 docker buildx build \
+            --"$DOCKER_ACTION" \
+            --build-arg BUILDKIT_INLINE_CACHE=1 \
+            --build-arg DOCKERHUB_REPO="$DOCKERHUB_REPO" \
+            --build-arg SYSTEM_VERSION="$SYSTEM_VERSION" \
+            --cache-from "$LATEST_IMAGE" \
+            --cache-from="$CURRENT_IMAGE" \
+            --file "$SERVICE/dockerfiles/Dockerfile.$IMAGE" \
+            --platform linux/amd64 \
+            --tag "$DOCKER_IMAGE" \
+            .
         finished=$?
-        attempts=$((attempts+1))
+        attempts=$((attempts + 1))
     done
 
     if [ $finished != 0 ] && [ $attempts -ge 3 ]; then
-        echo "Could not build $image_name after three attempts."
+        echo "Could not build $DOCKER_IMAGE after three attempts."
         exit 1
     fi
 fi

--- a/scripts/rebuild_es_index.sh
+++ b/scripts/rebuild_es_index.sh
@@ -2,7 +2,10 @@
 
 # This script should always run as if it were being called from
 # the directory it lives in.
-script_directory="$(cd "$(dirname "$0")" || exit; pwd)"
+script_directory="$(
+    cd "$(dirname "$0")" || exit
+    pwd
+)"
 cd "$script_directory" || exit
 
 ./run_manage.sh -i api_local -s api search_index --rebuild -f

--- a/scripts/reinit_database.sh
+++ b/scripts/reinit_database.sh
@@ -2,10 +2,12 @@
 
 # Reintializes the database so there's no data or migrations run against it.
 
-
 # This script should always run as if it were being called from
 # the directory it lives in.
-script_directory="$(cd "$(dirname "$0")" || exit; pwd)"
+script_directory="$(
+    cd "$(dirname "$0")" || exit
+    pwd
+)"
 cd "$script_directory" || exit
 
 # Clear it out.

--- a/scripts/run_all_tests.sh
+++ b/scripts/run_all_tests.sh
@@ -7,7 +7,10 @@ set -e
 
 # This script should always run as if it were being called from
 # the directory it lives in.
-script_directory="$(cd "$(dirname "$0")" || exit; pwd)"
+script_directory="$(
+    cd "$(dirname "$0")" || exit
+    pwd
+)"
 cd "$script_directory" || exit
 
 # Get access to all of the refinebio project

--- a/scripts/run_es.sh
+++ b/scripts/run_es.sh
@@ -1,13 +1,21 @@
 #! /bin/sh
 
-docker rm -f dres 2> /dev/null
+docker rm -f dres 2>/dev/null
 
-# Check if a docker database named "dres" exists, and if so just start it
+# Check if a docker database named "dres" exists, and if so just start it.
 if [ "$(docker ps -a --filter name=dres -q)" ]; then
-  docker start dres > /dev/null
-# Otherwise, run it with `docker run`
+    docker start dres >/dev/null
+# Otherwise, run it with `docker run`.
 else
-    docker run --name dres -p 9200:9200 -p 9300:9300 -e "discovery.type=single-node" -e "indices.query.bool.max_clause_count=16384" -d docker.elastic.co/elasticsearch/elasticsearch:6.5.4
+    docker run \
+        --detach \
+        --env "discovery.type=single-node" \
+        --env "indices.query.bool.max_clause_count=16384" \
+        --name dres \
+        --platform linux/amd64 \
+        --publish 9200:9200 \
+        --publish 9300:9300 \
+        docker.elastic.co/elasticsearch/elasticsearch:6.5.4
 fi
 
 echo "Started ElasticSearch."

--- a/scripts/run_postgres.sh
+++ b/scripts/run_postgres.sh
@@ -2,30 +2,39 @@
 
 # This script should always run as if it were being called from
 # the directory it lives in.
-script_directory="$(cd "$(dirname "$0")" || exit; pwd)"
+script_directory="$(
+    cd "$(dirname "$0")" || exit
+    pwd
+)"
 cd "$script_directory" || exit
 
 # Get access to all of refinebio
 cd ..
 
-# CircleCI Docker won't make this by default for some reason
+# CircleCI Docker won't make this by default for some reason.
 # This doubly nested directory is a hacky workaround to prevent permissions issues.
 # Suggested here:
 # https://github.com/docker/for-linux/issues/380#issuecomment-436419102
 VOLUMES="$script_directory/../volumes_postgres/volumes_postgres"
 if [ ! -d "$VOLUMES" ]; then
-  mkdir -p "$VOLUMES"
+    mkdir -p "$VOLUMES"
 fi
 
 # Check if a docker database named "drdb" exists, and if so just run it
 if [ "$(docker ps -a --filter name=drdb -q)" ]; then
-  docker start drdb > /dev/null
-  echo "Started database."
-# Otherwise, install it from docker hub
+    docker start drdb >/dev/null
+    echo "Started database."
+# Otherwise, install it from Docker Hub.
 else
-  # via https://hub.docker.com/_/postgres/
-  # 9.6.6 is the current (as of Jan 23 2018) RDS most recent version.
-  # Password can be exposed to git/CI because this is only for dev/testing purposes, not real data.
-  echo "Installing database..."
-  docker run -p 5432:5432 --name drdb -v "$VOLUMES":/var/lib/postgresql/data -e POSTGRES_PASSWORD=mysecretpassword -d postgres:9.6.6
+    # via https://hub.docker.com/_/postgres/
+    # 9.6.6 is the current (as of Jan 23 2018) RDS most recent version.
+    # Password can be exposed to git/CI because this is only for dev/testing purposes, not real data.
+    echo "Installing database..."
+    docker run \
+        --detach \
+        --env POSTGRES_PASSWORD=mysecretpassword \
+        --name drdb \
+        --publish 5432:5432 \
+        --volume "$VOLUMES":/var/lib/postgresql/data \
+        postgres:9.6.6
 fi

--- a/scripts/run_psql_shell.sh
+++ b/scripts/run_psql_shell.sh
@@ -1,2 +1,10 @@
 #! /bin/sh
-docker run -it -e PGPASSWORD=mysecretpassword --rm --link drdb:postgres postgres:9.6.6 psql -h postgres -U postgres -d data_refinery
+
+docker run \
+    --env PGPASSWORD=mysecretpassword \
+    --interactive \
+    --link drdb:postgres \
+    --rm \
+    --tty \
+    postgres:9.6.6 \
+    psql -h postgres -U postgres -d data_refinery

--- a/scripts/run_shell.sh
+++ b/scripts/run_shell.sh
@@ -12,7 +12,10 @@ set -e
 
 # This script should always run as if it were being called from
 # the directory it lives in.
-script_directory="$(cd "$(dirname "$0")" || exit; pwd)"
+script_directory="$(
+    cd "$(dirname "$0")" || exit
+    pwd
+)"
 cd "$script_directory" || exit
 
 # Import functions in common.sh
@@ -28,15 +31,21 @@ if [ ! -d "$volume_directory" ]; then
 fi
 chmod -R a+rwX "$volume_directory"
 
-docker build -t dr_shell -f foreman/dockerfiles/Dockerfile.foreman .
+docker build \
+    --file foreman/dockerfiles/Dockerfile.foreman \
+    --tag dr_shell \
+    .
 
 DB_HOST_IP=$(get_docker_db_ip_address)
 
-docker run -it \
-       --add-host="database:$DB_HOST_IP" \
-       --env AWS_ACCESS_KEY_ID="$AWS_ACCESS_KEY_ID" \
-       --env AWS_SECRET_ACCESS_KEY="$AWS_SECRET_ACCESS_KEY" \
-       --env-file foreman/environments/local \
-       --volume /tmp:/tmp \
-       --volume "$volume_directory":/home/user/data_store \
-       --interactive dr_shell python3 manage.py shell
+docker run \
+    --add-host="database:$DB_HOST_IP" \
+    --env AWS_ACCESS_KEY_ID="$AWS_ACCESS_KEY_ID" \
+    --env AWS_SECRET_ACCESS_KEY="$AWS_SECRET_ACCESS_KEY" \
+    --env-file foreman/environments/local \
+    --interactive \
+    --tty \
+    --volume "$volume_directory":/home/user/data_store \
+    --volume /tmp:/tmp \
+    dr_shell \
+    python3 manage.py shell

--- a/scripts/update_models.sh
+++ b/scripts/update_models.sh
@@ -1,18 +1,21 @@
 #! /bin/sh
-# Makes migrations and re-installs so Docker images update locally
+# Makes migrations and re-installs so Docker images update locally.
 
-# Exit on fail
+# Exit on fail.
 set -e
 
 # This script should always run as if it were being called from
 # the directory it lives in.
-script_directory="$(cd "$(dirname "$0")" || exit; pwd)"
+script_directory="$(
+    cd "$(dirname "$0")" || exit
+    pwd
+)"
 cd "$script_directory" || exit
 
-# Get access to all of refinebio
+# Get access to all of refinebio.
 cd ..
 
-if ! docker ps | tail -n +2 | awk '{ print $NF }' | grep drdb > /dev/null; then
+if ! docker ps | tail -n +2 | awk '{ print $NF }' | grep drdb >/dev/null; then
     echo "You must start Postgres first with:" >&2
     echo "./scripts/run_postgres.sh" >&2
     exit 1
@@ -25,7 +28,7 @@ if [ -z "$SYSTEM_VERSION" ]; then
 fi
 
 # Put this in place for common to read from.
-echo "$SYSTEM_VERSION" > common/version
+echo "$SYSTEM_VERSION" >common/version
 
 # Ensure there is only one distribution to copy over.
 rm -f common/dist/*

--- a/scripts/update_my_docker_images.sh
+++ b/scripts/update_my_docker_images.sh
@@ -109,7 +109,7 @@ echo "$SYSTEM_VERSION" >common/version
 # required by the workers and data_refinery_foreman images.
 ## Remove old common distributions if they exist.
 rm -f common/dist/*
-(cd common && python3 setup.py sdist) # Run in a subshell.
+(cd common && python3 setup.py sdist 1>/dev/null) # Run quietly in a subshell.
 
 ARCH="$(uname -m)"
 
@@ -146,8 +146,8 @@ for DOCKER_IMAGE in $DOCKER_IMAGES; do
         --build-arg BUILDKIT_INLINE_CACHE=1 \
         --build-arg DOCKERHUB_REPO="$DOCKERHUB_REPO" \
         --build-arg SYSTEM_VERSION="$SYSTEM_VERSION" \
-        --cache-from="$IMAGE_NAME:$SYSTEM_VERSION" \
-        --cache-from="$IMAGE_NAME:latest" \
+        --cache-from "$IMAGE_NAME:$SYSTEM_VERSION" \
+        --cache-from "$IMAGE_NAME:latest" \
         --file "$DOCKER_FILE_PATH" \
         --platform "linux/$SYSTEM_ARCH" \
         --push \

--- a/workers/dockerfiles/Dockerfile.affymetrix
+++ b/workers/dockerfiles/Dockerfile.affymetrix
@@ -1,4 +1,5 @@
-FROM ccdlstaging/dr_base:latest
+ARG DOCKERHUB_REPO
+FROM $DOCKERHUB_REPO/dr_base:latest
 
 # Fail in case of an error at any stage in the pipe.
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]

--- a/workers/dockerfiles/Dockerfile.affymetrix_local
+++ b/workers/dockerfiles/Dockerfile.affymetrix_local
@@ -1,4 +1,5 @@
-FROM ccdlstaging/dr_affymetrix:latest
+ARG DOCKERHUB_REPO
+FROM $DOCKERHUB_REPO/dr_base:latest
 
 # Fail in case of an error at any stage in the pipe.
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]

--- a/workers/dockerfiles/Dockerfile.downloaders
+++ b/workers/dockerfiles/Dockerfile.downloaders
@@ -1,4 +1,5 @@
-FROM ccdlstaging/dr_base:latest
+ARG DOCKERHUB_REPO
+FROM $DOCKERHUB_REPO/dr_base:latest
 
 # Fail in case of an error at any stage in the pipe.
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]

--- a/workers/dockerfiles/Dockerfile.illumina
+++ b/workers/dockerfiles/Dockerfile.illumina
@@ -1,4 +1,5 @@
-FROM ccdlstaging/dr_base:latest
+ARG DOCKERHUB_REPO
+FROM $DOCKERHUB_REPO/dr_base:latest
 
 # Fail in case of an error at any stage in the pipe.
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]

--- a/workers/dockerfiles/Dockerfile.no_op
+++ b/workers/dockerfiles/Dockerfile.no_op
@@ -1,4 +1,5 @@
-FROM ccdlstaging/dr_base:latest
+ARG DOCKERHUB_REPO
+FROM $DOCKERHUB_REPO/dr_base:latest
 
 # Fail in case of an error at any stage in the pipe.
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]

--- a/workers/dockerfiles/Dockerfile.salmon
+++ b/workers/dockerfiles/Dockerfile.salmon
@@ -1,4 +1,5 @@
-FROM ccdlstaging/dr_base:latest
+ARG DOCKERHUB_REPO
+FROM $DOCKERHUB_REPO/dr_base:latest
 
 # Fail in case of an error at any stage in the pipe.
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]

--- a/workers/dockerfiles/Dockerfile.smasher
+++ b/workers/dockerfiles/Dockerfile.smasher
@@ -1,4 +1,5 @@
-FROM ccdlstaging/dr_base:latest
+ARG DOCKERHUB_REPO
+FROM $DOCKERHUB_REPO/dr_base:latest
 
 # Fail in case of an error at any stage in the pipe.
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]

--- a/workers/dockerfiles/Dockerfile.transcriptome
+++ b/workers/dockerfiles/Dockerfile.transcriptome
@@ -1,4 +1,5 @@
-FROM ccdlstaging/dr_base:latest
+ARG DOCKERHUB_REPO
+FROM $DOCKERHUB_REPO/dr_base:latest
 
 # Fail in case of an error at any stage in the pipe.
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]

--- a/workers/run_job.sh
+++ b/workers/run_job.sh
@@ -1,67 +1,70 @@
 #!/bin/bash
 
-# Script for running a django management command to test the worker.
+# Script for running a Django management command to test the worker.
 
 while getopts "hi:" opt; do
     case $opt in
-        i)
-            image=$OPTARG
-            ;;
-        h)
-            echo "Runs a downloader or processor job. The following arguments are supported:"
-            echo "-h : Print this help message and exit."
-            echo "-i <IMAGE_NAME> : The image to use. Options are:"
-            echo "    downloaders (default)"
-            echo "    salmon"
-            echo "    transcriptome"
-            echo "    no_op"
-            echo "    downloaders"
-            echo "    illumina"
-            echo "    affymetrix"
-            echo "<MANAGEMENT COMMAND> : What kind of job to run."
-            echo "    Must be either 'run_downloader_job' or 'run_processor_job'."
-            echo "--job-name=<JOB_NAME> : The type of job to run."
-            echo "    For processor jobs, options are:"
-            echo "        AFFY_TO_PCL"
-            echo "        AGILENT_TWOCOLOR_TO_PCL"
-            echo "        SALMON"
-            echo "        ILLUMINA_TO_PCL"
-            echo "        TRANSCRIPTOME_INDEX_LONG"
-            echo "        TRANSCRIPTOME_INDEX_SHORT"
-            echo "        NO_OP"
-            echo "    For downloader jobs, options are:"
-            echo "        ARRAY_EXPRESS"
-            echo "        SRA"
-            echo "        TRANSCRIPTOME_INDEX"
-            echo "        GEO"
-            echo "--job-id=<JOB_ID> : The id of the job you want to run. Must already exist in the database."
-            echo ""
-            echo "Note that the <IMAGE_NAME> must correspond to the <JOB_NAME>."
-            echo "     AGILENT_TWOCOLOR_TO_PCL is a special case because it requires the 'affymetrix' image."
-            echo ""
-            echo "Examples:"
-            echo "    ./workers/run_job.sh run_downloader_job --job-name=SRA --job-id=12345"
-            echo "    ./workers/run_job.sh -i affymetrix run_processor_job --job-name=AGILENT_TWOCOLOR_TO_PCL --job-id=54321"
-            exit 0
-            ;;
-        \?)
-            echo "Invalid option: -$OPTARG" >&2
-            exit 1
-            ;;
-        :)
-            echo "Option -$OPTARG requires an argument." >&2
-            exit 1
-            ;;
+    i)
+        IMAGE="$OPTARG"
+        ;;
+    h)
+        echo "Runs a downloader or processor job. The following arguments are supported:"
+        echo "-h : Print this help message and exit."
+        echo "-i <IMAGE_NAME> : The image to use. Options are:"
+        echo "    downloaders (default)"
+        echo "    salmon"
+        echo "    transcriptome"
+        echo "    no_op"
+        echo "    downloaders"
+        echo "    illumina"
+        echo "    affymetrix"
+        echo "<MANAGEMENT COMMAND> : What kind of job to run."
+        echo "    Must be either 'run_downloader_job' or 'run_processor_job'."
+        echo "--job-name=<JOB_NAME> : The type of job to run."
+        echo "    For processor jobs, options are:"
+        echo "        AFFY_TO_PCL"
+        echo "        AGILENT_TWOCOLOR_TO_PCL"
+        echo "        SALMON"
+        echo "        ILLUMINA_TO_PCL"
+        echo "        TRANSCRIPTOME_INDEX_LONG"
+        echo "        TRANSCRIPTOME_INDEX_SHORT"
+        echo "        NO_OP"
+        echo "    For downloader jobs, options are:"
+        echo "        ARRAY_EXPRESS"
+        echo "        SRA"
+        echo "        TRANSCRIPTOME_INDEX"
+        echo "        GEO"
+        echo "--job-id=<JOB_ID> : The id of the job you want to run. Must already exist in the database."
+        echo ""
+        echo "Note that the <IMAGE_NAME> must correspond to the <JOB_NAME>."
+        echo "     AGILENT_TWOCOLOR_TO_PCL is a special case because it requires the 'affymetrix' image."
+        echo ""
+        echo "Examples:"
+        echo "    ./workers/run_job.sh run_downloader_job --job-name=SRA --job-id=12345"
+        echo "    ./workers/run_job.sh -i affymetrix run_processor_job --job-name=AGILENT_TWOCOLOR_TO_PCL --job-id=54321"
+        exit 0
+        ;;
+    \?)
+        echo "Invalid option: -$OPTARG" >&2
+        exit 1
+        ;;
+    :)
+        echo "Option -$OPTARG requires an argument." >&2
+        exit 1
+        ;;
     esac
 done
 
-if [[ -z "$image" ]]; then
-    image="downloaders"
+if [[ -z "$IMAGE" ]]; then
+    IMAGE="downloaders"
 fi
 
 # This script should always run as if it were being called from
 # the directory it lives in.
-script_directory="$(cd "$(dirname "$0")" || exit; pwd)"
+script_directory="$(
+    cd "$(dirname "$0")" || exit
+    pwd
+)"
 cd "$script_directory" || exit
 
 # However in order to give Docker access to all the code we have to
@@ -69,12 +72,12 @@ cd "$script_directory" || exit
 cd ..
 
 # Agilent uses the same image as affymetrix
-if [[ "$image" == "affymetrix" || "$image" == "agilent" ]]; then
-    ./scripts/prepare_image.sh -p -i affymetrix
-    image_name="ccdlstaging/dr_affymetrix"
+if [[ "$IMAGE" == "affymetrix" || "$IMAGE" == "agilent" ]]; then
+    ./scripts/prepare_image.sh -d -i affymetrix
+    IMAGE_NAME="$DOCKERHUB_REPO/dr_affymetrix"
 else
-    ./scripts/prepare_image.sh -i "$image"
-    image_name="ccdlstaging/dr_$image"
+    ./scripts/prepare_image.sh -i "$IMAGE"
+    IMAGE_NAME="$DOCKERHUB_REPO/dr_$IMAGE"
 fi
 
 volume_directory="$script_directory/volume"
@@ -83,16 +86,18 @@ if [ ! -d "$volume_directory" ]; then
 fi
 chmod -R a+rwX "$volume_directory"
 
-source scripts/common.sh
+. scripts/common.sh
+
 DB_HOST_IP=$(get_docker_db_ip_address)
 
 docker run \
-       -it \
-       --add-host=database:"$DB_HOST_IP" \
-       --env-file workers/environments/local \
-       --env AWS_ACCESS_KEY_ID \
-       --env AWS_SECRET_ACCESS_KEY \
-       --entrypoint ./manage.py \
-       --volume "$volume_directory":/home/user/data_store \
-       --link drdb:postgres \
-       "$image_name" "${@: -3}" "${@: -2}" "${@: -1}"
+    --add-host=database:"$DB_HOST_IP" \
+    --entrypoint ./manage.py \
+    --env AWS_ACCESS_KEY_ID \
+    --env AWS_SECRET_ACCESS_KEY \
+    --env-file workers/environments/local \
+    --interactive \
+    --link drdb:postgres \
+    --tty \
+    --volume "$volume_directory":/home/user/data_store \
+    "$IMAGE_NAME" "${@: -3}" "${@: -2}" "${@: -1}"

--- a/workers/run_tests.sh
+++ b/workers/run_tests.sh
@@ -3,7 +3,7 @@
 
 # Script for executing Django PyUnit tests within a Docker container.
 
-# Exit on failure
+# Exit on failure.
 set -e
 
 print_description() {
@@ -20,47 +20,49 @@ print_options() {
 
 while getopts ":t:h" opt; do
     case $opt in
-        t)
-            tag=$OPTARG
-            ;;
-        h)
-            print_description
-            echo
-            print_options
-            exit 0
-            ;;
-        \?)
-            echo "Invalid option: -$OPTARG" >&2
-            print_options >&2
-            exit 1
-            ;;
-        :)
-            echo "Option -$OPTARG requires an argument." >&2
-            print_options >&2
-            exit 1
-            ;;
+    t)
+        tag="$OPTARG"
+        ;;
+    h)
+        print_description
+        echo
+        print_options
+        exit 0
+        ;;
+    \?)
+        echo "Invalid option: -$OPTARG" >&2
+        print_options >&2
+        exit 1
+        ;;
+    :)
+        echo "Option -$OPTARG requires an argument." >&2
+        print_options >&2
+        exit 1
+        ;;
     esac
 done
 
 # This script should always run as if it were being called from
 # the directory it lives in.
-script_directory="$(cd "$(dirname "$0")" || exit; pwd)"
+script_directory="$(
+    cd "$(dirname "$0")" || exit
+    pwd
+)"
 cd "$script_directory" || exit
 
-# However in order to give Docker access to all the code we have to
+# However, in order to give Docker access to all the code we have to
 # move up a level
 cd ..
 
-# Ensure that postgres is running
+# Ensure that Postgres is running.
 if ! [ "$(docker ps --filter name=drdb -q)" ]; then
     echo "You must start Postgres first with:" >&2
     echo "./scripts/run_postgres.sh" >&2
     exit 1
 fi
 
-volume_directory="$script_directory/test_volume"
-
 test_data_repo="https://s3.amazonaws.com/data-refinery-test-assets"
+volume_directory="$script_directory/test_volume"
 
 if [ -z "$tag" ] || [ "$tag" = "salmon" ]; then
     # Download "salmon quant" test data The `newer` file was to
@@ -77,11 +79,11 @@ if [ -z "$tag" ] || [ "$tag" = "salmon" ]; then
         rm "$volume_directory"/salmon_tests.tar.gz
     fi
 
-    # salmontools test data
+    # SalmonTools test data.
     salmontools_test_zip="$test_data_repo/salmontools_test_data.tar.gz"
     salmontools_test_dir="$volume_directory/salmontools"
 
-    # Clean the test data directory
+    # Clean the test data directory.
     rm -rf "$salmontools_test_dir"
     mkdir -p "$salmontools_test_dir"
 
@@ -102,21 +104,21 @@ if [ -z "$tag" ] || [ "$tag" = "salmon" ]; then
         mkdir -p "$rna_seq_test_raw_dir"
         echo "Downloading $read_1_name for Salmon tests."
         wget -q -O "$rna_seq_test_data_1" \
-             "$test_data_repo/$read_1_name"
+            "$test_data_repo/$read_1_name"
         echo "Downloading $read_2_name for Salmon tests."
         wget -q -O "$rna_seq_test_data_2" \
-             "$test_data_repo/$read_2_name"
+            "$test_data_repo/$read_2_name"
     fi
     if [ ! -e "$dotsra" ]; then
         mkdir -p "$rna_seq_test_raw_dir"
         echo "Downloading $dotsra_name for Salmon tests."
         wget -q -O "$dotsra" \
-             "$test_data_repo/$dotsra_name"
+            "$test_data_repo/$dotsra_name"
     fi
 fi
 
 if [ -z "$tag" ] || [ "$tag" = "affymetrix" ]; then
-    # Make sure CEL for test is downloaded from S3
+    # Make sure CEL for test is downloaded from S3.
     cel_name="GSM1426071_CD_colon_active_1.CEL"
     cel_name2="GSM45588.CEL"
     cel_name3="GSM1364667_U_110208_7-02-10_S2.CEL"
@@ -135,35 +137,35 @@ if [ -z "$tag" ] || [ "$tag" = "affymetrix" ]; then
         mkdir -p "$cel_test_raw_dir"
         echo "Downloading CEL for tests."
         wget -q -O "$cel_test_data_1" \
-             "$test_data_repo/$cel_name"
+            "$test_data_repo/$cel_name"
     fi
     if [ ! -e "$cel_test_data_2" ]; then
         echo "Downloading Non-Brainarray CEL for tests."
         wget -q -O "$cel_test_data_2" \
-             "$test_data_repo/$cel_name2"
+            "$test_data_repo/$cel_name2"
     fi
     if [ ! -e "$cel_test_data_3" ]; then
         echo "Downloading Huex Brain Array CEL for tests."
         wget -q -O "$cel_test_data_3" \
-             "$test_data_repo/$cel_name3"
+            "$test_data_repo/$cel_name3"
     fi
     if [ ! -e "$pcl_test_data_1" ]; then
         mkdir -p "$pcl_test_dir"
         echo "Downloading pre-computed PCL for tests."
         wget -q -O "$pcl_test_data_1" \
-             "$test_data_repo/$pcl_name"
+            "$test_data_repo/$pcl_name"
     fi
     if [ ! -e "$pcl_test_data_2" ]; then
         mkdir -p "$pcl_test_dir"
         echo "Downloading pre-computed Non-Brainarray PCL for tests."
         wget -q -O "$pcl_test_data_2" \
-             "$test_data_repo/$pcl_name2"
+            "$test_data_repo/$pcl_name2"
     fi
     if [ ! -e "$pcl_test_data_3" ]; then
         mkdir -p "$pcl_test_dir"
         echo "Downloading pre-computed Huex Brain Array PCL for tests."
         wget -q -O "$pcl_test_data_3" \
-             "$test_data_repo/$pcl_name3"
+            "$test_data_repo/$pcl_name3"
     fi
 
 fi
@@ -176,14 +178,14 @@ if [ -z "$tag" ] || [ "$tag" = "transcriptome" ]; then
         mkdir -p "$tx_index_test_raw_dir"
         echo "Downloading fasta file for Transcriptome Index tests."
         wget -q -O "$tx_index_test_raw_dir/$fasta_file" \
-             "$test_data_repo/$fasta_file"
+            "$test_data_repo/$fasta_file"
     fi
     gtf_file="aegilops_tauschii_short.gtf.gz"
     if [ ! -e "$tx_index_test_raw_dir/$gtf_file" ]; then
         mkdir -p "$tx_index_test_raw_dir"
         echo "Downloading gtf file for Transcriptome Index tests."
         wget -q -O "$tx_index_test_raw_dir/$gtf_file" \
-             "$test_data_repo/$gtf_file"
+            "$test_data_repo/$gtf_file"
     fi
     tx_index_test_raw_dir2="$volume_directory/raw/TEST/TRANSCRIPTOME_INDEX/"
     gtf_file2="Homo_sapiens_testdata.gtf"
@@ -191,7 +193,7 @@ if [ -z "$tag" ] || [ "$tag" = "transcriptome" ]; then
         mkdir -p "$tx_index_test_raw_dir2"
         echo "Downloading second gtf file for Transcriptome Index tests."
         wget -q -O "$tx_index_test_raw_dir2/$gtf_file2" \
-             "$test_data_repo/$gtf_file2"
+            "$test_data_repo/$gtf_file2"
     fi
 fi
 
@@ -210,10 +212,9 @@ GSE41355_non-normalized.txt GSE100301_non-normalized.txt'
                 "$test_data_repo/$ilu_file"
         fi
 
-        i=$(( i + 1 ))
+        i=$((i + 1))
     done
     unset i
-
 
     ilu_test_ref_dir="$volume_directory/raw/TEST/ILLUMINA/reference"
     ilu_ref_file="Ad-Cre-2.AVG_Signal.tsv"
@@ -221,7 +222,7 @@ GSE41355_non-normalized.txt GSE100301_non-normalized.txt'
         mkdir -p "$ilu_test_ref_dir"
         echo "Downloading Illumin reference file for Illumina tests."
         wget -q -O "$ilu_test_ref_dir/$ilu_ref_file" \
-             "$test_data_repo/$ilu_ref_file"
+            "$test_data_repo/$ilu_ref_file"
     fi
 fi
 
@@ -233,7 +234,7 @@ if [ -z "$tag" ] || [ "$tag" = "agilent" ]; then
         mkdir -p "$at_test_raw_dir"
         echo "Downloading Agilent file for A2C tests."
         wget -q -O "$at_test_raw_dir/$at_file" \
-             "$test_data_repo/$at_file"
+            "$test_data_repo/$at_file"
     fi
 fi
 if [ -z "$tag" ] || [ "$tag" = "no_op" ]; then
@@ -243,37 +244,37 @@ if [ -z "$tag" ] || [ "$tag" = "no_op" ]; then
         mkdir -p "$no_test_raw_dir"
         echo "Downloading NOOP file1."
         wget -q -O "$no_test_raw_dir/$no_file1" \
-             "$test_data_repo/$no_file1"
+            "$test_data_repo/$no_file1"
     fi
     no_file2="GSM1234847_sample_table.txt"
     if [ ! -e "$no_test_raw_dir/$no_file2" ]; then
         mkdir -p "$no_test_raw_dir"
         echo "Downloading NOOP file2."
         wget -q -O "$no_test_raw_dir/$no_file2" \
-             "$test_data_repo/$no_file2"
+            "$test_data_repo/$no_file2"
     fi
     no_file3="GSM1234847_sample_table_headerless.txt"
     if [ ! -e "$no_test_raw_dir/$no_file3" ]; then
         mkdir -p "$no_test_raw_dir"
         echo "Processing NOOP file3."
-        tail -n +2 "$no_test_raw_dir/$no_file2" > "$no_test_raw_dir/$no_file3"
+        tail -n +2 "$no_test_raw_dir/$no_file2" >"$no_test_raw_dir/$no_file3"
     fi
     no_file4="GSM1089291-tbl-1.txt"
     if [ ! -e "$no_test_raw_dir/$no_file4" ]; then
         mkdir -p "$no_test_raw_dir"
         echo "Downloading NOOP file4."
         wget -q -O "$no_test_raw_dir/$no_file4" \
-             "$test_data_repo/$no_file4"
+            "$test_data_repo/$no_file4"
     fi
     no_file5="GSM1089291-tbl-1-modified.txt"
     if [ ! -e "$no_test_raw_dir/$no_file5" ]; then
         mkdir -p "$no_test_raw_dir"
         echo "Downloading NOOP file5."
         wget -q -O "$no_test_raw_dir/$no_file5" \
-             "$test_data_repo/$no_file5"
+            "$test_data_repo/$no_file5"
     fi
 
-    # Reference files
+    # Reference files.
     no_test_exp_dir="$volume_directory/TEST/NO_OP/EXPECTED"
     no_test_exp_files='gene_converted_GSM557500-tbl-1.txt GSM269747.PCL gene_converted_GSM1234847-tbl-1.txt gene_converted_GSM1089291-tbl-1.txt'
     mkdir -p "$no_test_exp_dir"
@@ -283,16 +284,16 @@ if [ -z "$tag" ] || [ "$tag" = "no_op" ]; then
         if ! [ -e "$no_test_exp_dir/$no_test_exp_file" ]; then
             echo "Downloading NOOP expected file$i."
             wget -O "$no_test_exp_dir/$no_test_exp_file" \
-                 "$test_data_repo/$no_test_exp_file"
+                "$test_data_repo/$no_test_exp_file"
         fi
 
-        i=$(( i + 1 ))
+        i=$((i + 1))
     done
     unset i
 fi
 
 if [ -z "$tag" ] || [ "$tag" = "smasher" ] || [ "$tag" = "compendia" ]; then
-    # Make sure PCL for test is downloaded from S3
+    # Make sure PCL for test is downloaded from S3.
     pcl_name="GSM1237810_T09-1084.PCL"
     pcl_name2="GSM1237812_S97-PURE.PCL"
     pcl_name3="GSM1238108-tbl-1.txt"
@@ -334,101 +335,101 @@ if [ -z "$tag" ] || [ "$tag" = "smasher" ] || [ "$tag" = "compendia" ]; then
         mkdir -p "$pcl_test_raw_dir"
         echo "Downloading PCL for tests."
         wget -q -O "$pcl_test_data_1" \
-             "$test_data_repo/$pcl_name"
+            "$test_data_repo/$pcl_name"
     fi
     if [ ! -e "$pcl_test_data_2" ]; then
         echo "Downloading PCL2 for tests."
         wget -q -O "$pcl_test_data_2" \
-             "$test_data_repo/$pcl_name2"
+            "$test_data_repo/$pcl_name2"
     fi
     if [ ! -e "$pcl_test_data_3" ]; then
         echo "Downloading PCL3 for tests."
         wget -q -O "$pcl_test_data_3" \
-             "$test_data_repo/$pcl_name3"
+            "$test_data_repo/$pcl_name3"
     fi
     if [ ! -e "$pcl_test_data_4" ]; then
         echo "Downloading PCL4 for tests."
         wget -q -O "$pcl_test_data_4" \
-             "$test_data_repo/$pcl_name4"
+            "$test_data_repo/$pcl_name4"
     fi
     if [ ! -e "$pcl_test_data_5" ]; then
         echo "Downloading PCL5 for tests."
         wget -q -O "$pcl_test_data_5" \
-             "$test_data_repo/$pcl_name5"
+            "$test_data_repo/$pcl_name5"
     fi
     if [ ! -e "$pcl_test_data_6" ]; then
         echo "Downloading PCL6 for tests."
         wget -q -O "$pcl_test_data_6" \
-             "$test_data_repo/$pcl_name6"
+            "$test_data_repo/$pcl_name6"
     fi
     if [ ! -e "$pcl_test_data_7" ]; then
         echo "Downloading PCL7 for tests."
         wget -q -O "$pcl_test_data_7" \
-             "$test_data_repo/$pcl_name7"
+            "$test_data_repo/$pcl_name7"
     fi
     if [ ! -e "$pcl_test_data_gs1" ]; then
         echo "Downloading PCLGS1 for tests."
         wget -q -O "$pcl_test_data_gs1" \
-             "$test_data_repo/$pcl_name_gs1"
+            "$test_data_repo/$pcl_name_gs1"
     fi
     if [ ! -e "$pcl_test_data_gs2" ]; then
         echo "Downloading PCLGS2 for tests."
         wget -q -O "$pcl_test_data_gs2" \
-             "$test_data_repo/$pcl_name_gs2"
+            "$test_data_repo/$pcl_name_gs2"
     fi
     if [ ! -e "$pcl_test_data_ts1" ]; then
         echo "Downloading PCLTS1 for tests."
         wget -q -O "$pcl_test_data_ts1" \
-             "$test_data_repo/$pcl_name_ts1"
+            "$test_data_repo/$pcl_name_ts1"
     fi
     if [ ! -e "$pcl_test_data_ts2" ]; then
         echo "Downloading PCLTS2 for tests."
         wget -q -O "$pcl_test_data_ts2" \
-             "$test_data_repo/$pcl_name_ts2"
+            "$test_data_repo/$pcl_name_ts2"
     fi
     if [ ! -e "$pcl_test_data_ta1" ]; then
         echo "Downloading PCLTA1 for tests."
         wget -q -O "$pcl_test_data_ta1" \
-             "$test_data_repo/$pcl_name_ta1"
+            "$test_data_repo/$pcl_name_ta1"
     fi
     if [ ! -e "$bad_test_data_1" ]; then
         mkdir -p "$bad_test_raw_dir"
         echo "Downloading Bad PCL for tests."
         wget -q -O "$bad_test_data_1" \
-             "$test_data_repo/$bad_name"
+            "$test_data_repo/$bad_name"
     fi
     if [ ! -e "$bad_test_data_2" ]; then
         mkdir -p "$bad_test_raw_dir"
         echo "Downloading Bad PCL for tests."
         wget -q -O "$bad_test_data_2" \
-             "$test_data_repo/$bad_name2"
+            "$test_data_repo/$bad_name2"
     fi
     if [ ! -e "$bad_test_data_3" ]; then
         mkdir -p "$bad_test_raw_dir"
         echo "Downloading Bad PCL for tests."
         wget -q -O "$bad_test_data_3" \
-             "$test_data_repo/$bad_name3"
+            "$test_data_repo/$bad_name3"
     fi
     if [ ! -e "$quant_test_data_1" ]; then
         mkdir -p "$quant_test_raw_dir"
         echo "Downloading Quant files for tests."
         wget -q -O "$quant_test_data_1" \
-             "$test_data_repo/$quant_name"
+            "$test_data_repo/$quant_name"
     fi
     if [ ! -e "$quant_test_data_2" ]; then
         mkdir -p "$quant_test_raw_dir"
         echo "Downloading Quant files for tests."
         wget -q -O "$quant_test_data_2" \
-             "$test_data_repo/$quant_name_2"
+            "$test_data_repo/$quant_name_2"
     fi
     # Mock out the AWS keys since we use VCR to mock out the request with these
-    # as the AWS credentials
+    # as the AWS credentials.
     export AWS_ACCESS_KEY_ID=XXX
     export AWS_SECRET_ACCESS_KEY=XXX
 fi
 
 if [ -z "$tag" ] || [ "$tag" = "qn" ]; then
-    # Make sure PCL for test is downloaded from S3
+    # Make sure PCL for test is downloaded from S3.
     qn_name="1.tsv"
     qn_test_raw_dir="$volume_directory/QN"
     qn_test_data_1="$qn_test_raw_dir/$qn_name"
@@ -436,7 +437,7 @@ if [ -z "$tag" ] || [ "$tag" = "qn" ]; then
         mkdir -p "$qn_test_raw_dir"
         echo "Downloading QN for tests."
         wget -q -O "$qn_test_data_1" \
-             "$test_data_repo/$qn_name"
+            "$test_data_repo/$qn_name"
     fi
     qn_name="2.tsv"
     qn_test_raw_dir="$volume_directory/QN"
@@ -445,7 +446,7 @@ if [ -z "$tag" ] || [ "$tag" = "qn" ]; then
         mkdir -p "$qn_test_raw_dir"
         echo "Downloading QN for tests."
         wget -q -O "$qn_test_data_2" \
-             "$test_data_repo/$qn_name"
+            "$test_data_repo/$qn_name"
     fi
     qn_name="3.tsv"
     qn_test_raw_dir="$volume_directory/QN"
@@ -454,7 +455,7 @@ if [ -z "$tag" ] || [ "$tag" = "qn" ]; then
         mkdir -p "$qn_test_raw_dir"
         echo "Downloading QN for tests."
         wget -q -O "$qn_test_data_3" \
-             "$test_data_repo/$qn_name"
+            "$test_data_repo/$qn_name"
     fi
     qn_name="4.tsv"
     qn_test_raw_dir="$volume_directory/QN"
@@ -463,7 +464,7 @@ if [ -z "$tag" ] || [ "$tag" = "qn" ]; then
         mkdir -p "$qn_test_raw_dir"
         echo "Downloading QN for tests."
         wget -q -O "$qn_test_data_4" \
-             "$test_data_repo/$qn_name"
+            "$test_data_repo/$qn_name"
     fi
     qn_name="5.tsv"
     qn_test_raw_dir="$volume_directory/QN"
@@ -472,7 +473,7 @@ if [ -z "$tag" ] || [ "$tag" = "qn" ]; then
         mkdir -p "$qn_test_raw_dir"
         echo "Downloading QN for tests."
         wget -q -O "$qn_test_data_5" \
-             "$test_data_repo/$qn_name"
+            "$test_data_repo/$qn_name"
     fi
     qn_name="6.tsv"
     qn_test_raw_dir="$volume_directory/QN"
@@ -481,7 +482,7 @@ if [ -z "$tag" ] || [ "$tag" = "qn" ]; then
         mkdir -p "$qn_test_raw_dir"
         echo "Downloading QN for tests."
         wget -q -O "$qn_test_data_6" \
-             "$test_data_repo/$qn_name"
+            "$test_data_repo/$qn_name"
     fi
     qn_name="7.tsv"
     qn_test_raw_dir="$volume_directory/QN"
@@ -490,7 +491,7 @@ if [ -z "$tag" ] || [ "$tag" = "qn" ]; then
         mkdir -p "$qn_test_raw_dir"
         echo "Downloading QN for tests."
         wget -q -O "$qn_test_data_7" \
-             "$test_data_repo/$qn_name"
+            "$test_data_repo/$qn_name"
     fi
 fi
 if [ -z "$tag" ] || [ "$tag" = "compendia" ]; then
@@ -522,7 +523,7 @@ if [ -z "$tag" ] || [ "$tag" = "compendia" ]; then
         mkdir -p "$qn_test_raw_dir"
         echo "Downloading QN for compendia tests."
         wget -q -O "$qn_test_data_1" \
-             "$test_data_repo/$qn_name"
+            "$test_data_repo/$qn_name"
     fi
 fi
 
@@ -533,47 +534,50 @@ DB_HOST_IP=$(get_docker_db_ip_address)
 chmod -R a+rwX "$volume_directory"
 
 worker_images="salmon transcriptome no_op downloaders smasher illumina agilent affymetrix qn affymetrix_local janitor compendia"
-
 for image in $worker_images; do
     if [ -z "$tag" ] || [ "$tag" = "$image" ]; then
         if [ "$image" = "agilent" ] || [ "$image" = "affymetrix" ]; then
-            # Agilent uses the same docker image as Affymetrix
-            ./scripts/prepare_image.sh -p -i affymetrix -s workers
-            ./scripts/prepare_image.sh -i affymetrix_local -d ccdlstaging
-            docker tag ccdlstaging/dr_affymetrix_local:latest ccdlstaging/dr_affymetrix:latest
-            image_name=ccdlstaging/dr_affymetrix
+            # Agilent uses the same docker image as Affymetrix.
+            ./scripts/prepare_image.sh -d -i affymetrix -s workers
+            ./scripts/prepare_image.sh -i affymetrix_local -r ccdlstaging
+            docker tag "$DOCKERHUB_REPO/dr_affymetrix_local:latest" "$DOCKERHUB_REPO/dr_affymetrix:latest"
+            image_name="$DOCKERHUB_REPO/dr_affymetrix"
         elif [ "$tag" = "qn" ]; then
             ./scripts/prepare_image.sh -i smasher -s workers
-            image_name=ccdlstaging/dr_smasher
+            image_name="$DOCKERHUB_REPO/dr_smasher"
         elif [ "$tag" = "janitor" ]; then
             ./scripts/prepare_image.sh -i smasher -s workers
-            image_name=ccdlstaging/dr_smasher
+            image_name="$DOCKERHUB_REPO/dr_smasher"
         else
             ./scripts/prepare_image.sh -i "$image" -s workers
-            image_name=ccdlstaging/dr_$image
+            image_name="$DOCKERHUB_REPO/dr_$image"
         fi
 
-        # Strip out tag argument
+        # Strip out tag argument.
         # shellcheck disable=2001
         args_without_tag="$(echo "$@" | sed "s/-t $tag//")"
         # shellcheck disable=2086
         test_command="$(run_tests_with_coverage --tag="$image" $args_without_tag)"
 
-        # Only run interactively if we are on a TTY
+        # Only run interactively if we are on a TTY.
         if [ -t 1 ]; then
-            INTERACTIVE="-i"
+            INTERACTIVE="--interactive"
         fi
 
         echo "Running tests with the following command:"
         echo "$test_command"
-        docker run -t $INTERACTIVE \
-               --add-host=database:"$DB_HOST_IP" \
-               --env-file workers/environments/test \
-               --env AWS_ACCESS_KEY_ID \
-               --env AWS_SECRET_ACCESS_KEY \
-               --memory=5G \
-               --platform linux/amd64 \
-               --volume "$volume_directory":/home/user/data_store \
-               "$image_name" bash -c "$test_command"
+        # shellcheck disable=SC2086
+        docker run \
+            --add-host=database:"$DB_HOST_IP" \
+            --env AWS_ACCESS_KEY_ID \
+            --env AWS_SECRET_ACCESS_KEY \
+            --env-file workers/environments/test \
+            --memory=5G \
+            --platform linux/amd64 \
+            --tty \
+            --volume "$volume_directory":/home/user/data_store \
+            $INTERACTIVE \
+            "$image_name" \
+            bash -c "$test_command"
     fi
 done


### PR DESCRIPTION
## Purpose/Implementation Notes
The current Docker container handling approach is heavily depends on `ccdlstaging` registry for local testing/deployment. This PR introduces a way to change the behaviour by using `DOCKERHUB_REPO` env variable and addresses a bunch of other smaller problems I noticed during refine.bio images building:

  - Isolate local/staging Docker registries
  - Change `-d`/`-r` deployment flags meaning
  - Add existing image based cache
  - Consolidate api/common/workers images build logic
  - Introduce prepare_image.sh `-u` flag
  - Introduce update_my_docker_images.sh `-b`/`-x` flags (remote builder and architecture)
  - Unify `source` operation syntax
  - Reformat .sh files
  - Standardize docker command options format

## Functional tests

NA

## Checklist


- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots

NA
