### PR TITLE
3283 sra metadata download

### DIFF
--- a/foreman/tests/surveyor/test_sra.py
+++ b/foreman/tests/surveyor/test_sra.py
@@ -226,11 +226,9 @@ class SraSurveyorTestCase(TestCase):
         self.assertEqual(metadata["run_ena_last_update"], "2017-08-11")
         self.assertEqual(metadata["run_ena_spot_count"], "32568360")
         self.assertEqual(metadata["sample_accession"], "DRS001521")
-        self.assertEqual(metadata["sample_center_name"], "BioSample")
-        self.assertEqual(metadata["sample_ena_base_count"], "3256836000")
-        self.assertEqual(metadata["sample_ena_first_public"], "2013-07-20")
-        self.assertEqual(metadata["sample_ena_last_update"], "2015-08-24")
-        self.assertEqual(metadata["sample_ena_spot_count"], "32568360")
+        self.assertEqual(metadata["sample_center_name"], "Group for Morphological Evolution, Center for Developmental Biology, Kobe Institute, RIKEN")
+        self.assertEqual(metadata["sample_ena_first_public"], "2013-02-27")
+        self.assertEqual(metadata["sample_ena_last_update"], "2014-11-12")
         self.assertEqual(
             metadata["sample_sample_comment"],
             ("mRNAseq of chicken at stage HH16 (biological " "replicate 1)"),
@@ -255,14 +253,7 @@ class SraSurveyorTestCase(TestCase):
         self.assertEqual(metadata["submission_title"], "Submitted by RIKEN_CDB on 19-JUL-2013")
 
         ncbi_url = SraSurveyor._build_ncbi_file_url(metadata["run_accession"])
-        self.assertTrue(
-            ncbi_url
-            in [
-                "anonftp@ftp.ncbi.nlm.nih.gov:/sra/sra-instant/reads/ByRun/sra/DRR/DRR002/DRR002116/DRR002116.sra",
-                "anonftp@ftp-private.ncbi.nlm.nih.gov:/sra/sra-instant/reads/ByRun/sra/DRR/DRR002/DRR002116/DRR002116.sra",
-                "dbtest@sra-download.ncbi.nlm.nih.gov:data/sracloud/traces/dra0/DRR/000002/DRR002116",
-            ]
-        )
+        self.assertEqual(ncbi_url, "https://sra-pub-run-odp.s3.amazonaws.com/sra/DRR002116/DRR002116")
 
     def test_sra_metadata_is_harmonized(self):
         metadata = SraSurveyor.gather_all_metadata("SRR3098582")

--- a/test_volume/cassettes/surveyor.sra.arrayexpress_alternate_accession.yaml
+++ b/test_volume/cassettes/surveyor.sra.arrayexpress_alternate_accession.yaml
@@ -9,7 +9,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/ERP108370
   response:
@@ -69,7 +69,7 @@ interactions:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:40:58 GMT
+      - Wed, 17 May 2023 18:35:36 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -87,7 +87,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/ERR2534072
   response:
@@ -128,7 +128,7 @@ interactions:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:40:58 GMT
+      - Wed, 17 May 2023 18:35:36 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -146,7 +146,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/ERX2552493
   response:
@@ -210,7 +210,7 @@ interactions:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:40:59 GMT
+      - Wed, 17 May 2023 18:35:37 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -228,63 +228,51 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/ERS2428787
   response:
     body:
       string: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<SAMPLE_SET>\n<SAMPLE accession=\"ERS2428787\"
-        alias=\"E-MTAB-6681:G144_KO8_RNAseq_DMSO1\" broker_name=\"ArrayExpress\" center_name=\"BRIC
-        - Biotech Research and Innovation Centre\">\n     <IDENTIFIERS>\n          <PRIMARY_ID>ERS2428787</PRIMARY_ID>\n
-        \         <EXTERNAL_ID namespace=\"BioSample\">SAMEA4608091</EXTERNAL_ID>\n
+        alias=\"E-MTAB-6681:G144_KO8_RNAseq_DMSO1\" center_name=\"BRIC - Biotech Research
+        and Innovation Centre\" broker_name=\"ArrayExpress\">\n     <IDENTIFIERS>\n
+        \         <PRIMARY_ID>ERS2428787</PRIMARY_ID>\n          <EXTERNAL_ID namespace=\"BioSample\">SAMEA4608091</EXTERNAL_ID>\n
         \         <SUBMITTER_ID namespace=\"BRIC - Biotech Research and Innovation
         Centre\">E-MTAB-6681:G144_KO8_RNAseq_DMSO1</SUBMITTER_ID>\n     </IDENTIFIERS>\n
         \    <TITLE>G144_KO8_RNAseq_DMSO1</TITLE>\n     <SAMPLE_NAME>\n          <TAXON_ID>9606</TAXON_ID>\n
         \         <SCIENTIFIC_NAME>Homo sapiens</SCIENTIFIC_NAME>\n          <COMMON_NAME>human</COMMON_NAME>\n
         \    </SAMPLE_NAME>\n     <DESCRIPTION>Protocols: CRISPR mediated KO of CIC:
         sgRNAs (Target sequence: mESCs: GCCTTCATGATCTTCAGCAAG; G144: GGGCGAGTGGTGGTATGCCC)
-        \ were cloned into pSpCas9(BB)-2A-GFP (Addgene 48138) and transfected into
-        mESCs (Lipofectamine 2000) or G144 cells (Amaxa Nucleofector II, Program A033).
+        were cloned into pSpCas9(BB)-2A-GFP (Addgene 48138) and transfected into mESCs
+        (Lipofectamine 2000) or G144 cells (Amaxa Nucleofector II, Program A033).
         GFP-positive cells were single cell sorted 48h post-transfection, expanded
         and screened by immunoblotting for CIC deletion. Inhibitor treatment with
         1 \u03BCM MEK inhibitor (PD0325901) was performed in 80% confluent cultures
         for 4 and 24 h respectively. DMSO was used as mock control. Cells were washed
-        once with PBS, lysed directly in RLT buffer (Qiagen).  Total RNA was extracted
-        using the RNAeasy kit (Qiagen).  500 ng of total RNA was used for library
-        preparation using TruSeq RNA Library Prep Kit v2 (Illumina) according to manufacturer
-        recommendations.</DESCRIPTION>\n     <SAMPLE_LINKS>\n          <SAMPLE_LINK>\n
-        \              <XREF_LINK>\n                    <DB>ENA-STUDY</DB>\n                    <ID>ERP108370</ID>\n
-        \              </XREF_LINK>\n          </SAMPLE_LINK>\n          <SAMPLE_LINK>\n
-        \              <XREF_LINK>\n                    <DB>ENA-EXPERIMENT</DB>\n
-        \                   <ID>ERX2552493</ID>\n               </XREF_LINK>\n          </SAMPLE_LINK>\n
-        \         <SAMPLE_LINK>\n               <XREF_LINK>\n                    <DB>ENA-RUN</DB>\n
-        \                   <ID>ERR2534072</ID>\n               </XREF_LINK>\n          </SAMPLE_LINK>\n
-        \         <SAMPLE_LINK>\n               <XREF_LINK>\n                    <DB>ENA-SUBMISSION</DB>\n
-        \                   <ID>ERA1350207</ID>\n               </XREF_LINK>\n          </SAMPLE_LINK>\n
-        \         <SAMPLE_LINK>\n               <XREF_LINK>\n                    <DB>ENA-FASTQ-FILES</DB>\n
-        \                   <ID><![CDATA[https://www.ebi.ac.uk/ena/portal/api/filereport?accession=ERS2428787&result=read_run&fields=run_accession,fastq_ftp,fastq_md5,fastq_bytes]]></ID>\n
-        \              </XREF_LINK>\n          </SAMPLE_LINK>\n          <SAMPLE_LINK>\n
-        \              <XREF_LINK>\n                    <DB>ENA-SUBMITTED-FILES</DB>\n
-        \                   <ID><![CDATA[https://www.ebi.ac.uk/ena/portal/api/filereport?accession=ERS2428787&result=read_run&fields=run_accession,submitted_ftp,submitted_md5,submitted_bytes,submitted_format]]></ID>\n
-        \              </XREF_LINK>\n          </SAMPLE_LINK>\n     </SAMPLE_LINKS>\n
-        \    <SAMPLE_ATTRIBUTES>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>isolate</TAG>\n
-        \              <VALUE>not applicable</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
-        \         <SAMPLE_ATTRIBUTE>\n               <TAG>organism</TAG>\n               <VALUE>Homo
-        sapiens</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
-        \              <TAG>organism part</TAG>\n               <VALUE>brain</VALUE>\n
-        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>cell_type</TAG>\n
-        \              <VALUE>glial cell</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
-        \         <SAMPLE_ATTRIBUTE>\n               <TAG>cell_line</TAG>\n               <VALUE>G144</VALUE>\n
+        once with PBS, lysed directly in RLT buffer (Qiagen). Total RNA was extracted
+        using the RNAeasy kit (Qiagen). 500 ng of total RNA was used for library preparation
+        using TruSeq RNA Library Prep Kit v2 (Illumina) according to manufacturer
+        recommendations.</DESCRIPTION>\n     <SAMPLE_LINKS>\n    <SAMPLE_LINK>\n        <XREF_LINK>\n
+        \           <DB>ENA-FASTQ-FILES</DB>\n            <ID><![CDATA[https://www.ebi.ac.uk/ena/portal/api/filereport?accession=ERS2428787&result=read_run&fields=run_accession,fastq_ftp,fastq_md5,fastq_bytes]]></ID>\n
+        \       </XREF_LINK>\n    </SAMPLE_LINK>\n    <SAMPLE_LINK>\n        <XREF_LINK>\n
+        \           <DB>ENA-SUBMITTED-FILES</DB>\n            <ID><![CDATA[https://www.ebi.ac.uk/ena/portal/api/filereport?accession=ERS2428787&result=read_run&fields=run_accession,submitted_ftp,submitted_md5,submitted_bytes,submitted_format]]></ID>\n
+        \       </XREF_LINK>\n    </SAMPLE_LINK>\n</SAMPLE_LINKS>\n<SAMPLE_ATTRIBUTES>\n
+        \         <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-CHECKLIST</TAG>\n               <VALUE>ERC000011</VALUE>\n
         \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>disease</TAG>\n
         \              <VALUE>glioblastoma multiforme</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
-        \         <SAMPLE_ATTRIBUTE>\n               <TAG>genotype</TAG>\n               <VALUE>CRISPR/Cas9
-        mediated knockout of CIC</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
-        \              <TAG>individual</TAG>\n               <VALUE>clonal line #8</VALUE>\n
-        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-CHECKLIST</TAG>\n
-        \              <VALUE>ERC000011</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
-        \              <TAG>ENA-SPOT-COUNT</TAG>\n               <VALUE>26844500</VALUE>\n
-        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-BASE-COUNT</TAG>\n
-        \              <VALUE>2027143150</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
+        \         <SAMPLE_ATTRIBUTE>\n               <TAG>individual</TAG>\n               <VALUE>clonal
+        line #8</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
+        \              <TAG>organism</TAG>\n               <VALUE>Homo sapiens</VALUE>\n
+        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>organism</TAG>\n
+        \              <VALUE>Homo sapiens</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
+        \         <SAMPLE_ATTRIBUTE>\n               <TAG>cell type</TAG>\n               <VALUE>glial
+        cell</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
+        \              <TAG>common name</TAG>\n               <VALUE>human</VALUE>\n
+        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>organism
+        part</TAG>\n               <VALUE>brain</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
+        \         <SAMPLE_ATTRIBUTE>\n               <TAG>cell line</TAG>\n               <VALUE>G144</VALUE>\n
+        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>genotype</TAG>\n
+        \              <VALUE>CRISPR/Cas9 mediated knockout of CIC</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
         \         <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-FIRST-PUBLIC</TAG>\n
         \              <VALUE>2018-05-30</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
         \         <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-LAST-UPDATE</TAG>\n
@@ -294,7 +282,7 @@ interactions:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:40:59 GMT
+      - Wed, 17 May 2023 18:35:38 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -312,7 +300,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/ERP108370
   response:
@@ -372,7 +360,7 @@ interactions:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:41:00 GMT
+      - Wed, 17 May 2023 18:35:38 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -390,7 +378,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/ERA1350207
   response:
@@ -426,7 +414,7 @@ interactions:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:41:00 GMT
+      - Wed, 17 May 2023 18:35:39 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -435,68 +423,6 @@ interactions:
       code: 200
       message: ''
 - request:
-    body: acc=ERR2534072&accept-proto=fasp&version=2.0
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '44'
-      User-Agent:
-      - python-requests/2.25.1
-    method: POST
-    uri: https://www.ncbi.nlm.nih.gov/Traces/names/names.cgi
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAAwzIsQrCMBAA0L1fEXDoVLm7pk3S3VkoTm7JNaVKMKGNiHAfr298JzpDc+y+vINc
-        5pmGXoMhsW4gHIGsEKDtwHTgbojTgJN2d+Ex+oDWWeo1MRheYk/Ijldn/IJBRDSAXF/pq9qt1nK0
-        quy5Zs5JPQ7lU8qfuKg176pu/8jhGbk2PwAAAP//AwCDIi4MjgAAAA==
-    headers:
-      Cache-Control:
-      - private
-      Connection:
-      - Keep-Alive
-      Content-Encoding:
-      - gzip
-      Content-Security-Policy:
-      - upgrade-insecure-requests
-      Content-Type:
-      - text/plain
-      Date:
-      - Wed, 28 Jul 2021 19:41:01 GMT
-      Keep-Alive:
-      - timeout=1, max=10
-      NCBI-PHID:
-      - CC95EE27101B2CD10000000000000001.m_1
-      NCBI-SID:
-      - CC95EE27101B2CD1_0000SID
-      Referrer-Policy:
-      - origin-when-cross-origin
-      Server:
-      - Apache
-      Set-Cookie:
-      - ncbi_sid=CC95EE27101B2CD1_0000SID; domain=.nih.gov; path=/; expires=Thu, 28
-        Jul 2022 19:41:01 GMT
-      SraNameServerOutputVersion:
-      - '2.0'
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains; preload
-      Transfer-Encoding:
-      - chunked
-      Vary:
-      - Accept-Encoding
-      X-UA-Compatible:
-      - IE=Edge
-      X-XSS-Protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
-- request:
     body: null
     headers:
       Accept:
@@ -506,29 +432,27 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/portal/api/filereport?accession=ERR2534072&result=read_run
   response:
     body:
-      string: "run_accession\tfastq_ftp\tfastq_bytes\tfastq_md5\tsubmitted_ftp\tsubmitted_bytes\tsubmitted_md5\tsra_ftp\tsra_bytes\tsra_md5\nERR2534072\tftp.sra.ebi.ac.uk/vol1/fastq/ERR253/002/ERR2534072/ERR2534072.fastq.gz\t1342496804\t060aa7646a7caa6b7db9e9b5126efd99\tftp.sra.ebi.ac.uk/vol1/run/ERR253/ERR2534072/G144_KO8_RNAseq_DMSO1.fastq.gz\t1397343408\t6f75b7add12efbe0413473419ed2f51b\t\t\t\n"
+      string: "run_accession\tfastq_ftp\tfastq_bytes\tfastq_md5\tbam_ftp\tbam_bytes\tbam_md5\tsubmitted_ftp\tsubmitted_bytes\tsubmitted_md5\tsra_ftp\tsra_bytes\tsra_md5\nERR2534072\tftp.sra.ebi.ac.uk/vol1/fastq/ERR253/002/ERR2534072/ERR2534072.fastq.gz\t1342496804\t060aa7646a7caa6b7db9e9b5126efd99\t\t\t\tftp.sra.ebi.ac.uk/vol1/run/ERR253/ERR2534072/G144_KO8_RNAseq_DMSO1.fastq.gz\t1397343408\t6f75b7add12efbe0413473419ed2f51b\tftp.sra.ebi.ac.uk/vol1/err/ERR253/002/ERR2534072\t895216008\t2ecc0c89596bcf20c7c1f8e77ab3d9f5\n"
     headers:
       Cache-Control:
       - no-cache, no-store, max-age=0, must-revalidate
+      Content-Length:
+      - '483'
       Content-Type:
       - text/plain
       Date:
-      - Wed, 28 Jul 2021 19:41:02 GMT
+      - Wed, 17 May 2023 18:35:39 GMT
       Expires:
       - '0'
       Pragma:
       - no-cache
-      Server:
-      - Apache-Coyote/1.1
       Strict-Transport-Security:
       - max-age=0
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Frame-Options:
@@ -537,7 +461,7 @@ interactions:
       - 1; mode=block
     status:
       code: 200
-      message: OK
+      message: ''
 - request:
     body: null
     headers:
@@ -548,7 +472,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/ERR2534073
   response:
@@ -589,7 +513,7 @@ interactions:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:41:03 GMT
+      - Wed, 17 May 2023 18:35:40 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -607,7 +531,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/ERX2552494
   response:
@@ -671,7 +595,7 @@ interactions:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:41:03 GMT
+      - Wed, 17 May 2023 18:35:40 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -689,63 +613,51 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/ERS2428788
   response:
     body:
       string: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<SAMPLE_SET>\n<SAMPLE accession=\"ERS2428788\"
-        alias=\"E-MTAB-6681:G144_KO8_RNAseq_DMSO2\" broker_name=\"ArrayExpress\" center_name=\"BRIC
-        - Biotech Research and Innovation Centre\">\n     <IDENTIFIERS>\n          <PRIMARY_ID>ERS2428788</PRIMARY_ID>\n
-        \         <EXTERNAL_ID namespace=\"BioSample\">SAMEA4608092</EXTERNAL_ID>\n
+        alias=\"E-MTAB-6681:G144_KO8_RNAseq_DMSO2\" center_name=\"BRIC - Biotech Research
+        and Innovation Centre\" broker_name=\"ArrayExpress\">\n     <IDENTIFIERS>\n
+        \         <PRIMARY_ID>ERS2428788</PRIMARY_ID>\n          <EXTERNAL_ID namespace=\"BioSample\">SAMEA4608092</EXTERNAL_ID>\n
         \         <SUBMITTER_ID namespace=\"BRIC - Biotech Research and Innovation
         Centre\">E-MTAB-6681:G144_KO8_RNAseq_DMSO2</SUBMITTER_ID>\n     </IDENTIFIERS>\n
         \    <TITLE>G144_KO8_RNAseq_DMSO2</TITLE>\n     <SAMPLE_NAME>\n          <TAXON_ID>9606</TAXON_ID>\n
         \         <SCIENTIFIC_NAME>Homo sapiens</SCIENTIFIC_NAME>\n          <COMMON_NAME>human</COMMON_NAME>\n
         \    </SAMPLE_NAME>\n     <DESCRIPTION>Protocols: CRISPR mediated KO of CIC:
         sgRNAs (Target sequence: mESCs: GCCTTCATGATCTTCAGCAAG; G144: GGGCGAGTGGTGGTATGCCC)
-        \ were cloned into pSpCas9(BB)-2A-GFP (Addgene 48138) and transfected into
-        mESCs (Lipofectamine 2000) or G144 cells (Amaxa Nucleofector II, Program A033).
+        were cloned into pSpCas9(BB)-2A-GFP (Addgene 48138) and transfected into mESCs
+        (Lipofectamine 2000) or G144 cells (Amaxa Nucleofector II, Program A033).
         GFP-positive cells were single cell sorted 48h post-transfection, expanded
         and screened by immunoblotting for CIC deletion. Inhibitor treatment with
         1 \u03BCM MEK inhibitor (PD0325901) was performed in 80% confluent cultures
         for 4 and 24 h respectively. DMSO was used as mock control. Cells were washed
-        once with PBS, lysed directly in RLT buffer (Qiagen).  Total RNA was extracted
-        using the RNAeasy kit (Qiagen).  500 ng of total RNA was used for library
-        preparation using TruSeq RNA Library Prep Kit v2 (Illumina) according to manufacturer
-        recommendations.</DESCRIPTION>\n     <SAMPLE_LINKS>\n          <SAMPLE_LINK>\n
-        \              <XREF_LINK>\n                    <DB>ENA-STUDY</DB>\n                    <ID>ERP108370</ID>\n
-        \              </XREF_LINK>\n          </SAMPLE_LINK>\n          <SAMPLE_LINK>\n
-        \              <XREF_LINK>\n                    <DB>ENA-EXPERIMENT</DB>\n
-        \                   <ID>ERX2552494</ID>\n               </XREF_LINK>\n          </SAMPLE_LINK>\n
-        \         <SAMPLE_LINK>\n               <XREF_LINK>\n                    <DB>ENA-RUN</DB>\n
-        \                   <ID>ERR2534073</ID>\n               </XREF_LINK>\n          </SAMPLE_LINK>\n
-        \         <SAMPLE_LINK>\n               <XREF_LINK>\n                    <DB>ENA-SUBMISSION</DB>\n
-        \                   <ID>ERA1350207</ID>\n               </XREF_LINK>\n          </SAMPLE_LINK>\n
-        \         <SAMPLE_LINK>\n               <XREF_LINK>\n                    <DB>ENA-FASTQ-FILES</DB>\n
-        \                   <ID><![CDATA[https://www.ebi.ac.uk/ena/portal/api/filereport?accession=ERS2428788&result=read_run&fields=run_accession,fastq_ftp,fastq_md5,fastq_bytes]]></ID>\n
-        \              </XREF_LINK>\n          </SAMPLE_LINK>\n          <SAMPLE_LINK>\n
-        \              <XREF_LINK>\n                    <DB>ENA-SUBMITTED-FILES</DB>\n
-        \                   <ID><![CDATA[https://www.ebi.ac.uk/ena/portal/api/filereport?accession=ERS2428788&result=read_run&fields=run_accession,submitted_ftp,submitted_md5,submitted_bytes,submitted_format]]></ID>\n
-        \              </XREF_LINK>\n          </SAMPLE_LINK>\n     </SAMPLE_LINKS>\n
-        \    <SAMPLE_ATTRIBUTES>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>isolate</TAG>\n
-        \              <VALUE>not applicable</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
-        \         <SAMPLE_ATTRIBUTE>\n               <TAG>organism</TAG>\n               <VALUE>Homo
-        sapiens</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
-        \              <TAG>organism part</TAG>\n               <VALUE>brain</VALUE>\n
-        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>cell_type</TAG>\n
-        \              <VALUE>glial cell</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
-        \         <SAMPLE_ATTRIBUTE>\n               <TAG>cell_line</TAG>\n               <VALUE>G144</VALUE>\n
+        once with PBS, lysed directly in RLT buffer (Qiagen). Total RNA was extracted
+        using the RNAeasy kit (Qiagen). 500 ng of total RNA was used for library preparation
+        using TruSeq RNA Library Prep Kit v2 (Illumina) according to manufacturer
+        recommendations.</DESCRIPTION>\n     <SAMPLE_LINKS>\n    <SAMPLE_LINK>\n        <XREF_LINK>\n
+        \           <DB>ENA-FASTQ-FILES</DB>\n            <ID><![CDATA[https://www.ebi.ac.uk/ena/portal/api/filereport?accession=ERS2428788&result=read_run&fields=run_accession,fastq_ftp,fastq_md5,fastq_bytes]]></ID>\n
+        \       </XREF_LINK>\n    </SAMPLE_LINK>\n    <SAMPLE_LINK>\n        <XREF_LINK>\n
+        \           <DB>ENA-SUBMITTED-FILES</DB>\n            <ID><![CDATA[https://www.ebi.ac.uk/ena/portal/api/filereport?accession=ERS2428788&result=read_run&fields=run_accession,submitted_ftp,submitted_md5,submitted_bytes,submitted_format]]></ID>\n
+        \       </XREF_LINK>\n    </SAMPLE_LINK>\n</SAMPLE_LINKS>\n<SAMPLE_ATTRIBUTES>\n
+        \         <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-CHECKLIST</TAG>\n               <VALUE>ERC000011</VALUE>\n
         \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>disease</TAG>\n
         \              <VALUE>glioblastoma multiforme</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
-        \         <SAMPLE_ATTRIBUTE>\n               <TAG>genotype</TAG>\n               <VALUE>CRISPR/Cas9
-        mediated knockout of CIC</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
-        \              <TAG>individual</TAG>\n               <VALUE>clonal line #8</VALUE>\n
-        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-CHECKLIST</TAG>\n
-        \              <VALUE>ERC000011</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
-        \              <TAG>ENA-SPOT-COUNT</TAG>\n               <VALUE>23128792</VALUE>\n
-        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-BASE-COUNT</TAG>\n
-        \              <VALUE>1746472850</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
+        \         <SAMPLE_ATTRIBUTE>\n               <TAG>individual</TAG>\n               <VALUE>clonal
+        line #8</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
+        \              <TAG>organism</TAG>\n               <VALUE>Homo sapiens</VALUE>\n
+        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>organism</TAG>\n
+        \              <VALUE>Homo sapiens</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
+        \         <SAMPLE_ATTRIBUTE>\n               <TAG>cell type</TAG>\n               <VALUE>glial
+        cell</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
+        \              <TAG>common name</TAG>\n               <VALUE>human</VALUE>\n
+        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>organism
+        part</TAG>\n               <VALUE>brain</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
+        \         <SAMPLE_ATTRIBUTE>\n               <TAG>cell line</TAG>\n               <VALUE>G144</VALUE>\n
+        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>genotype</TAG>\n
+        \              <VALUE>CRISPR/Cas9 mediated knockout of CIC</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
         \         <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-FIRST-PUBLIC</TAG>\n
         \              <VALUE>2018-05-30</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
         \         <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-LAST-UPDATE</TAG>\n
@@ -755,7 +667,7 @@ interactions:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:41:04 GMT
+      - Wed, 17 May 2023 18:35:40 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -773,7 +685,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/ERP108370
   response:
@@ -833,7 +745,7 @@ interactions:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:41:05 GMT
+      - Wed, 17 May 2023 18:35:41 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -851,7 +763,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/ERA1350207
   response:
@@ -887,7 +799,7 @@ interactions:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:41:05 GMT
+      - Wed, 17 May 2023 18:35:41 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -896,68 +808,6 @@ interactions:
       code: 200
       message: ''
 - request:
-    body: acc=ERR2534073&accept-proto=fasp&version=2.0
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '44'
-      User-Agent:
-      - python-requests/2.25.1
-    method: POST
-    uri: https://www.ncbi.nlm.nih.gov/Traces/names/names.cgi
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAAwzIuwrCMBQA0L1fEXDoVLl5p92dheLkdtOkVAkmJBER7sfrGc9JnGFoFcvb02Vd
-        hZYKrCRrwTlpjCQB3E1gJ5hvnC9aLlzdacao0ShUXntQlnMEMLg744N36AIRKQC6vtKXjUfvpY2s
-        1NzzlhN7NIYp5U8MbM+V9eMf2T/j1ocfAAAA//8DAIRWqlaOAAAA
-    headers:
-      Cache-Control:
-      - private
-      Connection:
-      - Keep-Alive
-      Content-Encoding:
-      - gzip
-      Content-Security-Policy:
-      - upgrade-insecure-requests
-      Content-Type:
-      - text/plain
-      Date:
-      - Wed, 28 Jul 2021 19:41:06 GMT
-      Keep-Alive:
-      - timeout=1, max=10
-      NCBI-PHID:
-      - CC95EE67101B2D210000000000000001.m_1
-      NCBI-SID:
-      - CC95EE67101B2D21_0000SID
-      Referrer-Policy:
-      - origin-when-cross-origin
-      Server:
-      - Apache
-      Set-Cookie:
-      - ncbi_sid=CC95EE67101B2D21_0000SID; domain=.nih.gov; path=/; expires=Thu, 28
-        Jul 2022 19:41:06 GMT
-      SraNameServerOutputVersion:
-      - '2.0'
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains; preload
-      Transfer-Encoding:
-      - chunked
-      Vary:
-      - Accept-Encoding
-      X-UA-Compatible:
-      - IE=Edge
-      X-XSS-Protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
-- request:
     body: null
     headers:
       Accept:
@@ -967,29 +817,27 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/portal/api/filereport?accession=ERR2534073&result=read_run
   response:
     body:
-      string: "run_accession\tfastq_ftp\tfastq_bytes\tfastq_md5\tsubmitted_ftp\tsubmitted_bytes\tsubmitted_md5\tsra_ftp\tsra_bytes\tsra_md5\nERR2534073\tftp.sra.ebi.ac.uk/vol1/fastq/ERR253/003/ERR2534073/ERR2534073.fastq.gz\t1156190981\td46334eb88f03b4c0713c7ed8abc231c\tftp.sra.ebi.ac.uk/vol1/run/ERR253/ERR2534073/G144_KO8_RNAseq_DMSO2.fastq.gz\t1203618482\td2b9ae59efaa7491eac26723ce6022e7\t\t\t\n"
+      string: "run_accession\tfastq_ftp\tfastq_bytes\tfastq_md5\tbam_ftp\tbam_bytes\tbam_md5\tsubmitted_ftp\tsubmitted_bytes\tsubmitted_md5\tsra_ftp\tsra_bytes\tsra_md5\nERR2534073\tftp.sra.ebi.ac.uk/vol1/fastq/ERR253/003/ERR2534073/ERR2534073.fastq.gz\t1156190981\td46334eb88f03b4c0713c7ed8abc231c\t\t\t\tftp.sra.ebi.ac.uk/vol1/run/ERR253/ERR2534073/G144_KO8_RNAseq_DMSO2.fastq.gz\t1203618482\td2b9ae59efaa7491eac26723ce6022e7\tftp.sra.ebi.ac.uk/vol1/err/ERR253/003/ERR2534073\t770883643\t616f7e4782c7ce9187068202610c359b\n"
     headers:
       Cache-Control:
       - no-cache, no-store, max-age=0, must-revalidate
+      Content-Length:
+      - '483'
       Content-Type:
       - text/plain
       Date:
-      - Wed, 28 Jul 2021 19:41:06 GMT
+      - Wed, 17 May 2023 18:35:42 GMT
       Expires:
       - '0'
       Pragma:
       - no-cache
-      Server:
-      - Apache-Coyote/1.1
       Strict-Transport-Security:
       - max-age=0
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Frame-Options:
@@ -998,7 +846,7 @@ interactions:
       - 1; mode=block
     status:
       code: 200
-      message: OK
+      message: ''
 - request:
     body: null
     headers:
@@ -1009,7 +857,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/ERR2534074
   response:
@@ -1050,7 +898,7 @@ interactions:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:41:07 GMT
+      - Wed, 17 May 2023 18:35:42 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -1068,7 +916,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/ERX2552495
   response:
@@ -1132,7 +980,7 @@ interactions:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:41:07 GMT
+      - Wed, 17 May 2023 18:35:43 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -1150,63 +998,51 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/ERS2428789
   response:
     body:
       string: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<SAMPLE_SET>\n<SAMPLE accession=\"ERS2428789\"
-        alias=\"E-MTAB-6681:G144_KO9_RNAseq_DMSO1\" broker_name=\"ArrayExpress\" center_name=\"BRIC
-        - Biotech Research and Innovation Centre\">\n     <IDENTIFIERS>\n          <PRIMARY_ID>ERS2428789</PRIMARY_ID>\n
-        \         <EXTERNAL_ID namespace=\"BioSample\">SAMEA4608093</EXTERNAL_ID>\n
+        alias=\"E-MTAB-6681:G144_KO9_RNAseq_DMSO1\" center_name=\"BRIC - Biotech Research
+        and Innovation Centre\" broker_name=\"ArrayExpress\">\n     <IDENTIFIERS>\n
+        \         <PRIMARY_ID>ERS2428789</PRIMARY_ID>\n          <EXTERNAL_ID namespace=\"BioSample\">SAMEA4608093</EXTERNAL_ID>\n
         \         <SUBMITTER_ID namespace=\"BRIC - Biotech Research and Innovation
         Centre\">E-MTAB-6681:G144_KO9_RNAseq_DMSO1</SUBMITTER_ID>\n     </IDENTIFIERS>\n
         \    <TITLE>G144_KO9_RNAseq_DMSO1</TITLE>\n     <SAMPLE_NAME>\n          <TAXON_ID>9606</TAXON_ID>\n
         \         <SCIENTIFIC_NAME>Homo sapiens</SCIENTIFIC_NAME>\n          <COMMON_NAME>human</COMMON_NAME>\n
         \    </SAMPLE_NAME>\n     <DESCRIPTION>Protocols: CRISPR mediated KO of CIC:
         sgRNAs (Target sequence: mESCs: GCCTTCATGATCTTCAGCAAG; G144: GGGCGAGTGGTGGTATGCCC)
-        \ were cloned into pSpCas9(BB)-2A-GFP (Addgene 48138) and transfected into
-        mESCs (Lipofectamine 2000) or G144 cells (Amaxa Nucleofector II, Program A033).
+        were cloned into pSpCas9(BB)-2A-GFP (Addgene 48138) and transfected into mESCs
+        (Lipofectamine 2000) or G144 cells (Amaxa Nucleofector II, Program A033).
         GFP-positive cells were single cell sorted 48h post-transfection, expanded
         and screened by immunoblotting for CIC deletion. Inhibitor treatment with
         1 \u03BCM MEK inhibitor (PD0325901) was performed in 80% confluent cultures
         for 4 and 24 h respectively. DMSO was used as mock control. Cells were washed
-        once with PBS, lysed directly in RLT buffer (Qiagen).  Total RNA was extracted
-        using the RNAeasy kit (Qiagen).  500 ng of total RNA was used for library
-        preparation using TruSeq RNA Library Prep Kit v2 (Illumina) according to manufacturer
-        recommendations.</DESCRIPTION>\n     <SAMPLE_LINKS>\n          <SAMPLE_LINK>\n
-        \              <XREF_LINK>\n                    <DB>ENA-STUDY</DB>\n                    <ID>ERP108370</ID>\n
-        \              </XREF_LINK>\n          </SAMPLE_LINK>\n          <SAMPLE_LINK>\n
-        \              <XREF_LINK>\n                    <DB>ENA-EXPERIMENT</DB>\n
-        \                   <ID>ERX2552495</ID>\n               </XREF_LINK>\n          </SAMPLE_LINK>\n
-        \         <SAMPLE_LINK>\n               <XREF_LINK>\n                    <DB>ENA-RUN</DB>\n
-        \                   <ID>ERR2534074</ID>\n               </XREF_LINK>\n          </SAMPLE_LINK>\n
-        \         <SAMPLE_LINK>\n               <XREF_LINK>\n                    <DB>ENA-SUBMISSION</DB>\n
-        \                   <ID>ERA1350207</ID>\n               </XREF_LINK>\n          </SAMPLE_LINK>\n
-        \         <SAMPLE_LINK>\n               <XREF_LINK>\n                    <DB>ENA-FASTQ-FILES</DB>\n
-        \                   <ID><![CDATA[https://www.ebi.ac.uk/ena/portal/api/filereport?accession=ERS2428789&result=read_run&fields=run_accession,fastq_ftp,fastq_md5,fastq_bytes]]></ID>\n
-        \              </XREF_LINK>\n          </SAMPLE_LINK>\n          <SAMPLE_LINK>\n
-        \              <XREF_LINK>\n                    <DB>ENA-SUBMITTED-FILES</DB>\n
-        \                   <ID><![CDATA[https://www.ebi.ac.uk/ena/portal/api/filereport?accession=ERS2428789&result=read_run&fields=run_accession,submitted_ftp,submitted_md5,submitted_bytes,submitted_format]]></ID>\n
-        \              </XREF_LINK>\n          </SAMPLE_LINK>\n     </SAMPLE_LINKS>\n
-        \    <SAMPLE_ATTRIBUTES>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>isolate</TAG>\n
-        \              <VALUE>not applicable</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
-        \         <SAMPLE_ATTRIBUTE>\n               <TAG>organism</TAG>\n               <VALUE>Homo
-        sapiens</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
-        \              <TAG>organism part</TAG>\n               <VALUE>brain</VALUE>\n
-        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>cell_type</TAG>\n
-        \              <VALUE>glial cell</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
-        \         <SAMPLE_ATTRIBUTE>\n               <TAG>cell_line</TAG>\n               <VALUE>G144</VALUE>\n
+        once with PBS, lysed directly in RLT buffer (Qiagen). Total RNA was extracted
+        using the RNAeasy kit (Qiagen). 500 ng of total RNA was used for library preparation
+        using TruSeq RNA Library Prep Kit v2 (Illumina) according to manufacturer
+        recommendations.</DESCRIPTION>\n     <SAMPLE_LINKS>\n    <SAMPLE_LINK>\n        <XREF_LINK>\n
+        \           <DB>ENA-FASTQ-FILES</DB>\n            <ID><![CDATA[https://www.ebi.ac.uk/ena/portal/api/filereport?accession=ERS2428789&result=read_run&fields=run_accession,fastq_ftp,fastq_md5,fastq_bytes]]></ID>\n
+        \       </XREF_LINK>\n    </SAMPLE_LINK>\n    <SAMPLE_LINK>\n        <XREF_LINK>\n
+        \           <DB>ENA-SUBMITTED-FILES</DB>\n            <ID><![CDATA[https://www.ebi.ac.uk/ena/portal/api/filereport?accession=ERS2428789&result=read_run&fields=run_accession,submitted_ftp,submitted_md5,submitted_bytes,submitted_format]]></ID>\n
+        \       </XREF_LINK>\n    </SAMPLE_LINK>\n</SAMPLE_LINKS>\n<SAMPLE_ATTRIBUTES>\n
+        \         <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-CHECKLIST</TAG>\n               <VALUE>ERC000011</VALUE>\n
         \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>disease</TAG>\n
         \              <VALUE>glioblastoma multiforme</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
-        \         <SAMPLE_ATTRIBUTE>\n               <TAG>genotype</TAG>\n               <VALUE>CRISPR/Cas9
-        mediated knockout of CIC</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
-        \              <TAG>individual</TAG>\n               <VALUE>clonal line #9</VALUE>\n
-        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-CHECKLIST</TAG>\n
-        \              <VALUE>ERC000011</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
-        \              <TAG>ENA-SPOT-COUNT</TAG>\n               <VALUE>22035122</VALUE>\n
-        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-BASE-COUNT</TAG>\n
-        \              <VALUE>1663855259</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
+        \         <SAMPLE_ATTRIBUTE>\n               <TAG>individual</TAG>\n               <VALUE>clonal
+        line #9</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
+        \              <TAG>organism</TAG>\n               <VALUE>Homo sapiens</VALUE>\n
+        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>organism</TAG>\n
+        \              <VALUE>Homo sapiens</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
+        \         <SAMPLE_ATTRIBUTE>\n               <TAG>cell type</TAG>\n               <VALUE>glial
+        cell</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
+        \              <TAG>common name</TAG>\n               <VALUE>human</VALUE>\n
+        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>organism
+        part</TAG>\n               <VALUE>brain</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
+        \         <SAMPLE_ATTRIBUTE>\n               <TAG>cell line</TAG>\n               <VALUE>G144</VALUE>\n
+        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>genotype</TAG>\n
+        \              <VALUE>CRISPR/Cas9 mediated knockout of CIC</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
         \         <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-FIRST-PUBLIC</TAG>\n
         \              <VALUE>2018-05-30</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
         \         <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-LAST-UPDATE</TAG>\n
@@ -1216,7 +1052,7 @@ interactions:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:41:08 GMT
+      - Wed, 17 May 2023 18:35:43 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -1234,7 +1070,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/ERP108370
   response:
@@ -1294,7 +1130,7 @@ interactions:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:41:09 GMT
+      - Wed, 17 May 2023 18:35:43 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -1312,7 +1148,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/ERA1350207
   response:
@@ -1348,7 +1184,7 @@ interactions:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:41:10 GMT
+      - Wed, 17 May 2023 18:35:44 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -1357,68 +1193,6 @@ interactions:
       code: 200
       message: ''
 - request:
-    body: acc=ERR2534074&accept-proto=fasp&version=2.0
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '44'
-      User-Agent:
-      - python-requests/2.25.1
-    method: POST
-    uri: https://www.ncbi.nlm.nih.gov/Traces/names/names.cgi
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAAwzIsQrDIBAA0D1fIXTIlHJ6Gmv2zoXQqdtFDWmRGNRSCvfx7RvfSZ2hq4WO98LX
-        eVYGNVjNFtE6NBpYgbwMYAdwdyknoyd0Dx6DBIdKKiITCONiR3LaO4XkZbQrM2sAvu3pK/qttaP2
-        4ii5ZZ+TeFZBKeVPDGLNRbTtH3l5Rd+6HwAAAP//AwC73zj3jgAAAA==
-    headers:
-      Cache-Control:
-      - private
-      Connection:
-      - Keep-Alive
-      Content-Encoding:
-      - gzip
-      Content-Security-Policy:
-      - upgrade-insecure-requests
-      Content-Type:
-      - text/plain
-      Date:
-      - Wed, 28 Jul 2021 19:41:10 GMT
-      Keep-Alive:
-      - timeout=1, max=10
-      NCBI-PHID:
-      - C7A41D9A101B2D610000000000000001.m_1
-      NCBI-SID:
-      - C7A41D9A101B2D61_0000SID
-      Referrer-Policy:
-      - origin-when-cross-origin
-      Server:
-      - Apache
-      Set-Cookie:
-      - ncbi_sid=C7A41D9A101B2D61_0000SID; domain=.nih.gov; path=/; expires=Thu, 28
-        Jul 2022 19:41:10 GMT
-      SraNameServerOutputVersion:
-      - '2.0'
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains; preload
-      Transfer-Encoding:
-      - chunked
-      Vary:
-      - Accept-Encoding
-      X-UA-Compatible:
-      - IE=Edge
-      X-XSS-Protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
-- request:
     body: null
     headers:
       Accept:
@@ -1428,29 +1202,27 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/portal/api/filereport?accession=ERR2534074&result=read_run
   response:
     body:
-      string: "run_accession\tfastq_ftp\tfastq_bytes\tfastq_md5\tsubmitted_ftp\tsubmitted_bytes\tsubmitted_md5\tsra_ftp\tsra_bytes\tsra_md5\nERR2534074\tftp.sra.ebi.ac.uk/vol1/fastq/ERR253/004/ERR2534074/ERR2534074.fastq.gz\t1100830559\t895a107af87e643e80f1aa33dda08a18\tftp.sra.ebi.ac.uk/vol1/run/ERR253/ERR2534074/G144_KO9_RNAseq_DMSO1.fastq.gz\t1145761230\ta75ea41c5c7c576caa5200cf820ee65c\t\t\t\n"
+      string: "run_accession\tfastq_ftp\tfastq_bytes\tfastq_md5\tbam_ftp\tbam_bytes\tbam_md5\tsubmitted_ftp\tsubmitted_bytes\tsubmitted_md5\tsra_ftp\tsra_bytes\tsra_md5\nERR2534074\tftp.sra.ebi.ac.uk/vol1/fastq/ERR253/004/ERR2534074/ERR2534074.fastq.gz\t1100830559\t895a107af87e643e80f1aa33dda08a18\t\t\t\tftp.sra.ebi.ac.uk/vol1/run/ERR253/ERR2534074/G144_KO9_RNAseq_DMSO1.fastq.gz\t1145761230\ta75ea41c5c7c576caa5200cf820ee65c\tftp.sra.ebi.ac.uk/vol1/err/ERR253/004/ERR2534074\t733793520\t4f79fc0ea6323a394a2adb88fbc571b4\n"
     headers:
       Cache-Control:
       - no-cache, no-store, max-age=0, must-revalidate
+      Content-Length:
+      - '483'
       Content-Type:
       - text/plain
       Date:
-      - Wed, 28 Jul 2021 19:41:10 GMT
+      - Wed, 17 May 2023 18:35:44 GMT
       Expires:
       - '0'
       Pragma:
       - no-cache
-      Server:
-      - Apache-Coyote/1.1
       Strict-Transport-Security:
       - max-age=0
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Frame-Options:
@@ -1459,7 +1231,7 @@ interactions:
       - 1; mode=block
     status:
       code: 200
-      message: OK
+      message: ''
 - request:
     body: null
     headers:
@@ -1470,7 +1242,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/ERR2534075
   response:
@@ -1511,7 +1283,7 @@ interactions:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:41:11 GMT
+      - Wed, 17 May 2023 18:35:45 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -1529,7 +1301,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/ERX2552496
   response:
@@ -1593,7 +1365,7 @@ interactions:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:41:11 GMT
+      - Wed, 17 May 2023 18:35:45 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -1611,63 +1383,51 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/ERS2428790
   response:
     body:
       string: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<SAMPLE_SET>\n<SAMPLE accession=\"ERS2428790\"
-        alias=\"E-MTAB-6681:G144_KO9_RNAseq_DMSO2\" broker_name=\"ArrayExpress\" center_name=\"BRIC
-        - Biotech Research and Innovation Centre\">\n     <IDENTIFIERS>\n          <PRIMARY_ID>ERS2428790</PRIMARY_ID>\n
-        \         <EXTERNAL_ID namespace=\"BioSample\">SAMEA4608094</EXTERNAL_ID>\n
+        alias=\"E-MTAB-6681:G144_KO9_RNAseq_DMSO2\" center_name=\"BRIC - Biotech Research
+        and Innovation Centre\" broker_name=\"ArrayExpress\">\n     <IDENTIFIERS>\n
+        \         <PRIMARY_ID>ERS2428790</PRIMARY_ID>\n          <EXTERNAL_ID namespace=\"BioSample\">SAMEA4608094</EXTERNAL_ID>\n
         \         <SUBMITTER_ID namespace=\"BRIC - Biotech Research and Innovation
         Centre\">E-MTAB-6681:G144_KO9_RNAseq_DMSO2</SUBMITTER_ID>\n     </IDENTIFIERS>\n
         \    <TITLE>G144_KO9_RNAseq_DMSO2</TITLE>\n     <SAMPLE_NAME>\n          <TAXON_ID>9606</TAXON_ID>\n
         \         <SCIENTIFIC_NAME>Homo sapiens</SCIENTIFIC_NAME>\n          <COMMON_NAME>human</COMMON_NAME>\n
         \    </SAMPLE_NAME>\n     <DESCRIPTION>Protocols: CRISPR mediated KO of CIC:
         sgRNAs (Target sequence: mESCs: GCCTTCATGATCTTCAGCAAG; G144: GGGCGAGTGGTGGTATGCCC)
-        \ were cloned into pSpCas9(BB)-2A-GFP (Addgene 48138) and transfected into
-        mESCs (Lipofectamine 2000) or G144 cells (Amaxa Nucleofector II, Program A033).
+        were cloned into pSpCas9(BB)-2A-GFP (Addgene 48138) and transfected into mESCs
+        (Lipofectamine 2000) or G144 cells (Amaxa Nucleofector II, Program A033).
         GFP-positive cells were single cell sorted 48h post-transfection, expanded
         and screened by immunoblotting for CIC deletion. Inhibitor treatment with
         1 \u03BCM MEK inhibitor (PD0325901) was performed in 80% confluent cultures
         for 4 and 24 h respectively. DMSO was used as mock control. Cells were washed
-        once with PBS, lysed directly in RLT buffer (Qiagen).  Total RNA was extracted
-        using the RNAeasy kit (Qiagen).  500 ng of total RNA was used for library
-        preparation using TruSeq RNA Library Prep Kit v2 (Illumina) according to manufacturer
-        recommendations.</DESCRIPTION>\n     <SAMPLE_LINKS>\n          <SAMPLE_LINK>\n
-        \              <XREF_LINK>\n                    <DB>ENA-STUDY</DB>\n                    <ID>ERP108370</ID>\n
-        \              </XREF_LINK>\n          </SAMPLE_LINK>\n          <SAMPLE_LINK>\n
-        \              <XREF_LINK>\n                    <DB>ENA-EXPERIMENT</DB>\n
-        \                   <ID>ERX2552496</ID>\n               </XREF_LINK>\n          </SAMPLE_LINK>\n
-        \         <SAMPLE_LINK>\n               <XREF_LINK>\n                    <DB>ENA-RUN</DB>\n
-        \                   <ID>ERR2534075</ID>\n               </XREF_LINK>\n          </SAMPLE_LINK>\n
-        \         <SAMPLE_LINK>\n               <XREF_LINK>\n                    <DB>ENA-SUBMISSION</DB>\n
-        \                   <ID>ERA1350207</ID>\n               </XREF_LINK>\n          </SAMPLE_LINK>\n
-        \         <SAMPLE_LINK>\n               <XREF_LINK>\n                    <DB>ENA-FASTQ-FILES</DB>\n
-        \                   <ID><![CDATA[https://www.ebi.ac.uk/ena/portal/api/filereport?accession=ERS2428790&result=read_run&fields=run_accession,fastq_ftp,fastq_md5,fastq_bytes]]></ID>\n
-        \              </XREF_LINK>\n          </SAMPLE_LINK>\n          <SAMPLE_LINK>\n
-        \              <XREF_LINK>\n                    <DB>ENA-SUBMITTED-FILES</DB>\n
-        \                   <ID><![CDATA[https://www.ebi.ac.uk/ena/portal/api/filereport?accession=ERS2428790&result=read_run&fields=run_accession,submitted_ftp,submitted_md5,submitted_bytes,submitted_format]]></ID>\n
-        \              </XREF_LINK>\n          </SAMPLE_LINK>\n     </SAMPLE_LINKS>\n
-        \    <SAMPLE_ATTRIBUTES>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>isolate</TAG>\n
-        \              <VALUE>not applicable</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
-        \         <SAMPLE_ATTRIBUTE>\n               <TAG>organism</TAG>\n               <VALUE>Homo
-        sapiens</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
-        \              <TAG>organism part</TAG>\n               <VALUE>brain</VALUE>\n
-        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>cell_type</TAG>\n
-        \              <VALUE>glial cell</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
-        \         <SAMPLE_ATTRIBUTE>\n               <TAG>cell_line</TAG>\n               <VALUE>G144</VALUE>\n
+        once with PBS, lysed directly in RLT buffer (Qiagen). Total RNA was extracted
+        using the RNAeasy kit (Qiagen). 500 ng of total RNA was used for library preparation
+        using TruSeq RNA Library Prep Kit v2 (Illumina) according to manufacturer
+        recommendations.</DESCRIPTION>\n     <SAMPLE_LINKS>\n    <SAMPLE_LINK>\n        <XREF_LINK>\n
+        \           <DB>ENA-FASTQ-FILES</DB>\n            <ID><![CDATA[https://www.ebi.ac.uk/ena/portal/api/filereport?accession=ERS2428790&result=read_run&fields=run_accession,fastq_ftp,fastq_md5,fastq_bytes]]></ID>\n
+        \       </XREF_LINK>\n    </SAMPLE_LINK>\n    <SAMPLE_LINK>\n        <XREF_LINK>\n
+        \           <DB>ENA-SUBMITTED-FILES</DB>\n            <ID><![CDATA[https://www.ebi.ac.uk/ena/portal/api/filereport?accession=ERS2428790&result=read_run&fields=run_accession,submitted_ftp,submitted_md5,submitted_bytes,submitted_format]]></ID>\n
+        \       </XREF_LINK>\n    </SAMPLE_LINK>\n</SAMPLE_LINKS>\n<SAMPLE_ATTRIBUTES>\n
+        \         <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-CHECKLIST</TAG>\n               <VALUE>ERC000011</VALUE>\n
         \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>disease</TAG>\n
         \              <VALUE>glioblastoma multiforme</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
-        \         <SAMPLE_ATTRIBUTE>\n               <TAG>genotype</TAG>\n               <VALUE>CRISPR/Cas9
-        mediated knockout of CIC</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
-        \              <TAG>individual</TAG>\n               <VALUE>clonal line #9</VALUE>\n
-        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-CHECKLIST</TAG>\n
-        \              <VALUE>ERC000011</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
-        \              <TAG>ENA-SPOT-COUNT</TAG>\n               <VALUE>19495488</VALUE>\n
-        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-BASE-COUNT</TAG>\n
-        \              <VALUE>1471706561</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
+        \         <SAMPLE_ATTRIBUTE>\n               <TAG>individual</TAG>\n               <VALUE>clonal
+        line #9</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
+        \              <TAG>organism</TAG>\n               <VALUE>Homo sapiens</VALUE>\n
+        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>organism</TAG>\n
+        \              <VALUE>Homo sapiens</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
+        \         <SAMPLE_ATTRIBUTE>\n               <TAG>cell type</TAG>\n               <VALUE>glial
+        cell</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
+        \              <TAG>common name</TAG>\n               <VALUE>human</VALUE>\n
+        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>organism
+        part</TAG>\n               <VALUE>brain</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
+        \         <SAMPLE_ATTRIBUTE>\n               <TAG>cell line</TAG>\n               <VALUE>G144</VALUE>\n
+        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>genotype</TAG>\n
+        \              <VALUE>CRISPR/Cas9 mediated knockout of CIC</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
         \         <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-FIRST-PUBLIC</TAG>\n
         \              <VALUE>2018-05-30</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
         \         <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-LAST-UPDATE</TAG>\n
@@ -1677,7 +1437,7 @@ interactions:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:41:13 GMT
+      - Wed, 17 May 2023 18:35:45 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -1695,7 +1455,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/ERP108370
   response:
@@ -1755,7 +1515,7 @@ interactions:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:41:14 GMT
+      - Wed, 17 May 2023 18:35:46 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -1773,7 +1533,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/ERA1350207
   response:
@@ -1809,7 +1569,7 @@ interactions:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:41:14 GMT
+      - Wed, 17 May 2023 18:35:46 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -1818,68 +1578,6 @@ interactions:
       code: 200
       message: ''
 - request:
-    body: acc=ERR2534075&accept-proto=fasp&version=2.0
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '44'
-      User-Agent:
-      - python-requests/2.25.1
-    method: POST
-    uri: https://www.ncbi.nlm.nih.gov/Traces/names/names.cgi
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAAwzIsQrDIBAA0D1fIXTIlHKeGk32zoXQqZsaJS1SRS2lcB/fvvGd8AxDq7a8HV22
-        DZWQoBXNMwgtOUdC4GYCPcFy43xVahV4p9ma6DAGuWgTHDpvFWi9o1EOoghIRBKArq/0ZePRe2kj
-        KzX37HNij8ZsSvkTdhZzZf34R3bP4PvwAwAA//8DAOJq3zaOAAAA
-    headers:
-      Cache-Control:
-      - private
-      Connection:
-      - Keep-Alive
-      Content-Encoding:
-      - gzip
-      Content-Security-Policy:
-      - upgrade-insecure-requests
-      Content-Type:
-      - text/plain
-      Date:
-      - Wed, 28 Jul 2021 19:41:14 GMT
-      Keep-Alive:
-      - timeout=1, max=10
-      NCBI-PHID:
-      - C7A41DAB101B2DA10000000000000001.m_1
-      NCBI-SID:
-      - C7A41DAB101B2DA1_0000SID
-      Referrer-Policy:
-      - origin-when-cross-origin
-      Server:
-      - Apache
-      Set-Cookie:
-      - ncbi_sid=C7A41DAB101B2DA1_0000SID; domain=.nih.gov; path=/; expires=Thu, 28
-        Jul 2022 19:41:14 GMT
-      SraNameServerOutputVersion:
-      - '2.0'
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains; preload
-      Transfer-Encoding:
-      - chunked
-      Vary:
-      - Accept-Encoding
-      X-UA-Compatible:
-      - IE=Edge
-      X-XSS-Protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
-- request:
     body: null
     headers:
       Accept:
@@ -1889,29 +1587,27 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/portal/api/filereport?accession=ERR2534075&result=read_run
   response:
     body:
-      string: "run_accession\tfastq_ftp\tfastq_bytes\tfastq_md5\tsubmitted_ftp\tsubmitted_bytes\tsubmitted_md5\tsra_ftp\tsra_bytes\tsra_md5\nERR2534075\tftp.sra.ebi.ac.uk/vol1/fastq/ERR253/005/ERR2534075/ERR2534075.fastq.gz\t988527951\td8909dd7d2ebe993b6a0136f1fdbbbdf\tftp.sra.ebi.ac.uk/vol1/run/ERR253/ERR2534075/G144_KO9_RNAseq_DMSO2.fastq.gz\t1028859346\tac67f56d04d171f4848bd680f7bc0948\t\t\t\n"
+      string: "run_accession\tfastq_ftp\tfastq_bytes\tfastq_md5\tbam_ftp\tbam_bytes\tbam_md5\tsubmitted_ftp\tsubmitted_bytes\tsubmitted_md5\tsra_ftp\tsra_bytes\tsra_md5\nERR2534075\tftp.sra.ebi.ac.uk/vol1/fastq/ERR253/005/ERR2534075/ERR2534075.fastq.gz\t988527951\td8909dd7d2ebe993b6a0136f1fdbbbdf\t\t\t\tftp.sra.ebi.ac.uk/vol1/run/ERR253/ERR2534075/G144_KO9_RNAseq_DMSO2.fastq.gz\t1028859346\tac67f56d04d171f4848bd680f7bc0948\tftp.sra.ebi.ac.uk/vol1/err/ERR253/005/ERR2534075\t660374092\t7a68cba094baf28e6b39d06d23e231e6\n"
     headers:
       Cache-Control:
       - no-cache, no-store, max-age=0, must-revalidate
+      Content-Length:
+      - '482'
       Content-Type:
       - text/plain
       Date:
-      - Wed, 28 Jul 2021 19:41:15 GMT
+      - Wed, 17 May 2023 18:35:47 GMT
       Expires:
       - '0'
       Pragma:
       - no-cache
-      Server:
-      - Apache-Coyote/1.1
       Strict-Transport-Security:
       - max-age=0
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Frame-Options:
@@ -1920,7 +1616,7 @@ interactions:
       - 1; mode=block
     status:
       code: 200
-      message: OK
+      message: ''
 - request:
     body: null
     headers:
@@ -1931,7 +1627,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/ERR2534076
   response:
@@ -1972,7 +1668,7 @@ interactions:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:41:15 GMT
+      - Wed, 17 May 2023 18:35:47 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -1990,7 +1686,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/ERX2552497
   response:
@@ -2058,7 +1754,7 @@ interactions:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:41:16 GMT
+      - Wed, 17 May 2023 18:35:48 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -2076,63 +1772,51 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/ERS2428791
   response:
     body:
       string: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<SAMPLE_SET>\n<SAMPLE accession=\"ERS2428791\"
-        alias=\"E-MTAB-6681:G144_KO8_RNAseq_24h_1\" broker_name=\"ArrayExpress\" center_name=\"BRIC
-        - Biotech Research and Innovation Centre\">\n     <IDENTIFIERS>\n          <PRIMARY_ID>ERS2428791</PRIMARY_ID>\n
-        \         <EXTERNAL_ID namespace=\"BioSample\">SAMEA4608095</EXTERNAL_ID>\n
+        alias=\"E-MTAB-6681:G144_KO8_RNAseq_24h_1\" center_name=\"BRIC - Biotech Research
+        and Innovation Centre\" broker_name=\"ArrayExpress\">\n     <IDENTIFIERS>\n
+        \         <PRIMARY_ID>ERS2428791</PRIMARY_ID>\n          <EXTERNAL_ID namespace=\"BioSample\">SAMEA4608095</EXTERNAL_ID>\n
         \         <SUBMITTER_ID namespace=\"BRIC - Biotech Research and Innovation
         Centre\">E-MTAB-6681:G144_KO8_RNAseq_24h_1</SUBMITTER_ID>\n     </IDENTIFIERS>\n
         \    <TITLE>G144_KO8_RNAseq_24h_1</TITLE>\n     <SAMPLE_NAME>\n          <TAXON_ID>9606</TAXON_ID>\n
         \         <SCIENTIFIC_NAME>Homo sapiens</SCIENTIFIC_NAME>\n          <COMMON_NAME>human</COMMON_NAME>\n
         \    </SAMPLE_NAME>\n     <DESCRIPTION>Protocols: CRISPR mediated KO of CIC:
         sgRNAs (Target sequence: mESCs: GCCTTCATGATCTTCAGCAAG; G144: GGGCGAGTGGTGGTATGCCC)
-        \ were cloned into pSpCas9(BB)-2A-GFP (Addgene 48138) and transfected into
-        mESCs (Lipofectamine 2000) or G144 cells (Amaxa Nucleofector II, Program A033).
+        were cloned into pSpCas9(BB)-2A-GFP (Addgene 48138) and transfected into mESCs
+        (Lipofectamine 2000) or G144 cells (Amaxa Nucleofector II, Program A033).
         GFP-positive cells were single cell sorted 48h post-transfection, expanded
         and screened by immunoblotting for CIC deletion. Inhibitor treatment with
         1 \u03BCM MEK inhibitor (PD0325901) was performed in 80% confluent cultures
         for 4 and 24 h respectively. DMSO was used as mock control. Cells were washed
-        once with PBS, lysed directly in RLT buffer (Qiagen).  Total RNA was extracted
-        using the RNAeasy kit (Qiagen).  500 ng of total RNA was used for library
-        preparation using TruSeq RNA Library Prep Kit v2 (Illumina) according to manufacturer
-        recommendations.</DESCRIPTION>\n     <SAMPLE_LINKS>\n          <SAMPLE_LINK>\n
-        \              <XREF_LINK>\n                    <DB>ENA-STUDY</DB>\n                    <ID>ERP108370</ID>\n
-        \              </XREF_LINK>\n          </SAMPLE_LINK>\n          <SAMPLE_LINK>\n
-        \              <XREF_LINK>\n                    <DB>ENA-EXPERIMENT</DB>\n
-        \                   <ID>ERX2552497</ID>\n               </XREF_LINK>\n          </SAMPLE_LINK>\n
-        \         <SAMPLE_LINK>\n               <XREF_LINK>\n                    <DB>ENA-RUN</DB>\n
-        \                   <ID>ERR2534076</ID>\n               </XREF_LINK>\n          </SAMPLE_LINK>\n
-        \         <SAMPLE_LINK>\n               <XREF_LINK>\n                    <DB>ENA-SUBMISSION</DB>\n
-        \                   <ID>ERA1350207</ID>\n               </XREF_LINK>\n          </SAMPLE_LINK>\n
-        \         <SAMPLE_LINK>\n               <XREF_LINK>\n                    <DB>ENA-FASTQ-FILES</DB>\n
-        \                   <ID><![CDATA[https://www.ebi.ac.uk/ena/portal/api/filereport?accession=ERS2428791&result=read_run&fields=run_accession,fastq_ftp,fastq_md5,fastq_bytes]]></ID>\n
-        \              </XREF_LINK>\n          </SAMPLE_LINK>\n          <SAMPLE_LINK>\n
-        \              <XREF_LINK>\n                    <DB>ENA-SUBMITTED-FILES</DB>\n
-        \                   <ID><![CDATA[https://www.ebi.ac.uk/ena/portal/api/filereport?accession=ERS2428791&result=read_run&fields=run_accession,submitted_ftp,submitted_md5,submitted_bytes,submitted_format]]></ID>\n
-        \              </XREF_LINK>\n          </SAMPLE_LINK>\n     </SAMPLE_LINKS>\n
-        \    <SAMPLE_ATTRIBUTES>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>isolate</TAG>\n
-        \              <VALUE>not applicable</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
-        \         <SAMPLE_ATTRIBUTE>\n               <TAG>organism</TAG>\n               <VALUE>Homo
-        sapiens</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
-        \              <TAG>organism part</TAG>\n               <VALUE>brain</VALUE>\n
-        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>cell_type</TAG>\n
-        \              <VALUE>glial cell</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
-        \         <SAMPLE_ATTRIBUTE>\n               <TAG>cell_line</TAG>\n               <VALUE>G144</VALUE>\n
+        once with PBS, lysed directly in RLT buffer (Qiagen). Total RNA was extracted
+        using the RNAeasy kit (Qiagen). 500 ng of total RNA was used for library preparation
+        using TruSeq RNA Library Prep Kit v2 (Illumina) according to manufacturer
+        recommendations.</DESCRIPTION>\n     <SAMPLE_LINKS>\n    <SAMPLE_LINK>\n        <XREF_LINK>\n
+        \           <DB>ENA-FASTQ-FILES</DB>\n            <ID><![CDATA[https://www.ebi.ac.uk/ena/portal/api/filereport?accession=ERS2428791&result=read_run&fields=run_accession,fastq_ftp,fastq_md5,fastq_bytes]]></ID>\n
+        \       </XREF_LINK>\n    </SAMPLE_LINK>\n    <SAMPLE_LINK>\n        <XREF_LINK>\n
+        \           <DB>ENA-SUBMITTED-FILES</DB>\n            <ID><![CDATA[https://www.ebi.ac.uk/ena/portal/api/filereport?accession=ERS2428791&result=read_run&fields=run_accession,submitted_ftp,submitted_md5,submitted_bytes,submitted_format]]></ID>\n
+        \       </XREF_LINK>\n    </SAMPLE_LINK>\n</SAMPLE_LINKS>\n<SAMPLE_ATTRIBUTES>\n
+        \         <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-CHECKLIST</TAG>\n               <VALUE>ERC000011</VALUE>\n
         \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>disease</TAG>\n
         \              <VALUE>glioblastoma multiforme</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
-        \         <SAMPLE_ATTRIBUTE>\n               <TAG>genotype</TAG>\n               <VALUE>CRISPR/Cas9
-        mediated knockout of CIC</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
-        \              <TAG>individual</TAG>\n               <VALUE>clonal line #8</VALUE>\n
-        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-CHECKLIST</TAG>\n
-        \              <VALUE>ERC000011</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
-        \              <TAG>ENA-SPOT-COUNT</TAG>\n               <VALUE>25500197</VALUE>\n
-        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-BASE-COUNT</TAG>\n
-        \              <VALUE>1925621166</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
+        \         <SAMPLE_ATTRIBUTE>\n               <TAG>individual</TAG>\n               <VALUE>clonal
+        line #8</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
+        \              <TAG>organism</TAG>\n               <VALUE>Homo sapiens</VALUE>\n
+        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>organism</TAG>\n
+        \              <VALUE>Homo sapiens</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
+        \         <SAMPLE_ATTRIBUTE>\n               <TAG>cell type</TAG>\n               <VALUE>glial
+        cell</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
+        \              <TAG>common name</TAG>\n               <VALUE>human</VALUE>\n
+        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>organism
+        part</TAG>\n               <VALUE>brain</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
+        \         <SAMPLE_ATTRIBUTE>\n               <TAG>cell line</TAG>\n               <VALUE>G144</VALUE>\n
+        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>genotype</TAG>\n
+        \              <VALUE>CRISPR/Cas9 mediated knockout of CIC</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
         \         <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-FIRST-PUBLIC</TAG>\n
         \              <VALUE>2018-05-30</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
         \         <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-LAST-UPDATE</TAG>\n
@@ -2142,7 +1826,7 @@ interactions:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:41:16 GMT
+      - Wed, 17 May 2023 18:35:47 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -2160,7 +1844,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/ERP108370
   response:
@@ -2220,7 +1904,7 @@ interactions:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:41:17 GMT
+      - Wed, 17 May 2023 18:35:48 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -2238,7 +1922,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/ERA1350207
   response:
@@ -2274,7 +1958,7 @@ interactions:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:41:19 GMT
+      - Wed, 17 May 2023 18:35:48 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -2283,68 +1967,6 @@ interactions:
       code: 200
       message: ''
 - request:
-    body: acc=ERR2534076&accept-proto=fasp&version=2.0
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '44'
-      User-Agent:
-      - python-requests/2.25.1
-    method: POST
-    uri: https://www.ncbi.nlm.nih.gov/Traces/names/names.cgi
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAAwzIvQrCMBAA4L1PEXDoVLn8XJJ2dxaKk1uaS6gSTGkjItzD6zd+J3WG7tjD9l74
-        Ms8KtQFn2aNFVB5GViD9AG6A8SblhDgZe2cXLfkcfDBZk9PREAVIlnSmMUFGZjYAfH2Vr+jX1raj
-        F9teW421iMchQin1k0jkuou2/qMuzxRb9wMAAP//AwChs8VGjgAAAA==
-    headers:
-      Cache-Control:
-      - private
-      Connection:
-      - Keep-Alive
-      Content-Encoding:
-      - gzip
-      Content-Security-Policy:
-      - upgrade-insecure-requests
-      Content-Type:
-      - text/plain
-      Date:
-      - Wed, 28 Jul 2021 19:41:19 GMT
-      Keep-Alive:
-      - timeout=1, max=10
-      NCBI-PHID:
-      - C7A41DBE101B2DF10000000000000001.m_1
-      NCBI-SID:
-      - C7A41DBE101B2DF1_0000SID
-      Referrer-Policy:
-      - origin-when-cross-origin
-      Server:
-      - Apache
-      Set-Cookie:
-      - ncbi_sid=C7A41DBE101B2DF1_0000SID; domain=.nih.gov; path=/; expires=Thu, 28
-        Jul 2022 19:41:19 GMT
-      SraNameServerOutputVersion:
-      - '2.0'
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains; preload
-      Transfer-Encoding:
-      - chunked
-      Vary:
-      - Accept-Encoding
-      X-UA-Compatible:
-      - IE=Edge
-      X-XSS-Protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
-- request:
     body: null
     headers:
       Accept:
@@ -2354,29 +1976,27 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/portal/api/filereport?accession=ERR2534076&result=read_run
   response:
     body:
-      string: "run_accession\tfastq_ftp\tfastq_bytes\tfastq_md5\tsubmitted_ftp\tsubmitted_bytes\tsubmitted_md5\tsra_ftp\tsra_bytes\tsra_md5\nERR2534076\tftp.sra.ebi.ac.uk/vol1/fastq/ERR253/006/ERR2534076/ERR2534076.fastq.gz\t1282020356\t40598b820ef337261d26b6135301d8ad\tftp.sra.ebi.ac.uk/vol1/run/ERR253/ERR2534076/G144_KO8_RNAseq_24h_1.fastq.gz\t1336023529\t87ef33d7d33e0eb591e1d11482e7f961\t\t\t\n"
+      string: "run_accession\tfastq_ftp\tfastq_bytes\tfastq_md5\tbam_ftp\tbam_bytes\tbam_md5\tsubmitted_ftp\tsubmitted_bytes\tsubmitted_md5\tsra_ftp\tsra_bytes\tsra_md5\nERR2534076\tftp.sra.ebi.ac.uk/vol1/fastq/ERR253/006/ERR2534076/ERR2534076.fastq.gz\t1282020356\t40598b820ef337261d26b6135301d8ad\t\t\t\tftp.sra.ebi.ac.uk/vol1/run/ERR253/ERR2534076/G144_KO8_RNAseq_24h_1.fastq.gz\t1336023529\t87ef33d7d33e0eb591e1d11482e7f961\tftp.sra.ebi.ac.uk/vol1/err/ERR253/006/ERR2534076\t856552789\t3d7918ae8eda2f5fb3e47f742c3c692b\n"
     headers:
       Cache-Control:
       - no-cache, no-store, max-age=0, must-revalidate
+      Content-Length:
+      - '483'
       Content-Type:
       - text/plain
       Date:
-      - Wed, 28 Jul 2021 19:41:19 GMT
+      - Wed, 17 May 2023 18:35:49 GMT
       Expires:
       - '0'
       Pragma:
       - no-cache
-      Server:
-      - Apache-Coyote/1.1
       Strict-Transport-Security:
       - max-age=0
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Frame-Options:
@@ -2385,7 +2005,7 @@ interactions:
       - 1; mode=block
     status:
       code: 200
-      message: OK
+      message: ''
 - request:
     body: null
     headers:
@@ -2396,7 +2016,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/ERR2534077
   response:
@@ -2437,7 +2057,7 @@ interactions:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:41:20 GMT
+      - Wed, 17 May 2023 18:35:49 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -2455,7 +2075,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/ERX2552498
   response:
@@ -2523,7 +2143,7 @@ interactions:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:41:20 GMT
+      - Wed, 17 May 2023 18:35:50 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -2541,63 +2161,51 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/ERS2428792
   response:
     body:
       string: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<SAMPLE_SET>\n<SAMPLE accession=\"ERS2428792\"
-        alias=\"E-MTAB-6681:G144_KO8_RNAseq_24h_2\" broker_name=\"ArrayExpress\" center_name=\"BRIC
-        - Biotech Research and Innovation Centre\">\n     <IDENTIFIERS>\n          <PRIMARY_ID>ERS2428792</PRIMARY_ID>\n
-        \         <EXTERNAL_ID namespace=\"BioSample\">SAMEA4608096</EXTERNAL_ID>\n
+        alias=\"E-MTAB-6681:G144_KO8_RNAseq_24h_2\" center_name=\"BRIC - Biotech Research
+        and Innovation Centre\" broker_name=\"ArrayExpress\">\n     <IDENTIFIERS>\n
+        \         <PRIMARY_ID>ERS2428792</PRIMARY_ID>\n          <EXTERNAL_ID namespace=\"BioSample\">SAMEA4608096</EXTERNAL_ID>\n
         \         <SUBMITTER_ID namespace=\"BRIC - Biotech Research and Innovation
         Centre\">E-MTAB-6681:G144_KO8_RNAseq_24h_2</SUBMITTER_ID>\n     </IDENTIFIERS>\n
         \    <TITLE>G144_KO8_RNAseq_24h_2</TITLE>\n     <SAMPLE_NAME>\n          <TAXON_ID>9606</TAXON_ID>\n
         \         <SCIENTIFIC_NAME>Homo sapiens</SCIENTIFIC_NAME>\n          <COMMON_NAME>human</COMMON_NAME>\n
         \    </SAMPLE_NAME>\n     <DESCRIPTION>Protocols: CRISPR mediated KO of CIC:
         sgRNAs (Target sequence: mESCs: GCCTTCATGATCTTCAGCAAG; G144: GGGCGAGTGGTGGTATGCCC)
-        \ were cloned into pSpCas9(BB)-2A-GFP (Addgene 48138) and transfected into
-        mESCs (Lipofectamine 2000) or G144 cells (Amaxa Nucleofector II, Program A033).
+        were cloned into pSpCas9(BB)-2A-GFP (Addgene 48138) and transfected into mESCs
+        (Lipofectamine 2000) or G144 cells (Amaxa Nucleofector II, Program A033).
         GFP-positive cells were single cell sorted 48h post-transfection, expanded
         and screened by immunoblotting for CIC deletion. Inhibitor treatment with
         1 \u03BCM MEK inhibitor (PD0325901) was performed in 80% confluent cultures
         for 4 and 24 h respectively. DMSO was used as mock control. Cells were washed
-        once with PBS, lysed directly in RLT buffer (Qiagen).  Total RNA was extracted
-        using the RNAeasy kit (Qiagen).  500 ng of total RNA was used for library
-        preparation using TruSeq RNA Library Prep Kit v2 (Illumina) according to manufacturer
-        recommendations.</DESCRIPTION>\n     <SAMPLE_LINKS>\n          <SAMPLE_LINK>\n
-        \              <XREF_LINK>\n                    <DB>ENA-STUDY</DB>\n                    <ID>ERP108370</ID>\n
-        \              </XREF_LINK>\n          </SAMPLE_LINK>\n          <SAMPLE_LINK>\n
-        \              <XREF_LINK>\n                    <DB>ENA-EXPERIMENT</DB>\n
-        \                   <ID>ERX2552498</ID>\n               </XREF_LINK>\n          </SAMPLE_LINK>\n
-        \         <SAMPLE_LINK>\n               <XREF_LINK>\n                    <DB>ENA-RUN</DB>\n
-        \                   <ID>ERR2534077</ID>\n               </XREF_LINK>\n          </SAMPLE_LINK>\n
-        \         <SAMPLE_LINK>\n               <XREF_LINK>\n                    <DB>ENA-SUBMISSION</DB>\n
-        \                   <ID>ERA1350207</ID>\n               </XREF_LINK>\n          </SAMPLE_LINK>\n
-        \         <SAMPLE_LINK>\n               <XREF_LINK>\n                    <DB>ENA-FASTQ-FILES</DB>\n
-        \                   <ID><![CDATA[https://www.ebi.ac.uk/ena/portal/api/filereport?accession=ERS2428792&result=read_run&fields=run_accession,fastq_ftp,fastq_md5,fastq_bytes]]></ID>\n
-        \              </XREF_LINK>\n          </SAMPLE_LINK>\n          <SAMPLE_LINK>\n
-        \              <XREF_LINK>\n                    <DB>ENA-SUBMITTED-FILES</DB>\n
-        \                   <ID><![CDATA[https://www.ebi.ac.uk/ena/portal/api/filereport?accession=ERS2428792&result=read_run&fields=run_accession,submitted_ftp,submitted_md5,submitted_bytes,submitted_format]]></ID>\n
-        \              </XREF_LINK>\n          </SAMPLE_LINK>\n     </SAMPLE_LINKS>\n
-        \    <SAMPLE_ATTRIBUTES>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>isolate</TAG>\n
-        \              <VALUE>not applicable</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
-        \         <SAMPLE_ATTRIBUTE>\n               <TAG>organism</TAG>\n               <VALUE>Homo
-        sapiens</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
-        \              <TAG>organism part</TAG>\n               <VALUE>brain</VALUE>\n
-        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>cell_type</TAG>\n
-        \              <VALUE>glial cell</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
-        \         <SAMPLE_ATTRIBUTE>\n               <TAG>cell_line</TAG>\n               <VALUE>G144</VALUE>\n
+        once with PBS, lysed directly in RLT buffer (Qiagen). Total RNA was extracted
+        using the RNAeasy kit (Qiagen). 500 ng of total RNA was used for library preparation
+        using TruSeq RNA Library Prep Kit v2 (Illumina) according to manufacturer
+        recommendations.</DESCRIPTION>\n     <SAMPLE_LINKS>\n    <SAMPLE_LINK>\n        <XREF_LINK>\n
+        \           <DB>ENA-FASTQ-FILES</DB>\n            <ID><![CDATA[https://www.ebi.ac.uk/ena/portal/api/filereport?accession=ERS2428792&result=read_run&fields=run_accession,fastq_ftp,fastq_md5,fastq_bytes]]></ID>\n
+        \       </XREF_LINK>\n    </SAMPLE_LINK>\n    <SAMPLE_LINK>\n        <XREF_LINK>\n
+        \           <DB>ENA-SUBMITTED-FILES</DB>\n            <ID><![CDATA[https://www.ebi.ac.uk/ena/portal/api/filereport?accession=ERS2428792&result=read_run&fields=run_accession,submitted_ftp,submitted_md5,submitted_bytes,submitted_format]]></ID>\n
+        \       </XREF_LINK>\n    </SAMPLE_LINK>\n</SAMPLE_LINKS>\n<SAMPLE_ATTRIBUTES>\n
+        \         <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-CHECKLIST</TAG>\n               <VALUE>ERC000011</VALUE>\n
         \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>disease</TAG>\n
         \              <VALUE>glioblastoma multiforme</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
-        \         <SAMPLE_ATTRIBUTE>\n               <TAG>genotype</TAG>\n               <VALUE>CRISPR/Cas9
-        mediated knockout of CIC</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
-        \              <TAG>individual</TAG>\n               <VALUE>clonal line #8</VALUE>\n
-        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-CHECKLIST</TAG>\n
-        \              <VALUE>ERC000011</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
-        \              <TAG>ENA-SPOT-COUNT</TAG>\n               <VALUE>22960406</VALUE>\n
-        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-BASE-COUNT</TAG>\n
-        \              <VALUE>1733737669</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
+        \         <SAMPLE_ATTRIBUTE>\n               <TAG>individual</TAG>\n               <VALUE>clonal
+        line #8</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
+        \              <TAG>organism</TAG>\n               <VALUE>Homo sapiens</VALUE>\n
+        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>organism</TAG>\n
+        \              <VALUE>Homo sapiens</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
+        \         <SAMPLE_ATTRIBUTE>\n               <TAG>cell type</TAG>\n               <VALUE>glial
+        cell</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
+        \              <TAG>common name</TAG>\n               <VALUE>human</VALUE>\n
+        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>organism
+        part</TAG>\n               <VALUE>brain</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
+        \         <SAMPLE_ATTRIBUTE>\n               <TAG>cell line</TAG>\n               <VALUE>G144</VALUE>\n
+        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>genotype</TAG>\n
+        \              <VALUE>CRISPR/Cas9 mediated knockout of CIC</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
         \         <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-FIRST-PUBLIC</TAG>\n
         \              <VALUE>2018-05-30</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
         \         <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-LAST-UPDATE</TAG>\n
@@ -2607,7 +2215,7 @@ interactions:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:41:21 GMT
+      - Wed, 17 May 2023 18:35:50 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -2625,7 +2233,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/ERP108370
   response:
@@ -2685,7 +2293,7 @@ interactions:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:41:25 GMT
+      - Wed, 17 May 2023 18:35:50 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -2703,7 +2311,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/ERA1350207
   response:
@@ -2739,7 +2347,7 @@ interactions:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:41:26 GMT
+      - Wed, 17 May 2023 18:35:51 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -2748,68 +2356,6 @@ interactions:
       code: 200
       message: ''
 - request:
-    body: acc=ERR2534077&accept-proto=fasp&version=2.0
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '44'
-      User-Agent:
-      - python-requests/2.25.1
-    method: POST
-    uri: https://www.ncbi.nlm.nih.gov/Traces/names/names.cgi
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAAwzIvQrCMBAA4L1PEXDoVLmkl1za3VkoTm7Nj1QJTUgjItzD6zd+J3WG7qhreTu+
-        LIvSIwIRkyFtEcmwAmkHoAGmm5Sz1rPSd0YTRgOe0EYNYEkFOYWAiN5ImJxnZgTg656+ot9aK0cv
-        Ss0t+5zE8xBrSvkTg3jkKtr2j+xe0bfuBwAA//8DAHqUUgGOAAAA
-    headers:
-      Cache-Control:
-      - private
-      Connection:
-      - Keep-Alive
-      Content-Encoding:
-      - gzip
-      Content-Security-Policy:
-      - upgrade-insecure-requests
-      Content-Type:
-      - text/plain
-      Date:
-      - Wed, 28 Jul 2021 19:41:26 GMT
-      Keep-Alive:
-      - timeout=1, max=10
-      NCBI-PHID:
-      - C7A41DDD101B2E610000000000000001.m_1
-      NCBI-SID:
-      - C7A41DDD101B2E61_0000SID
-      Referrer-Policy:
-      - origin-when-cross-origin
-      Server:
-      - Apache
-      Set-Cookie:
-      - ncbi_sid=C7A41DDD101B2E61_0000SID; domain=.nih.gov; path=/; expires=Thu, 28
-        Jul 2022 19:41:26 GMT
-      SraNameServerOutputVersion:
-      - '2.0'
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains; preload
-      Transfer-Encoding:
-      - chunked
-      Vary:
-      - Accept-Encoding
-      X-UA-Compatible:
-      - IE=Edge
-      X-XSS-Protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
-- request:
     body: null
     headers:
       Accept:
@@ -2819,29 +2365,27 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/portal/api/filereport?accession=ERR2534077&result=read_run
   response:
     body:
-      string: "run_accession\tfastq_ftp\tfastq_bytes\tfastq_md5\tsubmitted_ftp\tsubmitted_bytes\tsubmitted_md5\tsra_ftp\tsra_bytes\tsra_md5\nERR2534077\tftp.sra.ebi.ac.uk/vol1/fastq/ERR253/007/ERR2534077/ERR2534077.fastq.gz\t1150096005\t5a6030091948ae27ec5bc5a1ccb14001\tftp.sra.ebi.ac.uk/vol1/run/ERR253/ERR2534077/G144_KO8_RNAseq_24h_2.fastq.gz\t1197876304\t4890986fa779d752b6c3fd4f08c6104f\t\t\t\n"
+      string: "run_accession\tfastq_ftp\tfastq_bytes\tfastq_md5\tbam_ftp\tbam_bytes\tbam_md5\tsubmitted_ftp\tsubmitted_bytes\tsubmitted_md5\tsra_ftp\tsra_bytes\tsra_md5\nERR2534077\tftp.sra.ebi.ac.uk/vol1/fastq/ERR253/007/ERR2534077/ERR2534077.fastq.gz\t1150096005\t5a6030091948ae27ec5bc5a1ccb14001\t\t\t\tftp.sra.ebi.ac.uk/vol1/run/ERR253/ERR2534077/G144_KO8_RNAseq_24h_2.fastq.gz\t1197876304\t4890986fa779d752b6c3fd4f08c6104f\tftp.sra.ebi.ac.uk/vol1/err/ERR253/007/ERR2534077\t767584456\tdbccf1889a4cc651a06959ae3478d038\n"
     headers:
       Cache-Control:
       - no-cache, no-store, max-age=0, must-revalidate
+      Content-Length:
+      - '483'
       Content-Type:
       - text/plain
       Date:
-      - Wed, 28 Jul 2021 19:41:26 GMT
+      - Wed, 17 May 2023 18:35:52 GMT
       Expires:
       - '0'
       Pragma:
       - no-cache
-      Server:
-      - Apache-Coyote/1.1
       Strict-Transport-Security:
       - max-age=0
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Frame-Options:
@@ -2850,7 +2394,7 @@ interactions:
       - 1; mode=block
     status:
       code: 200
-      message: OK
+      message: ''
 - request:
     body: null
     headers:
@@ -2861,7 +2405,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/ERR2534078
   response:
@@ -2902,7 +2446,7 @@ interactions:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:41:27 GMT
+      - Wed, 17 May 2023 18:35:52 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -2920,7 +2464,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/ERX2552499
   response:
@@ -2988,7 +2532,7 @@ interactions:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:41:29 GMT
+      - Wed, 17 May 2023 18:35:52 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -3006,63 +2550,51 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/ERS2428793
   response:
     body:
       string: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<SAMPLE_SET>\n<SAMPLE accession=\"ERS2428793\"
-        alias=\"E-MTAB-6681:G144_KO8_RNAseq_4h_1\" broker_name=\"ArrayExpress\" center_name=\"BRIC
-        - Biotech Research and Innovation Centre\">\n     <IDENTIFIERS>\n          <PRIMARY_ID>ERS2428793</PRIMARY_ID>\n
-        \         <EXTERNAL_ID namespace=\"BioSample\">SAMEA4608097</EXTERNAL_ID>\n
+        alias=\"E-MTAB-6681:G144_KO8_RNAseq_4h_1\" center_name=\"BRIC - Biotech Research
+        and Innovation Centre\" broker_name=\"ArrayExpress\">\n     <IDENTIFIERS>\n
+        \         <PRIMARY_ID>ERS2428793</PRIMARY_ID>\n          <EXTERNAL_ID namespace=\"BioSample\">SAMEA4608097</EXTERNAL_ID>\n
         \         <SUBMITTER_ID namespace=\"BRIC - Biotech Research and Innovation
         Centre\">E-MTAB-6681:G144_KO8_RNAseq_4h_1</SUBMITTER_ID>\n     </IDENTIFIERS>\n
         \    <TITLE>G144_KO8_RNAseq_4h_1</TITLE>\n     <SAMPLE_NAME>\n          <TAXON_ID>9606</TAXON_ID>\n
         \         <SCIENTIFIC_NAME>Homo sapiens</SCIENTIFIC_NAME>\n          <COMMON_NAME>human</COMMON_NAME>\n
         \    </SAMPLE_NAME>\n     <DESCRIPTION>Protocols: CRISPR mediated KO of CIC:
         sgRNAs (Target sequence: mESCs: GCCTTCATGATCTTCAGCAAG; G144: GGGCGAGTGGTGGTATGCCC)
-        \ were cloned into pSpCas9(BB)-2A-GFP (Addgene 48138) and transfected into
-        mESCs (Lipofectamine 2000) or G144 cells (Amaxa Nucleofector II, Program A033).
+        were cloned into pSpCas9(BB)-2A-GFP (Addgene 48138) and transfected into mESCs
+        (Lipofectamine 2000) or G144 cells (Amaxa Nucleofector II, Program A033).
         GFP-positive cells were single cell sorted 48h post-transfection, expanded
         and screened by immunoblotting for CIC deletion. Inhibitor treatment with
         1 \u03BCM MEK inhibitor (PD0325901) was performed in 80% confluent cultures
         for 4 and 24 h respectively. DMSO was used as mock control. Cells were washed
-        once with PBS, lysed directly in RLT buffer (Qiagen).  Total RNA was extracted
-        using the RNAeasy kit (Qiagen).  500 ng of total RNA was used for library
-        preparation using TruSeq RNA Library Prep Kit v2 (Illumina) according to manufacturer
-        recommendations.</DESCRIPTION>\n     <SAMPLE_LINKS>\n          <SAMPLE_LINK>\n
-        \              <XREF_LINK>\n                    <DB>ENA-STUDY</DB>\n                    <ID>ERP108370</ID>\n
-        \              </XREF_LINK>\n          </SAMPLE_LINK>\n          <SAMPLE_LINK>\n
-        \              <XREF_LINK>\n                    <DB>ENA-EXPERIMENT</DB>\n
-        \                   <ID>ERX2552499</ID>\n               </XREF_LINK>\n          </SAMPLE_LINK>\n
-        \         <SAMPLE_LINK>\n               <XREF_LINK>\n                    <DB>ENA-RUN</DB>\n
-        \                   <ID>ERR2534078</ID>\n               </XREF_LINK>\n          </SAMPLE_LINK>\n
-        \         <SAMPLE_LINK>\n               <XREF_LINK>\n                    <DB>ENA-SUBMISSION</DB>\n
-        \                   <ID>ERA1350207</ID>\n               </XREF_LINK>\n          </SAMPLE_LINK>\n
-        \         <SAMPLE_LINK>\n               <XREF_LINK>\n                    <DB>ENA-FASTQ-FILES</DB>\n
-        \                   <ID><![CDATA[https://www.ebi.ac.uk/ena/portal/api/filereport?accession=ERS2428793&result=read_run&fields=run_accession,fastq_ftp,fastq_md5,fastq_bytes]]></ID>\n
-        \              </XREF_LINK>\n          </SAMPLE_LINK>\n          <SAMPLE_LINK>\n
-        \              <XREF_LINK>\n                    <DB>ENA-SUBMITTED-FILES</DB>\n
-        \                   <ID><![CDATA[https://www.ebi.ac.uk/ena/portal/api/filereport?accession=ERS2428793&result=read_run&fields=run_accession,submitted_ftp,submitted_md5,submitted_bytes,submitted_format]]></ID>\n
-        \              </XREF_LINK>\n          </SAMPLE_LINK>\n     </SAMPLE_LINKS>\n
-        \    <SAMPLE_ATTRIBUTES>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>isolate</TAG>\n
-        \              <VALUE>not applicable</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
-        \         <SAMPLE_ATTRIBUTE>\n               <TAG>organism</TAG>\n               <VALUE>Homo
-        sapiens</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
-        \              <TAG>organism part</TAG>\n               <VALUE>brain</VALUE>\n
-        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>cell_type</TAG>\n
-        \              <VALUE>glial cell</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
-        \         <SAMPLE_ATTRIBUTE>\n               <TAG>cell_line</TAG>\n               <VALUE>G144</VALUE>\n
+        once with PBS, lysed directly in RLT buffer (Qiagen). Total RNA was extracted
+        using the RNAeasy kit (Qiagen). 500 ng of total RNA was used for library preparation
+        using TruSeq RNA Library Prep Kit v2 (Illumina) according to manufacturer
+        recommendations.</DESCRIPTION>\n     <SAMPLE_LINKS>\n    <SAMPLE_LINK>\n        <XREF_LINK>\n
+        \           <DB>ENA-FASTQ-FILES</DB>\n            <ID><![CDATA[https://www.ebi.ac.uk/ena/portal/api/filereport?accession=ERS2428793&result=read_run&fields=run_accession,fastq_ftp,fastq_md5,fastq_bytes]]></ID>\n
+        \       </XREF_LINK>\n    </SAMPLE_LINK>\n    <SAMPLE_LINK>\n        <XREF_LINK>\n
+        \           <DB>ENA-SUBMITTED-FILES</DB>\n            <ID><![CDATA[https://www.ebi.ac.uk/ena/portal/api/filereport?accession=ERS2428793&result=read_run&fields=run_accession,submitted_ftp,submitted_md5,submitted_bytes,submitted_format]]></ID>\n
+        \       </XREF_LINK>\n    </SAMPLE_LINK>\n</SAMPLE_LINKS>\n<SAMPLE_ATTRIBUTES>\n
+        \         <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-CHECKLIST</TAG>\n               <VALUE>ERC000011</VALUE>\n
         \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>disease</TAG>\n
         \              <VALUE>glioblastoma multiforme</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
-        \         <SAMPLE_ATTRIBUTE>\n               <TAG>genotype</TAG>\n               <VALUE>CRISPR/Cas9
-        mediated knockout of CIC</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
-        \              <TAG>individual</TAG>\n               <VALUE>clonal line #8</VALUE>\n
-        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-CHECKLIST</TAG>\n
-        \              <VALUE>ERC000011</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
-        \              <TAG>ENA-SPOT-COUNT</TAG>\n               <VALUE>30777620</VALUE>\n
-        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-BASE-COUNT</TAG>\n
-        \              <VALUE>2323852146</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
+        \         <SAMPLE_ATTRIBUTE>\n               <TAG>individual</TAG>\n               <VALUE>clonal
+        line #8</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
+        \              <TAG>organism</TAG>\n               <VALUE>Homo sapiens</VALUE>\n
+        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>organism</TAG>\n
+        \              <VALUE>Homo sapiens</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
+        \         <SAMPLE_ATTRIBUTE>\n               <TAG>cell type</TAG>\n               <VALUE>glial
+        cell</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
+        \              <TAG>common name</TAG>\n               <VALUE>human</VALUE>\n
+        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>organism
+        part</TAG>\n               <VALUE>brain</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
+        \         <SAMPLE_ATTRIBUTE>\n               <TAG>cell line</TAG>\n               <VALUE>G144</VALUE>\n
+        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>genotype</TAG>\n
+        \              <VALUE>CRISPR/Cas9 mediated knockout of CIC</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
         \         <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-FIRST-PUBLIC</TAG>\n
         \              <VALUE>2018-05-30</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
         \         <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-LAST-UPDATE</TAG>\n
@@ -3072,7 +2604,7 @@ interactions:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:41:29 GMT
+      - Wed, 17 May 2023 18:35:52 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -3090,7 +2622,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/ERP108370
   response:
@@ -3150,7 +2682,7 @@ interactions:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:41:30 GMT
+      - Wed, 17 May 2023 18:35:52 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -3168,7 +2700,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/ERA1350207
   response:
@@ -3204,7 +2736,7 @@ interactions:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:41:30 GMT
+      - Wed, 17 May 2023 18:35:53 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -3213,68 +2745,6 @@ interactions:
       code: 200
       message: ''
 - request:
-    body: acc=ERR2534078&accept-proto=fasp&version=2.0
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '44'
-      User-Agent:
-      - python-requests/2.25.1
-    method: POST
-    uri: https://www.ncbi.nlm.nih.gov/Traces/names/names.cgi
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAAwzKvQrCMBAA4L1PEXDoVLm7/DXdnYXi5JbUlCrBhCYiwj28XT++E52hq7svn8CX
-        eSYtFdiREUijliAVE+A4gB3A3RAnbSfSd16jds4btOCCOhqGaIgiGOcCKiRmVgB8faef6LfWSu1F
-        2XPLS07iWYVPKX/jQ6x5F207IIdXXFr3BwAA//8DAACvVh+PAAAA
-    headers:
-      Cache-Control:
-      - private
-      Connection:
-      - Keep-Alive
-      Content-Encoding:
-      - gzip
-      Content-Security-Policy:
-      - upgrade-insecure-requests
-      Content-Type:
-      - text/plain
-      Date:
-      - Wed, 28 Jul 2021 19:41:31 GMT
-      Keep-Alive:
-      - timeout=1, max=10
-      NCBI-PHID:
-      - C7A41DF7101B2EB10000000000000001.m_1
-      NCBI-SID:
-      - C7A41DF7101B2EB1_0000SID
-      Referrer-Policy:
-      - origin-when-cross-origin
-      Server:
-      - Apache
-      Set-Cookie:
-      - ncbi_sid=C7A41DF7101B2EB1_0000SID; domain=.nih.gov; path=/; expires=Thu, 28
-        Jul 2022 19:41:31 GMT
-      SraNameServerOutputVersion:
-      - '2.0'
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains; preload
-      Transfer-Encoding:
-      - chunked
-      Vary:
-      - Accept-Encoding
-      X-UA-Compatible:
-      - IE=Edge
-      X-XSS-Protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
-- request:
     body: null
     headers:
       Accept:
@@ -3284,29 +2754,27 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/portal/api/filereport?accession=ERR2534078&result=read_run
   response:
     body:
-      string: "run_accession\tfastq_ftp\tfastq_bytes\tfastq_md5\tsubmitted_ftp\tsubmitted_bytes\tsubmitted_md5\tsra_ftp\tsra_bytes\tsra_md5\nERR2534078\tftp.sra.ebi.ac.uk/vol1/fastq/ERR253/008/ERR2534078/ERR2534078.fastq.gz\t1536621662\taec2ace3d7e6c37ea2cc645fec91b508\tftp.sra.ebi.ac.uk/vol1/run/ERR253/ERR2534078/G144_KO8_RNAseq_4h_1.fastq.gz\t1600009820\tf013cfe299039a31f0c60f89c94bddf5\t\t\t\n"
+      string: "run_accession\tfastq_ftp\tfastq_bytes\tfastq_md5\tbam_ftp\tbam_bytes\tbam_md5\tsubmitted_ftp\tsubmitted_bytes\tsubmitted_md5\tsra_ftp\tsra_bytes\tsra_md5\nERR2534078\tftp.sra.ebi.ac.uk/vol1/fastq/ERR253/008/ERR2534078/ERR2534078.fastq.gz\t1536621662\taec2ace3d7e6c37ea2cc645fec91b508\t\t\t\tftp.sra.ebi.ac.uk/vol1/run/ERR253/ERR2534078/G144_KO8_RNAseq_4h_1.fastq.gz\t1600009820\tf013cfe299039a31f0c60f89c94bddf5\tftp.sra.ebi.ac.uk/vol1/err/ERR253/008/ERR2534078\t1025153014\t6c80784e273565081f863cf58fae1fc9\n"
     headers:
       Cache-Control:
       - no-cache, no-store, max-age=0, must-revalidate
+      Content-Length:
+      - '483'
       Content-Type:
       - text/plain
       Date:
-      - Wed, 28 Jul 2021 19:41:32 GMT
+      - Wed, 17 May 2023 18:35:54 GMT
       Expires:
       - '0'
       Pragma:
       - no-cache
-      Server:
-      - Apache-Coyote/1.1
       Strict-Transport-Security:
       - max-age=0
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Frame-Options:
@@ -3315,7 +2783,7 @@ interactions:
       - 1; mode=block
     status:
       code: 200
-      message: OK
+      message: ''
 - request:
     body: null
     headers:
@@ -3326,7 +2794,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/ERR2534079
   response:
@@ -3367,7 +2835,7 @@ interactions:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:41:32 GMT
+      - Wed, 17 May 2023 18:35:53 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -3385,7 +2853,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/ERX2552500
   response:
@@ -3453,7 +2921,7 @@ interactions:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:41:32 GMT
+      - Wed, 17 May 2023 18:35:54 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -3471,63 +2939,51 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/ERS2428794
   response:
     body:
       string: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<SAMPLE_SET>\n<SAMPLE accession=\"ERS2428794\"
-        alias=\"E-MTAB-6681:G144_KO8_RNAseq_4h_2\" broker_name=\"ArrayExpress\" center_name=\"BRIC
-        - Biotech Research and Innovation Centre\">\n     <IDENTIFIERS>\n          <PRIMARY_ID>ERS2428794</PRIMARY_ID>\n
-        \         <EXTERNAL_ID namespace=\"BioSample\">SAMEA4608098</EXTERNAL_ID>\n
+        alias=\"E-MTAB-6681:G144_KO8_RNAseq_4h_2\" center_name=\"BRIC - Biotech Research
+        and Innovation Centre\" broker_name=\"ArrayExpress\">\n     <IDENTIFIERS>\n
+        \         <PRIMARY_ID>ERS2428794</PRIMARY_ID>\n          <EXTERNAL_ID namespace=\"BioSample\">SAMEA4608098</EXTERNAL_ID>\n
         \         <SUBMITTER_ID namespace=\"BRIC - Biotech Research and Innovation
         Centre\">E-MTAB-6681:G144_KO8_RNAseq_4h_2</SUBMITTER_ID>\n     </IDENTIFIERS>\n
         \    <TITLE>G144_KO8_RNAseq_4h_2</TITLE>\n     <SAMPLE_NAME>\n          <TAXON_ID>9606</TAXON_ID>\n
         \         <SCIENTIFIC_NAME>Homo sapiens</SCIENTIFIC_NAME>\n          <COMMON_NAME>human</COMMON_NAME>\n
         \    </SAMPLE_NAME>\n     <DESCRIPTION>Protocols: CRISPR mediated KO of CIC:
         sgRNAs (Target sequence: mESCs: GCCTTCATGATCTTCAGCAAG; G144: GGGCGAGTGGTGGTATGCCC)
-        \ were cloned into pSpCas9(BB)-2A-GFP (Addgene 48138) and transfected into
-        mESCs (Lipofectamine 2000) or G144 cells (Amaxa Nucleofector II, Program A033).
+        were cloned into pSpCas9(BB)-2A-GFP (Addgene 48138) and transfected into mESCs
+        (Lipofectamine 2000) or G144 cells (Amaxa Nucleofector II, Program A033).
         GFP-positive cells were single cell sorted 48h post-transfection, expanded
         and screened by immunoblotting for CIC deletion. Inhibitor treatment with
         1 \u03BCM MEK inhibitor (PD0325901) was performed in 80% confluent cultures
         for 4 and 24 h respectively. DMSO was used as mock control. Cells were washed
-        once with PBS, lysed directly in RLT buffer (Qiagen).  Total RNA was extracted
-        using the RNAeasy kit (Qiagen).  500 ng of total RNA was used for library
-        preparation using TruSeq RNA Library Prep Kit v2 (Illumina) according to manufacturer
-        recommendations.</DESCRIPTION>\n     <SAMPLE_LINKS>\n          <SAMPLE_LINK>\n
-        \              <XREF_LINK>\n                    <DB>ENA-STUDY</DB>\n                    <ID>ERP108370</ID>\n
-        \              </XREF_LINK>\n          </SAMPLE_LINK>\n          <SAMPLE_LINK>\n
-        \              <XREF_LINK>\n                    <DB>ENA-EXPERIMENT</DB>\n
-        \                   <ID>ERX2552500</ID>\n               </XREF_LINK>\n          </SAMPLE_LINK>\n
-        \         <SAMPLE_LINK>\n               <XREF_LINK>\n                    <DB>ENA-RUN</DB>\n
-        \                   <ID>ERR2534079</ID>\n               </XREF_LINK>\n          </SAMPLE_LINK>\n
-        \         <SAMPLE_LINK>\n               <XREF_LINK>\n                    <DB>ENA-SUBMISSION</DB>\n
-        \                   <ID>ERA1350207</ID>\n               </XREF_LINK>\n          </SAMPLE_LINK>\n
-        \         <SAMPLE_LINK>\n               <XREF_LINK>\n                    <DB>ENA-FASTQ-FILES</DB>\n
-        \                   <ID><![CDATA[https://www.ebi.ac.uk/ena/portal/api/filereport?accession=ERS2428794&result=read_run&fields=run_accession,fastq_ftp,fastq_md5,fastq_bytes]]></ID>\n
-        \              </XREF_LINK>\n          </SAMPLE_LINK>\n          <SAMPLE_LINK>\n
-        \              <XREF_LINK>\n                    <DB>ENA-SUBMITTED-FILES</DB>\n
-        \                   <ID><![CDATA[https://www.ebi.ac.uk/ena/portal/api/filereport?accession=ERS2428794&result=read_run&fields=run_accession,submitted_ftp,submitted_md5,submitted_bytes,submitted_format]]></ID>\n
-        \              </XREF_LINK>\n          </SAMPLE_LINK>\n     </SAMPLE_LINKS>\n
-        \    <SAMPLE_ATTRIBUTES>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>isolate</TAG>\n
-        \              <VALUE>not applicable</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
-        \         <SAMPLE_ATTRIBUTE>\n               <TAG>organism</TAG>\n               <VALUE>Homo
-        sapiens</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
-        \              <TAG>organism part</TAG>\n               <VALUE>brain</VALUE>\n
-        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>cell_type</TAG>\n
-        \              <VALUE>glial cell</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
-        \         <SAMPLE_ATTRIBUTE>\n               <TAG>cell_line</TAG>\n               <VALUE>G144</VALUE>\n
+        once with PBS, lysed directly in RLT buffer (Qiagen). Total RNA was extracted
+        using the RNAeasy kit (Qiagen). 500 ng of total RNA was used for library preparation
+        using TruSeq RNA Library Prep Kit v2 (Illumina) according to manufacturer
+        recommendations.</DESCRIPTION>\n     <SAMPLE_LINKS>\n    <SAMPLE_LINK>\n        <XREF_LINK>\n
+        \           <DB>ENA-FASTQ-FILES</DB>\n            <ID><![CDATA[https://www.ebi.ac.uk/ena/portal/api/filereport?accession=ERS2428794&result=read_run&fields=run_accession,fastq_ftp,fastq_md5,fastq_bytes]]></ID>\n
+        \       </XREF_LINK>\n    </SAMPLE_LINK>\n    <SAMPLE_LINK>\n        <XREF_LINK>\n
+        \           <DB>ENA-SUBMITTED-FILES</DB>\n            <ID><![CDATA[https://www.ebi.ac.uk/ena/portal/api/filereport?accession=ERS2428794&result=read_run&fields=run_accession,submitted_ftp,submitted_md5,submitted_bytes,submitted_format]]></ID>\n
+        \       </XREF_LINK>\n    </SAMPLE_LINK>\n</SAMPLE_LINKS>\n<SAMPLE_ATTRIBUTES>\n
+        \         <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-CHECKLIST</TAG>\n               <VALUE>ERC000011</VALUE>\n
         \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>disease</TAG>\n
         \              <VALUE>glioblastoma multiforme</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
-        \         <SAMPLE_ATTRIBUTE>\n               <TAG>genotype</TAG>\n               <VALUE>CRISPR/Cas9
-        mediated knockout of CIC</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
-        \              <TAG>individual</TAG>\n               <VALUE>clonal line #8</VALUE>\n
-        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-CHECKLIST</TAG>\n
-        \              <VALUE>ERC000011</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
-        \              <TAG>ENA-SPOT-COUNT</TAG>\n               <VALUE>22511265</VALUE>\n
-        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-BASE-COUNT</TAG>\n
-        \              <VALUE>1699936076</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
+        \         <SAMPLE_ATTRIBUTE>\n               <TAG>individual</TAG>\n               <VALUE>clonal
+        line #8</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
+        \              <TAG>organism</TAG>\n               <VALUE>Homo sapiens</VALUE>\n
+        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>organism</TAG>\n
+        \              <VALUE>Homo sapiens</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
+        \         <SAMPLE_ATTRIBUTE>\n               <TAG>cell type</TAG>\n               <VALUE>glial
+        cell</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
+        \              <TAG>common name</TAG>\n               <VALUE>human</VALUE>\n
+        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>organism
+        part</TAG>\n               <VALUE>brain</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
+        \         <SAMPLE_ATTRIBUTE>\n               <TAG>cell line</TAG>\n               <VALUE>G144</VALUE>\n
+        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>genotype</TAG>\n
+        \              <VALUE>CRISPR/Cas9 mediated knockout of CIC</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
         \         <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-FIRST-PUBLIC</TAG>\n
         \              <VALUE>2018-05-30</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
         \         <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-LAST-UPDATE</TAG>\n
@@ -3537,7 +2993,7 @@ interactions:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:41:33 GMT
+      - Wed, 17 May 2023 18:35:55 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -3555,7 +3011,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/ERP108370
   response:
@@ -3615,7 +3071,7 @@ interactions:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:41:34 GMT
+      - Wed, 17 May 2023 18:35:55 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -3633,7 +3089,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/ERA1350207
   response:
@@ -3669,7 +3125,7 @@ interactions:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:41:34 GMT
+      - Wed, 17 May 2023 18:35:55 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -3678,68 +3134,6 @@ interactions:
       code: 200
       message: ''
 - request:
-    body: acc=ERR2534079&accept-proto=fasp&version=2.0
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '44'
-      User-Agent:
-      - python-requests/2.25.1
-    method: POST
-    uri: https://www.ncbi.nlm.nih.gov/Traces/names/names.cgi
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAAwzIsQrCMBAA0L1fEXDoVLmcvVza3VkoTm5pklIlNKGNiHAfr298JzxDc+yuvGe5
-        ThPSpQcehInI9gZBELTtgDsY7lqPxCPwQyxphx6BOBgbvKUFjdHIke3iHLKI9ABy29JXtWut5WhV
-        2XPNPif1PJRLKX9iUEveVV3/kedX9LX5AQAA//8DAFfh71COAAAA
-    headers:
-      Cache-Control:
-      - private
-      Connection:
-      - Keep-Alive
-      Content-Encoding:
-      - gzip
-      Content-Security-Policy:
-      - upgrade-insecure-requests
-      Content-Type:
-      - text/plain
-      Date:
-      - Wed, 28 Jul 2021 19:41:35 GMT
-      Keep-Alive:
-      - timeout=1, max=10
-      NCBI-PHID:
-      - CC95EF24101B2EF10000000000000001.m_1
-      NCBI-SID:
-      - CC95EF24101B2EF1_0000SID
-      Referrer-Policy:
-      - origin-when-cross-origin
-      Server:
-      - Apache
-      Set-Cookie:
-      - ncbi_sid=CC95EF24101B2EF1_0000SID; domain=.nih.gov; path=/; expires=Thu, 28
-        Jul 2022 19:41:35 GMT
-      SraNameServerOutputVersion:
-      - '2.0'
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains; preload
-      Transfer-Encoding:
-      - chunked
-      Vary:
-      - Accept-Encoding
-      X-UA-Compatible:
-      - IE=Edge
-      X-XSS-Protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
-- request:
     body: null
     headers:
       Accept:
@@ -3749,29 +3143,27 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/portal/api/filereport?accession=ERR2534079&result=read_run
   response:
     body:
-      string: "run_accession\tfastq_ftp\tfastq_bytes\tfastq_md5\tsubmitted_ftp\tsubmitted_bytes\tsubmitted_md5\tsra_ftp\tsra_bytes\tsra_md5\nERR2534079\tftp.sra.ebi.ac.uk/vol1/fastq/ERR253/009/ERR2534079/ERR2534079.fastq.gz\t1132203170\t429470250bf1e5e7ab6fbb7fd7f1087f\tftp.sra.ebi.ac.uk/vol1/run/ERR253/ERR2534079/G144_KO8_RNAseq_4h_2.fastq.gz\t1178873511\t24f54a4b765784df91b47d5ed39eb311\t\t\t\n"
+      string: "run_accession\tfastq_ftp\tfastq_bytes\tfastq_md5\tbam_ftp\tbam_bytes\tbam_md5\tsubmitted_ftp\tsubmitted_bytes\tsubmitted_md5\tsra_ftp\tsra_bytes\tsra_md5\nERR2534079\tftp.sra.ebi.ac.uk/vol1/fastq/ERR253/009/ERR2534079/ERR2534079.fastq.gz\t1132203170\t429470250bf1e5e7ab6fbb7fd7f1087f\t\t\t\tftp.sra.ebi.ac.uk/vol1/run/ERR253/ERR2534079/G144_KO8_RNAseq_4h_2.fastq.gz\t1178873511\t24f54a4b765784df91b47d5ed39eb311\tftp.sra.ebi.ac.uk/vol1/err/ERR253/009/ERR2534079\t755584600\tdfc6e098febc3d3d5def75a8086fad94\n"
     headers:
       Cache-Control:
       - no-cache, no-store, max-age=0, must-revalidate
+      Content-Length:
+      - '482'
       Content-Type:
       - text/plain
       Date:
-      - Wed, 28 Jul 2021 19:41:35 GMT
+      - Wed, 17 May 2023 18:35:56 GMT
       Expires:
       - '0'
       Pragma:
       - no-cache
-      Server:
-      - Apache-Coyote/1.1
       Strict-Transport-Security:
       - max-age=0
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Frame-Options:
@@ -3780,7 +3172,7 @@ interactions:
       - 1; mode=block
     status:
       code: 200
-      message: OK
+      message: ''
 - request:
     body: null
     headers:
@@ -3791,7 +3183,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/ERR2534080
   response:
@@ -3832,7 +3224,7 @@ interactions:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:41:35 GMT
+      - Wed, 17 May 2023 18:35:56 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -3850,7 +3242,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/ERX2552501
   response:
@@ -3918,7 +3310,7 @@ interactions:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:41:36 GMT
+      - Wed, 17 May 2023 18:35:57 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -3936,63 +3328,51 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/ERS2428795
   response:
     body:
       string: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<SAMPLE_SET>\n<SAMPLE accession=\"ERS2428795\"
-        alias=\"E-MTAB-6681:G144_KO9_RNAseq_24h_1\" broker_name=\"ArrayExpress\" center_name=\"BRIC
-        - Biotech Research and Innovation Centre\">\n     <IDENTIFIERS>\n          <PRIMARY_ID>ERS2428795</PRIMARY_ID>\n
-        \         <EXTERNAL_ID namespace=\"BioSample\">SAMEA4608099</EXTERNAL_ID>\n
+        alias=\"E-MTAB-6681:G144_KO9_RNAseq_24h_1\" center_name=\"BRIC - Biotech Research
+        and Innovation Centre\" broker_name=\"ArrayExpress\">\n     <IDENTIFIERS>\n
+        \         <PRIMARY_ID>ERS2428795</PRIMARY_ID>\n          <EXTERNAL_ID namespace=\"BioSample\">SAMEA4608099</EXTERNAL_ID>\n
         \         <SUBMITTER_ID namespace=\"BRIC - Biotech Research and Innovation
         Centre\">E-MTAB-6681:G144_KO9_RNAseq_24h_1</SUBMITTER_ID>\n     </IDENTIFIERS>\n
         \    <TITLE>G144_KO9_RNAseq_24h_1</TITLE>\n     <SAMPLE_NAME>\n          <TAXON_ID>9606</TAXON_ID>\n
         \         <SCIENTIFIC_NAME>Homo sapiens</SCIENTIFIC_NAME>\n          <COMMON_NAME>human</COMMON_NAME>\n
         \    </SAMPLE_NAME>\n     <DESCRIPTION>Protocols: CRISPR mediated KO of CIC:
         sgRNAs (Target sequence: mESCs: GCCTTCATGATCTTCAGCAAG; G144: GGGCGAGTGGTGGTATGCCC)
-        \ were cloned into pSpCas9(BB)-2A-GFP (Addgene 48138) and transfected into
-        mESCs (Lipofectamine 2000) or G144 cells (Amaxa Nucleofector II, Program A033).
+        were cloned into pSpCas9(BB)-2A-GFP (Addgene 48138) and transfected into mESCs
+        (Lipofectamine 2000) or G144 cells (Amaxa Nucleofector II, Program A033).
         GFP-positive cells were single cell sorted 48h post-transfection, expanded
         and screened by immunoblotting for CIC deletion. Inhibitor treatment with
         1 \u03BCM MEK inhibitor (PD0325901) was performed in 80% confluent cultures
         for 4 and 24 h respectively. DMSO was used as mock control. Cells were washed
-        once with PBS, lysed directly in RLT buffer (Qiagen).  Total RNA was extracted
-        using the RNAeasy kit (Qiagen).  500 ng of total RNA was used for library
-        preparation using TruSeq RNA Library Prep Kit v2 (Illumina) according to manufacturer
-        recommendations.</DESCRIPTION>\n     <SAMPLE_LINKS>\n          <SAMPLE_LINK>\n
-        \              <XREF_LINK>\n                    <DB>ENA-STUDY</DB>\n                    <ID>ERP108370</ID>\n
-        \              </XREF_LINK>\n          </SAMPLE_LINK>\n          <SAMPLE_LINK>\n
-        \              <XREF_LINK>\n                    <DB>ENA-EXPERIMENT</DB>\n
-        \                   <ID>ERX2552501</ID>\n               </XREF_LINK>\n          </SAMPLE_LINK>\n
-        \         <SAMPLE_LINK>\n               <XREF_LINK>\n                    <DB>ENA-RUN</DB>\n
-        \                   <ID>ERR2534080</ID>\n               </XREF_LINK>\n          </SAMPLE_LINK>\n
-        \         <SAMPLE_LINK>\n               <XREF_LINK>\n                    <DB>ENA-SUBMISSION</DB>\n
-        \                   <ID>ERA1350207</ID>\n               </XREF_LINK>\n          </SAMPLE_LINK>\n
-        \         <SAMPLE_LINK>\n               <XREF_LINK>\n                    <DB>ENA-FASTQ-FILES</DB>\n
-        \                   <ID><![CDATA[https://www.ebi.ac.uk/ena/portal/api/filereport?accession=ERS2428795&result=read_run&fields=run_accession,fastq_ftp,fastq_md5,fastq_bytes]]></ID>\n
-        \              </XREF_LINK>\n          </SAMPLE_LINK>\n          <SAMPLE_LINK>\n
-        \              <XREF_LINK>\n                    <DB>ENA-SUBMITTED-FILES</DB>\n
-        \                   <ID><![CDATA[https://www.ebi.ac.uk/ena/portal/api/filereport?accession=ERS2428795&result=read_run&fields=run_accession,submitted_ftp,submitted_md5,submitted_bytes,submitted_format]]></ID>\n
-        \              </XREF_LINK>\n          </SAMPLE_LINK>\n     </SAMPLE_LINKS>\n
-        \    <SAMPLE_ATTRIBUTES>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>isolate</TAG>\n
-        \              <VALUE>not applicable</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
-        \         <SAMPLE_ATTRIBUTE>\n               <TAG>organism</TAG>\n               <VALUE>Homo
-        sapiens</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
-        \              <TAG>organism part</TAG>\n               <VALUE>brain</VALUE>\n
-        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>cell_type</TAG>\n
-        \              <VALUE>glial cell</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
-        \         <SAMPLE_ATTRIBUTE>\n               <TAG>cell_line</TAG>\n               <VALUE>G144</VALUE>\n
+        once with PBS, lysed directly in RLT buffer (Qiagen). Total RNA was extracted
+        using the RNAeasy kit (Qiagen). 500 ng of total RNA was used for library preparation
+        using TruSeq RNA Library Prep Kit v2 (Illumina) according to manufacturer
+        recommendations.</DESCRIPTION>\n     <SAMPLE_LINKS>\n    <SAMPLE_LINK>\n        <XREF_LINK>\n
+        \           <DB>ENA-FASTQ-FILES</DB>\n            <ID><![CDATA[https://www.ebi.ac.uk/ena/portal/api/filereport?accession=ERS2428795&result=read_run&fields=run_accession,fastq_ftp,fastq_md5,fastq_bytes]]></ID>\n
+        \       </XREF_LINK>\n    </SAMPLE_LINK>\n    <SAMPLE_LINK>\n        <XREF_LINK>\n
+        \           <DB>ENA-SUBMITTED-FILES</DB>\n            <ID><![CDATA[https://www.ebi.ac.uk/ena/portal/api/filereport?accession=ERS2428795&result=read_run&fields=run_accession,submitted_ftp,submitted_md5,submitted_bytes,submitted_format]]></ID>\n
+        \       </XREF_LINK>\n    </SAMPLE_LINK>\n</SAMPLE_LINKS>\n<SAMPLE_ATTRIBUTES>\n
+        \         <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-CHECKLIST</TAG>\n               <VALUE>ERC000011</VALUE>\n
         \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>disease</TAG>\n
         \              <VALUE>glioblastoma multiforme</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
-        \         <SAMPLE_ATTRIBUTE>\n               <TAG>genotype</TAG>\n               <VALUE>CRISPR/Cas9
-        mediated knockout of CIC</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
-        \              <TAG>individual</TAG>\n               <VALUE>clonal line #9</VALUE>\n
-        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-CHECKLIST</TAG>\n
-        \              <VALUE>ERC000011</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
-        \              <TAG>ENA-SPOT-COUNT</TAG>\n               <VALUE>26709956</VALUE>\n
-        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-BASE-COUNT</TAG>\n
-        \              <VALUE>2016956425</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
+        \         <SAMPLE_ATTRIBUTE>\n               <TAG>individual</TAG>\n               <VALUE>clonal
+        line #9</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
+        \              <TAG>organism</TAG>\n               <VALUE>Homo sapiens</VALUE>\n
+        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>organism</TAG>\n
+        \              <VALUE>Homo sapiens</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
+        \         <SAMPLE_ATTRIBUTE>\n               <TAG>cell type</TAG>\n               <VALUE>glial
+        cell</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
+        \              <TAG>common name</TAG>\n               <VALUE>human</VALUE>\n
+        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>organism
+        part</TAG>\n               <VALUE>brain</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
+        \         <SAMPLE_ATTRIBUTE>\n               <TAG>cell line</TAG>\n               <VALUE>G144</VALUE>\n
+        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>genotype</TAG>\n
+        \              <VALUE>CRISPR/Cas9 mediated knockout of CIC</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
         \         <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-FIRST-PUBLIC</TAG>\n
         \              <VALUE>2018-05-30</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
         \         <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-LAST-UPDATE</TAG>\n
@@ -4002,7 +3382,7 @@ interactions:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:41:37 GMT
+      - Wed, 17 May 2023 18:35:57 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -4020,7 +3400,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/ERP108370
   response:
@@ -4080,7 +3460,7 @@ interactions:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:41:38 GMT
+      - Wed, 17 May 2023 18:35:58 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -4098,7 +3478,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/ERA1350207
   response:
@@ -4134,7 +3514,7 @@ interactions:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:41:39 GMT
+      - Wed, 17 May 2023 18:35:57 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -4143,68 +3523,6 @@ interactions:
       code: 200
       message: ''
 - request:
-    body: acc=ERR2534080&accept-proto=fasp&version=2.0
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '44'
-      User-Agent:
-      - python-requests/2.25.1
-    method: POST
-    uri: https://www.ncbi.nlm.nih.gov/Traces/names/names.cgi
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAAwzIvQrCMBAA4L1PEXDoVLlc89vdWShObr2YUiU0IY2IcA+v3/id8AzdUZfyJr7M
-        M+pRgQN2zqNHoywjSDeAHcDfpJy0nfR458Wq1YG3qzY+hjEESVaSISSnTCBkZgXA1z19Rb+1Vo5e
-        lJpbDjmJ5yGWlPInPsSaq2jbPzK9YmjdDwAA//8DAD+CjnCOAAAA
-    headers:
-      Cache-Control:
-      - private
-      Connection:
-      - Keep-Alive
-      Content-Encoding:
-      - gzip
-      Content-Security-Policy:
-      - upgrade-insecure-requests
-      Content-Type:
-      - text/plain
-      Date:
-      - Wed, 28 Jul 2021 19:41:39 GMT
-      Keep-Alive:
-      - timeout=1, max=10
-      NCBI-PHID:
-      - CC95EF3E101B2F310000000000000001.m_1
-      NCBI-SID:
-      - CC95EF3E101B2F31_0000SID
-      Referrer-Policy:
-      - origin-when-cross-origin
-      Server:
-      - Apache
-      Set-Cookie:
-      - ncbi_sid=CC95EF3E101B2F31_0000SID; domain=.nih.gov; path=/; expires=Thu, 28
-        Jul 2022 19:41:39 GMT
-      SraNameServerOutputVersion:
-      - '2.0'
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains; preload
-      Transfer-Encoding:
-      - chunked
-      Vary:
-      - Accept-Encoding
-      X-UA-Compatible:
-      - IE=Edge
-      X-XSS-Protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
-- request:
     body: null
     headers:
       Accept:
@@ -4214,29 +3532,27 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/portal/api/filereport?accession=ERR2534080&result=read_run
   response:
     body:
-      string: "run_accession\tfastq_ftp\tfastq_bytes\tfastq_md5\tsubmitted_ftp\tsubmitted_bytes\tsubmitted_md5\tsra_ftp\tsra_bytes\tsra_md5\nERR2534080\tftp.sra.ebi.ac.uk/vol1/fastq/ERR253/000/ERR2534080/ERR2534080.fastq.gz\t1333847546\t831e6a1e98dca3e530e1409e73bac1ef\tftp.sra.ebi.ac.uk/vol1/run/ERR253/ERR2534080/G144_KO9_RNAseq_24h_1.fastq.gz\t1388655605\t1cafe0e6f1cb09d106bd723397442c86\t\t\t\n"
+      string: "run_accession\tfastq_ftp\tfastq_bytes\tfastq_md5\tbam_ftp\tbam_bytes\tbam_md5\tsubmitted_ftp\tsubmitted_bytes\tsubmitted_md5\tsra_ftp\tsra_bytes\tsra_md5\nERR2534080\tftp.sra.ebi.ac.uk/vol1/fastq/ERR253/000/ERR2534080/ERR2534080.fastq.gz\t1333847546\t831e6a1e98dca3e530e1409e73bac1ef\t\t\t\tftp.sra.ebi.ac.uk/vol1/run/ERR253/ERR2534080/G144_KO9_RNAseq_24h_1.fastq.gz\t1388655605\t1cafe0e6f1cb09d106bd723397442c86\tftp.sra.ebi.ac.uk/vol1/err/ERR253/000/ERR2534080\t889292627\tc6d6a22ba70b0c08eb9d64cb2584b472\n"
     headers:
       Cache-Control:
       - no-cache, no-store, max-age=0, must-revalidate
+      Content-Length:
+      - '483'
       Content-Type:
       - text/plain
       Date:
-      - Wed, 28 Jul 2021 19:41:40 GMT
+      - Wed, 17 May 2023 18:35:59 GMT
       Expires:
       - '0'
       Pragma:
       - no-cache
-      Server:
-      - Apache-Coyote/1.1
       Strict-Transport-Security:
       - max-age=0
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Frame-Options:
@@ -4245,7 +3561,7 @@ interactions:
       - 1; mode=block
     status:
       code: 200
-      message: OK
+      message: ''
 - request:
     body: null
     headers:
@@ -4256,7 +3572,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/ERR2534081
   response:
@@ -4297,7 +3613,7 @@ interactions:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:41:40 GMT
+      - Wed, 17 May 2023 18:35:59 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -4315,7 +3631,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/ERX2552502
   response:
@@ -4383,7 +3699,7 @@ interactions:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:41:40 GMT
+      - Wed, 17 May 2023 18:35:58 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -4401,63 +3717,51 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/ERS2428796
   response:
     body:
       string: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<SAMPLE_SET>\n<SAMPLE accession=\"ERS2428796\"
-        alias=\"E-MTAB-6681:G144_KO9_RNAseq_24h_2\" broker_name=\"ArrayExpress\" center_name=\"BRIC
-        - Biotech Research and Innovation Centre\">\n     <IDENTIFIERS>\n          <PRIMARY_ID>ERS2428796</PRIMARY_ID>\n
-        \         <EXTERNAL_ID namespace=\"BioSample\">SAMEA4608100</EXTERNAL_ID>\n
+        alias=\"E-MTAB-6681:G144_KO9_RNAseq_24h_2\" center_name=\"BRIC - Biotech Research
+        and Innovation Centre\" broker_name=\"ArrayExpress\">\n     <IDENTIFIERS>\n
+        \         <PRIMARY_ID>ERS2428796</PRIMARY_ID>\n          <EXTERNAL_ID namespace=\"BioSample\">SAMEA4608100</EXTERNAL_ID>\n
         \         <SUBMITTER_ID namespace=\"BRIC - Biotech Research and Innovation
         Centre\">E-MTAB-6681:G144_KO9_RNAseq_24h_2</SUBMITTER_ID>\n     </IDENTIFIERS>\n
         \    <TITLE>G144_KO9_RNAseq_24h_2</TITLE>\n     <SAMPLE_NAME>\n          <TAXON_ID>9606</TAXON_ID>\n
         \         <SCIENTIFIC_NAME>Homo sapiens</SCIENTIFIC_NAME>\n          <COMMON_NAME>human</COMMON_NAME>\n
         \    </SAMPLE_NAME>\n     <DESCRIPTION>Protocols: CRISPR mediated KO of CIC:
         sgRNAs (Target sequence: mESCs: GCCTTCATGATCTTCAGCAAG; G144: GGGCGAGTGGTGGTATGCCC)
-        \ were cloned into pSpCas9(BB)-2A-GFP (Addgene 48138) and transfected into
-        mESCs (Lipofectamine 2000) or G144 cells (Amaxa Nucleofector II, Program A033).
+        were cloned into pSpCas9(BB)-2A-GFP (Addgene 48138) and transfected into mESCs
+        (Lipofectamine 2000) or G144 cells (Amaxa Nucleofector II, Program A033).
         GFP-positive cells were single cell sorted 48h post-transfection, expanded
         and screened by immunoblotting for CIC deletion. Inhibitor treatment with
         1 \u03BCM MEK inhibitor (PD0325901) was performed in 80% confluent cultures
         for 4 and 24 h respectively. DMSO was used as mock control. Cells were washed
-        once with PBS, lysed directly in RLT buffer (Qiagen).  Total RNA was extracted
-        using the RNAeasy kit (Qiagen).  500 ng of total RNA was used for library
-        preparation using TruSeq RNA Library Prep Kit v2 (Illumina) according to manufacturer
-        recommendations.</DESCRIPTION>\n     <SAMPLE_LINKS>\n          <SAMPLE_LINK>\n
-        \              <XREF_LINK>\n                    <DB>ENA-STUDY</DB>\n                    <ID>ERP108370</ID>\n
-        \              </XREF_LINK>\n          </SAMPLE_LINK>\n          <SAMPLE_LINK>\n
-        \              <XREF_LINK>\n                    <DB>ENA-EXPERIMENT</DB>\n
-        \                   <ID>ERX2552502</ID>\n               </XREF_LINK>\n          </SAMPLE_LINK>\n
-        \         <SAMPLE_LINK>\n               <XREF_LINK>\n                    <DB>ENA-RUN</DB>\n
-        \                   <ID>ERR2534081</ID>\n               </XREF_LINK>\n          </SAMPLE_LINK>\n
-        \         <SAMPLE_LINK>\n               <XREF_LINK>\n                    <DB>ENA-SUBMISSION</DB>\n
-        \                   <ID>ERA1350207</ID>\n               </XREF_LINK>\n          </SAMPLE_LINK>\n
-        \         <SAMPLE_LINK>\n               <XREF_LINK>\n                    <DB>ENA-FASTQ-FILES</DB>\n
-        \                   <ID><![CDATA[https://www.ebi.ac.uk/ena/portal/api/filereport?accession=ERS2428796&result=read_run&fields=run_accession,fastq_ftp,fastq_md5,fastq_bytes]]></ID>\n
-        \              </XREF_LINK>\n          </SAMPLE_LINK>\n          <SAMPLE_LINK>\n
-        \              <XREF_LINK>\n                    <DB>ENA-SUBMITTED-FILES</DB>\n
-        \                   <ID><![CDATA[https://www.ebi.ac.uk/ena/portal/api/filereport?accession=ERS2428796&result=read_run&fields=run_accession,submitted_ftp,submitted_md5,submitted_bytes,submitted_format]]></ID>\n
-        \              </XREF_LINK>\n          </SAMPLE_LINK>\n     </SAMPLE_LINKS>\n
-        \    <SAMPLE_ATTRIBUTES>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>isolate</TAG>\n
-        \              <VALUE>not applicable</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
-        \         <SAMPLE_ATTRIBUTE>\n               <TAG>organism</TAG>\n               <VALUE>Homo
-        sapiens</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
-        \              <TAG>organism part</TAG>\n               <VALUE>brain</VALUE>\n
-        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>cell_type</TAG>\n
-        \              <VALUE>glial cell</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
-        \         <SAMPLE_ATTRIBUTE>\n               <TAG>cell_line</TAG>\n               <VALUE>G144</VALUE>\n
+        once with PBS, lysed directly in RLT buffer (Qiagen). Total RNA was extracted
+        using the RNAeasy kit (Qiagen). 500 ng of total RNA was used for library preparation
+        using TruSeq RNA Library Prep Kit v2 (Illumina) according to manufacturer
+        recommendations.</DESCRIPTION>\n     <SAMPLE_LINKS>\n    <SAMPLE_LINK>\n        <XREF_LINK>\n
+        \           <DB>ENA-FASTQ-FILES</DB>\n            <ID><![CDATA[https://www.ebi.ac.uk/ena/portal/api/filereport?accession=ERS2428796&result=read_run&fields=run_accession,fastq_ftp,fastq_md5,fastq_bytes]]></ID>\n
+        \       </XREF_LINK>\n    </SAMPLE_LINK>\n    <SAMPLE_LINK>\n        <XREF_LINK>\n
+        \           <DB>ENA-SUBMITTED-FILES</DB>\n            <ID><![CDATA[https://www.ebi.ac.uk/ena/portal/api/filereport?accession=ERS2428796&result=read_run&fields=run_accession,submitted_ftp,submitted_md5,submitted_bytes,submitted_format]]></ID>\n
+        \       </XREF_LINK>\n    </SAMPLE_LINK>\n</SAMPLE_LINKS>\n<SAMPLE_ATTRIBUTES>\n
+        \         <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-CHECKLIST</TAG>\n               <VALUE>ERC000011</VALUE>\n
         \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>disease</TAG>\n
         \              <VALUE>glioblastoma multiforme</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
-        \         <SAMPLE_ATTRIBUTE>\n               <TAG>genotype</TAG>\n               <VALUE>CRISPR/Cas9
-        mediated knockout of CIC</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
-        \              <TAG>individual</TAG>\n               <VALUE>clonal line #9</VALUE>\n
-        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-CHECKLIST</TAG>\n
-        \              <VALUE>ERC000011</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
-        \              <TAG>ENA-SPOT-COUNT</TAG>\n               <VALUE>28684129</VALUE>\n
-        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-BASE-COUNT</TAG>\n
-        \              <VALUE>2165709760</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
+        \         <SAMPLE_ATTRIBUTE>\n               <TAG>individual</TAG>\n               <VALUE>clonal
+        line #9</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
+        \              <TAG>organism</TAG>\n               <VALUE>Homo sapiens</VALUE>\n
+        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>organism</TAG>\n
+        \              <VALUE>Homo sapiens</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
+        \         <SAMPLE_ATTRIBUTE>\n               <TAG>cell type</TAG>\n               <VALUE>glial
+        cell</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
+        \              <TAG>common name</TAG>\n               <VALUE>human</VALUE>\n
+        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>organism
+        part</TAG>\n               <VALUE>brain</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
+        \         <SAMPLE_ATTRIBUTE>\n               <TAG>cell line</TAG>\n               <VALUE>G144</VALUE>\n
+        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>genotype</TAG>\n
+        \              <VALUE>CRISPR/Cas9 mediated knockout of CIC</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
         \         <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-FIRST-PUBLIC</TAG>\n
         \              <VALUE>2018-05-30</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
         \         <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-LAST-UPDATE</TAG>\n
@@ -4467,7 +3771,7 @@ interactions:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:41:41 GMT
+      - Wed, 17 May 2023 18:36:00 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -4485,7 +3789,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/ERP108370
   response:
@@ -4545,7 +3849,7 @@ interactions:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:41:41 GMT
+      - Wed, 17 May 2023 18:36:00 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -4563,7 +3867,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/ERA1350207
   response:
@@ -4599,7 +3903,7 @@ interactions:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:41:42 GMT
+      - Wed, 17 May 2023 18:36:00 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -4608,68 +3912,6 @@ interactions:
       code: 200
       message: ''
 - request:
-    body: acc=ERR2534081&accept-proto=fasp&version=2.0
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '44'
-      User-Agent:
-      - python-requests/2.25.1
-    method: POST
-    uri: https://www.ncbi.nlm.nih.gov/Traces/names/names.cgi
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAAwzLvQrDIBRA4T1PIXTIlHL91+ydC6FTN7VKWqSKWkrhPnyzno9zYmeYenP14/Gy
-        bUxyAYaiVYpJEJojA2oW0AvYG6WrtCvw+8E+OecNZ1yD9Z6rmICqEI89UsMQUQDg9Z1/ZN7HqH0m
-        tZVRQsnk2YnLuXzjg6TSyNiPUPwrhjH9AQAA//8DAAkU/ZeOAAAA
-    headers:
-      Cache-Control:
-      - private
-      Connection:
-      - Keep-Alive
-      Content-Encoding:
-      - gzip
-      Content-Security-Policy:
-      - upgrade-insecure-requests
-      Content-Type:
-      - text/plain
-      Date:
-      - Wed, 28 Jul 2021 19:41:43 GMT
-      Keep-Alive:
-      - timeout=1, max=10
-      NCBI-PHID:
-      - C7A41E75101B2F710000000000000001.m_1
-      NCBI-SID:
-      - C7A41E75101B2F71_0000SID
-      Referrer-Policy:
-      - origin-when-cross-origin
-      Server:
-      - Apache
-      Set-Cookie:
-      - ncbi_sid=C7A41E75101B2F71_0000SID; domain=.nih.gov; path=/; expires=Thu, 28
-        Jul 2022 19:41:43 GMT
-      SraNameServerOutputVersion:
-      - '2.0'
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains; preload
-      Transfer-Encoding:
-      - chunked
-      Vary:
-      - Accept-Encoding
-      X-UA-Compatible:
-      - IE=Edge
-      X-XSS-Protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
-- request:
     body: null
     headers:
       Accept:
@@ -4679,29 +3921,27 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/portal/api/filereport?accession=ERR2534081&result=read_run
   response:
     body:
-      string: "run_accession\tfastq_ftp\tfastq_bytes\tfastq_md5\tsubmitted_ftp\tsubmitted_bytes\tsubmitted_md5\tsra_ftp\tsra_bytes\tsra_md5\nERR2534081\tftp.sra.ebi.ac.uk/vol1/fastq/ERR253/001/ERR2534081/ERR2534081.fastq.gz\t1446750089\t788fc2528be1fba017c3e3256d283a6b\tftp.sra.ebi.ac.uk/vol1/run/ERR253/ERR2534081/G144_KO9_RNAseq_24h_2.fastq.gz\t1505999963\t7d8548778e311bb0dcc7eee2583dcedd\t\t\t\n"
+      string: "run_accession\tfastq_ftp\tfastq_bytes\tfastq_md5\tbam_ftp\tbam_bytes\tbam_md5\tsubmitted_ftp\tsubmitted_bytes\tsubmitted_md5\tsra_ftp\tsra_bytes\tsra_md5\nERR2534081\tftp.sra.ebi.ac.uk/vol1/fastq/ERR253/001/ERR2534081/ERR2534081.fastq.gz\t1446750089\t788fc2528be1fba017c3e3256d283a6b\t\t\t\tftp.sra.ebi.ac.uk/vol1/run/ERR253/ERR2534081/G144_KO9_RNAseq_24h_2.fastq.gz\t1505999963\t7d8548778e311bb0dcc7eee2583dcedd\tftp.sra.ebi.ac.uk/vol1/err/ERR253/001/ERR2534081\t966250453\tf1d1b0d4d2bc133dfb5df3d4b11f0ea3\n"
     headers:
       Cache-Control:
       - no-cache, no-store, max-age=0, must-revalidate
+      Content-Length:
+      - '483'
       Content-Type:
       - text/plain
       Date:
-      - Wed, 28 Jul 2021 19:41:44 GMT
+      - Wed, 17 May 2023 18:36:01 GMT
       Expires:
       - '0'
       Pragma:
       - no-cache
-      Server:
-      - Apache-Coyote/1.1
       Strict-Transport-Security:
       - max-age=0
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Frame-Options:
@@ -4710,7 +3950,7 @@ interactions:
       - 1; mode=block
     status:
       code: 200
-      message: OK
+      message: ''
 - request:
     body: null
     headers:
@@ -4721,7 +3961,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/ERR2534082
   response:
@@ -4762,7 +4002,7 @@ interactions:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:41:43 GMT
+      - Wed, 17 May 2023 18:36:01 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -4780,7 +4020,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/ERX2552503
   response:
@@ -4848,7 +4088,7 @@ interactions:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:41:44 GMT
+      - Wed, 17 May 2023 18:36:02 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -4866,63 +4106,51 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/ERS2428797
   response:
     body:
       string: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<SAMPLE_SET>\n<SAMPLE accession=\"ERS2428797\"
-        alias=\"E-MTAB-6681:G144_KO9_RNAseq_4h_1\" broker_name=\"ArrayExpress\" center_name=\"BRIC
-        - Biotech Research and Innovation Centre\">\n     <IDENTIFIERS>\n          <PRIMARY_ID>ERS2428797</PRIMARY_ID>\n
-        \         <EXTERNAL_ID namespace=\"BioSample\">SAMEA4608101</EXTERNAL_ID>\n
+        alias=\"E-MTAB-6681:G144_KO9_RNAseq_4h_1\" center_name=\"BRIC - Biotech Research
+        and Innovation Centre\" broker_name=\"ArrayExpress\">\n     <IDENTIFIERS>\n
+        \         <PRIMARY_ID>ERS2428797</PRIMARY_ID>\n          <EXTERNAL_ID namespace=\"BioSample\">SAMEA4608101</EXTERNAL_ID>\n
         \         <SUBMITTER_ID namespace=\"BRIC - Biotech Research and Innovation
         Centre\">E-MTAB-6681:G144_KO9_RNAseq_4h_1</SUBMITTER_ID>\n     </IDENTIFIERS>\n
         \    <TITLE>G144_KO9_RNAseq_4h_1</TITLE>\n     <SAMPLE_NAME>\n          <TAXON_ID>9606</TAXON_ID>\n
         \         <SCIENTIFIC_NAME>Homo sapiens</SCIENTIFIC_NAME>\n          <COMMON_NAME>human</COMMON_NAME>\n
         \    </SAMPLE_NAME>\n     <DESCRIPTION>Protocols: CRISPR mediated KO of CIC:
         sgRNAs (Target sequence: mESCs: GCCTTCATGATCTTCAGCAAG; G144: GGGCGAGTGGTGGTATGCCC)
-        \ were cloned into pSpCas9(BB)-2A-GFP (Addgene 48138) and transfected into
-        mESCs (Lipofectamine 2000) or G144 cells (Amaxa Nucleofector II, Program A033).
+        were cloned into pSpCas9(BB)-2A-GFP (Addgene 48138) and transfected into mESCs
+        (Lipofectamine 2000) or G144 cells (Amaxa Nucleofector II, Program A033).
         GFP-positive cells were single cell sorted 48h post-transfection, expanded
         and screened by immunoblotting for CIC deletion. Inhibitor treatment with
         1 \u03BCM MEK inhibitor (PD0325901) was performed in 80% confluent cultures
         for 4 and 24 h respectively. DMSO was used as mock control. Cells were washed
-        once with PBS, lysed directly in RLT buffer (Qiagen).  Total RNA was extracted
-        using the RNAeasy kit (Qiagen).  500 ng of total RNA was used for library
-        preparation using TruSeq RNA Library Prep Kit v2 (Illumina) according to manufacturer
-        recommendations.</DESCRIPTION>\n     <SAMPLE_LINKS>\n          <SAMPLE_LINK>\n
-        \              <XREF_LINK>\n                    <DB>ENA-STUDY</DB>\n                    <ID>ERP108370</ID>\n
-        \              </XREF_LINK>\n          </SAMPLE_LINK>\n          <SAMPLE_LINK>\n
-        \              <XREF_LINK>\n                    <DB>ENA-EXPERIMENT</DB>\n
-        \                   <ID>ERX2552503</ID>\n               </XREF_LINK>\n          </SAMPLE_LINK>\n
-        \         <SAMPLE_LINK>\n               <XREF_LINK>\n                    <DB>ENA-RUN</DB>\n
-        \                   <ID>ERR2534082</ID>\n               </XREF_LINK>\n          </SAMPLE_LINK>\n
-        \         <SAMPLE_LINK>\n               <XREF_LINK>\n                    <DB>ENA-SUBMISSION</DB>\n
-        \                   <ID>ERA1350207</ID>\n               </XREF_LINK>\n          </SAMPLE_LINK>\n
-        \         <SAMPLE_LINK>\n               <XREF_LINK>\n                    <DB>ENA-FASTQ-FILES</DB>\n
-        \                   <ID><![CDATA[https://www.ebi.ac.uk/ena/portal/api/filereport?accession=ERS2428797&result=read_run&fields=run_accession,fastq_ftp,fastq_md5,fastq_bytes]]></ID>\n
-        \              </XREF_LINK>\n          </SAMPLE_LINK>\n          <SAMPLE_LINK>\n
-        \              <XREF_LINK>\n                    <DB>ENA-SUBMITTED-FILES</DB>\n
-        \                   <ID><![CDATA[https://www.ebi.ac.uk/ena/portal/api/filereport?accession=ERS2428797&result=read_run&fields=run_accession,submitted_ftp,submitted_md5,submitted_bytes,submitted_format]]></ID>\n
-        \              </XREF_LINK>\n          </SAMPLE_LINK>\n     </SAMPLE_LINKS>\n
-        \    <SAMPLE_ATTRIBUTES>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>isolate</TAG>\n
-        \              <VALUE>not applicable</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
-        \         <SAMPLE_ATTRIBUTE>\n               <TAG>organism</TAG>\n               <VALUE>Homo
-        sapiens</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
-        \              <TAG>organism part</TAG>\n               <VALUE>brain</VALUE>\n
-        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>cell_type</TAG>\n
-        \              <VALUE>glial cell</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
-        \         <SAMPLE_ATTRIBUTE>\n               <TAG>cell_line</TAG>\n               <VALUE>G144</VALUE>\n
+        once with PBS, lysed directly in RLT buffer (Qiagen). Total RNA was extracted
+        using the RNAeasy kit (Qiagen). 500 ng of total RNA was used for library preparation
+        using TruSeq RNA Library Prep Kit v2 (Illumina) according to manufacturer
+        recommendations.</DESCRIPTION>\n     <SAMPLE_LINKS>\n    <SAMPLE_LINK>\n        <XREF_LINK>\n
+        \           <DB>ENA-FASTQ-FILES</DB>\n            <ID><![CDATA[https://www.ebi.ac.uk/ena/portal/api/filereport?accession=ERS2428797&result=read_run&fields=run_accession,fastq_ftp,fastq_md5,fastq_bytes]]></ID>\n
+        \       </XREF_LINK>\n    </SAMPLE_LINK>\n    <SAMPLE_LINK>\n        <XREF_LINK>\n
+        \           <DB>ENA-SUBMITTED-FILES</DB>\n            <ID><![CDATA[https://www.ebi.ac.uk/ena/portal/api/filereport?accession=ERS2428797&result=read_run&fields=run_accession,submitted_ftp,submitted_md5,submitted_bytes,submitted_format]]></ID>\n
+        \       </XREF_LINK>\n    </SAMPLE_LINK>\n</SAMPLE_LINKS>\n<SAMPLE_ATTRIBUTES>\n
+        \         <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-CHECKLIST</TAG>\n               <VALUE>ERC000011</VALUE>\n
         \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>disease</TAG>\n
         \              <VALUE>glioblastoma multiforme</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
-        \         <SAMPLE_ATTRIBUTE>\n               <TAG>genotype</TAG>\n               <VALUE>CRISPR/Cas9
-        mediated knockout of CIC</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
-        \              <TAG>individual</TAG>\n               <VALUE>clonal line #9</VALUE>\n
-        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-CHECKLIST</TAG>\n
-        \              <VALUE>ERC000011</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
-        \              <TAG>ENA-SPOT-COUNT</TAG>\n               <VALUE>36759653</VALUE>\n
-        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-BASE-COUNT</TAG>\n
-        \              <VALUE>2776723098</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
+        \         <SAMPLE_ATTRIBUTE>\n               <TAG>individual</TAG>\n               <VALUE>clonal
+        line #9</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
+        \              <TAG>organism</TAG>\n               <VALUE>Homo sapiens</VALUE>\n
+        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>organism</TAG>\n
+        \              <VALUE>Homo sapiens</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
+        \         <SAMPLE_ATTRIBUTE>\n               <TAG>cell type</TAG>\n               <VALUE>glial
+        cell</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
+        \              <TAG>common name</TAG>\n               <VALUE>human</VALUE>\n
+        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>organism
+        part</TAG>\n               <VALUE>brain</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
+        \         <SAMPLE_ATTRIBUTE>\n               <TAG>cell line</TAG>\n               <VALUE>G144</VALUE>\n
+        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>genotype</TAG>\n
+        \              <VALUE>CRISPR/Cas9 mediated knockout of CIC</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
         \         <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-FIRST-PUBLIC</TAG>\n
         \              <VALUE>2018-05-30</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
         \         <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-LAST-UPDATE</TAG>\n
@@ -4932,7 +4160,7 @@ interactions:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:41:44 GMT
+      - Wed, 17 May 2023 18:36:01 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -4950,7 +4178,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/ERP108370
   response:
@@ -5010,7 +4238,7 @@ interactions:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:41:45 GMT
+      - Wed, 17 May 2023 18:36:02 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -5028,7 +4256,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/ERA1350207
   response:
@@ -5064,7 +4292,7 @@ interactions:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:41:46 GMT
+      - Wed, 17 May 2023 18:36:03 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -5073,68 +4301,6 @@ interactions:
       code: 200
       message: ''
 - request:
-    body: acc=ERR2534082&accept-proto=fasp&version=2.0
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '44'
-      User-Agent:
-      - python-requests/2.25.1
-    method: POST
-    uri: https://www.ncbi.nlm.nih.gov/Traces/names/names.cgi
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAAwzIsQ6CMBQF0J2vaOLAhLnvtZXC7mxCnNxoKUHTUAI1xuR9vJ7xnPiM6tjH7e3l
-        OgxstYFjIdYgy9QaYZBr0Dbo7kS9dT3rh0xTB7pQCC54F52BZ+MjQc+sCbAiYgC5remr6qWU7ajV
-        tueSQ07qeagxpfyJk5rzrsryj+xfMZTqBwAA//8DAEXu4WyPAAAA
-    headers:
-      Cache-Control:
-      - private
-      Connection:
-      - Keep-Alive
-      Content-Encoding:
-      - gzip
-      Content-Security-Policy:
-      - upgrade-insecure-requests
-      Content-Type:
-      - text/plain
-      Date:
-      - Wed, 28 Jul 2021 19:41:47 GMT
-      Keep-Alive:
-      - timeout=1, max=10
-      NCBI-PHID:
-      - C7A41EA2101B2FB10000000000000001.m_1
-      NCBI-SID:
-      - C7A41EA2101B2FB1_0000SID
-      Referrer-Policy:
-      - origin-when-cross-origin
-      Server:
-      - Apache
-      Set-Cookie:
-      - ncbi_sid=C7A41EA2101B2FB1_0000SID; domain=.nih.gov; path=/; expires=Thu, 28
-        Jul 2022 19:41:47 GMT
-      SraNameServerOutputVersion:
-      - '2.0'
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains; preload
-      Transfer-Encoding:
-      - chunked
-      Vary:
-      - Accept-Encoding
-      X-UA-Compatible:
-      - IE=Edge
-      X-XSS-Protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
-- request:
     body: null
     headers:
       Accept:
@@ -5144,29 +4310,27 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/portal/api/filereport?accession=ERR2534082&result=read_run
   response:
     body:
-      string: "run_accession\tfastq_ftp\tfastq_bytes\tfastq_md5\tsubmitted_ftp\tsubmitted_bytes\tsubmitted_md5\tsra_ftp\tsra_bytes\tsra_md5\nERR2534082\tftp.sra.ebi.ac.uk/vol1/fastq/ERR253/002/ERR2534082/ERR2534082.fastq.gz\t1810089565\t7b93d8c5e3baaead488b919819d1f8b7\tftp.sra.ebi.ac.uk/vol1/run/ERR253/ERR2534082/G144_KO9_RNAseq_4h_1.fastq.gz\t1914915905\t0050389f2fbb6b230a0adf29580c38df\t\t\t\n"
+      string: "run_accession\tfastq_ftp\tfastq_bytes\tfastq_md5\tbam_ftp\tbam_bytes\tbam_md5\tsubmitted_ftp\tsubmitted_bytes\tsubmitted_md5\tsra_ftp\tsra_bytes\tsra_md5\nERR2534082\tftp.sra.ebi.ac.uk/vol1/fastq/ERR253/002/ERR2534082/ERR2534082.fastq.gz\t1810089565\t7b93d8c5e3baaead488b919819d1f8b7\t\t\t\tftp.sra.ebi.ac.uk/vol1/run/ERR253/ERR2534082/G144_KO9_RNAseq_4h_1.fastq.gz\t1914915905\t0050389f2fbb6b230a0adf29580c38df\tftp.sra.ebi.ac.uk/vol1/err/ERR253/002/ERR2534082\t1230152154\tdae4a49ebab73aa65c79030b43c2e931\n"
     headers:
       Cache-Control:
       - no-cache, no-store, max-age=0, must-revalidate
+      Content-Length:
+      - '483'
       Content-Type:
       - text/plain
       Date:
-      - Wed, 28 Jul 2021 19:41:48 GMT
+      - Wed, 17 May 2023 18:36:03 GMT
       Expires:
       - '0'
       Pragma:
       - no-cache
-      Server:
-      - Apache-Coyote/1.1
       Strict-Transport-Security:
       - max-age=0
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Frame-Options:
@@ -5175,7 +4339,7 @@ interactions:
       - 1; mode=block
     status:
       code: 200
-      message: OK
+      message: ''
 - request:
     body: null
     headers:
@@ -5186,7 +4350,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/ERR2534083
   response:
@@ -5227,7 +4391,7 @@ interactions:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:41:49 GMT
+      - Wed, 17 May 2023 18:36:03 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -5245,7 +4409,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/ERX2552504
   response:
@@ -5313,7 +4477,7 @@ interactions:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:41:49 GMT
+      - Wed, 17 May 2023 18:36:04 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -5331,63 +4495,51 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/ERS2428798
   response:
     body:
       string: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<SAMPLE_SET>\n<SAMPLE accession=\"ERS2428798\"
-        alias=\"E-MTAB-6681:G144_KO9_RNAseq_4h_2\" broker_name=\"ArrayExpress\" center_name=\"BRIC
-        - Biotech Research and Innovation Centre\">\n     <IDENTIFIERS>\n          <PRIMARY_ID>ERS2428798</PRIMARY_ID>\n
-        \         <EXTERNAL_ID namespace=\"BioSample\">SAMEA4608102</EXTERNAL_ID>\n
+        alias=\"E-MTAB-6681:G144_KO9_RNAseq_4h_2\" center_name=\"BRIC - Biotech Research
+        and Innovation Centre\" broker_name=\"ArrayExpress\">\n     <IDENTIFIERS>\n
+        \         <PRIMARY_ID>ERS2428798</PRIMARY_ID>\n          <EXTERNAL_ID namespace=\"BioSample\">SAMEA4608102</EXTERNAL_ID>\n
         \         <SUBMITTER_ID namespace=\"BRIC - Biotech Research and Innovation
         Centre\">E-MTAB-6681:G144_KO9_RNAseq_4h_2</SUBMITTER_ID>\n     </IDENTIFIERS>\n
         \    <TITLE>G144_KO9_RNAseq_4h_2</TITLE>\n     <SAMPLE_NAME>\n          <TAXON_ID>9606</TAXON_ID>\n
         \         <SCIENTIFIC_NAME>Homo sapiens</SCIENTIFIC_NAME>\n          <COMMON_NAME>human</COMMON_NAME>\n
         \    </SAMPLE_NAME>\n     <DESCRIPTION>Protocols: CRISPR mediated KO of CIC:
         sgRNAs (Target sequence: mESCs: GCCTTCATGATCTTCAGCAAG; G144: GGGCGAGTGGTGGTATGCCC)
-        \ were cloned into pSpCas9(BB)-2A-GFP (Addgene 48138) and transfected into
-        mESCs (Lipofectamine 2000) or G144 cells (Amaxa Nucleofector II, Program A033).
+        were cloned into pSpCas9(BB)-2A-GFP (Addgene 48138) and transfected into mESCs
+        (Lipofectamine 2000) or G144 cells (Amaxa Nucleofector II, Program A033).
         GFP-positive cells were single cell sorted 48h post-transfection, expanded
         and screened by immunoblotting for CIC deletion. Inhibitor treatment with
         1 \u03BCM MEK inhibitor (PD0325901) was performed in 80% confluent cultures
         for 4 and 24 h respectively. DMSO was used as mock control. Cells were washed
-        once with PBS, lysed directly in RLT buffer (Qiagen).  Total RNA was extracted
-        using the RNAeasy kit (Qiagen).  500 ng of total RNA was used for library
-        preparation using TruSeq RNA Library Prep Kit v2 (Illumina) according to manufacturer
-        recommendations.</DESCRIPTION>\n     <SAMPLE_LINKS>\n          <SAMPLE_LINK>\n
-        \              <XREF_LINK>\n                    <DB>ENA-STUDY</DB>\n                    <ID>ERP108370</ID>\n
-        \              </XREF_LINK>\n          </SAMPLE_LINK>\n          <SAMPLE_LINK>\n
-        \              <XREF_LINK>\n                    <DB>ENA-EXPERIMENT</DB>\n
-        \                   <ID>ERX2552504</ID>\n               </XREF_LINK>\n          </SAMPLE_LINK>\n
-        \         <SAMPLE_LINK>\n               <XREF_LINK>\n                    <DB>ENA-RUN</DB>\n
-        \                   <ID>ERR2534083</ID>\n               </XREF_LINK>\n          </SAMPLE_LINK>\n
-        \         <SAMPLE_LINK>\n               <XREF_LINK>\n                    <DB>ENA-SUBMISSION</DB>\n
-        \                   <ID>ERA1350207</ID>\n               </XREF_LINK>\n          </SAMPLE_LINK>\n
-        \         <SAMPLE_LINK>\n               <XREF_LINK>\n                    <DB>ENA-FASTQ-FILES</DB>\n
-        \                   <ID><![CDATA[https://www.ebi.ac.uk/ena/portal/api/filereport?accession=ERS2428798&result=read_run&fields=run_accession,fastq_ftp,fastq_md5,fastq_bytes]]></ID>\n
-        \              </XREF_LINK>\n          </SAMPLE_LINK>\n          <SAMPLE_LINK>\n
-        \              <XREF_LINK>\n                    <DB>ENA-SUBMITTED-FILES</DB>\n
-        \                   <ID><![CDATA[https://www.ebi.ac.uk/ena/portal/api/filereport?accession=ERS2428798&result=read_run&fields=run_accession,submitted_ftp,submitted_md5,submitted_bytes,submitted_format]]></ID>\n
-        \              </XREF_LINK>\n          </SAMPLE_LINK>\n     </SAMPLE_LINKS>\n
-        \    <SAMPLE_ATTRIBUTES>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>isolate</TAG>\n
-        \              <VALUE>not applicable</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
-        \         <SAMPLE_ATTRIBUTE>\n               <TAG>organism</TAG>\n               <VALUE>Homo
-        sapiens</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
-        \              <TAG>organism part</TAG>\n               <VALUE>brain</VALUE>\n
-        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>cell_type</TAG>\n
-        \              <VALUE>glial cell</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
-        \         <SAMPLE_ATTRIBUTE>\n               <TAG>cell_line</TAG>\n               <VALUE>G144</VALUE>\n
+        once with PBS, lysed directly in RLT buffer (Qiagen). Total RNA was extracted
+        using the RNAeasy kit (Qiagen). 500 ng of total RNA was used for library preparation
+        using TruSeq RNA Library Prep Kit v2 (Illumina) according to manufacturer
+        recommendations.</DESCRIPTION>\n     <SAMPLE_LINKS>\n    <SAMPLE_LINK>\n        <XREF_LINK>\n
+        \           <DB>ENA-FASTQ-FILES</DB>\n            <ID><![CDATA[https://www.ebi.ac.uk/ena/portal/api/filereport?accession=ERS2428798&result=read_run&fields=run_accession,fastq_ftp,fastq_md5,fastq_bytes]]></ID>\n
+        \       </XREF_LINK>\n    </SAMPLE_LINK>\n    <SAMPLE_LINK>\n        <XREF_LINK>\n
+        \           <DB>ENA-SUBMITTED-FILES</DB>\n            <ID><![CDATA[https://www.ebi.ac.uk/ena/portal/api/filereport?accession=ERS2428798&result=read_run&fields=run_accession,submitted_ftp,submitted_md5,submitted_bytes,submitted_format]]></ID>\n
+        \       </XREF_LINK>\n    </SAMPLE_LINK>\n</SAMPLE_LINKS>\n<SAMPLE_ATTRIBUTES>\n
+        \         <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-CHECKLIST</TAG>\n               <VALUE>ERC000011</VALUE>\n
         \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>disease</TAG>\n
         \              <VALUE>glioblastoma multiforme</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
-        \         <SAMPLE_ATTRIBUTE>\n               <TAG>genotype</TAG>\n               <VALUE>CRISPR/Cas9
-        mediated knockout of CIC</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
-        \              <TAG>individual</TAG>\n               <VALUE>clonal line #9</VALUE>\n
-        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-CHECKLIST</TAG>\n
-        \              <VALUE>ERC000011</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
-        \              <TAG>ENA-SPOT-COUNT</TAG>\n               <VALUE>28325395</VALUE>\n
-        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-BASE-COUNT</TAG>\n
-        \              <VALUE>2139937955</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
+        \         <SAMPLE_ATTRIBUTE>\n               <TAG>individual</TAG>\n               <VALUE>clonal
+        line #9</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
+        \              <TAG>organism</TAG>\n               <VALUE>Homo sapiens</VALUE>\n
+        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>organism</TAG>\n
+        \              <VALUE>Homo sapiens</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
+        \         <SAMPLE_ATTRIBUTE>\n               <TAG>cell type</TAG>\n               <VALUE>glial
+        cell</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
+        \              <TAG>common name</TAG>\n               <VALUE>human</VALUE>\n
+        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>organism
+        part</TAG>\n               <VALUE>brain</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
+        \         <SAMPLE_ATTRIBUTE>\n               <TAG>cell line</TAG>\n               <VALUE>G144</VALUE>\n
+        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>genotype</TAG>\n
+        \              <VALUE>CRISPR/Cas9 mediated knockout of CIC</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
         \         <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-FIRST-PUBLIC</TAG>\n
         \              <VALUE>2018-05-30</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
         \         <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-LAST-UPDATE</TAG>\n
@@ -5397,7 +4549,7 @@ interactions:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:41:50 GMT
+      - Wed, 17 May 2023 18:36:04 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -5415,7 +4567,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/ERP108370
   response:
@@ -5475,7 +4627,7 @@ interactions:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:41:51 GMT
+      - Wed, 17 May 2023 18:36:04 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -5493,7 +4645,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/ERA1350207
   response:
@@ -5529,7 +4681,7 @@ interactions:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:41:51 GMT
+      - Wed, 17 May 2023 18:36:05 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -5538,68 +4690,6 @@ interactions:
       code: 200
       message: ''
 - request:
-    body: acc=ERR2534083&accept-proto=fasp&version=2.0
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '44'
-      User-Agent:
-      - python-requests/2.25.1
-    method: POST
-    uri: https://www.ncbi.nlm.nih.gov/Traces/names/names.cgi
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAAwzIsQqDMBAA0N2vCHRwspx3F3O6dy5Ip25GI7aERkxKKdzHt298JzxDlY9pf3u9
-        jCNaYhDS3pLjjp0oQisNuAb6W4sDwEDdXTtyKEKIC1MvsthAtEJoCW1gdl5VGUCvr/g19VbKnmuz
-        H6mkOUXzyGaKMX3CYtZ0mLL9I/lnmEv1AwAA//8DAGfSJeKOAAAA
-    headers:
-      Cache-Control:
-      - private
-      Connection:
-      - Keep-Alive
-      Content-Encoding:
-      - gzip
-      Content-Security-Policy:
-      - upgrade-insecure-requests
-      Content-Type:
-      - text/plain
-      Date:
-      - Wed, 28 Jul 2021 19:41:52 GMT
-      Keep-Alive:
-      - timeout=1, max=10
-      NCBI-PHID:
-      - C7A41EC6101B30010000000000000001.m_1
-      NCBI-SID:
-      - C7A41EC6101B3001_0000SID
-      Referrer-Policy:
-      - origin-when-cross-origin
-      Server:
-      - Apache
-      Set-Cookie:
-      - ncbi_sid=C7A41EC6101B3001_0000SID; domain=.nih.gov; path=/; expires=Thu, 28
-        Jul 2022 19:41:52 GMT
-      SraNameServerOutputVersion:
-      - '2.0'
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains; preload
-      Transfer-Encoding:
-      - chunked
-      Vary:
-      - Accept-Encoding
-      X-UA-Compatible:
-      - IE=Edge
-      X-XSS-Protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
-- request:
     body: null
     headers:
       Accept:
@@ -5609,29 +4699,27 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/portal/api/filereport?accession=ERR2534083&result=read_run
   response:
     body:
-      string: "run_accession\tfastq_ftp\tfastq_bytes\tfastq_md5\tsubmitted_ftp\tsubmitted_bytes\tsubmitted_md5\tsra_ftp\tsra_bytes\tsra_md5\nERR2534083\tftp.sra.ebi.ac.uk/vol1/fastq/ERR253/003/ERR2534083/ERR2534083.fastq.gz\t1364338778\t5d9c21fcdbf30929dd54fe64a2858096\tftp.sra.ebi.ac.uk/vol1/run/ERR253/ERR2534083/G144_KO9_RNAseq_4h_2.fastq.gz\t1476580896\tb175da8f8c4548f974ca380386daa3b9\t\t\t\n"
+      string: "run_accession\tfastq_ftp\tfastq_bytes\tfastq_md5\tbam_ftp\tbam_bytes\tbam_md5\tsubmitted_ftp\tsubmitted_bytes\tsubmitted_md5\tsra_ftp\tsra_bytes\tsra_md5\nERR2534083\tftp.sra.ebi.ac.uk/vol1/fastq/ERR253/003/ERR2534083/ERR2534083.fastq.gz\t1364338778\t5d9c21fcdbf30929dd54fe64a2858096\t\t\t\tftp.sra.ebi.ac.uk/vol1/run/ERR253/ERR2534083/G144_KO9_RNAseq_4h_2.fastq.gz\t1476580896\tb175da8f8c4548f974ca380386daa3b9\tftp.sra.ebi.ac.uk/vol1/err/ERR253/003/ERR2534083\t953746458\ta8d792feb447419a62dc2ad2388904f9\n"
     headers:
       Cache-Control:
       - no-cache, no-store, max-age=0, must-revalidate
+      Content-Length:
+      - '482'
       Content-Type:
       - text/plain
       Date:
-      - Wed, 28 Jul 2021 19:41:52 GMT
+      - Wed, 17 May 2023 18:36:06 GMT
       Expires:
       - '0'
       Pragma:
       - no-cache
-      Server:
-      - Apache-Coyote/1.1
       Strict-Transport-Security:
       - max-age=0
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Frame-Options:
@@ -5640,7 +4728,7 @@ interactions:
       - 1; mode=block
     status:
       code: 200
-      message: OK
+      message: ''
 - request:
     body: null
     headers:
@@ -5651,7 +4739,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/ERR2534084
   response:
@@ -5693,7 +4781,7 @@ interactions:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:41:53 GMT
+      - Wed, 17 May 2023 18:36:05 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -5711,7 +4799,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/ERX2552505
   response:
@@ -5775,7 +4863,7 @@ interactions:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:41:53 GMT
+      - Wed, 17 May 2023 18:36:07 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -5793,14 +4881,14 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/ERS2428799
   response:
     body:
       string: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<SAMPLE_SET>\n<SAMPLE accession=\"ERS2428799\"
-        alias=\"E-MTAB-6681:G144_Parental_RNAseq_DMSO1\" broker_name=\"ArrayExpress\"
-        center_name=\"BRIC - Biotech Research and Innovation Centre\">\n     <IDENTIFIERS>\n
+        alias=\"E-MTAB-6681:G144_Parental_RNAseq_DMSO1\" center_name=\"BRIC - Biotech
+        Research and Innovation Centre\" broker_name=\"ArrayExpress\">\n     <IDENTIFIERS>\n
         \         <PRIMARY_ID>ERS2428799</PRIMARY_ID>\n          <EXTERNAL_ID namespace=\"BioSample\">SAMEA4608103</EXTERNAL_ID>\n
         \         <SUBMITTER_ID namespace=\"BRIC - Biotech Research and Innovation
         Centre\">E-MTAB-6681:G144_Parental_RNAseq_DMSO1</SUBMITTER_ID>\n     </IDENTIFIERS>\n
@@ -5808,57 +4896,45 @@ interactions:
         \         <SCIENTIFIC_NAME>Homo sapiens</SCIENTIFIC_NAME>\n          <COMMON_NAME>human</COMMON_NAME>\n
         \    </SAMPLE_NAME>\n     <DESCRIPTION>Protocols: CRISPR mediated KO of CIC:
         sgRNAs (Target sequence: mESCs: GCCTTCATGATCTTCAGCAAG; G144: GGGCGAGTGGTGGTATGCCC)
-        \ were cloned into pSpCas9(BB)-2A-GFP (Addgene 48138) and transfected into
-        mESCs (Lipofectamine 2000) or G144 cells (Amaxa Nucleofector II, Program A033).
+        were cloned into pSpCas9(BB)-2A-GFP (Addgene 48138) and transfected into mESCs
+        (Lipofectamine 2000) or G144 cells (Amaxa Nucleofector II, Program A033).
         GFP-positive cells were single cell sorted 48h post-transfection, expanded
         and screened by immunoblotting for CIC deletion. Inhibitor treatment with
         1 \u03BCM MEK inhibitor (PD0325901) was performed in 80% confluent cultures
         for 4 and 24 h respectively. DMSO was used as mock control. Cells were washed
-        once with PBS, lysed directly in RLT buffer (Qiagen).  Total RNA was extracted
-        using the RNAeasy kit (Qiagen).  500 ng of total RNA was used for library
-        preparation using TruSeq RNA Library Prep Kit v2 (Illumina) according to manufacturer
-        recommendations.</DESCRIPTION>\n     <SAMPLE_LINKS>\n          <SAMPLE_LINK>\n
-        \              <XREF_LINK>\n                    <DB>ENA-STUDY</DB>\n                    <ID>ERP108370</ID>\n
-        \              </XREF_LINK>\n          </SAMPLE_LINK>\n          <SAMPLE_LINK>\n
-        \              <XREF_LINK>\n                    <DB>ENA-EXPERIMENT</DB>\n
-        \                   <ID>ERX2552505</ID>\n               </XREF_LINK>\n          </SAMPLE_LINK>\n
-        \         <SAMPLE_LINK>\n               <XREF_LINK>\n                    <DB>ENA-RUN</DB>\n
-        \                   <ID>ERR2534084</ID>\n               </XREF_LINK>\n          </SAMPLE_LINK>\n
-        \         <SAMPLE_LINK>\n               <XREF_LINK>\n                    <DB>ENA-SUBMISSION</DB>\n
-        \                   <ID>ERA1350207</ID>\n               </XREF_LINK>\n          </SAMPLE_LINK>\n
-        \         <SAMPLE_LINK>\n               <XREF_LINK>\n                    <DB>ENA-FASTQ-FILES</DB>\n
-        \                   <ID><![CDATA[https://www.ebi.ac.uk/ena/portal/api/filereport?accession=ERS2428799&result=read_run&fields=run_accession,fastq_ftp,fastq_md5,fastq_bytes]]></ID>\n
-        \              </XREF_LINK>\n          </SAMPLE_LINK>\n          <SAMPLE_LINK>\n
-        \              <XREF_LINK>\n                    <DB>ENA-SUBMITTED-FILES</DB>\n
-        \                   <ID><![CDATA[https://www.ebi.ac.uk/ena/portal/api/filereport?accession=ERS2428799&result=read_run&fields=run_accession,submitted_ftp,submitted_md5,submitted_bytes,submitted_format]]></ID>\n
-        \              </XREF_LINK>\n          </SAMPLE_LINK>\n     </SAMPLE_LINKS>\n
-        \    <SAMPLE_ATTRIBUTES>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>isolate</TAG>\n
-        \              <VALUE>not applicable</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
-        \         <SAMPLE_ATTRIBUTE>\n               <TAG>organism</TAG>\n               <VALUE>Homo
-        sapiens</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
-        \              <TAG>organism part</TAG>\n               <VALUE>brain</VALUE>\n
-        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>cell_type</TAG>\n
-        \              <VALUE>glial cell</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
-        \         <SAMPLE_ATTRIBUTE>\n               <TAG>cell_line</TAG>\n               <VALUE>G144</VALUE>\n
+        once with PBS, lysed directly in RLT buffer (Qiagen). Total RNA was extracted
+        using the RNAeasy kit (Qiagen). 500 ng of total RNA was used for library preparation
+        using TruSeq RNA Library Prep Kit v2 (Illumina) according to manufacturer
+        recommendations.</DESCRIPTION>\n     <SAMPLE_LINKS>\n    <SAMPLE_LINK>\n        <XREF_LINK>\n
+        \           <DB>ENA-FASTQ-FILES</DB>\n            <ID><![CDATA[https://www.ebi.ac.uk/ena/portal/api/filereport?accession=ERS2428799&result=read_run&fields=run_accession,fastq_ftp,fastq_md5,fastq_bytes]]></ID>\n
+        \       </XREF_LINK>\n    </SAMPLE_LINK>\n    <SAMPLE_LINK>\n        <XREF_LINK>\n
+        \           <DB>ENA-SUBMITTED-FILES</DB>\n            <ID><![CDATA[https://www.ebi.ac.uk/ena/portal/api/filereport?accession=ERS2428799&result=read_run&fields=run_accession,submitted_ftp,submitted_md5,submitted_bytes,submitted_format]]></ID>\n
+        \       </XREF_LINK>\n    </SAMPLE_LINK>\n</SAMPLE_LINKS>\n<SAMPLE_ATTRIBUTES>\n
+        \         <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-CHECKLIST</TAG>\n               <VALUE>ERC000011</VALUE>\n
         \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>disease</TAG>\n
         \              <VALUE>glioblastoma multiforme</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
+        \         <SAMPLE_ATTRIBUTE>\n               <TAG>individual</TAG>\n               <VALUE>1</VALUE>\n
+        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>organism</TAG>\n
+        \              <VALUE>Homo sapiens</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
+        \         <SAMPLE_ATTRIBUTE>\n               <TAG>organism</TAG>\n               <VALUE>Homo
+        sapiens</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
+        \              <TAG>cell type</TAG>\n               <VALUE>glial cell</VALUE>\n
+        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>common
+        name</TAG>\n               <VALUE>human</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
+        \         <SAMPLE_ATTRIBUTE>\n               <TAG>organism part</TAG>\n               <VALUE>brain</VALUE>\n
+        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>cell
+        line</TAG>\n               <VALUE>G144</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
         \         <SAMPLE_ATTRIBUTE>\n               <TAG>genotype</TAG>\n               <VALUE>wild
         type genotype</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
-        \              <TAG>individual</TAG>\n               <VALUE>1</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
-        \         <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-CHECKLIST</TAG>\n               <VALUE>ERC000011</VALUE>\n
-        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-SPOT-COUNT</TAG>\n
-        \              <VALUE>26499768</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
-        \              <TAG>ENA-BASE-COUNT</TAG>\n               <VALUE>2000152520</VALUE>\n
-        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-FIRST-PUBLIC</TAG>\n
-        \              <VALUE>2018-05-30</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
-        \         <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-LAST-UPDATE</TAG>\n
+        \              <TAG>ENA-FIRST-PUBLIC</TAG>\n               <VALUE>2018-05-30</VALUE>\n
+        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-LAST-UPDATE</TAG>\n
         \              <VALUE>2018-04-24</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
         \    </SAMPLE_ATTRIBUTES>\n</SAMPLE>\n</SAMPLE_SET>\n"
     headers:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:41:54 GMT
+      - Wed, 17 May 2023 18:36:07 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -5876,7 +4952,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/ERP108370
   response:
@@ -5936,7 +5012,7 @@ interactions:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:41:54 GMT
+      - Wed, 17 May 2023 18:36:07 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -5954,7 +5030,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/ERA1350207
   response:
@@ -5990,7 +5066,7 @@ interactions:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:41:55 GMT
+      - Wed, 17 May 2023 18:36:07 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -5999,68 +5075,6 @@ interactions:
       code: 200
       message: ''
 - request:
-    body: acc=ERR2534084&accept-proto=fasp&version=2.0
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '44'
-      User-Agent:
-      - python-requests/2.25.1
-    method: POST
-    uri: https://www.ncbi.nlm.nih.gov/Traces/names/names.cgi
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAAwzIvQrCMBAA4L1PEXDoVLlcc/np7iwUJ7cmbagSTGgiItzD6zd+JzxDV4+lvD1f
-        5hlpVGAVW9RKAjrNCNIOYAZwNyknchOZOxOOgdDFqAKsligY2LxxOjqPZIJlZgXA11f6in5vrdRe
-        lCO3HHISjyqWlPJnW0XMh2j7P7J/bqF1PwAAAP//AwCTsKqLjgAAAA==
-    headers:
-      Cache-Control:
-      - private
-      Connection:
-      - Keep-Alive
-      Content-Encoding:
-      - gzip
-      Content-Security-Policy:
-      - upgrade-insecure-requests
-      Content-Type:
-      - text/plain
-      Date:
-      - Wed, 28 Jul 2021 19:41:56 GMT
-      Keep-Alive:
-      - timeout=1, max=10
-      NCBI-PHID:
-      - CC95EFB4101B30410000000000000001.m_1
-      NCBI-SID:
-      - CC95EFB4101B3041_0000SID
-      Referrer-Policy:
-      - origin-when-cross-origin
-      Server:
-      - Apache
-      Set-Cookie:
-      - ncbi_sid=CC95EFB4101B3041_0000SID; domain=.nih.gov; path=/; expires=Thu, 28
-        Jul 2022 19:41:56 GMT
-      SraNameServerOutputVersion:
-      - '2.0'
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains; preload
-      Transfer-Encoding:
-      - chunked
-      Vary:
-      - Accept-Encoding
-      X-UA-Compatible:
-      - IE=Edge
-      X-XSS-Protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
-- request:
     body: null
     headers:
       Accept:
@@ -6070,29 +5084,27 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/portal/api/filereport?accession=ERR2534084&result=read_run
   response:
     body:
-      string: "run_accession\tfastq_ftp\tfastq_bytes\tfastq_md5\tsubmitted_ftp\tsubmitted_bytes\tsubmitted_md5\tsra_ftp\tsra_bytes\tsra_md5\nERR2534084\tftp.sra.ebi.ac.uk/vol1/fastq/ERR253/004/ERR2534084/ERR2534084.fastq.gz\t1246412999\t66ea10048085214a1d6a2164fad08440\tftp.sra.ebi.ac.uk/vol1/run/ERR253/ERR2534084/G144_Parental_RNAseq_DMSO1.fastq.gz\t1298135488\ta174bf37dd39e1848734eebd87555d64\t\t\t\n"
+      string: "run_accession\tfastq_ftp\tfastq_bytes\tfastq_md5\tbam_ftp\tbam_bytes\tbam_md5\tsubmitted_ftp\tsubmitted_bytes\tsubmitted_md5\tsra_ftp\tsra_bytes\tsra_md5\nERR2534084\tftp.sra.ebi.ac.uk/vol1/fastq/ERR253/004/ERR2534084/ERR2534084.fastq.gz\t1246412999\t66ea10048085214a1d6a2164fad08440\t\t\t\tftp.sra.ebi.ac.uk/vol1/run/ERR253/ERR2534084/G144_Parental_RNAseq_DMSO1.fastq.gz\t1298135488\ta174bf37dd39e1848734eebd87555d64\tftp.sra.ebi.ac.uk/vol1/err/ERR253/004/ERR2534084\t826410276\t07fa8afa15db6810690ce69acd63ec31\n"
     headers:
       Cache-Control:
       - no-cache, no-store, max-age=0, must-revalidate
+      Content-Length:
+      - '488'
       Content-Type:
       - text/plain
       Date:
-      - Wed, 28 Jul 2021 19:41:57 GMT
+      - Wed, 17 May 2023 18:36:08 GMT
       Expires:
       - '0'
       Pragma:
       - no-cache
-      Server:
-      - Apache-Coyote/1.1
       Strict-Transport-Security:
       - max-age=0
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Frame-Options:
@@ -6101,7 +5113,7 @@ interactions:
       - 1; mode=block
     status:
       code: 200
-      message: OK
+      message: ''
 - request:
     body: null
     headers:
@@ -6112,7 +5124,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/ERR2534085
   response:
@@ -6154,7 +5166,7 @@ interactions:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:41:57 GMT
+      - Wed, 17 May 2023 18:36:08 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -6172,7 +5184,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/ERX2552506
   response:
@@ -6236,7 +5248,7 @@ interactions:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:41:58 GMT
+      - Wed, 17 May 2023 18:36:08 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -6254,14 +5266,14 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/ERS2428800
   response:
     body:
       string: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<SAMPLE_SET>\n<SAMPLE accession=\"ERS2428800\"
-        alias=\"E-MTAB-6681:G144_Parental_RNAseq_DMSO2\" broker_name=\"ArrayExpress\"
-        center_name=\"BRIC - Biotech Research and Innovation Centre\">\n     <IDENTIFIERS>\n
+        alias=\"E-MTAB-6681:G144_Parental_RNAseq_DMSO2\" center_name=\"BRIC - Biotech
+        Research and Innovation Centre\" broker_name=\"ArrayExpress\">\n     <IDENTIFIERS>\n
         \         <PRIMARY_ID>ERS2428800</PRIMARY_ID>\n          <EXTERNAL_ID namespace=\"BioSample\">SAMEA4608104</EXTERNAL_ID>\n
         \         <SUBMITTER_ID namespace=\"BRIC - Biotech Research and Innovation
         Centre\">E-MTAB-6681:G144_Parental_RNAseq_DMSO2</SUBMITTER_ID>\n     </IDENTIFIERS>\n
@@ -6269,57 +5281,45 @@ interactions:
         \         <SCIENTIFIC_NAME>Homo sapiens</SCIENTIFIC_NAME>\n          <COMMON_NAME>human</COMMON_NAME>\n
         \    </SAMPLE_NAME>\n     <DESCRIPTION>Protocols: CRISPR mediated KO of CIC:
         sgRNAs (Target sequence: mESCs: GCCTTCATGATCTTCAGCAAG; G144: GGGCGAGTGGTGGTATGCCC)
-        \ were cloned into pSpCas9(BB)-2A-GFP (Addgene 48138) and transfected into
-        mESCs (Lipofectamine 2000) or G144 cells (Amaxa Nucleofector II, Program A033).
+        were cloned into pSpCas9(BB)-2A-GFP (Addgene 48138) and transfected into mESCs
+        (Lipofectamine 2000) or G144 cells (Amaxa Nucleofector II, Program A033).
         GFP-positive cells were single cell sorted 48h post-transfection, expanded
         and screened by immunoblotting for CIC deletion. Inhibitor treatment with
         1 \u03BCM MEK inhibitor (PD0325901) was performed in 80% confluent cultures
         for 4 and 24 h respectively. DMSO was used as mock control. Cells were washed
-        once with PBS, lysed directly in RLT buffer (Qiagen).  Total RNA was extracted
-        using the RNAeasy kit (Qiagen).  500 ng of total RNA was used for library
-        preparation using TruSeq RNA Library Prep Kit v2 (Illumina) according to manufacturer
-        recommendations.</DESCRIPTION>\n     <SAMPLE_LINKS>\n          <SAMPLE_LINK>\n
-        \              <XREF_LINK>\n                    <DB>ENA-STUDY</DB>\n                    <ID>ERP108370</ID>\n
-        \              </XREF_LINK>\n          </SAMPLE_LINK>\n          <SAMPLE_LINK>\n
-        \              <XREF_LINK>\n                    <DB>ENA-EXPERIMENT</DB>\n
-        \                   <ID>ERX2552506</ID>\n               </XREF_LINK>\n          </SAMPLE_LINK>\n
-        \         <SAMPLE_LINK>\n               <XREF_LINK>\n                    <DB>ENA-RUN</DB>\n
-        \                   <ID>ERR2534085</ID>\n               </XREF_LINK>\n          </SAMPLE_LINK>\n
-        \         <SAMPLE_LINK>\n               <XREF_LINK>\n                    <DB>ENA-SUBMISSION</DB>\n
-        \                   <ID>ERA1350207</ID>\n               </XREF_LINK>\n          </SAMPLE_LINK>\n
-        \         <SAMPLE_LINK>\n               <XREF_LINK>\n                    <DB>ENA-FASTQ-FILES</DB>\n
-        \                   <ID><![CDATA[https://www.ebi.ac.uk/ena/portal/api/filereport?accession=ERS2428800&result=read_run&fields=run_accession,fastq_ftp,fastq_md5,fastq_bytes]]></ID>\n
-        \              </XREF_LINK>\n          </SAMPLE_LINK>\n          <SAMPLE_LINK>\n
-        \              <XREF_LINK>\n                    <DB>ENA-SUBMITTED-FILES</DB>\n
-        \                   <ID><![CDATA[https://www.ebi.ac.uk/ena/portal/api/filereport?accession=ERS2428800&result=read_run&fields=run_accession,submitted_ftp,submitted_md5,submitted_bytes,submitted_format]]></ID>\n
-        \              </XREF_LINK>\n          </SAMPLE_LINK>\n     </SAMPLE_LINKS>\n
-        \    <SAMPLE_ATTRIBUTES>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>isolate</TAG>\n
-        \              <VALUE>not applicable</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
-        \         <SAMPLE_ATTRIBUTE>\n               <TAG>organism</TAG>\n               <VALUE>Homo
-        sapiens</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
-        \              <TAG>organism part</TAG>\n               <VALUE>brain</VALUE>\n
-        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>cell_type</TAG>\n
-        \              <VALUE>glial cell</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
-        \         <SAMPLE_ATTRIBUTE>\n               <TAG>cell_line</TAG>\n               <VALUE>G144</VALUE>\n
+        once with PBS, lysed directly in RLT buffer (Qiagen). Total RNA was extracted
+        using the RNAeasy kit (Qiagen). 500 ng of total RNA was used for library preparation
+        using TruSeq RNA Library Prep Kit v2 (Illumina) according to manufacturer
+        recommendations.</DESCRIPTION>\n     <SAMPLE_LINKS>\n    <SAMPLE_LINK>\n        <XREF_LINK>\n
+        \           <DB>ENA-FASTQ-FILES</DB>\n            <ID><![CDATA[https://www.ebi.ac.uk/ena/portal/api/filereport?accession=ERS2428800&result=read_run&fields=run_accession,fastq_ftp,fastq_md5,fastq_bytes]]></ID>\n
+        \       </XREF_LINK>\n    </SAMPLE_LINK>\n    <SAMPLE_LINK>\n        <XREF_LINK>\n
+        \           <DB>ENA-SUBMITTED-FILES</DB>\n            <ID><![CDATA[https://www.ebi.ac.uk/ena/portal/api/filereport?accession=ERS2428800&result=read_run&fields=run_accession,submitted_ftp,submitted_md5,submitted_bytes,submitted_format]]></ID>\n
+        \       </XREF_LINK>\n    </SAMPLE_LINK>\n</SAMPLE_LINKS>\n<SAMPLE_ATTRIBUTES>\n
+        \         <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-CHECKLIST</TAG>\n               <VALUE>ERC000011</VALUE>\n
         \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>disease</TAG>\n
         \              <VALUE>glioblastoma multiforme</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
+        \         <SAMPLE_ATTRIBUTE>\n               <TAG>individual</TAG>\n               <VALUE>1</VALUE>\n
+        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>organism</TAG>\n
+        \              <VALUE>Homo sapiens</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
+        \         <SAMPLE_ATTRIBUTE>\n               <TAG>organism</TAG>\n               <VALUE>Homo
+        sapiens</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
+        \              <TAG>cell type</TAG>\n               <VALUE>glial cell</VALUE>\n
+        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>common
+        name</TAG>\n               <VALUE>human</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
+        \         <SAMPLE_ATTRIBUTE>\n               <TAG>organism part</TAG>\n               <VALUE>brain</VALUE>\n
+        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>cell
+        line</TAG>\n               <VALUE>G144</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
         \         <SAMPLE_ATTRIBUTE>\n               <TAG>genotype</TAG>\n               <VALUE>wild
         type genotype</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
-        \              <TAG>individual</TAG>\n               <VALUE>1</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
-        \         <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-CHECKLIST</TAG>\n               <VALUE>ERC000011</VALUE>\n
-        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-SPOT-COUNT</TAG>\n
-        \              <VALUE>21013213</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
-        \              <TAG>ENA-BASE-COUNT</TAG>\n               <VALUE>1586164243</VALUE>\n
-        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-FIRST-PUBLIC</TAG>\n
-        \              <VALUE>2018-05-30</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
-        \         <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-LAST-UPDATE</TAG>\n
+        \              <TAG>ENA-FIRST-PUBLIC</TAG>\n               <VALUE>2018-05-30</VALUE>\n
+        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-LAST-UPDATE</TAG>\n
         \              <VALUE>2018-04-24</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
         \    </SAMPLE_ATTRIBUTES>\n</SAMPLE>\n</SAMPLE_SET>\n"
     headers:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:41:59 GMT
+      - Wed, 17 May 2023 18:36:09 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -6337,7 +5337,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/ERP108370
   response:
@@ -6397,7 +5397,7 @@ interactions:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:42:00 GMT
+      - Wed, 17 May 2023 18:36:10 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -6415,7 +5415,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/ERA1350207
   response:
@@ -6451,7 +5451,7 @@ interactions:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:42:00 GMT
+      - Wed, 17 May 2023 18:36:10 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -6460,68 +5460,6 @@ interactions:
       code: 200
       message: ''
 - request:
-    body: acc=ERR2534085&accept-proto=fasp&version=2.0
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '44'
-      User-Agent:
-      - python-requests/2.25.1
-    method: POST
-    uri: https://www.ncbi.nlm.nih.gov/Traces/names/names.cgi
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAAwzIsQ6CMBQF0J2vaOLAhLl9bekru7MJcXIDLEHTUAI1xuR9vJ7xnOiM6tiH7T3K
-        pe/JGQt20jpjGGxICJob+AbhpqmD7uDvElsbbPSYPIeA0bchRBA7PZOfrWYRsYBc1/RV9VLKdtRq
-        23PJU07qeaghpfyJDzXnXZXlH3l8xalUPwAAAP//AwCBHJBrjgAAAA==
-    headers:
-      Cache-Control:
-      - private
-      Connection:
-      - Keep-Alive
-      Content-Encoding:
-      - gzip
-      Content-Security-Policy:
-      - upgrade-insecure-requests
-      Content-Type:
-      - text/plain
-      Date:
-      - Wed, 28 Jul 2021 19:42:00 GMT
-      Keep-Alive:
-      - timeout=1, max=10
-      NCBI-PHID:
-      - CC95EFE5101B30810000000000000001.m_1
-      NCBI-SID:
-      - CC95EFE5101B3081_0000SID
-      Referrer-Policy:
-      - origin-when-cross-origin
-      Server:
-      - Apache
-      Set-Cookie:
-      - ncbi_sid=CC95EFE5101B3081_0000SID; domain=.nih.gov; path=/; expires=Thu, 28
-        Jul 2022 19:42:00 GMT
-      SraNameServerOutputVersion:
-      - '2.0'
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains; preload
-      Transfer-Encoding:
-      - chunked
-      Vary:
-      - Accept-Encoding
-      X-UA-Compatible:
-      - IE=Edge
-      X-XSS-Protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
-- request:
     body: null
     headers:
       Accept:
@@ -6531,29 +5469,27 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/portal/api/filereport?accession=ERR2534085&result=read_run
   response:
     body:
-      string: "run_accession\tfastq_ftp\tfastq_bytes\tfastq_md5\tsubmitted_ftp\tsubmitted_bytes\tsubmitted_md5\tsra_ftp\tsra_bytes\tsra_md5\nERR2534085\tftp.sra.ebi.ac.uk/vol1/fastq/ERR253/005/ERR2534085/ERR2534085.fastq.gz\t986001790\t4921d2019bec9d2eb3746caca23307b2\tftp.sra.ebi.ac.uk/vol1/run/ERR253/ERR2534085/G144_Parental_RNAseq_DMSO2.fastq.gz\t1027314622\t20fc8816e51bd3da97def0ead2a60b0b\t\t\t\n"
+      string: "run_accession\tfastq_ftp\tfastq_bytes\tfastq_md5\tbam_ftp\tbam_bytes\tbam_md5\tsubmitted_ftp\tsubmitted_bytes\tsubmitted_md5\tsra_ftp\tsra_bytes\tsra_md5\nERR2534085\tftp.sra.ebi.ac.uk/vol1/fastq/ERR253/005/ERR2534085/ERR2534085.fastq.gz\t986001790\t4921d2019bec9d2eb3746caca23307b2\t\t\t\tftp.sra.ebi.ac.uk/vol1/run/ERR253/ERR2534085/G144_Parental_RNAseq_DMSO2.fastq.gz\t1027314622\t20fc8816e51bd3da97def0ead2a60b0b\tftp.sra.ebi.ac.uk/vol1/err/ERR253/005/ERR2534085\t653380812\t3bd5c5cdab98d0c41477923cb8135c14\n"
     headers:
       Cache-Control:
       - no-cache, no-store, max-age=0, must-revalidate
+      Content-Length:
+      - '487'
       Content-Type:
       - text/plain
       Date:
-      - Wed, 28 Jul 2021 19:42:01 GMT
+      - Wed, 17 May 2023 18:36:11 GMT
       Expires:
       - '0'
       Pragma:
       - no-cache
-      Server:
-      - Apache-Coyote/1.1
       Strict-Transport-Security:
       - max-age=0
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Frame-Options:
@@ -6562,7 +5498,7 @@ interactions:
       - 1; mode=block
     status:
       code: 200
-      message: OK
+      message: ''
 - request:
     body: null
     headers:
@@ -6573,7 +5509,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/ERR2534086
   response:
@@ -6615,7 +5551,7 @@ interactions:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:42:01 GMT
+      - Wed, 17 May 2023 18:36:11 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -6633,7 +5569,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/ERX2552507
   response:
@@ -6697,7 +5633,7 @@ interactions:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:42:02 GMT
+      - Wed, 17 May 2023 18:36:11 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -6715,14 +5651,14 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/ERS2428801
   response:
     body:
       string: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<SAMPLE_SET>\n<SAMPLE accession=\"ERS2428801\"
-        alias=\"E-MTAB-6681:G144_Parental_RNAseq_DMSO3\" broker_name=\"ArrayExpress\"
-        center_name=\"BRIC - Biotech Research and Innovation Centre\">\n     <IDENTIFIERS>\n
+        alias=\"E-MTAB-6681:G144_Parental_RNAseq_DMSO3\" center_name=\"BRIC - Biotech
+        Research and Innovation Centre\" broker_name=\"ArrayExpress\">\n     <IDENTIFIERS>\n
         \         <PRIMARY_ID>ERS2428801</PRIMARY_ID>\n          <EXTERNAL_ID namespace=\"BioSample\">SAMEA4608105</EXTERNAL_ID>\n
         \         <SUBMITTER_ID namespace=\"BRIC - Biotech Research and Innovation
         Centre\">E-MTAB-6681:G144_Parental_RNAseq_DMSO3</SUBMITTER_ID>\n     </IDENTIFIERS>\n
@@ -6730,57 +5666,45 @@ interactions:
         \         <SCIENTIFIC_NAME>Homo sapiens</SCIENTIFIC_NAME>\n          <COMMON_NAME>human</COMMON_NAME>\n
         \    </SAMPLE_NAME>\n     <DESCRIPTION>Protocols: CRISPR mediated KO of CIC:
         sgRNAs (Target sequence: mESCs: GCCTTCATGATCTTCAGCAAG; G144: GGGCGAGTGGTGGTATGCCC)
-        \ were cloned into pSpCas9(BB)-2A-GFP (Addgene 48138) and transfected into
-        mESCs (Lipofectamine 2000) or G144 cells (Amaxa Nucleofector II, Program A033).
+        were cloned into pSpCas9(BB)-2A-GFP (Addgene 48138) and transfected into mESCs
+        (Lipofectamine 2000) or G144 cells (Amaxa Nucleofector II, Program A033).
         GFP-positive cells were single cell sorted 48h post-transfection, expanded
         and screened by immunoblotting for CIC deletion. Inhibitor treatment with
         1 \u03BCM MEK inhibitor (PD0325901) was performed in 80% confluent cultures
         for 4 and 24 h respectively. DMSO was used as mock control. Cells were washed
-        once with PBS, lysed directly in RLT buffer (Qiagen).  Total RNA was extracted
-        using the RNAeasy kit (Qiagen).  500 ng of total RNA was used for library
-        preparation using TruSeq RNA Library Prep Kit v2 (Illumina) according to manufacturer
-        recommendations.</DESCRIPTION>\n     <SAMPLE_LINKS>\n          <SAMPLE_LINK>\n
-        \              <XREF_LINK>\n                    <DB>ENA-STUDY</DB>\n                    <ID>ERP108370</ID>\n
-        \              </XREF_LINK>\n          </SAMPLE_LINK>\n          <SAMPLE_LINK>\n
-        \              <XREF_LINK>\n                    <DB>ENA-EXPERIMENT</DB>\n
-        \                   <ID>ERX2552507</ID>\n               </XREF_LINK>\n          </SAMPLE_LINK>\n
-        \         <SAMPLE_LINK>\n               <XREF_LINK>\n                    <DB>ENA-RUN</DB>\n
-        \                   <ID>ERR2534086</ID>\n               </XREF_LINK>\n          </SAMPLE_LINK>\n
-        \         <SAMPLE_LINK>\n               <XREF_LINK>\n                    <DB>ENA-SUBMISSION</DB>\n
-        \                   <ID>ERA1350207</ID>\n               </XREF_LINK>\n          </SAMPLE_LINK>\n
-        \         <SAMPLE_LINK>\n               <XREF_LINK>\n                    <DB>ENA-FASTQ-FILES</DB>\n
-        \                   <ID><![CDATA[https://www.ebi.ac.uk/ena/portal/api/filereport?accession=ERS2428801&result=read_run&fields=run_accession,fastq_ftp,fastq_md5,fastq_bytes]]></ID>\n
-        \              </XREF_LINK>\n          </SAMPLE_LINK>\n          <SAMPLE_LINK>\n
-        \              <XREF_LINK>\n                    <DB>ENA-SUBMITTED-FILES</DB>\n
-        \                   <ID><![CDATA[https://www.ebi.ac.uk/ena/portal/api/filereport?accession=ERS2428801&result=read_run&fields=run_accession,submitted_ftp,submitted_md5,submitted_bytes,submitted_format]]></ID>\n
-        \              </XREF_LINK>\n          </SAMPLE_LINK>\n     </SAMPLE_LINKS>\n
-        \    <SAMPLE_ATTRIBUTES>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>isolate</TAG>\n
-        \              <VALUE>not applicable</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
-        \         <SAMPLE_ATTRIBUTE>\n               <TAG>organism</TAG>\n               <VALUE>Homo
-        sapiens</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
-        \              <TAG>organism part</TAG>\n               <VALUE>brain</VALUE>\n
-        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>cell_type</TAG>\n
-        \              <VALUE>glial cell</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
-        \         <SAMPLE_ATTRIBUTE>\n               <TAG>cell_line</TAG>\n               <VALUE>G144</VALUE>\n
+        once with PBS, lysed directly in RLT buffer (Qiagen). Total RNA was extracted
+        using the RNAeasy kit (Qiagen). 500 ng of total RNA was used for library preparation
+        using TruSeq RNA Library Prep Kit v2 (Illumina) according to manufacturer
+        recommendations.</DESCRIPTION>\n     <SAMPLE_LINKS>\n    <SAMPLE_LINK>\n        <XREF_LINK>\n
+        \           <DB>ENA-FASTQ-FILES</DB>\n            <ID><![CDATA[https://www.ebi.ac.uk/ena/portal/api/filereport?accession=ERS2428801&result=read_run&fields=run_accession,fastq_ftp,fastq_md5,fastq_bytes]]></ID>\n
+        \       </XREF_LINK>\n    </SAMPLE_LINK>\n    <SAMPLE_LINK>\n        <XREF_LINK>\n
+        \           <DB>ENA-SUBMITTED-FILES</DB>\n            <ID><![CDATA[https://www.ebi.ac.uk/ena/portal/api/filereport?accession=ERS2428801&result=read_run&fields=run_accession,submitted_ftp,submitted_md5,submitted_bytes,submitted_format]]></ID>\n
+        \       </XREF_LINK>\n    </SAMPLE_LINK>\n</SAMPLE_LINKS>\n<SAMPLE_ATTRIBUTES>\n
+        \         <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-CHECKLIST</TAG>\n               <VALUE>ERC000011</VALUE>\n
         \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>disease</TAG>\n
         \              <VALUE>glioblastoma multiforme</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
+        \         <SAMPLE_ATTRIBUTE>\n               <TAG>individual</TAG>\n               <VALUE>1</VALUE>\n
+        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>organism</TAG>\n
+        \              <VALUE>Homo sapiens</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
+        \         <SAMPLE_ATTRIBUTE>\n               <TAG>organism</TAG>\n               <VALUE>Homo
+        sapiens</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
+        \              <TAG>cell type</TAG>\n               <VALUE>glial cell</VALUE>\n
+        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>common
+        name</TAG>\n               <VALUE>human</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
+        \         <SAMPLE_ATTRIBUTE>\n               <TAG>organism part</TAG>\n               <VALUE>brain</VALUE>\n
+        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>cell
+        line</TAG>\n               <VALUE>G144</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
         \         <SAMPLE_ATTRIBUTE>\n               <TAG>genotype</TAG>\n               <VALUE>wild
         type genotype</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
-        \              <TAG>individual</TAG>\n               <VALUE>1</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
-        \         <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-CHECKLIST</TAG>\n               <VALUE>ERC000011</VALUE>\n
-        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-SPOT-COUNT</TAG>\n
-        \              <VALUE>19622120</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
-        \              <TAG>ENA-BASE-COUNT</TAG>\n               <VALUE>1481141759</VALUE>\n
-        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-FIRST-PUBLIC</TAG>\n
-        \              <VALUE>2018-05-30</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
-        \         <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-LAST-UPDATE</TAG>\n
+        \              <TAG>ENA-FIRST-PUBLIC</TAG>\n               <VALUE>2018-05-30</VALUE>\n
+        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-LAST-UPDATE</TAG>\n
         \              <VALUE>2018-04-24</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
         \    </SAMPLE_ATTRIBUTES>\n</SAMPLE>\n</SAMPLE_SET>\n"
     headers:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:42:02 GMT
+      - Wed, 17 May 2023 18:36:12 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -6798,7 +5722,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/ERP108370
   response:
@@ -6858,7 +5782,7 @@ interactions:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:42:03 GMT
+      - Wed, 17 May 2023 18:36:12 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -6876,7 +5800,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/ERA1350207
   response:
@@ -6912,7 +5836,7 @@ interactions:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:42:04 GMT
+      - Wed, 17 May 2023 18:36:12 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -6921,68 +5845,6 @@ interactions:
       code: 200
       message: ''
 - request:
-    body: acc=ERR2534086&accept-proto=fasp&version=2.0
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '44'
-      User-Agent:
-      - python-requests/2.25.1
-    method: POST
-    uri: https://www.ncbi.nlm.nih.gov/Traces/names/names.cgi
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAAwzKuwrCMBQA0L1fEXDoVLk33jza3VkoTm55SZXQhDYiwv14ux7OSZ6h2zdXP56v
-        8yzVhcBq1hKBrNLIEtAOYAYY7ygnwIn0g8liNARxBHRJkUrJHNmFGFwIXidmJgC+rfkn+qW1uvei
-        bqWVULJ47cLlXL4pimfZRFsOKP6dQuv+AAAA//8DAGKPr42OAAAA
-    headers:
-      Cache-Control:
-      - private
-      Connection:
-      - Keep-Alive
-      Content-Encoding:
-      - gzip
-      Content-Security-Policy:
-      - upgrade-insecure-requests
-      Content-Type:
-      - text/plain
-      Date:
-      - Wed, 28 Jul 2021 19:42:04 GMT
-      Keep-Alive:
-      - timeout=1, max=10
-      NCBI-PHID:
-      - C7A41F5B101B30C10000000000000001.m_1
-      NCBI-SID:
-      - C7A41F5B101B30C1_0000SID
-      Referrer-Policy:
-      - origin-when-cross-origin
-      Server:
-      - Apache
-      Set-Cookie:
-      - ncbi_sid=C7A41F5B101B30C1_0000SID; domain=.nih.gov; path=/; expires=Thu, 28
-        Jul 2022 19:42:04 GMT
-      SraNameServerOutputVersion:
-      - '2.0'
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains; preload
-      Transfer-Encoding:
-      - chunked
-      Vary:
-      - Accept-Encoding
-      X-UA-Compatible:
-      - IE=Edge
-      X-XSS-Protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
-- request:
     body: null
     headers:
       Accept:
@@ -6992,29 +5854,27 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/portal/api/filereport?accession=ERR2534086&result=read_run
   response:
     body:
-      string: "run_accession\tfastq_ftp\tfastq_bytes\tfastq_md5\tsubmitted_ftp\tsubmitted_bytes\tsubmitted_md5\tsra_ftp\tsra_bytes\tsra_md5\nERR2534086\tftp.sra.ebi.ac.uk/vol1/fastq/ERR253/006/ERR2534086/ERR2534086.fastq.gz\t935756969\tf60033d4f40591a93092b83ad0a487f1\tftp.sra.ebi.ac.uk/vol1/run/ERR253/ERR2534086/G144_Parental_RNAseq_DMSO3.fastq.gz\t974487429\t7d15b05abbea7e4f253dbe1311c983ee\t\t\t\n"
+      string: "run_accession\tfastq_ftp\tfastq_bytes\tfastq_md5\tbam_ftp\tbam_bytes\tbam_md5\tsubmitted_ftp\tsubmitted_bytes\tsubmitted_md5\tsra_ftp\tsra_bytes\tsra_md5\nERR2534086\tftp.sra.ebi.ac.uk/vol1/fastq/ERR253/006/ERR2534086/ERR2534086.fastq.gz\t935756969\tf60033d4f40591a93092b83ad0a487f1\t\t\t\tftp.sra.ebi.ac.uk/vol1/run/ERR253/ERR2534086/G144_Parental_RNAseq_DMSO3.fastq.gz\t974487429\t7d15b05abbea7e4f253dbe1311c983ee\tftp.sra.ebi.ac.uk/vol1/err/ERR253/006/ERR2534086\t621048541\te8ab1e766393dcc1d82eb263b85dd56b\n"
     headers:
       Cache-Control:
       - no-cache, no-store, max-age=0, must-revalidate
+      Content-Length:
+      - '486'
       Content-Type:
       - text/plain
       Date:
-      - Wed, 28 Jul 2021 19:42:05 GMT
+      - Wed, 17 May 2023 18:36:13 GMT
       Expires:
       - '0'
       Pragma:
       - no-cache
-      Server:
-      - Apache-Coyote/1.1
       Strict-Transport-Security:
       - max-age=0
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Frame-Options:
@@ -7023,7 +5883,7 @@ interactions:
       - 1; mode=block
     status:
       code: 200
-      message: OK
+      message: ''
 - request:
     body: null
     headers:
@@ -7034,7 +5894,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/ERR2534087
   response:
@@ -7076,7 +5936,7 @@ interactions:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:42:06 GMT
+      - Wed, 17 May 2023 18:36:14 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -7094,7 +5954,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/ERX2552508
   response:
@@ -7158,7 +6018,7 @@ interactions:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:42:06 GMT
+      - Wed, 17 May 2023 18:36:13 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -7176,14 +6036,14 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/ERS2428802
   response:
     body:
       string: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<SAMPLE_SET>\n<SAMPLE accession=\"ERS2428802\"
-        alias=\"E-MTAB-6681:G144_WTclone_RNAseq_DMSO1\" broker_name=\"ArrayExpress\"
-        center_name=\"BRIC - Biotech Research and Innovation Centre\">\n     <IDENTIFIERS>\n
+        alias=\"E-MTAB-6681:G144_WTclone_RNAseq_DMSO1\" center_name=\"BRIC - Biotech
+        Research and Innovation Centre\" broker_name=\"ArrayExpress\">\n     <IDENTIFIERS>\n
         \         <PRIMARY_ID>ERS2428802</PRIMARY_ID>\n          <EXTERNAL_ID namespace=\"BioSample\">SAMEA4608106</EXTERNAL_ID>\n
         \         <SUBMITTER_ID namespace=\"BRIC - Biotech Research and Innovation
         Centre\">E-MTAB-6681:G144_WTclone_RNAseq_DMSO1</SUBMITTER_ID>\n     </IDENTIFIERS>\n
@@ -7191,57 +6051,45 @@ interactions:
         \         <SCIENTIFIC_NAME>Homo sapiens</SCIENTIFIC_NAME>\n          <COMMON_NAME>human</COMMON_NAME>\n
         \    </SAMPLE_NAME>\n     <DESCRIPTION>Protocols: CRISPR mediated KO of CIC:
         sgRNAs (Target sequence: mESCs: GCCTTCATGATCTTCAGCAAG; G144: GGGCGAGTGGTGGTATGCCC)
-        \ were cloned into pSpCas9(BB)-2A-GFP (Addgene 48138) and transfected into
-        mESCs (Lipofectamine 2000) or G144 cells (Amaxa Nucleofector II, Program A033).
+        were cloned into pSpCas9(BB)-2A-GFP (Addgene 48138) and transfected into mESCs
+        (Lipofectamine 2000) or G144 cells (Amaxa Nucleofector II, Program A033).
         GFP-positive cells were single cell sorted 48h post-transfection, expanded
         and screened by immunoblotting for CIC deletion. Inhibitor treatment with
         1 \u03BCM MEK inhibitor (PD0325901) was performed in 80% confluent cultures
         for 4 and 24 h respectively. DMSO was used as mock control. Cells were washed
-        once with PBS, lysed directly in RLT buffer (Qiagen).  Total RNA was extracted
-        using the RNAeasy kit (Qiagen).  500 ng of total RNA was used for library
-        preparation using TruSeq RNA Library Prep Kit v2 (Illumina) according to manufacturer
-        recommendations.</DESCRIPTION>\n     <SAMPLE_LINKS>\n          <SAMPLE_LINK>\n
-        \              <XREF_LINK>\n                    <DB>ENA-STUDY</DB>\n                    <ID>ERP108370</ID>\n
-        \              </XREF_LINK>\n          </SAMPLE_LINK>\n          <SAMPLE_LINK>\n
-        \              <XREF_LINK>\n                    <DB>ENA-EXPERIMENT</DB>\n
-        \                   <ID>ERX2552508</ID>\n               </XREF_LINK>\n          </SAMPLE_LINK>\n
-        \         <SAMPLE_LINK>\n               <XREF_LINK>\n                    <DB>ENA-RUN</DB>\n
-        \                   <ID>ERR2534087</ID>\n               </XREF_LINK>\n          </SAMPLE_LINK>\n
-        \         <SAMPLE_LINK>\n               <XREF_LINK>\n                    <DB>ENA-SUBMISSION</DB>\n
-        \                   <ID>ERA1350207</ID>\n               </XREF_LINK>\n          </SAMPLE_LINK>\n
-        \         <SAMPLE_LINK>\n               <XREF_LINK>\n                    <DB>ENA-FASTQ-FILES</DB>\n
-        \                   <ID><![CDATA[https://www.ebi.ac.uk/ena/portal/api/filereport?accession=ERS2428802&result=read_run&fields=run_accession,fastq_ftp,fastq_md5,fastq_bytes]]></ID>\n
-        \              </XREF_LINK>\n          </SAMPLE_LINK>\n          <SAMPLE_LINK>\n
-        \              <XREF_LINK>\n                    <DB>ENA-SUBMITTED-FILES</DB>\n
-        \                   <ID><![CDATA[https://www.ebi.ac.uk/ena/portal/api/filereport?accession=ERS2428802&result=read_run&fields=run_accession,submitted_ftp,submitted_md5,submitted_bytes,submitted_format]]></ID>\n
-        \              </XREF_LINK>\n          </SAMPLE_LINK>\n     </SAMPLE_LINKS>\n
-        \    <SAMPLE_ATTRIBUTES>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>isolate</TAG>\n
-        \              <VALUE>not applicable</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
-        \         <SAMPLE_ATTRIBUTE>\n               <TAG>organism</TAG>\n               <VALUE>Homo
-        sapiens</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
-        \              <TAG>organism part</TAG>\n               <VALUE>brain</VALUE>\n
-        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>cell_type</TAG>\n
-        \              <VALUE>glial cell</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
-        \         <SAMPLE_ATTRIBUTE>\n               <TAG>cell_line</TAG>\n               <VALUE>G144</VALUE>\n
+        once with PBS, lysed directly in RLT buffer (Qiagen). Total RNA was extracted
+        using the RNAeasy kit (Qiagen). 500 ng of total RNA was used for library preparation
+        using TruSeq RNA Library Prep Kit v2 (Illumina) according to manufacturer
+        recommendations.</DESCRIPTION>\n     <SAMPLE_LINKS>\n    <SAMPLE_LINK>\n        <XREF_LINK>\n
+        \           <DB>ENA-FASTQ-FILES</DB>\n            <ID><![CDATA[https://www.ebi.ac.uk/ena/portal/api/filereport?accession=ERS2428802&result=read_run&fields=run_accession,fastq_ftp,fastq_md5,fastq_bytes]]></ID>\n
+        \       </XREF_LINK>\n    </SAMPLE_LINK>\n    <SAMPLE_LINK>\n        <XREF_LINK>\n
+        \           <DB>ENA-SUBMITTED-FILES</DB>\n            <ID><![CDATA[https://www.ebi.ac.uk/ena/portal/api/filereport?accession=ERS2428802&result=read_run&fields=run_accession,submitted_ftp,submitted_md5,submitted_bytes,submitted_format]]></ID>\n
+        \       </XREF_LINK>\n    </SAMPLE_LINK>\n</SAMPLE_LINKS>\n<SAMPLE_ATTRIBUTES>\n
+        \         <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-CHECKLIST</TAG>\n               <VALUE>ERC000011</VALUE>\n
         \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>disease</TAG>\n
         \              <VALUE>glioblastoma multiforme</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
+        \         <SAMPLE_ATTRIBUTE>\n               <TAG>individual</TAG>\n               <VALUE>2</VALUE>\n
+        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>organism</TAG>\n
+        \              <VALUE>Homo sapiens</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
+        \         <SAMPLE_ATTRIBUTE>\n               <TAG>organism</TAG>\n               <VALUE>Homo
+        sapiens</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
+        \              <TAG>cell type</TAG>\n               <VALUE>glial cell</VALUE>\n
+        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>common
+        name</TAG>\n               <VALUE>human</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
+        \         <SAMPLE_ATTRIBUTE>\n               <TAG>organism part</TAG>\n               <VALUE>brain</VALUE>\n
+        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>cell
+        line</TAG>\n               <VALUE>G144</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
         \         <SAMPLE_ATTRIBUTE>\n               <TAG>genotype</TAG>\n               <VALUE>wild
         type genotype</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
-        \              <TAG>individual</TAG>\n               <VALUE>2</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
-        \         <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-CHECKLIST</TAG>\n               <VALUE>ERC000011</VALUE>\n
-        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-SPOT-COUNT</TAG>\n
-        \              <VALUE>24489613</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
-        \              <TAG>ENA-BASE-COUNT</TAG>\n               <VALUE>1849283386</VALUE>\n
-        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-FIRST-PUBLIC</TAG>\n
-        \              <VALUE>2018-05-30</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
-        \         <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-LAST-UPDATE</TAG>\n
+        \              <TAG>ENA-FIRST-PUBLIC</TAG>\n               <VALUE>2018-05-30</VALUE>\n
+        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-LAST-UPDATE</TAG>\n
         \              <VALUE>2018-04-24</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
         \    </SAMPLE_ATTRIBUTES>\n</SAMPLE>\n</SAMPLE_SET>\n"
     headers:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:42:07 GMT
+      - Wed, 17 May 2023 18:36:15 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -7259,7 +6107,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/ERP108370
   response:
@@ -7319,7 +6167,7 @@ interactions:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:42:08 GMT
+      - Wed, 17 May 2023 18:36:15 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -7337,7 +6185,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/ERA1350207
   response:
@@ -7373,7 +6221,7 @@ interactions:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:42:08 GMT
+      - Wed, 17 May 2023 18:36:15 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -7382,68 +6230,6 @@ interactions:
       code: 200
       message: ''
 - request:
-    body: acc=ERR2534087&accept-proto=fasp&version=2.0
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '44'
-      User-Agent:
-      - python-requests/2.25.1
-    method: POST
-    uri: https://www.ncbi.nlm.nih.gov/Traces/names/names.cgi
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAAwzIsQrCMBAA0L1fEXDoVLm7pOm1u7NQnNySNKVKMCWNiHAfr298JzpDcxS3v71c
-        5pl6bYAHYTRsrR5JCJA7GDoYb0gT4AT2LuDQc1iQHJKPMQJrz9BrWi0OwUcRMQByfaWvarda96NV
-        e8k1h5zU41AupfyJi1pzUXX7R/bPGGrzAwAA//8DAHWr/8SOAAAA
-    headers:
-      Cache-Control:
-      - private
-      Connection:
-      - Keep-Alive
-      Content-Encoding:
-      - gzip
-      Content-Security-Policy:
-      - upgrade-insecure-requests
-      Content-Type:
-      - text/plain
-      Date:
-      - Wed, 28 Jul 2021 19:42:08 GMT
-      Keep-Alive:
-      - timeout=1, max=10
-      NCBI-PHID:
-      - C7A42023101B31110000000000000001.m_1
-      NCBI-SID:
-      - C7A42023101B3111_0000SID
-      Referrer-Policy:
-      - origin-when-cross-origin
-      Server:
-      - Apache
-      Set-Cookie:
-      - ncbi_sid=C7A42023101B3111_0000SID; domain=.nih.gov; path=/; expires=Thu, 28
-        Jul 2022 19:42:09 GMT
-      SraNameServerOutputVersion:
-      - '2.0'
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains; preload
-      Transfer-Encoding:
-      - chunked
-      Vary:
-      - Accept-Encoding
-      X-UA-Compatible:
-      - IE=Edge
-      X-XSS-Protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
-- request:
     body: null
     headers:
       Accept:
@@ -7453,29 +6239,27 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/portal/api/filereport?accession=ERR2534087&result=read_run
   response:
     body:
-      string: "run_accession\tfastq_ftp\tfastq_bytes\tfastq_md5\tsubmitted_ftp\tsubmitted_bytes\tsubmitted_md5\tsra_ftp\tsra_bytes\tsra_md5\nERR2534087\tftp.sra.ebi.ac.uk/vol1/fastq/ERR253/007/ERR2534087/ERR2534087.fastq.gz\t1222071540\t70a8511739490d8e3694c82dabf027d1\tftp.sra.ebi.ac.uk/vol1/run/ERR253/ERR2534087/G144_WTclone_RNAseq_DMSO1.fastq.gz\t1272114070\t836d2e5186e468db4640ac7731e36f59\t\t\t\n"
+      string: "run_accession\tfastq_ftp\tfastq_bytes\tfastq_md5\tbam_ftp\tbam_bytes\tbam_md5\tsubmitted_ftp\tsubmitted_bytes\tsubmitted_md5\tsra_ftp\tsra_bytes\tsra_md5\nERR2534087\tftp.sra.ebi.ac.uk/vol1/fastq/ERR253/007/ERR2534087/ERR2534087.fastq.gz\t1222071540\t70a8511739490d8e3694c82dabf027d1\t\t\t\tftp.sra.ebi.ac.uk/vol1/run/ERR253/ERR2534087/G144_WTclone_RNAseq_DMSO1.fastq.gz\t1272114070\t836d2e5186e468db4640ac7731e36f59\tftp.sra.ebi.ac.uk/vol1/err/ERR253/007/ERR2534087\t814866372\t5074b01b1cf6f1fc02bcfd476e074d8b\n"
     headers:
       Cache-Control:
       - no-cache, no-store, max-age=0, must-revalidate
+      Content-Length:
+      - '487'
       Content-Type:
       - text/plain
       Date:
-      - Wed, 28 Jul 2021 19:42:09 GMT
+      - Wed, 17 May 2023 18:36:16 GMT
       Expires:
       - '0'
       Pragma:
       - no-cache
-      Server:
-      - Apache-Coyote/1.1
       Strict-Transport-Security:
       - max-age=0
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Frame-Options:
@@ -7484,7 +6268,7 @@ interactions:
       - 1; mode=block
     status:
       code: 200
-      message: OK
+      message: ''
 - request:
     body: null
     headers:
@@ -7495,7 +6279,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/ERR2534088
   response:
@@ -7537,7 +6321,7 @@ interactions:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:42:10 GMT
+      - Wed, 17 May 2023 18:36:16 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -7555,7 +6339,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/ERX2552509
   response:
@@ -7619,7 +6403,7 @@ interactions:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:42:10 GMT
+      - Wed, 17 May 2023 18:36:16 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -7637,14 +6421,14 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/ERS2428803
   response:
     body:
       string: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<SAMPLE_SET>\n<SAMPLE accession=\"ERS2428803\"
-        alias=\"E-MTAB-6681:G144_WTclone_RNAseq_DMSO2\" broker_name=\"ArrayExpress\"
-        center_name=\"BRIC - Biotech Research and Innovation Centre\">\n     <IDENTIFIERS>\n
+        alias=\"E-MTAB-6681:G144_WTclone_RNAseq_DMSO2\" center_name=\"BRIC - Biotech
+        Research and Innovation Centre\" broker_name=\"ArrayExpress\">\n     <IDENTIFIERS>\n
         \         <PRIMARY_ID>ERS2428803</PRIMARY_ID>\n          <EXTERNAL_ID namespace=\"BioSample\">SAMEA4608107</EXTERNAL_ID>\n
         \         <SUBMITTER_ID namespace=\"BRIC - Biotech Research and Innovation
         Centre\">E-MTAB-6681:G144_WTclone_RNAseq_DMSO2</SUBMITTER_ID>\n     </IDENTIFIERS>\n
@@ -7652,57 +6436,45 @@ interactions:
         \         <SCIENTIFIC_NAME>Homo sapiens</SCIENTIFIC_NAME>\n          <COMMON_NAME>human</COMMON_NAME>\n
         \    </SAMPLE_NAME>\n     <DESCRIPTION>Protocols: CRISPR mediated KO of CIC:
         sgRNAs (Target sequence: mESCs: GCCTTCATGATCTTCAGCAAG; G144: GGGCGAGTGGTGGTATGCCC)
-        \ were cloned into pSpCas9(BB)-2A-GFP (Addgene 48138) and transfected into
-        mESCs (Lipofectamine 2000) or G144 cells (Amaxa Nucleofector II, Program A033).
+        were cloned into pSpCas9(BB)-2A-GFP (Addgene 48138) and transfected into mESCs
+        (Lipofectamine 2000) or G144 cells (Amaxa Nucleofector II, Program A033).
         GFP-positive cells were single cell sorted 48h post-transfection, expanded
         and screened by immunoblotting for CIC deletion. Inhibitor treatment with
         1 \u03BCM MEK inhibitor (PD0325901) was performed in 80% confluent cultures
         for 4 and 24 h respectively. DMSO was used as mock control. Cells were washed
-        once with PBS, lysed directly in RLT buffer (Qiagen).  Total RNA was extracted
-        using the RNAeasy kit (Qiagen).  500 ng of total RNA was used for library
-        preparation using TruSeq RNA Library Prep Kit v2 (Illumina) according to manufacturer
-        recommendations.</DESCRIPTION>\n     <SAMPLE_LINKS>\n          <SAMPLE_LINK>\n
-        \              <XREF_LINK>\n                    <DB>ENA-STUDY</DB>\n                    <ID>ERP108370</ID>\n
-        \              </XREF_LINK>\n          </SAMPLE_LINK>\n          <SAMPLE_LINK>\n
-        \              <XREF_LINK>\n                    <DB>ENA-EXPERIMENT</DB>\n
-        \                   <ID>ERX2552509</ID>\n               </XREF_LINK>\n          </SAMPLE_LINK>\n
-        \         <SAMPLE_LINK>\n               <XREF_LINK>\n                    <DB>ENA-RUN</DB>\n
-        \                   <ID>ERR2534088</ID>\n               </XREF_LINK>\n          </SAMPLE_LINK>\n
-        \         <SAMPLE_LINK>\n               <XREF_LINK>\n                    <DB>ENA-SUBMISSION</DB>\n
-        \                   <ID>ERA1350207</ID>\n               </XREF_LINK>\n          </SAMPLE_LINK>\n
-        \         <SAMPLE_LINK>\n               <XREF_LINK>\n                    <DB>ENA-FASTQ-FILES</DB>\n
-        \                   <ID><![CDATA[https://www.ebi.ac.uk/ena/portal/api/filereport?accession=ERS2428803&result=read_run&fields=run_accession,fastq_ftp,fastq_md5,fastq_bytes]]></ID>\n
-        \              </XREF_LINK>\n          </SAMPLE_LINK>\n          <SAMPLE_LINK>\n
-        \              <XREF_LINK>\n                    <DB>ENA-SUBMITTED-FILES</DB>\n
-        \                   <ID><![CDATA[https://www.ebi.ac.uk/ena/portal/api/filereport?accession=ERS2428803&result=read_run&fields=run_accession,submitted_ftp,submitted_md5,submitted_bytes,submitted_format]]></ID>\n
-        \              </XREF_LINK>\n          </SAMPLE_LINK>\n     </SAMPLE_LINKS>\n
-        \    <SAMPLE_ATTRIBUTES>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>isolate</TAG>\n
-        \              <VALUE>not applicable</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
-        \         <SAMPLE_ATTRIBUTE>\n               <TAG>organism</TAG>\n               <VALUE>Homo
-        sapiens</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
-        \              <TAG>organism part</TAG>\n               <VALUE>brain</VALUE>\n
-        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>cell_type</TAG>\n
-        \              <VALUE>glial cell</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
-        \         <SAMPLE_ATTRIBUTE>\n               <TAG>cell_line</TAG>\n               <VALUE>G144</VALUE>\n
+        once with PBS, lysed directly in RLT buffer (Qiagen). Total RNA was extracted
+        using the RNAeasy kit (Qiagen). 500 ng of total RNA was used for library preparation
+        using TruSeq RNA Library Prep Kit v2 (Illumina) according to manufacturer
+        recommendations.</DESCRIPTION>\n     <SAMPLE_LINKS>\n    <SAMPLE_LINK>\n        <XREF_LINK>\n
+        \           <DB>ENA-FASTQ-FILES</DB>\n            <ID><![CDATA[https://www.ebi.ac.uk/ena/portal/api/filereport?accession=ERS2428803&result=read_run&fields=run_accession,fastq_ftp,fastq_md5,fastq_bytes]]></ID>\n
+        \       </XREF_LINK>\n    </SAMPLE_LINK>\n    <SAMPLE_LINK>\n        <XREF_LINK>\n
+        \           <DB>ENA-SUBMITTED-FILES</DB>\n            <ID><![CDATA[https://www.ebi.ac.uk/ena/portal/api/filereport?accession=ERS2428803&result=read_run&fields=run_accession,submitted_ftp,submitted_md5,submitted_bytes,submitted_format]]></ID>\n
+        \       </XREF_LINK>\n    </SAMPLE_LINK>\n</SAMPLE_LINKS>\n<SAMPLE_ATTRIBUTES>\n
+        \         <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-CHECKLIST</TAG>\n               <VALUE>ERC000011</VALUE>\n
         \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>disease</TAG>\n
         \              <VALUE>glioblastoma multiforme</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
+        \         <SAMPLE_ATTRIBUTE>\n               <TAG>individual</TAG>\n               <VALUE>2</VALUE>\n
+        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>organism</TAG>\n
+        \              <VALUE>Homo sapiens</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
+        \         <SAMPLE_ATTRIBUTE>\n               <TAG>organism</TAG>\n               <VALUE>Homo
+        sapiens</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
+        \              <TAG>cell type</TAG>\n               <VALUE>glial cell</VALUE>\n
+        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>common
+        name</TAG>\n               <VALUE>human</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
+        \         <SAMPLE_ATTRIBUTE>\n               <TAG>organism part</TAG>\n               <VALUE>brain</VALUE>\n
+        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>cell
+        line</TAG>\n               <VALUE>G144</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
         \         <SAMPLE_ATTRIBUTE>\n               <TAG>genotype</TAG>\n               <VALUE>wild
         type genotype</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
-        \              <TAG>individual</TAG>\n               <VALUE>2</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
-        \         <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-CHECKLIST</TAG>\n               <VALUE>ERC000011</VALUE>\n
-        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-SPOT-COUNT</TAG>\n
-        \              <VALUE>21027363</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
-        \              <TAG>ENA-BASE-COUNT</TAG>\n               <VALUE>1587910747</VALUE>\n
-        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-FIRST-PUBLIC</TAG>\n
-        \              <VALUE>2018-05-30</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
-        \         <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-LAST-UPDATE</TAG>\n
+        \              <TAG>ENA-FIRST-PUBLIC</TAG>\n               <VALUE>2018-05-30</VALUE>\n
+        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-LAST-UPDATE</TAG>\n
         \              <VALUE>2018-04-24</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
         \    </SAMPLE_ATTRIBUTES>\n</SAMPLE>\n</SAMPLE_SET>\n"
     headers:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:42:11 GMT
+      - Wed, 17 May 2023 18:36:17 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -7720,7 +6492,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/ERP108370
   response:
@@ -7780,7 +6552,7 @@ interactions:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:42:12 GMT
+      - Wed, 17 May 2023 18:36:17 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -7798,7 +6570,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/ERA1350207
   response:
@@ -7834,7 +6606,7 @@ interactions:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:42:12 GMT
+      - Wed, 17 May 2023 18:36:17 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -7843,68 +6615,6 @@ interactions:
       code: 200
       message: ''
 - request:
-    body: acc=ERR2534088&accept-proto=fasp&version=2.0
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '44'
-      User-Agent:
-      - python-requests/2.25.1
-    method: POST
-    uri: https://www.ncbi.nlm.nih.gov/Traces/names/names.cgi
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAAwzLsQqDMBAG4L1PEejgZPm9GO/i3rkgnbppVGwJjWhKKdzD1/WD70wXnPatXz+D
-        XruOnK0hogzyIhAooZISXMLfK2phW1QPZXZTI5ZDTTz6ETw4Dn4Wcg0f36pqDejtHX+mWHJe98Ks
-        W8oppGieu+ljTN9pNHPaTF4OSMNrCvn0BwAA//8DAGsMO5SOAAAA
-    headers:
-      Cache-Control:
-      - private
-      Connection:
-      - Keep-Alive
-      Content-Encoding:
-      - gzip
-      Content-Security-Policy:
-      - upgrade-insecure-requests
-      Content-Type:
-      - text/plain
-      Date:
-      - Wed, 28 Jul 2021 19:42:13 GMT
-      Keep-Alive:
-      - timeout=1, max=10
-      NCBI-PHID:
-      - CC95F187101B31510000000000000001.m_1
-      NCBI-SID:
-      - CC95F187101B3151_0000SID
-      Referrer-Policy:
-      - origin-when-cross-origin
-      Server:
-      - Apache
-      Set-Cookie:
-      - ncbi_sid=CC95F187101B3151_0000SID; domain=.nih.gov; path=/; expires=Thu, 28
-        Jul 2022 19:42:13 GMT
-      SraNameServerOutputVersion:
-      - '2.0'
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains; preload
-      Transfer-Encoding:
-      - chunked
-      Vary:
-      - Accept-Encoding
-      X-UA-Compatible:
-      - IE=Edge
-      X-XSS-Protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
-- request:
     body: null
     headers:
       Accept:
@@ -7914,29 +6624,27 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/portal/api/filereport?accession=ERR2534088&result=read_run
   response:
     body:
-      string: "run_accession\tfastq_ftp\tfastq_bytes\tfastq_md5\tsubmitted_ftp\tsubmitted_bytes\tsubmitted_md5\tsra_ftp\tsra_bytes\tsra_md5\nERR2534088\tftp.sra.ebi.ac.uk/vol1/fastq/ERR253/008/ERR2534088/ERR2534088.fastq.gz\t1054521498\tab57f3177e3796fa02fa9c921ad187d2\tftp.sra.ebi.ac.uk/vol1/run/ERR253/ERR2534088/G144_WTclone_RNAseq_DMSO2.fastq.gz\t1099839401\tc5d2613fe09ae1bbc2ace0892b8ce3ec\t\t\t\n"
+      string: "run_accession\tfastq_ftp\tfastq_bytes\tfastq_md5\tbam_ftp\tbam_bytes\tbam_md5\tsubmitted_ftp\tsubmitted_bytes\tsubmitted_md5\tsra_ftp\tsra_bytes\tsra_md5\nERR2534088\tftp.sra.ebi.ac.uk/vol1/fastq/ERR253/008/ERR2534088/ERR2534088.fastq.gz\t1054521498\tab57f3177e3796fa02fa9c921ad187d2\t\t\t\tftp.sra.ebi.ac.uk/vol1/run/ERR253/ERR2534088/G144_WTclone_RNAseq_DMSO2.fastq.gz\t1099839401\tc5d2613fe09ae1bbc2ace0892b8ce3ec\tftp.sra.ebi.ac.uk/vol1/err/ERR253/008/ERR2534088\t702988060\t5a27cc3525de29872a1d83a10269e7bd\n"
     headers:
       Cache-Control:
       - no-cache, no-store, max-age=0, must-revalidate
+      Content-Length:
+      - '487'
       Content-Type:
       - text/plain
       Date:
-      - Wed, 28 Jul 2021 19:42:13 GMT
+      - Wed, 17 May 2023 18:36:18 GMT
       Expires:
       - '0'
       Pragma:
       - no-cache
-      Server:
-      - Apache-Coyote/1.1
       Strict-Transport-Security:
       - max-age=0
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Frame-Options:
@@ -7945,7 +6653,7 @@ interactions:
       - 1; mode=block
     status:
       code: 200
-      message: OK
+      message: ''
 - request:
     body: null
     headers:
@@ -7956,7 +6664,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/ERR2534089
   response:
@@ -7998,7 +6706,7 @@ interactions:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:42:14 GMT
+      - Wed, 17 May 2023 18:36:18 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -8016,7 +6724,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/ERX2552510
   response:
@@ -8084,7 +6792,7 @@ interactions:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:42:14 GMT
+      - Wed, 17 May 2023 18:36:19 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -8102,14 +6810,14 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/ERS2428804
   response:
     body:
       string: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<SAMPLE_SET>\n<SAMPLE accession=\"ERS2428804\"
-        alias=\"E-MTAB-6681:G144_Parental_RNAseq_24h_1\" broker_name=\"ArrayExpress\"
-        center_name=\"BRIC - Biotech Research and Innovation Centre\">\n     <IDENTIFIERS>\n
+        alias=\"E-MTAB-6681:G144_Parental_RNAseq_24h_1\" center_name=\"BRIC - Biotech
+        Research and Innovation Centre\" broker_name=\"ArrayExpress\">\n     <IDENTIFIERS>\n
         \         <PRIMARY_ID>ERS2428804</PRIMARY_ID>\n          <EXTERNAL_ID namespace=\"BioSample\">SAMEA4608108</EXTERNAL_ID>\n
         \         <SUBMITTER_ID namespace=\"BRIC - Biotech Research and Innovation
         Centre\">E-MTAB-6681:G144_Parental_RNAseq_24h_1</SUBMITTER_ID>\n     </IDENTIFIERS>\n
@@ -8117,57 +6825,45 @@ interactions:
         \         <SCIENTIFIC_NAME>Homo sapiens</SCIENTIFIC_NAME>\n          <COMMON_NAME>human</COMMON_NAME>\n
         \    </SAMPLE_NAME>\n     <DESCRIPTION>Protocols: CRISPR mediated KO of CIC:
         sgRNAs (Target sequence: mESCs: GCCTTCATGATCTTCAGCAAG; G144: GGGCGAGTGGTGGTATGCCC)
-        \ were cloned into pSpCas9(BB)-2A-GFP (Addgene 48138) and transfected into
-        mESCs (Lipofectamine 2000) or G144 cells (Amaxa Nucleofector II, Program A033).
+        were cloned into pSpCas9(BB)-2A-GFP (Addgene 48138) and transfected into mESCs
+        (Lipofectamine 2000) or G144 cells (Amaxa Nucleofector II, Program A033).
         GFP-positive cells were single cell sorted 48h post-transfection, expanded
         and screened by immunoblotting for CIC deletion. Inhibitor treatment with
         1 \u03BCM MEK inhibitor (PD0325901) was performed in 80% confluent cultures
         for 4 and 24 h respectively. DMSO was used as mock control. Cells were washed
-        once with PBS, lysed directly in RLT buffer (Qiagen).  Total RNA was extracted
-        using the RNAeasy kit (Qiagen).  500 ng of total RNA was used for library
-        preparation using TruSeq RNA Library Prep Kit v2 (Illumina) according to manufacturer
-        recommendations.</DESCRIPTION>\n     <SAMPLE_LINKS>\n          <SAMPLE_LINK>\n
-        \              <XREF_LINK>\n                    <DB>ENA-STUDY</DB>\n                    <ID>ERP108370</ID>\n
-        \              </XREF_LINK>\n          </SAMPLE_LINK>\n          <SAMPLE_LINK>\n
-        \              <XREF_LINK>\n                    <DB>ENA-EXPERIMENT</DB>\n
-        \                   <ID>ERX2552510</ID>\n               </XREF_LINK>\n          </SAMPLE_LINK>\n
-        \         <SAMPLE_LINK>\n               <XREF_LINK>\n                    <DB>ENA-RUN</DB>\n
-        \                   <ID>ERR2534089</ID>\n               </XREF_LINK>\n          </SAMPLE_LINK>\n
-        \         <SAMPLE_LINK>\n               <XREF_LINK>\n                    <DB>ENA-SUBMISSION</DB>\n
-        \                   <ID>ERA1350207</ID>\n               </XREF_LINK>\n          </SAMPLE_LINK>\n
-        \         <SAMPLE_LINK>\n               <XREF_LINK>\n                    <DB>ENA-FASTQ-FILES</DB>\n
-        \                   <ID><![CDATA[https://www.ebi.ac.uk/ena/portal/api/filereport?accession=ERS2428804&result=read_run&fields=run_accession,fastq_ftp,fastq_md5,fastq_bytes]]></ID>\n
-        \              </XREF_LINK>\n          </SAMPLE_LINK>\n          <SAMPLE_LINK>\n
-        \              <XREF_LINK>\n                    <DB>ENA-SUBMITTED-FILES</DB>\n
-        \                   <ID><![CDATA[https://www.ebi.ac.uk/ena/portal/api/filereport?accession=ERS2428804&result=read_run&fields=run_accession,submitted_ftp,submitted_md5,submitted_bytes,submitted_format]]></ID>\n
-        \              </XREF_LINK>\n          </SAMPLE_LINK>\n     </SAMPLE_LINKS>\n
-        \    <SAMPLE_ATTRIBUTES>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>isolate</TAG>\n
-        \              <VALUE>not applicable</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
-        \         <SAMPLE_ATTRIBUTE>\n               <TAG>organism</TAG>\n               <VALUE>Homo
-        sapiens</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
-        \              <TAG>organism part</TAG>\n               <VALUE>brain</VALUE>\n
-        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>cell_type</TAG>\n
-        \              <VALUE>glial cell</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
-        \         <SAMPLE_ATTRIBUTE>\n               <TAG>cell_line</TAG>\n               <VALUE>G144</VALUE>\n
+        once with PBS, lysed directly in RLT buffer (Qiagen). Total RNA was extracted
+        using the RNAeasy kit (Qiagen). 500 ng of total RNA was used for library preparation
+        using TruSeq RNA Library Prep Kit v2 (Illumina) according to manufacturer
+        recommendations.</DESCRIPTION>\n     <SAMPLE_LINKS>\n    <SAMPLE_LINK>\n        <XREF_LINK>\n
+        \           <DB>ENA-FASTQ-FILES</DB>\n            <ID><![CDATA[https://www.ebi.ac.uk/ena/portal/api/filereport?accession=ERS2428804&result=read_run&fields=run_accession,fastq_ftp,fastq_md5,fastq_bytes]]></ID>\n
+        \       </XREF_LINK>\n    </SAMPLE_LINK>\n    <SAMPLE_LINK>\n        <XREF_LINK>\n
+        \           <DB>ENA-SUBMITTED-FILES</DB>\n            <ID><![CDATA[https://www.ebi.ac.uk/ena/portal/api/filereport?accession=ERS2428804&result=read_run&fields=run_accession,submitted_ftp,submitted_md5,submitted_bytes,submitted_format]]></ID>\n
+        \       </XREF_LINK>\n    </SAMPLE_LINK>\n</SAMPLE_LINKS>\n<SAMPLE_ATTRIBUTES>\n
+        \         <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-CHECKLIST</TAG>\n               <VALUE>ERC000011</VALUE>\n
         \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>disease</TAG>\n
         \              <VALUE>glioblastoma multiforme</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
+        \         <SAMPLE_ATTRIBUTE>\n               <TAG>individual</TAG>\n               <VALUE>1</VALUE>\n
+        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>organism</TAG>\n
+        \              <VALUE>Homo sapiens</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
+        \         <SAMPLE_ATTRIBUTE>\n               <TAG>organism</TAG>\n               <VALUE>Homo
+        sapiens</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
+        \              <TAG>cell type</TAG>\n               <VALUE>glial cell</VALUE>\n
+        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>common
+        name</TAG>\n               <VALUE>human</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
+        \         <SAMPLE_ATTRIBUTE>\n               <TAG>organism part</TAG>\n               <VALUE>brain</VALUE>\n
+        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>cell
+        line</TAG>\n               <VALUE>G144</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
         \         <SAMPLE_ATTRIBUTE>\n               <TAG>genotype</TAG>\n               <VALUE>wild
         type genotype</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
-        \              <TAG>individual</TAG>\n               <VALUE>1</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
-        \         <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-CHECKLIST</TAG>\n               <VALUE>ERC000011</VALUE>\n
-        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-SPOT-COUNT</TAG>\n
-        \              <VALUE>19941600</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
-        \              <TAG>ENA-BASE-COUNT</TAG>\n               <VALUE>1505399955</VALUE>\n
-        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-FIRST-PUBLIC</TAG>\n
-        \              <VALUE>2018-05-30</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
-        \         <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-LAST-UPDATE</TAG>\n
+        \              <TAG>ENA-FIRST-PUBLIC</TAG>\n               <VALUE>2018-05-30</VALUE>\n
+        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-LAST-UPDATE</TAG>\n
         \              <VALUE>2018-04-24</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
         \    </SAMPLE_ATTRIBUTES>\n</SAMPLE>\n</SAMPLE_SET>\n"
     headers:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:42:15 GMT
+      - Wed, 17 May 2023 18:36:20 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -8185,7 +6881,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/ERP108370
   response:
@@ -8245,7 +6941,7 @@ interactions:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:42:16 GMT
+      - Wed, 17 May 2023 18:36:19 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -8263,7 +6959,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/ERA1350207
   response:
@@ -8299,7 +6995,7 @@ interactions:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:42:16 GMT
+      - Wed, 17 May 2023 18:36:20 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -8308,68 +7004,6 @@ interactions:
       code: 200
       message: ''
 - request:
-    body: acc=ERR2534089&accept-proto=fasp&version=2.0
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '44'
-      User-Agent:
-      - python-requests/2.25.1
-    method: POST
-    uri: https://www.ncbi.nlm.nih.gov/Traces/names/names.cgi
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAAwzIsQrCMBAA0L1fEXDoVLleL5e0u7NQnNySNKVKMKWJiHAfr298JzxDUw63v71c
-        5hn1QGBHYQTSPRoWhN52YDoYbz1OgBPZuwRjV2D2gZhwHRnJD5H9YjBaHZ0TEQKQ6yt9VbvVupdW
-        7UeuOeSkHkW5lPInLmrNh6rbP7J/xlCbHwAAAP//AwB3pIyPjgAAAA==
-    headers:
-      Cache-Control:
-      - private
-      Connection:
-      - Keep-Alive
-      Content-Encoding:
-      - gzip
-      Content-Security-Policy:
-      - upgrade-insecure-requests
-      Content-Type:
-      - text/plain
-      Date:
-      - Wed, 28 Jul 2021 19:42:17 GMT
-      Keep-Alive:
-      - timeout=1, max=10
-      NCBI-PHID:
-      - CC95F218101B31910000000000000001.m_1
-      NCBI-SID:
-      - CC95F218101B3191_0000SID
-      Referrer-Policy:
-      - origin-when-cross-origin
-      Server:
-      - Apache
-      Set-Cookie:
-      - ncbi_sid=CC95F218101B3191_0000SID; domain=.nih.gov; path=/; expires=Thu, 28
-        Jul 2022 19:42:17 GMT
-      SraNameServerOutputVersion:
-      - '2.0'
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains; preload
-      Transfer-Encoding:
-      - chunked
-      Vary:
-      - Accept-Encoding
-      X-UA-Compatible:
-      - IE=Edge
-      X-XSS-Protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
-- request:
     body: null
     headers:
       Accept:
@@ -8379,29 +7013,27 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/portal/api/filereport?accession=ERR2534089&result=read_run
   response:
     body:
-      string: "run_accession\tfastq_ftp\tfastq_bytes\tfastq_md5\tsubmitted_ftp\tsubmitted_bytes\tsubmitted_md5\tsra_ftp\tsra_bytes\tsra_md5\nERR2534089\tftp.sra.ebi.ac.uk/vol1/fastq/ERR253/009/ERR2534089/ERR2534089.fastq.gz\t936697735\t61cddd1766f5e4757fefd4a99865d3e0\tftp.sra.ebi.ac.uk/vol1/run/ERR253/ERR2534089/G144_Parental_RNAseq_24h_1.fastq.gz\t975986547\ta1cd512c64c06f21259ee1c41beb2a5a\t\t\t\n"
+      string: "run_accession\tfastq_ftp\tfastq_bytes\tfastq_md5\tbam_ftp\tbam_bytes\tbam_md5\tsubmitted_ftp\tsubmitted_bytes\tsubmitted_md5\tsra_ftp\tsra_bytes\tsra_md5\nERR2534089\tftp.sra.ebi.ac.uk/vol1/fastq/ERR253/009/ERR2534089/ERR2534089.fastq.gz\t936697735\t61cddd1766f5e4757fefd4a99865d3e0\t\t\t\tftp.sra.ebi.ac.uk/vol1/run/ERR253/ERR2534089/G144_Parental_RNAseq_24h_1.fastq.gz\t975986547\ta1cd512c64c06f21259ee1c41beb2a5a\tftp.sra.ebi.ac.uk/vol1/err/ERR253/009/ERR2534089\t620451256\tf566db3b1af03f9261b549a2f85ca46c\n"
     headers:
       Cache-Control:
       - no-cache, no-store, max-age=0, must-revalidate
+      Content-Length:
+      - '486'
       Content-Type:
       - text/plain
       Date:
-      - Wed, 28 Jul 2021 19:42:18 GMT
+      - Wed, 17 May 2023 18:36:21 GMT
       Expires:
       - '0'
       Pragma:
       - no-cache
-      Server:
-      - Apache-Coyote/1.1
       Strict-Transport-Security:
       - max-age=0
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Frame-Options:
@@ -8410,7 +7042,7 @@ interactions:
       - 1; mode=block
     status:
       code: 200
-      message: OK
+      message: ''
 - request:
     body: null
     headers:
@@ -8421,7 +7053,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/ERR2534090
   response:
@@ -8463,7 +7095,7 @@ interactions:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:42:18 GMT
+      - Wed, 17 May 2023 18:36:20 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -8481,7 +7113,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/ERX2552511
   response:
@@ -8549,7 +7181,7 @@ interactions:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:42:18 GMT
+      - Wed, 17 May 2023 18:36:21 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -8567,14 +7199,14 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/ERS2428805
   response:
     body:
       string: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<SAMPLE_SET>\n<SAMPLE accession=\"ERS2428805\"
-        alias=\"E-MTAB-6681:G144_Parental_RNAseq_24h_2\" broker_name=\"ArrayExpress\"
-        center_name=\"BRIC - Biotech Research and Innovation Centre\">\n     <IDENTIFIERS>\n
+        alias=\"E-MTAB-6681:G144_Parental_RNAseq_24h_2\" center_name=\"BRIC - Biotech
+        Research and Innovation Centre\" broker_name=\"ArrayExpress\">\n     <IDENTIFIERS>\n
         \         <PRIMARY_ID>ERS2428805</PRIMARY_ID>\n          <EXTERNAL_ID namespace=\"BioSample\">SAMEA4608109</EXTERNAL_ID>\n
         \         <SUBMITTER_ID namespace=\"BRIC - Biotech Research and Innovation
         Centre\">E-MTAB-6681:G144_Parental_RNAseq_24h_2</SUBMITTER_ID>\n     </IDENTIFIERS>\n
@@ -8582,57 +7214,45 @@ interactions:
         \         <SCIENTIFIC_NAME>Homo sapiens</SCIENTIFIC_NAME>\n          <COMMON_NAME>human</COMMON_NAME>\n
         \    </SAMPLE_NAME>\n     <DESCRIPTION>Protocols: CRISPR mediated KO of CIC:
         sgRNAs (Target sequence: mESCs: GCCTTCATGATCTTCAGCAAG; G144: GGGCGAGTGGTGGTATGCCC)
-        \ were cloned into pSpCas9(BB)-2A-GFP (Addgene 48138) and transfected into
-        mESCs (Lipofectamine 2000) or G144 cells (Amaxa Nucleofector II, Program A033).
+        were cloned into pSpCas9(BB)-2A-GFP (Addgene 48138) and transfected into mESCs
+        (Lipofectamine 2000) or G144 cells (Amaxa Nucleofector II, Program A033).
         GFP-positive cells were single cell sorted 48h post-transfection, expanded
         and screened by immunoblotting for CIC deletion. Inhibitor treatment with
         1 \u03BCM MEK inhibitor (PD0325901) was performed in 80% confluent cultures
         for 4 and 24 h respectively. DMSO was used as mock control. Cells were washed
-        once with PBS, lysed directly in RLT buffer (Qiagen).  Total RNA was extracted
-        using the RNAeasy kit (Qiagen).  500 ng of total RNA was used for library
-        preparation using TruSeq RNA Library Prep Kit v2 (Illumina) according to manufacturer
-        recommendations.</DESCRIPTION>\n     <SAMPLE_LINKS>\n          <SAMPLE_LINK>\n
-        \              <XREF_LINK>\n                    <DB>ENA-STUDY</DB>\n                    <ID>ERP108370</ID>\n
-        \              </XREF_LINK>\n          </SAMPLE_LINK>\n          <SAMPLE_LINK>\n
-        \              <XREF_LINK>\n                    <DB>ENA-EXPERIMENT</DB>\n
-        \                   <ID>ERX2552511</ID>\n               </XREF_LINK>\n          </SAMPLE_LINK>\n
-        \         <SAMPLE_LINK>\n               <XREF_LINK>\n                    <DB>ENA-RUN</DB>\n
-        \                   <ID>ERR2534090</ID>\n               </XREF_LINK>\n          </SAMPLE_LINK>\n
-        \         <SAMPLE_LINK>\n               <XREF_LINK>\n                    <DB>ENA-SUBMISSION</DB>\n
-        \                   <ID>ERA1350207</ID>\n               </XREF_LINK>\n          </SAMPLE_LINK>\n
-        \         <SAMPLE_LINK>\n               <XREF_LINK>\n                    <DB>ENA-FASTQ-FILES</DB>\n
-        \                   <ID><![CDATA[https://www.ebi.ac.uk/ena/portal/api/filereport?accession=ERS2428805&result=read_run&fields=run_accession,fastq_ftp,fastq_md5,fastq_bytes]]></ID>\n
-        \              </XREF_LINK>\n          </SAMPLE_LINK>\n          <SAMPLE_LINK>\n
-        \              <XREF_LINK>\n                    <DB>ENA-SUBMITTED-FILES</DB>\n
-        \                   <ID><![CDATA[https://www.ebi.ac.uk/ena/portal/api/filereport?accession=ERS2428805&result=read_run&fields=run_accession,submitted_ftp,submitted_md5,submitted_bytes,submitted_format]]></ID>\n
-        \              </XREF_LINK>\n          </SAMPLE_LINK>\n     </SAMPLE_LINKS>\n
-        \    <SAMPLE_ATTRIBUTES>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>isolate</TAG>\n
-        \              <VALUE>not applicable</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
-        \         <SAMPLE_ATTRIBUTE>\n               <TAG>organism</TAG>\n               <VALUE>Homo
-        sapiens</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
-        \              <TAG>organism part</TAG>\n               <VALUE>brain</VALUE>\n
-        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>cell_type</TAG>\n
-        \              <VALUE>glial cell</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
-        \         <SAMPLE_ATTRIBUTE>\n               <TAG>cell_line</TAG>\n               <VALUE>G144</VALUE>\n
+        once with PBS, lysed directly in RLT buffer (Qiagen). Total RNA was extracted
+        using the RNAeasy kit (Qiagen). 500 ng of total RNA was used for library preparation
+        using TruSeq RNA Library Prep Kit v2 (Illumina) according to manufacturer
+        recommendations.</DESCRIPTION>\n     <SAMPLE_LINKS>\n    <SAMPLE_LINK>\n        <XREF_LINK>\n
+        \           <DB>ENA-FASTQ-FILES</DB>\n            <ID><![CDATA[https://www.ebi.ac.uk/ena/portal/api/filereport?accession=ERS2428805&result=read_run&fields=run_accession,fastq_ftp,fastq_md5,fastq_bytes]]></ID>\n
+        \       </XREF_LINK>\n    </SAMPLE_LINK>\n    <SAMPLE_LINK>\n        <XREF_LINK>\n
+        \           <DB>ENA-SUBMITTED-FILES</DB>\n            <ID><![CDATA[https://www.ebi.ac.uk/ena/portal/api/filereport?accession=ERS2428805&result=read_run&fields=run_accession,submitted_ftp,submitted_md5,submitted_bytes,submitted_format]]></ID>\n
+        \       </XREF_LINK>\n    </SAMPLE_LINK>\n</SAMPLE_LINKS>\n<SAMPLE_ATTRIBUTES>\n
+        \         <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-CHECKLIST</TAG>\n               <VALUE>ERC000011</VALUE>\n
         \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>disease</TAG>\n
         \              <VALUE>glioblastoma multiforme</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
+        \         <SAMPLE_ATTRIBUTE>\n               <TAG>individual</TAG>\n               <VALUE>1</VALUE>\n
+        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>organism</TAG>\n
+        \              <VALUE>Homo sapiens</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
+        \         <SAMPLE_ATTRIBUTE>\n               <TAG>organism</TAG>\n               <VALUE>Homo
+        sapiens</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
+        \              <TAG>cell type</TAG>\n               <VALUE>glial cell</VALUE>\n
+        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>common
+        name</TAG>\n               <VALUE>human</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
+        \         <SAMPLE_ATTRIBUTE>\n               <TAG>organism part</TAG>\n               <VALUE>brain</VALUE>\n
+        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>cell
+        line</TAG>\n               <VALUE>G144</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
         \         <SAMPLE_ATTRIBUTE>\n               <TAG>genotype</TAG>\n               <VALUE>wild
         type genotype</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
-        \              <TAG>individual</TAG>\n               <VALUE>1</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
-        \         <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-CHECKLIST</TAG>\n               <VALUE>ERC000011</VALUE>\n
-        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-SPOT-COUNT</TAG>\n
-        \              <VALUE>22598916</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
-        \              <TAG>ENA-BASE-COUNT</TAG>\n               <VALUE>1705763883</VALUE>\n
-        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-FIRST-PUBLIC</TAG>\n
-        \              <VALUE>2018-05-30</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
-        \         <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-LAST-UPDATE</TAG>\n
+        \              <TAG>ENA-FIRST-PUBLIC</TAG>\n               <VALUE>2018-05-30</VALUE>\n
+        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-LAST-UPDATE</TAG>\n
         \              <VALUE>2018-04-24</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
         \    </SAMPLE_ATTRIBUTES>\n</SAMPLE>\n</SAMPLE_SET>\n"
     headers:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:42:19 GMT
+      - Wed, 17 May 2023 18:36:22 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -8650,7 +7270,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/ERP108370
   response:
@@ -8710,7 +7330,7 @@ interactions:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:42:21 GMT
+      - Wed, 17 May 2023 18:36:22 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -8728,7 +7348,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/ERA1350207
   response:
@@ -8764,7 +7384,7 @@ interactions:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:42:21 GMT
+      - Wed, 17 May 2023 18:36:23 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -8773,68 +7393,6 @@ interactions:
       code: 200
       message: ''
 - request:
-    body: acc=ERR2534090&accept-proto=fasp&version=2.0
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '44'
-      User-Agent:
-      - python-requests/2.25.1
-    method: POST
-    uri: https://www.ncbi.nlm.nih.gov/Traces/names/names.cgi
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAAwzIvQrCMBAA4L1PEXDoVLlc/i7dnYXi5NY2KVWCCWlEhHt4/cbvhGfojjqX98KX
-        aUKjNHhgB4o8gnaMIGkAN4C/SRwBR2XvbDyRXkluaIx1UgeM3lhScdkCzQ6YWQPw9ZW+ot9bK0cv
-        Ss0trzmJxyHmlPInBrHlKtr+j7w849q6HwAAAP//AwAtt9b2jgAAAA==
-    headers:
-      Cache-Control:
-      - private
-      Connection:
-      - Keep-Alive
-      Content-Encoding:
-      - gzip
-      Content-Security-Policy:
-      - upgrade-insecure-requests
-      Content-Type:
-      - text/plain
-      Date:
-      - Wed, 28 Jul 2021 19:42:21 GMT
-      Keep-Alive:
-      - timeout=1, max=10
-      NCBI-PHID:
-      - C7A42111101B31D10000000000000001.m_1
-      NCBI-SID:
-      - C7A42111101B31D1_0000SID
-      Referrer-Policy:
-      - origin-when-cross-origin
-      Server:
-      - Apache
-      Set-Cookie:
-      - ncbi_sid=C7A42111101B31D1_0000SID; domain=.nih.gov; path=/; expires=Thu, 28
-        Jul 2022 19:42:21 GMT
-      SraNameServerOutputVersion:
-      - '2.0'
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains; preload
-      Transfer-Encoding:
-      - chunked
-      Vary:
-      - Accept-Encoding
-      X-UA-Compatible:
-      - IE=Edge
-      X-XSS-Protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
-- request:
     body: null
     headers:
       Accept:
@@ -8844,29 +7402,27 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/portal/api/filereport?accession=ERR2534090&result=read_run
   response:
     body:
-      string: "run_accession\tfastq_ftp\tfastq_bytes\tfastq_md5\tsubmitted_ftp\tsubmitted_bytes\tsubmitted_md5\tsra_ftp\tsra_bytes\tsra_md5\nERR2534090\tftp.sra.ebi.ac.uk/vol1/fastq/ERR253/000/ERR2534090/ERR2534090.fastq.gz\t1061721210\tb6f84a04edb37b59613dc8d59e9647ce\tftp.sra.ebi.ac.uk/vol1/run/ERR253/ERR2534090/G144_Parental_RNAseq_24h_2.fastq.gz\t1106158490\t50a58f0d2237a1bd2453da5df48228a8\t\t\t\n"
+      string: "run_accession\tfastq_ftp\tfastq_bytes\tfastq_md5\tbam_ftp\tbam_bytes\tbam_md5\tsubmitted_ftp\tsubmitted_bytes\tsubmitted_md5\tsra_ftp\tsra_bytes\tsra_md5\nERR2534090\tftp.sra.ebi.ac.uk/vol1/fastq/ERR253/000/ERR2534090/ERR2534090.fastq.gz\t1061721210\tb6f84a04edb37b59613dc8d59e9647ce\t\t\t\tftp.sra.ebi.ac.uk/vol1/run/ERR253/ERR2534090/G144_Parental_RNAseq_24h_2.fastq.gz\t1106158490\t50a58f0d2237a1bd2453da5df48228a8\tftp.sra.ebi.ac.uk/vol1/err/ERR253/000/ERR2534090\t703892027\t530679b65da50bc03b2ea62c2e6e91d0\n"
     headers:
       Cache-Control:
       - no-cache, no-store, max-age=0, must-revalidate
+      Content-Length:
+      - '488'
       Content-Type:
       - text/plain
       Date:
-      - Wed, 28 Jul 2021 19:42:27 GMT
+      - Wed, 17 May 2023 18:36:23 GMT
       Expires:
       - '0'
       Pragma:
       - no-cache
-      Server:
-      - Apache-Coyote/1.1
       Strict-Transport-Security:
       - max-age=0
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Frame-Options:
@@ -8875,7 +7431,7 @@ interactions:
       - 1; mode=block
     status:
       code: 200
-      message: OK
+      message: ''
 - request:
     body: null
     headers:
@@ -8886,7 +7442,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/ERR2534091
   response:
@@ -8928,7 +7484,7 @@ interactions:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:42:27 GMT
+      - Wed, 17 May 2023 18:36:24 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -8946,7 +7502,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/ERX2552512
   response:
@@ -9014,7 +7570,7 @@ interactions:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:42:28 GMT
+      - Wed, 17 May 2023 18:36:24 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -9032,14 +7588,14 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/ERS2428806
   response:
     body:
       string: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<SAMPLE_SET>\n<SAMPLE accession=\"ERS2428806\"
-        alias=\"E-MTAB-6681:G144_Parental_RNAseq_24h_3\" broker_name=\"ArrayExpress\"
-        center_name=\"BRIC - Biotech Research and Innovation Centre\">\n     <IDENTIFIERS>\n
+        alias=\"E-MTAB-6681:G144_Parental_RNAseq_24h_3\" center_name=\"BRIC - Biotech
+        Research and Innovation Centre\" broker_name=\"ArrayExpress\">\n     <IDENTIFIERS>\n
         \         <PRIMARY_ID>ERS2428806</PRIMARY_ID>\n          <EXTERNAL_ID namespace=\"BioSample\">SAMEA4608110</EXTERNAL_ID>\n
         \         <SUBMITTER_ID namespace=\"BRIC - Biotech Research and Innovation
         Centre\">E-MTAB-6681:G144_Parental_RNAseq_24h_3</SUBMITTER_ID>\n     </IDENTIFIERS>\n
@@ -9047,57 +7603,45 @@ interactions:
         \         <SCIENTIFIC_NAME>Homo sapiens</SCIENTIFIC_NAME>\n          <COMMON_NAME>human</COMMON_NAME>\n
         \    </SAMPLE_NAME>\n     <DESCRIPTION>Protocols: CRISPR mediated KO of CIC:
         sgRNAs (Target sequence: mESCs: GCCTTCATGATCTTCAGCAAG; G144: GGGCGAGTGGTGGTATGCCC)
-        \ were cloned into pSpCas9(BB)-2A-GFP (Addgene 48138) and transfected into
-        mESCs (Lipofectamine 2000) or G144 cells (Amaxa Nucleofector II, Program A033).
+        were cloned into pSpCas9(BB)-2A-GFP (Addgene 48138) and transfected into mESCs
+        (Lipofectamine 2000) or G144 cells (Amaxa Nucleofector II, Program A033).
         GFP-positive cells were single cell sorted 48h post-transfection, expanded
         and screened by immunoblotting for CIC deletion. Inhibitor treatment with
         1 \u03BCM MEK inhibitor (PD0325901) was performed in 80% confluent cultures
         for 4 and 24 h respectively. DMSO was used as mock control. Cells were washed
-        once with PBS, lysed directly in RLT buffer (Qiagen).  Total RNA was extracted
-        using the RNAeasy kit (Qiagen).  500 ng of total RNA was used for library
-        preparation using TruSeq RNA Library Prep Kit v2 (Illumina) according to manufacturer
-        recommendations.</DESCRIPTION>\n     <SAMPLE_LINKS>\n          <SAMPLE_LINK>\n
-        \              <XREF_LINK>\n                    <DB>ENA-STUDY</DB>\n                    <ID>ERP108370</ID>\n
-        \              </XREF_LINK>\n          </SAMPLE_LINK>\n          <SAMPLE_LINK>\n
-        \              <XREF_LINK>\n                    <DB>ENA-EXPERIMENT</DB>\n
-        \                   <ID>ERX2552512</ID>\n               </XREF_LINK>\n          </SAMPLE_LINK>\n
-        \         <SAMPLE_LINK>\n               <XREF_LINK>\n                    <DB>ENA-RUN</DB>\n
-        \                   <ID>ERR2534091</ID>\n               </XREF_LINK>\n          </SAMPLE_LINK>\n
-        \         <SAMPLE_LINK>\n               <XREF_LINK>\n                    <DB>ENA-SUBMISSION</DB>\n
-        \                   <ID>ERA1350207</ID>\n               </XREF_LINK>\n          </SAMPLE_LINK>\n
-        \         <SAMPLE_LINK>\n               <XREF_LINK>\n                    <DB>ENA-FASTQ-FILES</DB>\n
-        \                   <ID><![CDATA[https://www.ebi.ac.uk/ena/portal/api/filereport?accession=ERS2428806&result=read_run&fields=run_accession,fastq_ftp,fastq_md5,fastq_bytes]]></ID>\n
-        \              </XREF_LINK>\n          </SAMPLE_LINK>\n          <SAMPLE_LINK>\n
-        \              <XREF_LINK>\n                    <DB>ENA-SUBMITTED-FILES</DB>\n
-        \                   <ID><![CDATA[https://www.ebi.ac.uk/ena/portal/api/filereport?accession=ERS2428806&result=read_run&fields=run_accession,submitted_ftp,submitted_md5,submitted_bytes,submitted_format]]></ID>\n
-        \              </XREF_LINK>\n          </SAMPLE_LINK>\n     </SAMPLE_LINKS>\n
-        \    <SAMPLE_ATTRIBUTES>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>isolate</TAG>\n
-        \              <VALUE>not applicable</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
-        \         <SAMPLE_ATTRIBUTE>\n               <TAG>organism</TAG>\n               <VALUE>Homo
-        sapiens</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
-        \              <TAG>organism part</TAG>\n               <VALUE>brain</VALUE>\n
-        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>cell_type</TAG>\n
-        \              <VALUE>glial cell</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
-        \         <SAMPLE_ATTRIBUTE>\n               <TAG>cell_line</TAG>\n               <VALUE>G144</VALUE>\n
+        once with PBS, lysed directly in RLT buffer (Qiagen). Total RNA was extracted
+        using the RNAeasy kit (Qiagen). 500 ng of total RNA was used for library preparation
+        using TruSeq RNA Library Prep Kit v2 (Illumina) according to manufacturer
+        recommendations.</DESCRIPTION>\n     <SAMPLE_LINKS>\n    <SAMPLE_LINK>\n        <XREF_LINK>\n
+        \           <DB>ENA-FASTQ-FILES</DB>\n            <ID><![CDATA[https://www.ebi.ac.uk/ena/portal/api/filereport?accession=ERS2428806&result=read_run&fields=run_accession,fastq_ftp,fastq_md5,fastq_bytes]]></ID>\n
+        \       </XREF_LINK>\n    </SAMPLE_LINK>\n    <SAMPLE_LINK>\n        <XREF_LINK>\n
+        \           <DB>ENA-SUBMITTED-FILES</DB>\n            <ID><![CDATA[https://www.ebi.ac.uk/ena/portal/api/filereport?accession=ERS2428806&result=read_run&fields=run_accession,submitted_ftp,submitted_md5,submitted_bytes,submitted_format]]></ID>\n
+        \       </XREF_LINK>\n    </SAMPLE_LINK>\n</SAMPLE_LINKS>\n<SAMPLE_ATTRIBUTES>\n
+        \         <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-CHECKLIST</TAG>\n               <VALUE>ERC000011</VALUE>\n
         \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>disease</TAG>\n
         \              <VALUE>glioblastoma multiforme</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
+        \         <SAMPLE_ATTRIBUTE>\n               <TAG>individual</TAG>\n               <VALUE>1</VALUE>\n
+        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>organism</TAG>\n
+        \              <VALUE>Homo sapiens</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
+        \         <SAMPLE_ATTRIBUTE>\n               <TAG>organism</TAG>\n               <VALUE>Homo
+        sapiens</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
+        \              <TAG>cell type</TAG>\n               <VALUE>glial cell</VALUE>\n
+        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>common
+        name</TAG>\n               <VALUE>human</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
+        \         <SAMPLE_ATTRIBUTE>\n               <TAG>organism part</TAG>\n               <VALUE>brain</VALUE>\n
+        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>cell
+        line</TAG>\n               <VALUE>G144</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
         \         <SAMPLE_ATTRIBUTE>\n               <TAG>genotype</TAG>\n               <VALUE>wild
         type genotype</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
-        \              <TAG>individual</TAG>\n               <VALUE>1</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
-        \         <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-CHECKLIST</TAG>\n               <VALUE>ERC000011</VALUE>\n
-        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-SPOT-COUNT</TAG>\n
-        \              <VALUE>20997810</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
-        \              <TAG>ENA-BASE-COUNT</TAG>\n               <VALUE>1585139118</VALUE>\n
-        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-FIRST-PUBLIC</TAG>\n
-        \              <VALUE>2018-05-30</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
-        \         <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-LAST-UPDATE</TAG>\n
+        \              <TAG>ENA-FIRST-PUBLIC</TAG>\n               <VALUE>2018-05-30</VALUE>\n
+        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-LAST-UPDATE</TAG>\n
         \              <VALUE>2018-04-24</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
         \    </SAMPLE_ATTRIBUTES>\n</SAMPLE>\n</SAMPLE_SET>\n"
     headers:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:42:29 GMT
+      - Wed, 17 May 2023 18:36:25 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -9115,7 +7659,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/ERP108370
   response:
@@ -9175,7 +7719,7 @@ interactions:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:42:29 GMT
+      - Wed, 17 May 2023 18:36:25 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -9193,7 +7737,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/ERA1350207
   response:
@@ -9229,7 +7773,7 @@ interactions:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:42:31 GMT
+      - Wed, 17 May 2023 18:36:25 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -9238,68 +7782,6 @@ interactions:
       code: 200
       message: ''
 - request:
-    body: acc=ERR2534091&accept-proto=fasp&version=2.0
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '44'
-      User-Agent:
-      - python-requests/2.25.1
-    method: POST
-    uri: https://www.ncbi.nlm.nih.gov/Traces/names/names.cgi
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAAwzIsQrCMBAA0L1fEXDoVLlcc821u7NQnNyapKVKMCGNiHAfr298JzxDc5Qlv51c
-        5hmpNzBqGYgGZmAWBM0d2A7Gm8YJzNQPd7HaUmAH3vWLCW4jo8nyitp4JEAQEQMg11f8qnavNR+t
-        yiXV5FNUj0MtMabPGtSWiqr7P5J7rr42PwAAAP//AwA2wGMdjgAAAA==
-    headers:
-      Cache-Control:
-      - private
-      Connection:
-      - Keep-Alive
-      Content-Encoding:
-      - gzip
-      Content-Security-Policy:
-      - upgrade-insecure-requests
-      Content-Type:
-      - text/plain
-      Date:
-      - Wed, 28 Jul 2021 19:42:31 GMT
-      Keep-Alive:
-      - timeout=1, max=10
-      NCBI-PHID:
-      - CC95F25B101B32710000000000000001.m_1
-      NCBI-SID:
-      - CC95F25B101B3271_0000SID
-      Referrer-Policy:
-      - origin-when-cross-origin
-      Server:
-      - Apache
-      Set-Cookie:
-      - ncbi_sid=CC95F25B101B3271_0000SID; domain=.nih.gov; path=/; expires=Thu, 28
-        Jul 2022 19:42:31 GMT
-      SraNameServerOutputVersion:
-      - '2.0'
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains; preload
-      Transfer-Encoding:
-      - chunked
-      Vary:
-      - Accept-Encoding
-      X-UA-Compatible:
-      - IE=Edge
-      X-XSS-Protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
-- request:
     body: null
     headers:
       Accept:
@@ -9309,29 +7791,27 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/portal/api/filereport?accession=ERR2534091&result=read_run
   response:
     body:
-      string: "run_accession\tfastq_ftp\tfastq_bytes\tfastq_md5\tsubmitted_ftp\tsubmitted_bytes\tsubmitted_md5\tsra_ftp\tsra_bytes\tsra_md5\nERR2534091\tftp.sra.ebi.ac.uk/vol1/fastq/ERR253/001/ERR2534091/ERR2534091.fastq.gz\t989268235\t0802cce838493fc43f1633340c764b14\tftp.sra.ebi.ac.uk/vol1/run/ERR253/ERR2534091/G144_Parental_RNAseq_24h_3.fastq.gz\t1030713695\tde063ac40bec17deefda44342353dd0d\t\t\t\n"
+      string: "run_accession\tfastq_ftp\tfastq_bytes\tfastq_md5\tbam_ftp\tbam_bytes\tbam_md5\tsubmitted_ftp\tsubmitted_bytes\tsubmitted_md5\tsra_ftp\tsra_bytes\tsra_md5\nERR2534091\tftp.sra.ebi.ac.uk/vol1/fastq/ERR253/001/ERR2534091/ERR2534091.fastq.gz\t989268235\t0802cce838493fc43f1633340c764b14\t\t\t\tftp.sra.ebi.ac.uk/vol1/run/ERR253/ERR2534091/G144_Parental_RNAseq_24h_3.fastq.gz\t1030713695\tde063ac40bec17deefda44342353dd0d\tftp.sra.ebi.ac.uk/vol1/err/ERR253/001/ERR2534091\t655688068\tbde1222054dbb257c4c7c293285f348c\n"
     headers:
       Cache-Control:
       - no-cache, no-store, max-age=0, must-revalidate
+      Content-Length:
+      - '487'
       Content-Type:
       - text/plain
       Date:
-      - Wed, 28 Jul 2021 19:42:31 GMT
+      - Wed, 17 May 2023 18:36:26 GMT
       Expires:
       - '0'
       Pragma:
       - no-cache
-      Server:
-      - Apache-Coyote/1.1
       Strict-Transport-Security:
       - max-age=0
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Frame-Options:
@@ -9340,7 +7820,7 @@ interactions:
       - 1; mode=block
     status:
       code: 200
-      message: OK
+      message: ''
 - request:
     body: null
     headers:
@@ -9351,7 +7831,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/ERR2534092
   response:
@@ -9393,7 +7873,7 @@ interactions:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:42:33 GMT
+      - Wed, 17 May 2023 18:36:26 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -9411,7 +7891,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/ERX2552513
   response:
@@ -9479,7 +7959,7 @@ interactions:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:42:33 GMT
+      - Wed, 17 May 2023 18:36:27 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -9497,14 +7977,14 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/ERS2428807
   response:
     body:
       string: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<SAMPLE_SET>\n<SAMPLE accession=\"ERS2428807\"
-        alias=\"E-MTAB-6681:G144_Parental_RNAseq_4h_1\" broker_name=\"ArrayExpress\"
-        center_name=\"BRIC - Biotech Research and Innovation Centre\">\n     <IDENTIFIERS>\n
+        alias=\"E-MTAB-6681:G144_Parental_RNAseq_4h_1\" center_name=\"BRIC - Biotech
+        Research and Innovation Centre\" broker_name=\"ArrayExpress\">\n     <IDENTIFIERS>\n
         \         <PRIMARY_ID>ERS2428807</PRIMARY_ID>\n          <EXTERNAL_ID namespace=\"BioSample\">SAMEA4608111</EXTERNAL_ID>\n
         \         <SUBMITTER_ID namespace=\"BRIC - Biotech Research and Innovation
         Centre\">E-MTAB-6681:G144_Parental_RNAseq_4h_1</SUBMITTER_ID>\n     </IDENTIFIERS>\n
@@ -9512,57 +7992,45 @@ interactions:
         \         <SCIENTIFIC_NAME>Homo sapiens</SCIENTIFIC_NAME>\n          <COMMON_NAME>human</COMMON_NAME>\n
         \    </SAMPLE_NAME>\n     <DESCRIPTION>Protocols: CRISPR mediated KO of CIC:
         sgRNAs (Target sequence: mESCs: GCCTTCATGATCTTCAGCAAG; G144: GGGCGAGTGGTGGTATGCCC)
-        \ were cloned into pSpCas9(BB)-2A-GFP (Addgene 48138) and transfected into
-        mESCs (Lipofectamine 2000) or G144 cells (Amaxa Nucleofector II, Program A033).
+        were cloned into pSpCas9(BB)-2A-GFP (Addgene 48138) and transfected into mESCs
+        (Lipofectamine 2000) or G144 cells (Amaxa Nucleofector II, Program A033).
         GFP-positive cells were single cell sorted 48h post-transfection, expanded
         and screened by immunoblotting for CIC deletion. Inhibitor treatment with
         1 \u03BCM MEK inhibitor (PD0325901) was performed in 80% confluent cultures
         for 4 and 24 h respectively. DMSO was used as mock control. Cells were washed
-        once with PBS, lysed directly in RLT buffer (Qiagen).  Total RNA was extracted
-        using the RNAeasy kit (Qiagen).  500 ng of total RNA was used for library
-        preparation using TruSeq RNA Library Prep Kit v2 (Illumina) according to manufacturer
-        recommendations.</DESCRIPTION>\n     <SAMPLE_LINKS>\n          <SAMPLE_LINK>\n
-        \              <XREF_LINK>\n                    <DB>ENA-STUDY</DB>\n                    <ID>ERP108370</ID>\n
-        \              </XREF_LINK>\n          </SAMPLE_LINK>\n          <SAMPLE_LINK>\n
-        \              <XREF_LINK>\n                    <DB>ENA-EXPERIMENT</DB>\n
-        \                   <ID>ERX2552513</ID>\n               </XREF_LINK>\n          </SAMPLE_LINK>\n
-        \         <SAMPLE_LINK>\n               <XREF_LINK>\n                    <DB>ENA-RUN</DB>\n
-        \                   <ID>ERR2534092</ID>\n               </XREF_LINK>\n          </SAMPLE_LINK>\n
-        \         <SAMPLE_LINK>\n               <XREF_LINK>\n                    <DB>ENA-SUBMISSION</DB>\n
-        \                   <ID>ERA1350207</ID>\n               </XREF_LINK>\n          </SAMPLE_LINK>\n
-        \         <SAMPLE_LINK>\n               <XREF_LINK>\n                    <DB>ENA-FASTQ-FILES</DB>\n
-        \                   <ID><![CDATA[https://www.ebi.ac.uk/ena/portal/api/filereport?accession=ERS2428807&result=read_run&fields=run_accession,fastq_ftp,fastq_md5,fastq_bytes]]></ID>\n
-        \              </XREF_LINK>\n          </SAMPLE_LINK>\n          <SAMPLE_LINK>\n
-        \              <XREF_LINK>\n                    <DB>ENA-SUBMITTED-FILES</DB>\n
-        \                   <ID><![CDATA[https://www.ebi.ac.uk/ena/portal/api/filereport?accession=ERS2428807&result=read_run&fields=run_accession,submitted_ftp,submitted_md5,submitted_bytes,submitted_format]]></ID>\n
-        \              </XREF_LINK>\n          </SAMPLE_LINK>\n     </SAMPLE_LINKS>\n
-        \    <SAMPLE_ATTRIBUTES>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>isolate</TAG>\n
-        \              <VALUE>not applicable</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
-        \         <SAMPLE_ATTRIBUTE>\n               <TAG>organism</TAG>\n               <VALUE>Homo
-        sapiens</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
-        \              <TAG>organism part</TAG>\n               <VALUE>brain</VALUE>\n
-        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>cell_type</TAG>\n
-        \              <VALUE>glial cell</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
-        \         <SAMPLE_ATTRIBUTE>\n               <TAG>cell_line</TAG>\n               <VALUE>G144</VALUE>\n
+        once with PBS, lysed directly in RLT buffer (Qiagen). Total RNA was extracted
+        using the RNAeasy kit (Qiagen). 500 ng of total RNA was used for library preparation
+        using TruSeq RNA Library Prep Kit v2 (Illumina) according to manufacturer
+        recommendations.</DESCRIPTION>\n     <SAMPLE_LINKS>\n    <SAMPLE_LINK>\n        <XREF_LINK>\n
+        \           <DB>ENA-FASTQ-FILES</DB>\n            <ID><![CDATA[https://www.ebi.ac.uk/ena/portal/api/filereport?accession=ERS2428807&result=read_run&fields=run_accession,fastq_ftp,fastq_md5,fastq_bytes]]></ID>\n
+        \       </XREF_LINK>\n    </SAMPLE_LINK>\n    <SAMPLE_LINK>\n        <XREF_LINK>\n
+        \           <DB>ENA-SUBMITTED-FILES</DB>\n            <ID><![CDATA[https://www.ebi.ac.uk/ena/portal/api/filereport?accession=ERS2428807&result=read_run&fields=run_accession,submitted_ftp,submitted_md5,submitted_bytes,submitted_format]]></ID>\n
+        \       </XREF_LINK>\n    </SAMPLE_LINK>\n</SAMPLE_LINKS>\n<SAMPLE_ATTRIBUTES>\n
+        \         <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-CHECKLIST</TAG>\n               <VALUE>ERC000011</VALUE>\n
         \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>disease</TAG>\n
         \              <VALUE>glioblastoma multiforme</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
+        \         <SAMPLE_ATTRIBUTE>\n               <TAG>individual</TAG>\n               <VALUE>1</VALUE>\n
+        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>organism</TAG>\n
+        \              <VALUE>Homo sapiens</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
+        \         <SAMPLE_ATTRIBUTE>\n               <TAG>organism</TAG>\n               <VALUE>Homo
+        sapiens</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
+        \              <TAG>cell type</TAG>\n               <VALUE>glial cell</VALUE>\n
+        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>common
+        name</TAG>\n               <VALUE>human</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
+        \         <SAMPLE_ATTRIBUTE>\n               <TAG>organism part</TAG>\n               <VALUE>brain</VALUE>\n
+        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>cell
+        line</TAG>\n               <VALUE>G144</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
         \         <SAMPLE_ATTRIBUTE>\n               <TAG>genotype</TAG>\n               <VALUE>wild
         type genotype</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
-        \              <TAG>individual</TAG>\n               <VALUE>1</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
-        \         <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-CHECKLIST</TAG>\n               <VALUE>ERC000011</VALUE>\n
-        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-SPOT-COUNT</TAG>\n
-        \              <VALUE>21890892</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
-        \              <TAG>ENA-BASE-COUNT</TAG>\n               <VALUE>1652585468</VALUE>\n
-        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-FIRST-PUBLIC</TAG>\n
-        \              <VALUE>2018-05-30</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
-        \         <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-LAST-UPDATE</TAG>\n
+        \              <TAG>ENA-FIRST-PUBLIC</TAG>\n               <VALUE>2018-05-30</VALUE>\n
+        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-LAST-UPDATE</TAG>\n
         \              <VALUE>2018-04-24</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
         \    </SAMPLE_ATTRIBUTES>\n</SAMPLE>\n</SAMPLE_SET>\n"
     headers:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:42:34 GMT
+      - Wed, 17 May 2023 18:36:26 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -9580,7 +8048,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/ERP108370
   response:
@@ -9640,7 +8108,7 @@ interactions:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:42:35 GMT
+      - Wed, 17 May 2023 18:36:27 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -9658,7 +8126,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/ERA1350207
   response:
@@ -9694,7 +8162,7 @@ interactions:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:42:35 GMT
+      - Wed, 17 May 2023 18:36:28 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -9703,68 +8171,6 @@ interactions:
       code: 200
       message: ''
 - request:
-    body: acc=ERR2534092&accept-proto=fasp&version=2.0
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '44'
-      User-Agent:
-      - python-requests/2.25.1
-    method: POST
-    uri: https://www.ncbi.nlm.nih.gov/Traces/names/names.cgi
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAAwzIvQrCMBAA4L1PEXDoVLlL0jTX3VkoTm75K1WCKWlEhHt4/cbvJM/QHdXtb8+X
-        ZZGj0kCSjdWEdhqRJaAdYBqAbihnMDOoO6cUEnnlkUZwGA1RXFWyRkfydsXAzBqAr6/8Ff3W2n70
-        Yq+llVCyeBzC5Vw+KYq1VNG2fxT/TKF1PwAAAP//AwDBPahJjgAAAA==
-    headers:
-      Cache-Control:
-      - private
-      Connection:
-      - Keep-Alive
-      Content-Encoding:
-      - gzip
-      Content-Security-Policy:
-      - upgrade-insecure-requests
-      Content-Type:
-      - text/plain
-      Date:
-      - Wed, 28 Jul 2021 19:42:36 GMT
-      Keep-Alive:
-      - timeout=1, max=10
-      NCBI-PHID:
-      - C7A42164101B32C10000000000000001.m_1
-      NCBI-SID:
-      - C7A42164101B32C1_0000SID
-      Referrer-Policy:
-      - origin-when-cross-origin
-      Server:
-      - Apache
-      Set-Cookie:
-      - ncbi_sid=C7A42164101B32C1_0000SID; domain=.nih.gov; path=/; expires=Thu, 28
-        Jul 2022 19:42:36 GMT
-      SraNameServerOutputVersion:
-      - '2.0'
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains; preload
-      Transfer-Encoding:
-      - chunked
-      Vary:
-      - Accept-Encoding
-      X-UA-Compatible:
-      - IE=Edge
-      X-XSS-Protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
-- request:
     body: null
     headers:
       Accept:
@@ -9774,29 +8180,27 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/portal/api/filereport?accession=ERR2534092&result=read_run
   response:
     body:
-      string: "run_accession\tfastq_ftp\tfastq_bytes\tfastq_md5\tsubmitted_ftp\tsubmitted_bytes\tsubmitted_md5\tsra_ftp\tsra_bytes\tsra_md5\nERR2534092\tftp.sra.ebi.ac.uk/vol1/fastq/ERR253/002/ERR2534092/ERR2534092.fastq.gz\t1032472887\t653c55e458a2554089c39a4e18d70927\tftp.sra.ebi.ac.uk/vol1/run/ERR253/ERR2534092/G144_Parental_RNAseq_4h_1.fastq.gz\t1075913209\t6d410b59ed993b1c515ec502cad05534\t\t\t\n"
+      string: "run_accession\tfastq_ftp\tfastq_bytes\tfastq_md5\tbam_ftp\tbam_bytes\tbam_md5\tsubmitted_ftp\tsubmitted_bytes\tsubmitted_md5\tsra_ftp\tsra_bytes\tsra_md5\nERR2534092\tftp.sra.ebi.ac.uk/vol1/fastq/ERR253/002/ERR2534092/ERR2534092.fastq.gz\t1032472887\t653c55e458a2554089c39a4e18d70927\t\t\t\tftp.sra.ebi.ac.uk/vol1/run/ERR253/ERR2534092/G144_Parental_RNAseq_4h_1.fastq.gz\t1075913209\t6d410b59ed993b1c515ec502cad05534\tftp.sra.ebi.ac.uk/vol1/err/ERR253/002/ERR2534092\t684918731\t8180fa815cec978c15eaaefb49009f50\n"
     headers:
       Cache-Control:
       - no-cache, no-store, max-age=0, must-revalidate
+      Content-Length:
+      - '487'
       Content-Type:
       - text/plain
       Date:
-      - Wed, 28 Jul 2021 19:42:42 GMT
+      - Wed, 17 May 2023 18:36:28 GMT
       Expires:
       - '0'
       Pragma:
       - no-cache
-      Server:
-      - Apache-Coyote/1.1
       Strict-Transport-Security:
       - max-age=0
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Frame-Options:
@@ -9805,7 +8209,7 @@ interactions:
       - 1; mode=block
     status:
       code: 200
-      message: OK
+      message: ''
 - request:
     body: null
     headers:
@@ -9816,7 +8220,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/ERR2534093
   response:
@@ -9858,7 +8262,7 @@ interactions:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:42:42 GMT
+      - Wed, 17 May 2023 18:36:29 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -9876,7 +8280,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/ERX2552514
   response:
@@ -9944,7 +8348,7 @@ interactions:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:42:43 GMT
+      - Wed, 17 May 2023 18:36:29 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -9962,14 +8366,14 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/ERS2428808
   response:
     body:
       string: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<SAMPLE_SET>\n<SAMPLE accession=\"ERS2428808\"
-        alias=\"E-MTAB-6681:G144_Parental_RNAseq_4h_2\" broker_name=\"ArrayExpress\"
-        center_name=\"BRIC - Biotech Research and Innovation Centre\">\n     <IDENTIFIERS>\n
+        alias=\"E-MTAB-6681:G144_Parental_RNAseq_4h_2\" center_name=\"BRIC - Biotech
+        Research and Innovation Centre\" broker_name=\"ArrayExpress\">\n     <IDENTIFIERS>\n
         \         <PRIMARY_ID>ERS2428808</PRIMARY_ID>\n          <EXTERNAL_ID namespace=\"BioSample\">SAMEA4608112</EXTERNAL_ID>\n
         \         <SUBMITTER_ID namespace=\"BRIC - Biotech Research and Innovation
         Centre\">E-MTAB-6681:G144_Parental_RNAseq_4h_2</SUBMITTER_ID>\n     </IDENTIFIERS>\n
@@ -9977,57 +8381,45 @@ interactions:
         \         <SCIENTIFIC_NAME>Homo sapiens</SCIENTIFIC_NAME>\n          <COMMON_NAME>human</COMMON_NAME>\n
         \    </SAMPLE_NAME>\n     <DESCRIPTION>Protocols: CRISPR mediated KO of CIC:
         sgRNAs (Target sequence: mESCs: GCCTTCATGATCTTCAGCAAG; G144: GGGCGAGTGGTGGTATGCCC)
-        \ were cloned into pSpCas9(BB)-2A-GFP (Addgene 48138) and transfected into
-        mESCs (Lipofectamine 2000) or G144 cells (Amaxa Nucleofector II, Program A033).
+        were cloned into pSpCas9(BB)-2A-GFP (Addgene 48138) and transfected into mESCs
+        (Lipofectamine 2000) or G144 cells (Amaxa Nucleofector II, Program A033).
         GFP-positive cells were single cell sorted 48h post-transfection, expanded
         and screened by immunoblotting for CIC deletion. Inhibitor treatment with
         1 \u03BCM MEK inhibitor (PD0325901) was performed in 80% confluent cultures
         for 4 and 24 h respectively. DMSO was used as mock control. Cells were washed
-        once with PBS, lysed directly in RLT buffer (Qiagen).  Total RNA was extracted
-        using the RNAeasy kit (Qiagen).  500 ng of total RNA was used for library
-        preparation using TruSeq RNA Library Prep Kit v2 (Illumina) according to manufacturer
-        recommendations.</DESCRIPTION>\n     <SAMPLE_LINKS>\n          <SAMPLE_LINK>\n
-        \              <XREF_LINK>\n                    <DB>ENA-STUDY</DB>\n                    <ID>ERP108370</ID>\n
-        \              </XREF_LINK>\n          </SAMPLE_LINK>\n          <SAMPLE_LINK>\n
-        \              <XREF_LINK>\n                    <DB>ENA-EXPERIMENT</DB>\n
-        \                   <ID>ERX2552514</ID>\n               </XREF_LINK>\n          </SAMPLE_LINK>\n
-        \         <SAMPLE_LINK>\n               <XREF_LINK>\n                    <DB>ENA-RUN</DB>\n
-        \                   <ID>ERR2534093</ID>\n               </XREF_LINK>\n          </SAMPLE_LINK>\n
-        \         <SAMPLE_LINK>\n               <XREF_LINK>\n                    <DB>ENA-SUBMISSION</DB>\n
-        \                   <ID>ERA1350207</ID>\n               </XREF_LINK>\n          </SAMPLE_LINK>\n
-        \         <SAMPLE_LINK>\n               <XREF_LINK>\n                    <DB>ENA-FASTQ-FILES</DB>\n
-        \                   <ID><![CDATA[https://www.ebi.ac.uk/ena/portal/api/filereport?accession=ERS2428808&result=read_run&fields=run_accession,fastq_ftp,fastq_md5,fastq_bytes]]></ID>\n
-        \              </XREF_LINK>\n          </SAMPLE_LINK>\n          <SAMPLE_LINK>\n
-        \              <XREF_LINK>\n                    <DB>ENA-SUBMITTED-FILES</DB>\n
-        \                   <ID><![CDATA[https://www.ebi.ac.uk/ena/portal/api/filereport?accession=ERS2428808&result=read_run&fields=run_accession,submitted_ftp,submitted_md5,submitted_bytes,submitted_format]]></ID>\n
-        \              </XREF_LINK>\n          </SAMPLE_LINK>\n     </SAMPLE_LINKS>\n
-        \    <SAMPLE_ATTRIBUTES>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>isolate</TAG>\n
-        \              <VALUE>not applicable</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
-        \         <SAMPLE_ATTRIBUTE>\n               <TAG>organism</TAG>\n               <VALUE>Homo
-        sapiens</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
-        \              <TAG>organism part</TAG>\n               <VALUE>brain</VALUE>\n
-        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>cell_type</TAG>\n
-        \              <VALUE>glial cell</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
-        \         <SAMPLE_ATTRIBUTE>\n               <TAG>cell_line</TAG>\n               <VALUE>G144</VALUE>\n
+        once with PBS, lysed directly in RLT buffer (Qiagen). Total RNA was extracted
+        using the RNAeasy kit (Qiagen). 500 ng of total RNA was used for library preparation
+        using TruSeq RNA Library Prep Kit v2 (Illumina) according to manufacturer
+        recommendations.</DESCRIPTION>\n     <SAMPLE_LINKS>\n    <SAMPLE_LINK>\n        <XREF_LINK>\n
+        \           <DB>ENA-FASTQ-FILES</DB>\n            <ID><![CDATA[https://www.ebi.ac.uk/ena/portal/api/filereport?accession=ERS2428808&result=read_run&fields=run_accession,fastq_ftp,fastq_md5,fastq_bytes]]></ID>\n
+        \       </XREF_LINK>\n    </SAMPLE_LINK>\n    <SAMPLE_LINK>\n        <XREF_LINK>\n
+        \           <DB>ENA-SUBMITTED-FILES</DB>\n            <ID><![CDATA[https://www.ebi.ac.uk/ena/portal/api/filereport?accession=ERS2428808&result=read_run&fields=run_accession,submitted_ftp,submitted_md5,submitted_bytes,submitted_format]]></ID>\n
+        \       </XREF_LINK>\n    </SAMPLE_LINK>\n</SAMPLE_LINKS>\n<SAMPLE_ATTRIBUTES>\n
+        \         <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-CHECKLIST</TAG>\n               <VALUE>ERC000011</VALUE>\n
         \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>disease</TAG>\n
         \              <VALUE>glioblastoma multiforme</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
+        \         <SAMPLE_ATTRIBUTE>\n               <TAG>individual</TAG>\n               <VALUE>1</VALUE>\n
+        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>organism</TAG>\n
+        \              <VALUE>Homo sapiens</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
+        \         <SAMPLE_ATTRIBUTE>\n               <TAG>organism</TAG>\n               <VALUE>Homo
+        sapiens</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
+        \              <TAG>cell type</TAG>\n               <VALUE>glial cell</VALUE>\n
+        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>common
+        name</TAG>\n               <VALUE>human</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
+        \         <SAMPLE_ATTRIBUTE>\n               <TAG>organism part</TAG>\n               <VALUE>brain</VALUE>\n
+        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>cell
+        line</TAG>\n               <VALUE>G144</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
         \         <SAMPLE_ATTRIBUTE>\n               <TAG>genotype</TAG>\n               <VALUE>wild
         type genotype</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
-        \              <TAG>individual</TAG>\n               <VALUE>1</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
-        \         <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-CHECKLIST</TAG>\n               <VALUE>ERC000011</VALUE>\n
-        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-SPOT-COUNT</TAG>\n
-        \              <VALUE>20416177</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
-        \              <TAG>ENA-BASE-COUNT</TAG>\n               <VALUE>1541046510</VALUE>\n
-        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-FIRST-PUBLIC</TAG>\n
-        \              <VALUE>2018-05-30</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
-        \         <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-LAST-UPDATE</TAG>\n
+        \              <TAG>ENA-FIRST-PUBLIC</TAG>\n               <VALUE>2018-05-30</VALUE>\n
+        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-LAST-UPDATE</TAG>\n
         \              <VALUE>2018-04-24</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
         \    </SAMPLE_ATTRIBUTES>\n</SAMPLE>\n</SAMPLE_SET>\n"
     headers:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:42:43 GMT
+      - Wed, 17 May 2023 18:36:30 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -10045,7 +8437,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/ERP108370
   response:
@@ -10105,7 +8497,7 @@ interactions:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:42:43 GMT
+      - Wed, 17 May 2023 18:36:30 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -10123,7 +8515,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/ERA1350207
   response:
@@ -10159,7 +8551,7 @@ interactions:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:42:44 GMT
+      - Wed, 17 May 2023 18:36:30 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -10168,68 +8560,6 @@ interactions:
       code: 200
       message: ''
 - request:
-    body: acc=ERR2534093&accept-proto=fasp&version=2.0
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '44'
-      User-Agent:
-      - python-requests/2.25.1
-    method: POST
-    uri: https://www.ncbi.nlm.nih.gov/Traces/names/names.cgi
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAAwzLsQrDIBAA0D1fIXTIlHKep9HsnQuhUzdjlLRIDImlFO7jm/XBu+AVmmP322fi
-        2ziiVgROsVE9KmOkZQRpO+g7cA+JA5gB6cnKJKKAErWO1iZno0s6kHFz8HRGZiYAvq/5J9ql1u1o
-        xbaXWkLJ4nUIn3P5xlmksou6nFCmdwy1+QMAAP//AwC4yyTmjgAAAA==
-    headers:
-      Cache-Control:
-      - private
-      Connection:
-      - Keep-Alive
-      Content-Encoding:
-      - gzip
-      Content-Security-Policy:
-      - upgrade-insecure-requests
-      Content-Type:
-      - text/plain
-      Date:
-      - Wed, 28 Jul 2021 19:42:45 GMT
-      Keep-Alive:
-      - timeout=1, max=10
-      NCBI-PHID:
-      - C7A421B2101B33510000000000000001.m_1
-      NCBI-SID:
-      - C7A421B2101B3351_0000SID
-      Referrer-Policy:
-      - origin-when-cross-origin
-      Server:
-      - Apache
-      Set-Cookie:
-      - ncbi_sid=C7A421B2101B3351_0000SID; domain=.nih.gov; path=/; expires=Thu, 28
-        Jul 2022 19:42:45 GMT
-      SraNameServerOutputVersion:
-      - '2.0'
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains; preload
-      Transfer-Encoding:
-      - chunked
-      Vary:
-      - Accept-Encoding
-      X-UA-Compatible:
-      - IE=Edge
-      X-XSS-Protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
-- request:
     body: null
     headers:
       Accept:
@@ -10239,29 +8569,27 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/portal/api/filereport?accession=ERR2534093&result=read_run
   response:
     body:
-      string: "run_accession\tfastq_ftp\tfastq_bytes\tfastq_md5\tsubmitted_ftp\tsubmitted_bytes\tsubmitted_md5\tsra_ftp\tsra_bytes\tsra_md5\nERR2534093\tftp.sra.ebi.ac.uk/vol1/fastq/ERR253/003/ERR2534093/ERR2534093.fastq.gz\t961178965\t6e274ff76681397696f3da627dabb387\tftp.sra.ebi.ac.uk/vol1/run/ERR253/ERR2534093/G144_Parental_RNAseq_4h_2.fastq.gz\t1001231193\t1d9adb545303b3a0d7e9f20ca98f45d7\t\t\t\n"
+      string: "run_accession\tfastq_ftp\tfastq_bytes\tfastq_md5\tbam_ftp\tbam_bytes\tbam_md5\tsubmitted_ftp\tsubmitted_bytes\tsubmitted_md5\tsra_ftp\tsra_bytes\tsra_md5\nERR2534093\tftp.sra.ebi.ac.uk/vol1/fastq/ERR253/003/ERR2534093/ERR2534093.fastq.gz\t961178965\t6e274ff76681397696f3da627dabb387\t\t\t\tftp.sra.ebi.ac.uk/vol1/run/ERR253/ERR2534093/G144_Parental_RNAseq_4h_2.fastq.gz\t1001231193\t1d9adb545303b3a0d7e9f20ca98f45d7\tftp.sra.ebi.ac.uk/vol1/err/ERR253/003/ERR2534093\t637236598\t76040bde5e5f7e6ec50451975626a15a\n"
     headers:
       Cache-Control:
       - no-cache, no-store, max-age=0, must-revalidate
+      Content-Length:
+      - '486'
       Content-Type:
       - text/plain
       Date:
-      - Wed, 28 Jul 2021 19:42:46 GMT
+      - Wed, 17 May 2023 18:36:30 GMT
       Expires:
       - '0'
       Pragma:
       - no-cache
-      Server:
-      - Apache-Coyote/1.1
       Strict-Transport-Security:
       - max-age=0
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Frame-Options:
@@ -10270,7 +8598,7 @@ interactions:
       - 1; mode=block
     status:
       code: 200
-      message: OK
+      message: ''
 - request:
     body: null
     headers:
@@ -10281,7 +8609,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/ERR2534094
   response:
@@ -10323,7 +8651,7 @@ interactions:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:42:46 GMT
+      - Wed, 17 May 2023 18:36:31 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -10341,7 +8669,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/ERX2552515
   response:
@@ -10409,7 +8737,7 @@ interactions:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:42:47 GMT
+      - Wed, 17 May 2023 18:36:32 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -10427,14 +8755,14 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/ERS2428809
   response:
     body:
       string: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<SAMPLE_SET>\n<SAMPLE accession=\"ERS2428809\"
-        alias=\"E-MTAB-6681:G144_Parental_RNAseq_4h_3\" broker_name=\"ArrayExpress\"
-        center_name=\"BRIC - Biotech Research and Innovation Centre\">\n     <IDENTIFIERS>\n
+        alias=\"E-MTAB-6681:G144_Parental_RNAseq_4h_3\" center_name=\"BRIC - Biotech
+        Research and Innovation Centre\" broker_name=\"ArrayExpress\">\n     <IDENTIFIERS>\n
         \         <PRIMARY_ID>ERS2428809</PRIMARY_ID>\n          <EXTERNAL_ID namespace=\"BioSample\">SAMEA4608113</EXTERNAL_ID>\n
         \         <SUBMITTER_ID namespace=\"BRIC - Biotech Research and Innovation
         Centre\">E-MTAB-6681:G144_Parental_RNAseq_4h_3</SUBMITTER_ID>\n     </IDENTIFIERS>\n
@@ -10442,57 +8770,45 @@ interactions:
         \         <SCIENTIFIC_NAME>Homo sapiens</SCIENTIFIC_NAME>\n          <COMMON_NAME>human</COMMON_NAME>\n
         \    </SAMPLE_NAME>\n     <DESCRIPTION>Protocols: CRISPR mediated KO of CIC:
         sgRNAs (Target sequence: mESCs: GCCTTCATGATCTTCAGCAAG; G144: GGGCGAGTGGTGGTATGCCC)
-        \ were cloned into pSpCas9(BB)-2A-GFP (Addgene 48138) and transfected into
-        mESCs (Lipofectamine 2000) or G144 cells (Amaxa Nucleofector II, Program A033).
+        were cloned into pSpCas9(BB)-2A-GFP (Addgene 48138) and transfected into mESCs
+        (Lipofectamine 2000) or G144 cells (Amaxa Nucleofector II, Program A033).
         GFP-positive cells were single cell sorted 48h post-transfection, expanded
         and screened by immunoblotting for CIC deletion. Inhibitor treatment with
         1 \u03BCM MEK inhibitor (PD0325901) was performed in 80% confluent cultures
         for 4 and 24 h respectively. DMSO was used as mock control. Cells were washed
-        once with PBS, lysed directly in RLT buffer (Qiagen).  Total RNA was extracted
-        using the RNAeasy kit (Qiagen).  500 ng of total RNA was used for library
-        preparation using TruSeq RNA Library Prep Kit v2 (Illumina) according to manufacturer
-        recommendations.</DESCRIPTION>\n     <SAMPLE_LINKS>\n          <SAMPLE_LINK>\n
-        \              <XREF_LINK>\n                    <DB>ENA-STUDY</DB>\n                    <ID>ERP108370</ID>\n
-        \              </XREF_LINK>\n          </SAMPLE_LINK>\n          <SAMPLE_LINK>\n
-        \              <XREF_LINK>\n                    <DB>ENA-EXPERIMENT</DB>\n
-        \                   <ID>ERX2552515</ID>\n               </XREF_LINK>\n          </SAMPLE_LINK>\n
-        \         <SAMPLE_LINK>\n               <XREF_LINK>\n                    <DB>ENA-RUN</DB>\n
-        \                   <ID>ERR2534094</ID>\n               </XREF_LINK>\n          </SAMPLE_LINK>\n
-        \         <SAMPLE_LINK>\n               <XREF_LINK>\n                    <DB>ENA-SUBMISSION</DB>\n
-        \                   <ID>ERA1350207</ID>\n               </XREF_LINK>\n          </SAMPLE_LINK>\n
-        \         <SAMPLE_LINK>\n               <XREF_LINK>\n                    <DB>ENA-FASTQ-FILES</DB>\n
-        \                   <ID><![CDATA[https://www.ebi.ac.uk/ena/portal/api/filereport?accession=ERS2428809&result=read_run&fields=run_accession,fastq_ftp,fastq_md5,fastq_bytes]]></ID>\n
-        \              </XREF_LINK>\n          </SAMPLE_LINK>\n          <SAMPLE_LINK>\n
-        \              <XREF_LINK>\n                    <DB>ENA-SUBMITTED-FILES</DB>\n
-        \                   <ID><![CDATA[https://www.ebi.ac.uk/ena/portal/api/filereport?accession=ERS2428809&result=read_run&fields=run_accession,submitted_ftp,submitted_md5,submitted_bytes,submitted_format]]></ID>\n
-        \              </XREF_LINK>\n          </SAMPLE_LINK>\n     </SAMPLE_LINKS>\n
-        \    <SAMPLE_ATTRIBUTES>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>isolate</TAG>\n
-        \              <VALUE>not applicable</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
-        \         <SAMPLE_ATTRIBUTE>\n               <TAG>organism</TAG>\n               <VALUE>Homo
-        sapiens</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
-        \              <TAG>organism part</TAG>\n               <VALUE>brain</VALUE>\n
-        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>cell_type</TAG>\n
-        \              <VALUE>glial cell</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
-        \         <SAMPLE_ATTRIBUTE>\n               <TAG>cell_line</TAG>\n               <VALUE>G144</VALUE>\n
+        once with PBS, lysed directly in RLT buffer (Qiagen). Total RNA was extracted
+        using the RNAeasy kit (Qiagen). 500 ng of total RNA was used for library preparation
+        using TruSeq RNA Library Prep Kit v2 (Illumina) according to manufacturer
+        recommendations.</DESCRIPTION>\n     <SAMPLE_LINKS>\n    <SAMPLE_LINK>\n        <XREF_LINK>\n
+        \           <DB>ENA-FASTQ-FILES</DB>\n            <ID><![CDATA[https://www.ebi.ac.uk/ena/portal/api/filereport?accession=ERS2428809&result=read_run&fields=run_accession,fastq_ftp,fastq_md5,fastq_bytes]]></ID>\n
+        \       </XREF_LINK>\n    </SAMPLE_LINK>\n    <SAMPLE_LINK>\n        <XREF_LINK>\n
+        \           <DB>ENA-SUBMITTED-FILES</DB>\n            <ID><![CDATA[https://www.ebi.ac.uk/ena/portal/api/filereport?accession=ERS2428809&result=read_run&fields=run_accession,submitted_ftp,submitted_md5,submitted_bytes,submitted_format]]></ID>\n
+        \       </XREF_LINK>\n    </SAMPLE_LINK>\n</SAMPLE_LINKS>\n<SAMPLE_ATTRIBUTES>\n
+        \         <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-CHECKLIST</TAG>\n               <VALUE>ERC000011</VALUE>\n
         \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>disease</TAG>\n
         \              <VALUE>glioblastoma multiforme</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
+        \         <SAMPLE_ATTRIBUTE>\n               <TAG>individual</TAG>\n               <VALUE>1</VALUE>\n
+        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>organism</TAG>\n
+        \              <VALUE>Homo sapiens</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
+        \         <SAMPLE_ATTRIBUTE>\n               <TAG>organism</TAG>\n               <VALUE>Homo
+        sapiens</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
+        \              <TAG>cell type</TAG>\n               <VALUE>glial cell</VALUE>\n
+        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>common
+        name</TAG>\n               <VALUE>human</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
+        \         <SAMPLE_ATTRIBUTE>\n               <TAG>organism part</TAG>\n               <VALUE>brain</VALUE>\n
+        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>cell
+        line</TAG>\n               <VALUE>G144</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
         \         <SAMPLE_ATTRIBUTE>\n               <TAG>genotype</TAG>\n               <VALUE>wild
         type genotype</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
-        \              <TAG>individual</TAG>\n               <VALUE>1</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
-        \         <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-CHECKLIST</TAG>\n               <VALUE>ERC000011</VALUE>\n
-        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-SPOT-COUNT</TAG>\n
-        \              <VALUE>21534233</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
-        \              <TAG>ENA-BASE-COUNT</TAG>\n               <VALUE>1625567863</VALUE>\n
-        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-FIRST-PUBLIC</TAG>\n
-        \              <VALUE>2018-05-30</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
-        \         <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-LAST-UPDATE</TAG>\n
+        \              <TAG>ENA-FIRST-PUBLIC</TAG>\n               <VALUE>2018-05-30</VALUE>\n
+        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-LAST-UPDATE</TAG>\n
         \              <VALUE>2018-04-24</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
         \    </SAMPLE_ATTRIBUTES>\n</SAMPLE>\n</SAMPLE_SET>\n"
     headers:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:42:48 GMT
+      - Wed, 17 May 2023 18:36:32 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -10510,7 +8826,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/ERP108370
   response:
@@ -10570,7 +8886,7 @@ interactions:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:42:48 GMT
+      - Wed, 17 May 2023 18:36:32 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -10588,7 +8904,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/ERA1350207
   response:
@@ -10624,7 +8940,7 @@ interactions:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:42:48 GMT
+      - Wed, 17 May 2023 18:36:33 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -10633,68 +8949,6 @@ interactions:
       code: 200
       message: ''
 - request:
-    body: acc=ERR2534094&accept-proto=fasp&version=2.0
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '44'
-      User-Agent:
-      - python-requests/2.25.1
-    method: POST
-    uri: https://www.ncbi.nlm.nih.gov/Traces/names/names.cgi
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAAwzLsQrDIBCA4T1PIXTIlHJnPDXZOxdCp24aLWmRGtRSCvfwzfbzwX+SZ+hqcfvH
-        82VZJI0KJsXaoFUKYGIJaAcwA0w3lDPQTHjnMToywRFpb9FHixS1CTqEeBSCYeZj5us7/US/tbbX
-        Xuwlt7zmJJ5VuJTyNwbxyEW07YDsX3Ft3R8AAP//AwCBx/lKjgAAAA==
-    headers:
-      Cache-Control:
-      - private
-      Connection:
-      - Keep-Alive
-      Content-Encoding:
-      - gzip
-      Content-Security-Policy:
-      - upgrade-insecure-requests
-      Content-Type:
-      - text/plain
-      Date:
-      - Wed, 28 Jul 2021 19:42:49 GMT
-      Keep-Alive:
-      - timeout=1, max=10
-      NCBI-PHID:
-      - CC95F2CE101B33910000000000000001.m_1
-      NCBI-SID:
-      - CC95F2CE101B3391_0000SID
-      Referrer-Policy:
-      - origin-when-cross-origin
-      Server:
-      - Apache
-      Set-Cookie:
-      - ncbi_sid=CC95F2CE101B3391_0000SID; domain=.nih.gov; path=/; expires=Thu, 28
-        Jul 2022 19:42:49 GMT
-      SraNameServerOutputVersion:
-      - '2.0'
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains; preload
-      Transfer-Encoding:
-      - chunked
-      Vary:
-      - Accept-Encoding
-      X-UA-Compatible:
-      - IE=Edge
-      X-XSS-Protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
-- request:
     body: null
     headers:
       Accept:
@@ -10704,29 +8958,27 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/portal/api/filereport?accession=ERR2534094&result=read_run
   response:
     body:
-      string: "run_accession\tfastq_ftp\tfastq_bytes\tfastq_md5\tsubmitted_ftp\tsubmitted_bytes\tsubmitted_md5\tsra_ftp\tsra_bytes\tsra_md5\nERR2534094\tftp.sra.ebi.ac.uk/vol1/fastq/ERR253/004/ERR2534094/ERR2534094.fastq.gz\t1013301291\ta4f593c11cf4db4f5a141897ad94274c\tftp.sra.ebi.ac.uk/vol1/run/ERR253/ERR2534094/G144_Parental_RNAseq_4h_3.fastq.gz\t1055226153\t3dad11032609517b430aab1d1df2835c\t\t\t\n"
+      string: "run_accession\tfastq_ftp\tfastq_bytes\tfastq_md5\tbam_ftp\tbam_bytes\tbam_md5\tsubmitted_ftp\tsubmitted_bytes\tsubmitted_md5\tsra_ftp\tsra_bytes\tsra_md5\nERR2534094\tftp.sra.ebi.ac.uk/vol1/fastq/ERR253/004/ERR2534094/ERR2534094.fastq.gz\t1013301291\ta4f593c11cf4db4f5a141897ad94274c\t\t\t\tftp.sra.ebi.ac.uk/vol1/run/ERR253/ERR2534094/G144_Parental_RNAseq_4h_3.fastq.gz\t1055226153\t3dad11032609517b430aab1d1df2835c\tftp.sra.ebi.ac.uk/vol1/err/ERR253/004/ERR2534094\t671843989\ta3fc50904843ae9b102922429126c0cf\n"
     headers:
       Cache-Control:
       - no-cache, no-store, max-age=0, must-revalidate
+      Content-Length:
+      - '487'
       Content-Type:
       - text/plain
       Date:
-      - Wed, 28 Jul 2021 19:42:50 GMT
+      - Wed, 17 May 2023 18:36:33 GMT
       Expires:
       - '0'
       Pragma:
       - no-cache
-      Server:
-      - Apache-Coyote/1.1
       Strict-Transport-Security:
       - max-age=0
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Frame-Options:
@@ -10735,7 +8987,7 @@ interactions:
       - 1; mode=block
     status:
       code: 200
-      message: OK
+      message: ''
 - request:
     body: null
     headers:
@@ -10746,7 +8998,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/ERR2534095
   response:
@@ -10788,7 +9040,7 @@ interactions:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:42:51 GMT
+      - Wed, 17 May 2023 18:36:33 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -10806,7 +9058,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/ERX2552516
   response:
@@ -10874,7 +9126,7 @@ interactions:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:42:52 GMT
+      - Wed, 17 May 2023 18:36:34 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -10892,14 +9144,14 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/ERS2428810
   response:
     body:
       string: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<SAMPLE_SET>\n<SAMPLE accession=\"ERS2428810\"
-        alias=\"E-MTAB-6681:G144_WTclone_RNAseq_24h_1\" broker_name=\"ArrayExpress\"
-        center_name=\"BRIC - Biotech Research and Innovation Centre\">\n     <IDENTIFIERS>\n
+        alias=\"E-MTAB-6681:G144_WTclone_RNAseq_24h_1\" center_name=\"BRIC - Biotech
+        Research and Innovation Centre\" broker_name=\"ArrayExpress\">\n     <IDENTIFIERS>\n
         \         <PRIMARY_ID>ERS2428810</PRIMARY_ID>\n          <EXTERNAL_ID namespace=\"BioSample\">SAMEA4608114</EXTERNAL_ID>\n
         \         <SUBMITTER_ID namespace=\"BRIC - Biotech Research and Innovation
         Centre\">E-MTAB-6681:G144_WTclone_RNAseq_24h_1</SUBMITTER_ID>\n     </IDENTIFIERS>\n
@@ -10907,57 +9159,45 @@ interactions:
         \         <SCIENTIFIC_NAME>Homo sapiens</SCIENTIFIC_NAME>\n          <COMMON_NAME>human</COMMON_NAME>\n
         \    </SAMPLE_NAME>\n     <DESCRIPTION>Protocols: CRISPR mediated KO of CIC:
         sgRNAs (Target sequence: mESCs: GCCTTCATGATCTTCAGCAAG; G144: GGGCGAGTGGTGGTATGCCC)
-        \ were cloned into pSpCas9(BB)-2A-GFP (Addgene 48138) and transfected into
-        mESCs (Lipofectamine 2000) or G144 cells (Amaxa Nucleofector II, Program A033).
+        were cloned into pSpCas9(BB)-2A-GFP (Addgene 48138) and transfected into mESCs
+        (Lipofectamine 2000) or G144 cells (Amaxa Nucleofector II, Program A033).
         GFP-positive cells were single cell sorted 48h post-transfection, expanded
         and screened by immunoblotting for CIC deletion. Inhibitor treatment with
         1 \u03BCM MEK inhibitor (PD0325901) was performed in 80% confluent cultures
         for 4 and 24 h respectively. DMSO was used as mock control. Cells were washed
-        once with PBS, lysed directly in RLT buffer (Qiagen).  Total RNA was extracted
-        using the RNAeasy kit (Qiagen).  500 ng of total RNA was used for library
-        preparation using TruSeq RNA Library Prep Kit v2 (Illumina) according to manufacturer
-        recommendations.</DESCRIPTION>\n     <SAMPLE_LINKS>\n          <SAMPLE_LINK>\n
-        \              <XREF_LINK>\n                    <DB>ENA-STUDY</DB>\n                    <ID>ERP108370</ID>\n
-        \              </XREF_LINK>\n          </SAMPLE_LINK>\n          <SAMPLE_LINK>\n
-        \              <XREF_LINK>\n                    <DB>ENA-EXPERIMENT</DB>\n
-        \                   <ID>ERX2552516</ID>\n               </XREF_LINK>\n          </SAMPLE_LINK>\n
-        \         <SAMPLE_LINK>\n               <XREF_LINK>\n                    <DB>ENA-RUN</DB>\n
-        \                   <ID>ERR2534095</ID>\n               </XREF_LINK>\n          </SAMPLE_LINK>\n
-        \         <SAMPLE_LINK>\n               <XREF_LINK>\n                    <DB>ENA-SUBMISSION</DB>\n
-        \                   <ID>ERA1350207</ID>\n               </XREF_LINK>\n          </SAMPLE_LINK>\n
-        \         <SAMPLE_LINK>\n               <XREF_LINK>\n                    <DB>ENA-FASTQ-FILES</DB>\n
-        \                   <ID><![CDATA[https://www.ebi.ac.uk/ena/portal/api/filereport?accession=ERS2428810&result=read_run&fields=run_accession,fastq_ftp,fastq_md5,fastq_bytes]]></ID>\n
-        \              </XREF_LINK>\n          </SAMPLE_LINK>\n          <SAMPLE_LINK>\n
-        \              <XREF_LINK>\n                    <DB>ENA-SUBMITTED-FILES</DB>\n
-        \                   <ID><![CDATA[https://www.ebi.ac.uk/ena/portal/api/filereport?accession=ERS2428810&result=read_run&fields=run_accession,submitted_ftp,submitted_md5,submitted_bytes,submitted_format]]></ID>\n
-        \              </XREF_LINK>\n          </SAMPLE_LINK>\n     </SAMPLE_LINKS>\n
-        \    <SAMPLE_ATTRIBUTES>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>isolate</TAG>\n
-        \              <VALUE>not applicable</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
-        \         <SAMPLE_ATTRIBUTE>\n               <TAG>organism</TAG>\n               <VALUE>Homo
-        sapiens</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
-        \              <TAG>organism part</TAG>\n               <VALUE>brain</VALUE>\n
-        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>cell_type</TAG>\n
-        \              <VALUE>glial cell</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
-        \         <SAMPLE_ATTRIBUTE>\n               <TAG>cell_line</TAG>\n               <VALUE>G144</VALUE>\n
+        once with PBS, lysed directly in RLT buffer (Qiagen). Total RNA was extracted
+        using the RNAeasy kit (Qiagen). 500 ng of total RNA was used for library preparation
+        using TruSeq RNA Library Prep Kit v2 (Illumina) according to manufacturer
+        recommendations.</DESCRIPTION>\n     <SAMPLE_LINKS>\n    <SAMPLE_LINK>\n        <XREF_LINK>\n
+        \           <DB>ENA-FASTQ-FILES</DB>\n            <ID><![CDATA[https://www.ebi.ac.uk/ena/portal/api/filereport?accession=ERS2428810&result=read_run&fields=run_accession,fastq_ftp,fastq_md5,fastq_bytes]]></ID>\n
+        \       </XREF_LINK>\n    </SAMPLE_LINK>\n    <SAMPLE_LINK>\n        <XREF_LINK>\n
+        \           <DB>ENA-SUBMITTED-FILES</DB>\n            <ID><![CDATA[https://www.ebi.ac.uk/ena/portal/api/filereport?accession=ERS2428810&result=read_run&fields=run_accession,submitted_ftp,submitted_md5,submitted_bytes,submitted_format]]></ID>\n
+        \       </XREF_LINK>\n    </SAMPLE_LINK>\n</SAMPLE_LINKS>\n<SAMPLE_ATTRIBUTES>\n
+        \         <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-CHECKLIST</TAG>\n               <VALUE>ERC000011</VALUE>\n
         \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>disease</TAG>\n
         \              <VALUE>glioblastoma multiforme</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
+        \         <SAMPLE_ATTRIBUTE>\n               <TAG>individual</TAG>\n               <VALUE>2</VALUE>\n
+        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>organism</TAG>\n
+        \              <VALUE>Homo sapiens</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
+        \         <SAMPLE_ATTRIBUTE>\n               <TAG>organism</TAG>\n               <VALUE>Homo
+        sapiens</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
+        \              <TAG>cell type</TAG>\n               <VALUE>glial cell</VALUE>\n
+        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>common
+        name</TAG>\n               <VALUE>human</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
+        \         <SAMPLE_ATTRIBUTE>\n               <TAG>organism part</TAG>\n               <VALUE>brain</VALUE>\n
+        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>cell
+        line</TAG>\n               <VALUE>G144</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
         \         <SAMPLE_ATTRIBUTE>\n               <TAG>genotype</TAG>\n               <VALUE>wild
         type genotype</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
-        \              <TAG>individual</TAG>\n               <VALUE>2</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
-        \         <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-CHECKLIST</TAG>\n               <VALUE>ERC000011</VALUE>\n
-        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-SPOT-COUNT</TAG>\n
-        \              <VALUE>21431687</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
-        \              <TAG>ENA-BASE-COUNT</TAG>\n               <VALUE>1618365016</VALUE>\n
-        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-FIRST-PUBLIC</TAG>\n
-        \              <VALUE>2018-05-30</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
-        \         <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-LAST-UPDATE</TAG>\n
+        \              <TAG>ENA-FIRST-PUBLIC</TAG>\n               <VALUE>2018-05-30</VALUE>\n
+        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-LAST-UPDATE</TAG>\n
         \              <VALUE>2018-04-24</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
         \    </SAMPLE_ATTRIBUTES>\n</SAMPLE>\n</SAMPLE_SET>\n"
     headers:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:42:53 GMT
+      - Wed, 17 May 2023 18:36:34 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -10975,7 +9215,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/ERP108370
   response:
@@ -11035,7 +9275,7 @@ interactions:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:42:53 GMT
+      - Wed, 17 May 2023 18:36:34 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -11053,7 +9293,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/ERA1350207
   response:
@@ -11089,7 +9329,7 @@ interactions:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:42:54 GMT
+      - Wed, 17 May 2023 18:36:35 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -11098,68 +9338,6 @@ interactions:
       code: 200
       message: ''
 - request:
-    body: acc=ERR2534095&accept-proto=fasp&version=2.0
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '44'
-      User-Agent:
-      - python-requests/2.25.1
-    method: POST
-    uri: https://www.ncbi.nlm.nih.gov/Traces/names/names.cgi
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAAwzIuwrCMBQA0L1fEXDoVLmPJE26OwvFya1NE6oEU9qICPfj9YznRGdojn3a3rNc
-        xpEMa/BGetQ9WwYWAnQd9B34G9IAbjB8l5AcTt5iSsyMRGg5RgyowdLiyIiIBpDrK39Vu9a6Ha3a
-        9lJLKFk9DjXlXD5xUansqq7/KPMzhtr8AAAA//8DAD7fHNyOAAAA
-    headers:
-      Cache-Control:
-      - private
-      Connection:
-      - Keep-Alive
-      Content-Encoding:
-      - gzip
-      Content-Security-Policy:
-      - upgrade-insecure-requests
-      Content-Type:
-      - text/plain
-      Date:
-      - Wed, 28 Jul 2021 19:42:54 GMT
-      Keep-Alive:
-      - timeout=1, max=10
-      NCBI-PHID:
-      - C7A421F0101B33E10000000000000001.m_1
-      NCBI-SID:
-      - C7A421F0101B33E1_0000SID
-      Referrer-Policy:
-      - origin-when-cross-origin
-      Server:
-      - Apache
-      Set-Cookie:
-      - ncbi_sid=C7A421F0101B33E1_0000SID; domain=.nih.gov; path=/; expires=Thu, 28
-        Jul 2022 19:42:54 GMT
-      SraNameServerOutputVersion:
-      - '2.0'
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains; preload
-      Transfer-Encoding:
-      - chunked
-      Vary:
-      - Accept-Encoding
-      X-UA-Compatible:
-      - IE=Edge
-      X-XSS-Protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
-- request:
     body: null
     headers:
       Accept:
@@ -11169,29 +9347,27 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/portal/api/filereport?accession=ERR2534095&result=read_run
   response:
     body:
-      string: "run_accession\tfastq_ftp\tfastq_bytes\tfastq_md5\tsubmitted_ftp\tsubmitted_bytes\tsubmitted_md5\tsra_ftp\tsra_bytes\tsra_md5\nERR2534095\tftp.sra.ebi.ac.uk/vol1/fastq/ERR253/005/ERR2534095/ERR2534095.fastq.gz\t1071271905\tf7df87aa02b5689dae89556042df7223\tftp.sra.ebi.ac.uk/vol1/run/ERR253/ERR2534095/G144_WTclone_RNAseq_24h_1.fastq.gz\t1116056605\tc410683ea6b481add8548e826b53091d\t\t\t\n"
+      string: "run_accession\tfastq_ftp\tfastq_bytes\tfastq_md5\tbam_ftp\tbam_bytes\tbam_md5\tsubmitted_ftp\tsubmitted_bytes\tsubmitted_md5\tsra_ftp\tsra_bytes\tsra_md5\nERR2534095\tftp.sra.ebi.ac.uk/vol1/fastq/ERR253/005/ERR2534095/ERR2534095.fastq.gz\t1071271905\tf7df87aa02b5689dae89556042df7223\t\t\t\tftp.sra.ebi.ac.uk/vol1/run/ERR253/ERR2534095/G144_WTclone_RNAseq_24h_1.fastq.gz\t1116056605\tc410683ea6b481add8548e826b53091d\tftp.sra.ebi.ac.uk/vol1/err/ERR253/005/ERR2534095\t714736283\tbcef41770242d71d9ffaa3c0b9a9b50d\n"
     headers:
       Cache-Control:
       - no-cache, no-store, max-age=0, must-revalidate
+      Content-Length:
+      - '487'
       Content-Type:
       - text/plain
       Date:
-      - Wed, 28 Jul 2021 19:42:55 GMT
+      - Wed, 17 May 2023 18:36:35 GMT
       Expires:
       - '0'
       Pragma:
       - no-cache
-      Server:
-      - Apache-Coyote/1.1
       Strict-Transport-Security:
       - max-age=0
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Frame-Options:
@@ -11200,7 +9376,7 @@ interactions:
       - 1; mode=block
     status:
       code: 200
-      message: OK
+      message: ''
 - request:
     body: null
     headers:
@@ -11211,7 +9387,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/ERR2534096
   response:
@@ -11253,7 +9429,7 @@ interactions:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:42:56 GMT
+      - Wed, 17 May 2023 18:36:35 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -11271,7 +9447,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/ERX2552517
   response:
@@ -11339,7 +9515,7 @@ interactions:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:42:56 GMT
+      - Wed, 17 May 2023 18:36:36 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -11357,14 +9533,14 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/ERS2428811
   response:
     body:
       string: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<SAMPLE_SET>\n<SAMPLE accession=\"ERS2428811\"
-        alias=\"E-MTAB-6681:G144_WTclone_RNAseq_24h_2\" broker_name=\"ArrayExpress\"
-        center_name=\"BRIC - Biotech Research and Innovation Centre\">\n     <IDENTIFIERS>\n
+        alias=\"E-MTAB-6681:G144_WTclone_RNAseq_24h_2\" center_name=\"BRIC - Biotech
+        Research and Innovation Centre\" broker_name=\"ArrayExpress\">\n     <IDENTIFIERS>\n
         \         <PRIMARY_ID>ERS2428811</PRIMARY_ID>\n          <EXTERNAL_ID namespace=\"BioSample\">SAMEA4608115</EXTERNAL_ID>\n
         \         <SUBMITTER_ID namespace=\"BRIC - Biotech Research and Innovation
         Centre\">E-MTAB-6681:G144_WTclone_RNAseq_24h_2</SUBMITTER_ID>\n     </IDENTIFIERS>\n
@@ -11372,57 +9548,45 @@ interactions:
         \         <SCIENTIFIC_NAME>Homo sapiens</SCIENTIFIC_NAME>\n          <COMMON_NAME>human</COMMON_NAME>\n
         \    </SAMPLE_NAME>\n     <DESCRIPTION>Protocols: CRISPR mediated KO of CIC:
         sgRNAs (Target sequence: mESCs: GCCTTCATGATCTTCAGCAAG; G144: GGGCGAGTGGTGGTATGCCC)
-        \ were cloned into pSpCas9(BB)-2A-GFP (Addgene 48138) and transfected into
-        mESCs (Lipofectamine 2000) or G144 cells (Amaxa Nucleofector II, Program A033).
+        were cloned into pSpCas9(BB)-2A-GFP (Addgene 48138) and transfected into mESCs
+        (Lipofectamine 2000) or G144 cells (Amaxa Nucleofector II, Program A033).
         GFP-positive cells were single cell sorted 48h post-transfection, expanded
         and screened by immunoblotting for CIC deletion. Inhibitor treatment with
         1 \u03BCM MEK inhibitor (PD0325901) was performed in 80% confluent cultures
         for 4 and 24 h respectively. DMSO was used as mock control. Cells were washed
-        once with PBS, lysed directly in RLT buffer (Qiagen).  Total RNA was extracted
-        using the RNAeasy kit (Qiagen).  500 ng of total RNA was used for library
-        preparation using TruSeq RNA Library Prep Kit v2 (Illumina) according to manufacturer
-        recommendations.</DESCRIPTION>\n     <SAMPLE_LINKS>\n          <SAMPLE_LINK>\n
-        \              <XREF_LINK>\n                    <DB>ENA-STUDY</DB>\n                    <ID>ERP108370</ID>\n
-        \              </XREF_LINK>\n          </SAMPLE_LINK>\n          <SAMPLE_LINK>\n
-        \              <XREF_LINK>\n                    <DB>ENA-EXPERIMENT</DB>\n
-        \                   <ID>ERX2552517</ID>\n               </XREF_LINK>\n          </SAMPLE_LINK>\n
-        \         <SAMPLE_LINK>\n               <XREF_LINK>\n                    <DB>ENA-RUN</DB>\n
-        \                   <ID>ERR2534096</ID>\n               </XREF_LINK>\n          </SAMPLE_LINK>\n
-        \         <SAMPLE_LINK>\n               <XREF_LINK>\n                    <DB>ENA-SUBMISSION</DB>\n
-        \                   <ID>ERA1350207</ID>\n               </XREF_LINK>\n          </SAMPLE_LINK>\n
-        \         <SAMPLE_LINK>\n               <XREF_LINK>\n                    <DB>ENA-FASTQ-FILES</DB>\n
-        \                   <ID><![CDATA[https://www.ebi.ac.uk/ena/portal/api/filereport?accession=ERS2428811&result=read_run&fields=run_accession,fastq_ftp,fastq_md5,fastq_bytes]]></ID>\n
-        \              </XREF_LINK>\n          </SAMPLE_LINK>\n          <SAMPLE_LINK>\n
-        \              <XREF_LINK>\n                    <DB>ENA-SUBMITTED-FILES</DB>\n
-        \                   <ID><![CDATA[https://www.ebi.ac.uk/ena/portal/api/filereport?accession=ERS2428811&result=read_run&fields=run_accession,submitted_ftp,submitted_md5,submitted_bytes,submitted_format]]></ID>\n
-        \              </XREF_LINK>\n          </SAMPLE_LINK>\n     </SAMPLE_LINKS>\n
-        \    <SAMPLE_ATTRIBUTES>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>isolate</TAG>\n
-        \              <VALUE>not applicable</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
-        \         <SAMPLE_ATTRIBUTE>\n               <TAG>organism</TAG>\n               <VALUE>Homo
-        sapiens</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
-        \              <TAG>organism part</TAG>\n               <VALUE>brain</VALUE>\n
-        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>cell_type</TAG>\n
-        \              <VALUE>glial cell</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
-        \         <SAMPLE_ATTRIBUTE>\n               <TAG>cell_line</TAG>\n               <VALUE>G144</VALUE>\n
+        once with PBS, lysed directly in RLT buffer (Qiagen). Total RNA was extracted
+        using the RNAeasy kit (Qiagen). 500 ng of total RNA was used for library preparation
+        using TruSeq RNA Library Prep Kit v2 (Illumina) according to manufacturer
+        recommendations.</DESCRIPTION>\n     <SAMPLE_LINKS>\n    <SAMPLE_LINK>\n        <XREF_LINK>\n
+        \           <DB>ENA-FASTQ-FILES</DB>\n            <ID><![CDATA[https://www.ebi.ac.uk/ena/portal/api/filereport?accession=ERS2428811&result=read_run&fields=run_accession,fastq_ftp,fastq_md5,fastq_bytes]]></ID>\n
+        \       </XREF_LINK>\n    </SAMPLE_LINK>\n    <SAMPLE_LINK>\n        <XREF_LINK>\n
+        \           <DB>ENA-SUBMITTED-FILES</DB>\n            <ID><![CDATA[https://www.ebi.ac.uk/ena/portal/api/filereport?accession=ERS2428811&result=read_run&fields=run_accession,submitted_ftp,submitted_md5,submitted_bytes,submitted_format]]></ID>\n
+        \       </XREF_LINK>\n    </SAMPLE_LINK>\n</SAMPLE_LINKS>\n<SAMPLE_ATTRIBUTES>\n
+        \         <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-CHECKLIST</TAG>\n               <VALUE>ERC000011</VALUE>\n
         \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>disease</TAG>\n
         \              <VALUE>glioblastoma multiforme</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
+        \         <SAMPLE_ATTRIBUTE>\n               <TAG>individual</TAG>\n               <VALUE>2</VALUE>\n
+        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>organism</TAG>\n
+        \              <VALUE>Homo sapiens</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
+        \         <SAMPLE_ATTRIBUTE>\n               <TAG>organism</TAG>\n               <VALUE>Homo
+        sapiens</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
+        \              <TAG>cell type</TAG>\n               <VALUE>glial cell</VALUE>\n
+        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>common
+        name</TAG>\n               <VALUE>human</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
+        \         <SAMPLE_ATTRIBUTE>\n               <TAG>organism part</TAG>\n               <VALUE>brain</VALUE>\n
+        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>cell
+        line</TAG>\n               <VALUE>G144</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
         \         <SAMPLE_ATTRIBUTE>\n               <TAG>genotype</TAG>\n               <VALUE>wild
         type genotype</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
-        \              <TAG>individual</TAG>\n               <VALUE>2</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
-        \         <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-CHECKLIST</TAG>\n               <VALUE>ERC000011</VALUE>\n
-        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-SPOT-COUNT</TAG>\n
-        \              <VALUE>20910521</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
-        \              <TAG>ENA-BASE-COUNT</TAG>\n               <VALUE>1578993339</VALUE>\n
-        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-FIRST-PUBLIC</TAG>\n
-        \              <VALUE>2018-05-30</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
-        \         <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-LAST-UPDATE</TAG>\n
+        \              <TAG>ENA-FIRST-PUBLIC</TAG>\n               <VALUE>2018-05-30</VALUE>\n
+        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-LAST-UPDATE</TAG>\n
         \              <VALUE>2018-04-24</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
         \    </SAMPLE_ATTRIBUTES>\n</SAMPLE>\n</SAMPLE_SET>\n"
     headers:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:42:57 GMT
+      - Wed, 17 May 2023 18:36:36 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -11440,7 +9604,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/ERP108370
   response:
@@ -11500,7 +9664,7 @@ interactions:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:42:58 GMT
+      - Wed, 17 May 2023 18:36:37 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -11518,7 +9682,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/ERA1350207
   response:
@@ -11554,7 +9718,7 @@ interactions:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:42:58 GMT
+      - Wed, 17 May 2023 18:36:37 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -11563,68 +9727,6 @@ interactions:
       code: 200
       message: ''
 - request:
-    body: acc=ERR2534096&accept-proto=fasp&version=2.0
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '44'
-      User-Agent:
-      - python-requests/2.25.1
-    method: POST
-    uri: https://www.ncbi.nlm.nih.gov/Traces/names/names.cgi
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAAwzLvQrCMBAA4L1PEXDoVLk789N0dxaKk1uaplQJJiQREe7h7frBd6IzdLW4/Fn4
-        Os+kLhKsZm0VISplmADHAcwA9o40gZ3APFihkx7ISjXSiEB61YCbcwGP55CYWQLw7R1/ot9by7UX
-        uaSWfIriWYWLMX3DKrZURNsPSMsr+Nb9AQAA//8DAJ9eOruOAAAA
-    headers:
-      Cache-Control:
-      - private
-      Connection:
-      - Keep-Alive
-      Content-Encoding:
-      - gzip
-      Content-Security-Policy:
-      - upgrade-insecure-requests
-      Content-Type:
-      - text/plain
-      Date:
-      - Wed, 28 Jul 2021 19:42:59 GMT
-      Keep-Alive:
-      - timeout=1, max=10
-      NCBI-PHID:
-      - C7A42211101B34310000000000000001.m_1
-      NCBI-SID:
-      - C7A42211101B3431_0000SID
-      Referrer-Policy:
-      - origin-when-cross-origin
-      Server:
-      - Apache
-      Set-Cookie:
-      - ncbi_sid=C7A42211101B3431_0000SID; domain=.nih.gov; path=/; expires=Thu, 28
-        Jul 2022 19:42:59 GMT
-      SraNameServerOutputVersion:
-      - '2.0'
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains; preload
-      Transfer-Encoding:
-      - chunked
-      Vary:
-      - Accept-Encoding
-      X-UA-Compatible:
-      - IE=Edge
-      X-XSS-Protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
-- request:
     body: null
     headers:
       Accept:
@@ -11634,29 +9736,27 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/portal/api/filereport?accession=ERR2534096&result=read_run
   response:
     body:
-      string: "run_accession\tfastq_ftp\tfastq_bytes\tfastq_md5\tsubmitted_ftp\tsubmitted_bytes\tsubmitted_md5\tsra_ftp\tsra_bytes\tsra_md5\nERR2534096\tftp.sra.ebi.ac.uk/vol1/fastq/ERR253/006/ERR2534096/ERR2534096.fastq.gz\t1042880074\tec7e2a6c4f5a25107d99a50c115d4f7c\tftp.sra.ebi.ac.uk/vol1/run/ERR253/ERR2534096/G144_WTclone_RNAseq_24h_2.fastq.gz\t1086208196\teb01cfdff7dfd39cfd30e5a6be2045ef\t\t\t\n"
+      string: "run_accession\tfastq_ftp\tfastq_bytes\tfastq_md5\tbam_ftp\tbam_bytes\tbam_md5\tsubmitted_ftp\tsubmitted_bytes\tsubmitted_md5\tsra_ftp\tsra_bytes\tsra_md5\nERR2534096\tftp.sra.ebi.ac.uk/vol1/fastq/ERR253/006/ERR2534096/ERR2534096.fastq.gz\t1042880074\tec7e2a6c4f5a25107d99a50c115d4f7c\t\t\t\tftp.sra.ebi.ac.uk/vol1/run/ERR253/ERR2534096/G144_WTclone_RNAseq_24h_2.fastq.gz\t1086208196\teb01cfdff7dfd39cfd30e5a6be2045ef\tftp.sra.ebi.ac.uk/vol1/err/ERR253/006/ERR2534096\t695211537\t2d925f829c915f6865142e9fa914b7b7\n"
     headers:
       Cache-Control:
       - no-cache, no-store, max-age=0, must-revalidate
+      Content-Length:
+      - '487'
       Content-Type:
       - text/plain
       Date:
-      - Wed, 28 Jul 2021 19:42:59 GMT
+      - Wed, 17 May 2023 18:36:38 GMT
       Expires:
       - '0'
       Pragma:
       - no-cache
-      Server:
-      - Apache-Coyote/1.1
       Strict-Transport-Security:
       - max-age=0
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Frame-Options:
@@ -11665,7 +9765,7 @@ interactions:
       - 1; mode=block
     status:
       code: 200
-      message: OK
+      message: ''
 - request:
     body: null
     headers:
@@ -11676,7 +9776,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/ERR2534097
   response:
@@ -11718,7 +9818,7 @@ interactions:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:43:00 GMT
+      - Wed, 17 May 2023 18:36:38 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -11736,7 +9836,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/ERX2552518
   response:
@@ -11804,7 +9904,7 @@ interactions:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:43:01 GMT
+      - Wed, 17 May 2023 18:36:39 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -11822,14 +9922,14 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/ERS2428812
   response:
     body:
       string: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<SAMPLE_SET>\n<SAMPLE accession=\"ERS2428812\"
-        alias=\"E-MTAB-6681:G144_WTclone_RNAseq_4h_1\" broker_name=\"ArrayExpress\"
-        center_name=\"BRIC - Biotech Research and Innovation Centre\">\n     <IDENTIFIERS>\n
+        alias=\"E-MTAB-6681:G144_WTclone_RNAseq_4h_1\" center_name=\"BRIC - Biotech
+        Research and Innovation Centre\" broker_name=\"ArrayExpress\">\n     <IDENTIFIERS>\n
         \         <PRIMARY_ID>ERS2428812</PRIMARY_ID>\n          <EXTERNAL_ID namespace=\"BioSample\">SAMEA4608116</EXTERNAL_ID>\n
         \         <SUBMITTER_ID namespace=\"BRIC - Biotech Research and Innovation
         Centre\">E-MTAB-6681:G144_WTclone_RNAseq_4h_1</SUBMITTER_ID>\n     </IDENTIFIERS>\n
@@ -11837,57 +9937,45 @@ interactions:
         \         <SCIENTIFIC_NAME>Homo sapiens</SCIENTIFIC_NAME>\n          <COMMON_NAME>human</COMMON_NAME>\n
         \    </SAMPLE_NAME>\n     <DESCRIPTION>Protocols: CRISPR mediated KO of CIC:
         sgRNAs (Target sequence: mESCs: GCCTTCATGATCTTCAGCAAG; G144: GGGCGAGTGGTGGTATGCCC)
-        \ were cloned into pSpCas9(BB)-2A-GFP (Addgene 48138) and transfected into
-        mESCs (Lipofectamine 2000) or G144 cells (Amaxa Nucleofector II, Program A033).
+        were cloned into pSpCas9(BB)-2A-GFP (Addgene 48138) and transfected into mESCs
+        (Lipofectamine 2000) or G144 cells (Amaxa Nucleofector II, Program A033).
         GFP-positive cells were single cell sorted 48h post-transfection, expanded
         and screened by immunoblotting for CIC deletion. Inhibitor treatment with
         1 \u03BCM MEK inhibitor (PD0325901) was performed in 80% confluent cultures
         for 4 and 24 h respectively. DMSO was used as mock control. Cells were washed
-        once with PBS, lysed directly in RLT buffer (Qiagen).  Total RNA was extracted
-        using the RNAeasy kit (Qiagen).  500 ng of total RNA was used for library
-        preparation using TruSeq RNA Library Prep Kit v2 (Illumina) according to manufacturer
-        recommendations.</DESCRIPTION>\n     <SAMPLE_LINKS>\n          <SAMPLE_LINK>\n
-        \              <XREF_LINK>\n                    <DB>ENA-STUDY</DB>\n                    <ID>ERP108370</ID>\n
-        \              </XREF_LINK>\n          </SAMPLE_LINK>\n          <SAMPLE_LINK>\n
-        \              <XREF_LINK>\n                    <DB>ENA-EXPERIMENT</DB>\n
-        \                   <ID>ERX2552518</ID>\n               </XREF_LINK>\n          </SAMPLE_LINK>\n
-        \         <SAMPLE_LINK>\n               <XREF_LINK>\n                    <DB>ENA-RUN</DB>\n
-        \                   <ID>ERR2534097</ID>\n               </XREF_LINK>\n          </SAMPLE_LINK>\n
-        \         <SAMPLE_LINK>\n               <XREF_LINK>\n                    <DB>ENA-SUBMISSION</DB>\n
-        \                   <ID>ERA1350207</ID>\n               </XREF_LINK>\n          </SAMPLE_LINK>\n
-        \         <SAMPLE_LINK>\n               <XREF_LINK>\n                    <DB>ENA-FASTQ-FILES</DB>\n
-        \                   <ID><![CDATA[https://www.ebi.ac.uk/ena/portal/api/filereport?accession=ERS2428812&result=read_run&fields=run_accession,fastq_ftp,fastq_md5,fastq_bytes]]></ID>\n
-        \              </XREF_LINK>\n          </SAMPLE_LINK>\n          <SAMPLE_LINK>\n
-        \              <XREF_LINK>\n                    <DB>ENA-SUBMITTED-FILES</DB>\n
-        \                   <ID><![CDATA[https://www.ebi.ac.uk/ena/portal/api/filereport?accession=ERS2428812&result=read_run&fields=run_accession,submitted_ftp,submitted_md5,submitted_bytes,submitted_format]]></ID>\n
-        \              </XREF_LINK>\n          </SAMPLE_LINK>\n     </SAMPLE_LINKS>\n
-        \    <SAMPLE_ATTRIBUTES>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>isolate</TAG>\n
-        \              <VALUE>not applicable</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
-        \         <SAMPLE_ATTRIBUTE>\n               <TAG>organism</TAG>\n               <VALUE>Homo
-        sapiens</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
-        \              <TAG>organism part</TAG>\n               <VALUE>brain</VALUE>\n
-        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>cell_type</TAG>\n
-        \              <VALUE>glial cell</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
-        \         <SAMPLE_ATTRIBUTE>\n               <TAG>cell_line</TAG>\n               <VALUE>G144</VALUE>\n
+        once with PBS, lysed directly in RLT buffer (Qiagen). Total RNA was extracted
+        using the RNAeasy kit (Qiagen). 500 ng of total RNA was used for library preparation
+        using TruSeq RNA Library Prep Kit v2 (Illumina) according to manufacturer
+        recommendations.</DESCRIPTION>\n     <SAMPLE_LINKS>\n    <SAMPLE_LINK>\n        <XREF_LINK>\n
+        \           <DB>ENA-FASTQ-FILES</DB>\n            <ID><![CDATA[https://www.ebi.ac.uk/ena/portal/api/filereport?accession=ERS2428812&result=read_run&fields=run_accession,fastq_ftp,fastq_md5,fastq_bytes]]></ID>\n
+        \       </XREF_LINK>\n    </SAMPLE_LINK>\n    <SAMPLE_LINK>\n        <XREF_LINK>\n
+        \           <DB>ENA-SUBMITTED-FILES</DB>\n            <ID><![CDATA[https://www.ebi.ac.uk/ena/portal/api/filereport?accession=ERS2428812&result=read_run&fields=run_accession,submitted_ftp,submitted_md5,submitted_bytes,submitted_format]]></ID>\n
+        \       </XREF_LINK>\n    </SAMPLE_LINK>\n</SAMPLE_LINKS>\n<SAMPLE_ATTRIBUTES>\n
+        \         <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-CHECKLIST</TAG>\n               <VALUE>ERC000011</VALUE>\n
         \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>disease</TAG>\n
         \              <VALUE>glioblastoma multiforme</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
+        \         <SAMPLE_ATTRIBUTE>\n               <TAG>individual</TAG>\n               <VALUE>2</VALUE>\n
+        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>organism</TAG>\n
+        \              <VALUE>Homo sapiens</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
+        \         <SAMPLE_ATTRIBUTE>\n               <TAG>organism</TAG>\n               <VALUE>Homo
+        sapiens</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
+        \              <TAG>cell type</TAG>\n               <VALUE>glial cell</VALUE>\n
+        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>common
+        name</TAG>\n               <VALUE>human</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
+        \         <SAMPLE_ATTRIBUTE>\n               <TAG>organism part</TAG>\n               <VALUE>brain</VALUE>\n
+        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>cell
+        line</TAG>\n               <VALUE>G144</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
         \         <SAMPLE_ATTRIBUTE>\n               <TAG>genotype</TAG>\n               <VALUE>wild
         type genotype</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
-        \              <TAG>individual</TAG>\n               <VALUE>2</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
-        \         <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-CHECKLIST</TAG>\n               <VALUE>ERC000011</VALUE>\n
-        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-SPOT-COUNT</TAG>\n
-        \              <VALUE>25292323</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
-        \              <TAG>ENA-BASE-COUNT</TAG>\n               <VALUE>1909946064</VALUE>\n
-        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-FIRST-PUBLIC</TAG>\n
-        \              <VALUE>2018-05-30</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
-        \         <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-LAST-UPDATE</TAG>\n
+        \              <TAG>ENA-FIRST-PUBLIC</TAG>\n               <VALUE>2018-05-30</VALUE>\n
+        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-LAST-UPDATE</TAG>\n
         \              <VALUE>2018-04-24</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
         \    </SAMPLE_ATTRIBUTES>\n</SAMPLE>\n</SAMPLE_SET>\n"
     headers:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:43:02 GMT
+      - Wed, 17 May 2023 18:36:38 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -11905,7 +9993,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/ERP108370
   response:
@@ -11965,7 +10053,7 @@ interactions:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:43:02 GMT
+      - Wed, 17 May 2023 18:36:39 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -11983,7 +10071,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/ERA1350207
   response:
@@ -12019,7 +10107,7 @@ interactions:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:43:03 GMT
+      - Wed, 17 May 2023 18:36:39 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -12028,68 +10116,6 @@ interactions:
       code: 200
       message: ''
 - request:
-    body: acc=ERR2534097&accept-proto=fasp&version=2.0
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '44'
-      User-Agent:
-      - python-requests/2.25.1
-    method: POST
-    uri: https://www.ncbi.nlm.nih.gov/Traces/names/names.cgi
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAAwzIsQrDIBAA0D1fIXTIlHKeZ9TsnQuhUzc1SlqkhsRSCvfx7RvfCc/QHbvf3oEv
-        84xaETjDlpAMKiBGkHYAM4C7SZwkTGTvTKPXUS9JG59jyjbIMVqk7DSkrFVmZgLg66t8Rb+2th29
-        2PbaaqxFPA7hS6mftIhcd9HWf9TwTLF1PwAAAP//AwCFY2v6jgAAAA==
-    headers:
-      Cache-Control:
-      - private
-      Connection:
-      - Keep-Alive
-      Content-Encoding:
-      - gzip
-      Content-Security-Policy:
-      - upgrade-insecure-requests
-      Content-Type:
-      - text/plain
-      Date:
-      - Wed, 28 Jul 2021 19:43:04 GMT
-      Keep-Alive:
-      - timeout=1, max=10
-      NCBI-PHID:
-      - CC95F426101B34810000000000000001.m_1
-      NCBI-SID:
-      - CC95F426101B3481_0000SID
-      Referrer-Policy:
-      - origin-when-cross-origin
-      Server:
-      - Apache
-      Set-Cookie:
-      - ncbi_sid=CC95F426101B3481_0000SID; domain=.nih.gov; path=/; expires=Thu, 28
-        Jul 2022 19:43:04 GMT
-      SraNameServerOutputVersion:
-      - '2.0'
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains; preload
-      Transfer-Encoding:
-      - chunked
-      Vary:
-      - Accept-Encoding
-      X-UA-Compatible:
-      - IE=Edge
-      X-XSS-Protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
-- request:
     body: null
     headers:
       Accept:
@@ -12099,29 +10125,27 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/portal/api/filereport?accession=ERR2534097&result=read_run
   response:
     body:
-      string: "run_accession\tfastq_ftp\tfastq_bytes\tfastq_md5\tsubmitted_ftp\tsubmitted_bytes\tsubmitted_md5\tsra_ftp\tsra_bytes\tsra_md5\nERR2534097\tftp.sra.ebi.ac.uk/vol1/fastq/ERR253/007/ERR2534097/ERR2534097.fastq.gz\t1263173701\t131910cd72175e2b1218785a96cf6eff\tftp.sra.ebi.ac.uk/vol1/run/ERR253/ERR2534097/G144_WTclone_RNAseq_4h_1.fastq.gz\t1316839373\ta47d39765d40e29c4806c97d6c1b7e8a\t\t\t\n"
+      string: "run_accession\tfastq_ftp\tfastq_bytes\tfastq_md5\tbam_ftp\tbam_bytes\tbam_md5\tsubmitted_ftp\tsubmitted_bytes\tsubmitted_md5\tsra_ftp\tsra_bytes\tsra_md5\nERR2534097\tftp.sra.ebi.ac.uk/vol1/fastq/ERR253/007/ERR2534097/ERR2534097.fastq.gz\t1263173701\t131910cd72175e2b1218785a96cf6eff\t\t\t\tftp.sra.ebi.ac.uk/vol1/run/ERR253/ERR2534097/G144_WTclone_RNAseq_4h_1.fastq.gz\t1316839373\ta47d39765d40e29c4806c97d6c1b7e8a\tftp.sra.ebi.ac.uk/vol1/err/ERR253/007/ERR2534097\t842472284\taa05d164f498e7b9a8bdacf95cf71358\n"
     headers:
       Cache-Control:
       - no-cache, no-store, max-age=0, must-revalidate
+      Content-Length:
+      - '486'
       Content-Type:
       - text/plain
       Date:
-      - Wed, 28 Jul 2021 19:43:04 GMT
+      - Wed, 17 May 2023 18:36:41 GMT
       Expires:
       - '0'
       Pragma:
       - no-cache
-      Server:
-      - Apache-Coyote/1.1
       Strict-Transport-Security:
       - max-age=0
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Frame-Options:
@@ -12130,7 +10154,7 @@ interactions:
       - 1; mode=block
     status:
       code: 200
-      message: OK
+      message: ''
 - request:
     body: null
     headers:
@@ -12141,7 +10165,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/ERR2534098
   response:
@@ -12183,7 +10207,7 @@ interactions:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:43:06 GMT
+      - Wed, 17 May 2023 18:36:41 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -12201,7 +10225,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/ERX2552519
   response:
@@ -12269,7 +10293,7 @@ interactions:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:43:06 GMT
+      - Wed, 17 May 2023 18:36:41 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -12287,14 +10311,14 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/ERS2428813
   response:
     body:
       string: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<SAMPLE_SET>\n<SAMPLE accession=\"ERS2428813\"
-        alias=\"E-MTAB-6681:G144_WTclone_RNAseq_4h_2\" broker_name=\"ArrayExpress\"
-        center_name=\"BRIC - Biotech Research and Innovation Centre\">\n     <IDENTIFIERS>\n
+        alias=\"E-MTAB-6681:G144_WTclone_RNAseq_4h_2\" center_name=\"BRIC - Biotech
+        Research and Innovation Centre\" broker_name=\"ArrayExpress\">\n     <IDENTIFIERS>\n
         \         <PRIMARY_ID>ERS2428813</PRIMARY_ID>\n          <EXTERNAL_ID namespace=\"BioSample\">SAMEA4608117</EXTERNAL_ID>\n
         \         <SUBMITTER_ID namespace=\"BRIC - Biotech Research and Innovation
         Centre\">E-MTAB-6681:G144_WTclone_RNAseq_4h_2</SUBMITTER_ID>\n     </IDENTIFIERS>\n
@@ -12302,57 +10326,45 @@ interactions:
         \         <SCIENTIFIC_NAME>Homo sapiens</SCIENTIFIC_NAME>\n          <COMMON_NAME>human</COMMON_NAME>\n
         \    </SAMPLE_NAME>\n     <DESCRIPTION>Protocols: CRISPR mediated KO of CIC:
         sgRNAs (Target sequence: mESCs: GCCTTCATGATCTTCAGCAAG; G144: GGGCGAGTGGTGGTATGCCC)
-        \ were cloned into pSpCas9(BB)-2A-GFP (Addgene 48138) and transfected into
-        mESCs (Lipofectamine 2000) or G144 cells (Amaxa Nucleofector II, Program A033).
+        were cloned into pSpCas9(BB)-2A-GFP (Addgene 48138) and transfected into mESCs
+        (Lipofectamine 2000) or G144 cells (Amaxa Nucleofector II, Program A033).
         GFP-positive cells were single cell sorted 48h post-transfection, expanded
         and screened by immunoblotting for CIC deletion. Inhibitor treatment with
         1 \u03BCM MEK inhibitor (PD0325901) was performed in 80% confluent cultures
         for 4 and 24 h respectively. DMSO was used as mock control. Cells were washed
-        once with PBS, lysed directly in RLT buffer (Qiagen).  Total RNA was extracted
-        using the RNAeasy kit (Qiagen).  500 ng of total RNA was used for library
-        preparation using TruSeq RNA Library Prep Kit v2 (Illumina) according to manufacturer
-        recommendations.</DESCRIPTION>\n     <SAMPLE_LINKS>\n          <SAMPLE_LINK>\n
-        \              <XREF_LINK>\n                    <DB>ENA-STUDY</DB>\n                    <ID>ERP108370</ID>\n
-        \              </XREF_LINK>\n          </SAMPLE_LINK>\n          <SAMPLE_LINK>\n
-        \              <XREF_LINK>\n                    <DB>ENA-EXPERIMENT</DB>\n
-        \                   <ID>ERX2552519</ID>\n               </XREF_LINK>\n          </SAMPLE_LINK>\n
-        \         <SAMPLE_LINK>\n               <XREF_LINK>\n                    <DB>ENA-RUN</DB>\n
-        \                   <ID>ERR2534098</ID>\n               </XREF_LINK>\n          </SAMPLE_LINK>\n
-        \         <SAMPLE_LINK>\n               <XREF_LINK>\n                    <DB>ENA-SUBMISSION</DB>\n
-        \                   <ID>ERA1350207</ID>\n               </XREF_LINK>\n          </SAMPLE_LINK>\n
-        \         <SAMPLE_LINK>\n               <XREF_LINK>\n                    <DB>ENA-FASTQ-FILES</DB>\n
-        \                   <ID><![CDATA[https://www.ebi.ac.uk/ena/portal/api/filereport?accession=ERS2428813&result=read_run&fields=run_accession,fastq_ftp,fastq_md5,fastq_bytes]]></ID>\n
-        \              </XREF_LINK>\n          </SAMPLE_LINK>\n          <SAMPLE_LINK>\n
-        \              <XREF_LINK>\n                    <DB>ENA-SUBMITTED-FILES</DB>\n
-        \                   <ID><![CDATA[https://www.ebi.ac.uk/ena/portal/api/filereport?accession=ERS2428813&result=read_run&fields=run_accession,submitted_ftp,submitted_md5,submitted_bytes,submitted_format]]></ID>\n
-        \              </XREF_LINK>\n          </SAMPLE_LINK>\n     </SAMPLE_LINKS>\n
-        \    <SAMPLE_ATTRIBUTES>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>isolate</TAG>\n
-        \              <VALUE>not applicable</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
-        \         <SAMPLE_ATTRIBUTE>\n               <TAG>organism</TAG>\n               <VALUE>Homo
-        sapiens</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
-        \              <TAG>organism part</TAG>\n               <VALUE>brain</VALUE>\n
-        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>cell_type</TAG>\n
-        \              <VALUE>glial cell</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
-        \         <SAMPLE_ATTRIBUTE>\n               <TAG>cell_line</TAG>\n               <VALUE>G144</VALUE>\n
+        once with PBS, lysed directly in RLT buffer (Qiagen). Total RNA was extracted
+        using the RNAeasy kit (Qiagen). 500 ng of total RNA was used for library preparation
+        using TruSeq RNA Library Prep Kit v2 (Illumina) according to manufacturer
+        recommendations.</DESCRIPTION>\n     <SAMPLE_LINKS>\n    <SAMPLE_LINK>\n        <XREF_LINK>\n
+        \           <DB>ENA-FASTQ-FILES</DB>\n            <ID><![CDATA[https://www.ebi.ac.uk/ena/portal/api/filereport?accession=ERS2428813&result=read_run&fields=run_accession,fastq_ftp,fastq_md5,fastq_bytes]]></ID>\n
+        \       </XREF_LINK>\n    </SAMPLE_LINK>\n    <SAMPLE_LINK>\n        <XREF_LINK>\n
+        \           <DB>ENA-SUBMITTED-FILES</DB>\n            <ID><![CDATA[https://www.ebi.ac.uk/ena/portal/api/filereport?accession=ERS2428813&result=read_run&fields=run_accession,submitted_ftp,submitted_md5,submitted_bytes,submitted_format]]></ID>\n
+        \       </XREF_LINK>\n    </SAMPLE_LINK>\n</SAMPLE_LINKS>\n<SAMPLE_ATTRIBUTES>\n
+        \         <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-CHECKLIST</TAG>\n               <VALUE>ERC000011</VALUE>\n
         \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>disease</TAG>\n
         \              <VALUE>glioblastoma multiforme</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
+        \         <SAMPLE_ATTRIBUTE>\n               <TAG>individual</TAG>\n               <VALUE>2</VALUE>\n
+        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>organism</TAG>\n
+        \              <VALUE>Homo sapiens</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
+        \         <SAMPLE_ATTRIBUTE>\n               <TAG>organism</TAG>\n               <VALUE>Homo
+        sapiens</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
+        \              <TAG>cell type</TAG>\n               <VALUE>glial cell</VALUE>\n
+        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>common
+        name</TAG>\n               <VALUE>human</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
+        \         <SAMPLE_ATTRIBUTE>\n               <TAG>organism part</TAG>\n               <VALUE>brain</VALUE>\n
+        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>cell
+        line</TAG>\n               <VALUE>G144</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
         \         <SAMPLE_ATTRIBUTE>\n               <TAG>genotype</TAG>\n               <VALUE>wild
         type genotype</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
-        \              <TAG>individual</TAG>\n               <VALUE>2</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
-        \         <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-CHECKLIST</TAG>\n               <VALUE>ERC000011</VALUE>\n
-        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-SPOT-COUNT</TAG>\n
-        \              <VALUE>22815094</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
-        \              <TAG>ENA-BASE-COUNT</TAG>\n               <VALUE>1722860231</VALUE>\n
-        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-FIRST-PUBLIC</TAG>\n
-        \              <VALUE>2018-05-30</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
-        \         <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-LAST-UPDATE</TAG>\n
+        \              <TAG>ENA-FIRST-PUBLIC</TAG>\n               <VALUE>2018-05-30</VALUE>\n
+        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-LAST-UPDATE</TAG>\n
         \              <VALUE>2018-04-24</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
         \    </SAMPLE_ATTRIBUTES>\n</SAMPLE>\n</SAMPLE_SET>\n"
     headers:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:43:07 GMT
+      - Wed, 17 May 2023 18:36:41 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -12370,7 +10382,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/ERP108370
   response:
@@ -12430,7 +10442,7 @@ interactions:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:43:07 GMT
+      - Wed, 17 May 2023 18:36:42 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -12448,7 +10460,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/ERA1350207
   response:
@@ -12484,7 +10496,7 @@ interactions:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:43:08 GMT
+      - Wed, 17 May 2023 18:36:43 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -12492,68 +10504,6 @@ interactions:
     status:
       code: 200
       message: ''
-- request:
-    body: acc=ERR2534098&accept-proto=fasp&version=2.0
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '44'
-      User-Agent:
-      - python-requests/2.25.1
-    method: POST
-    uri: https://www.ncbi.nlm.nih.gov/Traces/names/names.cgi
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAAwzIvQrCMBAA4L1PEXDoVLlLLn/dnYXi5NYmKVWCCW1EhHt4/cbvJM/QHftc3wtf
-        pklqReAdW0PKGdDAEtANYAfwN5Qj4ij1nUkhrR6NRnIRg1ySS5ZWY9OclFKRmQmAr6/8Ff3WWj16
-        UffSSihZPA4x51w+KYq17KJt/yjLM4XW/QAAAP//AwA+9dR2jgAAAA==
-    headers:
-      Cache-Control:
-      - private
-      Connection:
-      - Keep-Alive
-      Content-Encoding:
-      - gzip
-      Content-Security-Policy:
-      - upgrade-insecure-requests
-      Content-Type:
-      - text/plain
-      Date:
-      - Wed, 28 Jul 2021 19:43:08 GMT
-      Keep-Alive:
-      - timeout=1, max=10
-      NCBI-PHID:
-      - CC95F471101B34C10000000000000001.m_1
-      NCBI-SID:
-      - CC95F471101B34C1_0000SID
-      Referrer-Policy:
-      - origin-when-cross-origin
-      Server:
-      - Apache
-      Set-Cookie:
-      - ncbi_sid=CC95F471101B34C1_0000SID; domain=.nih.gov; path=/; expires=Thu, 28
-        Jul 2022 19:43:08 GMT
-      SraNameServerOutputVersion:
-      - '2.0'
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains; preload
-      Transfer-Encoding:
-      - chunked
-      Vary:
-      - Accept-Encoding
-      X-UA-Compatible:
-      - IE=Edge
-      X-XSS-Protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
 - request:
     body: null
     headers:
@@ -12564,29 +10514,27 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/portal/api/filereport?accession=ERR2534098&result=read_run
   response:
     body:
-      string: "run_accession\tfastq_ftp\tfastq_bytes\tfastq_md5\tsubmitted_ftp\tsubmitted_bytes\tsubmitted_md5\tsra_ftp\tsra_bytes\tsra_md5\nERR2534098\tftp.sra.ebi.ac.uk/vol1/fastq/ERR253/008/ERR2534098/ERR2534098.fastq.gz\t1145401804\t911c351cdd7ab7c10a10d06f0bc3e3ea\tftp.sra.ebi.ac.uk/vol1/run/ERR253/ERR2534098/G144_WTclone_RNAseq_4h_2.fastq.gz\t1192847608\t01566d01b53ff691ae40cb37416c8335\t\t\t\n"
+      string: "run_accession\tfastq_ftp\tfastq_bytes\tfastq_md5\tbam_ftp\tbam_bytes\tbam_md5\tsubmitted_ftp\tsubmitted_bytes\tsubmitted_md5\tsra_ftp\tsra_bytes\tsra_md5\nERR2534098\tftp.sra.ebi.ac.uk/vol1/fastq/ERR253/008/ERR2534098/ERR2534098.fastq.gz\t1145401804\t911c351cdd7ab7c10a10d06f0bc3e3ea\t\t\t\tftp.sra.ebi.ac.uk/vol1/run/ERR253/ERR2534098/G144_WTclone_RNAseq_4h_2.fastq.gz\t1192847608\t01566d01b53ff691ae40cb37416c8335\tftp.sra.ebi.ac.uk/vol1/err/ERR253/008/ERR2534098\t764386030\tbcd1929ccf8e70fdbf8ef73684f2bbb1\n"
     headers:
       Cache-Control:
       - no-cache, no-store, max-age=0, must-revalidate
+      Content-Length:
+      - '486'
       Content-Type:
       - text/plain
       Date:
-      - Wed, 28 Jul 2021 19:43:09 GMT
+      - Wed, 17 May 2023 18:36:43 GMT
       Expires:
       - '0'
       Pragma:
       - no-cache
-      Server:
-      - Apache-Coyote/1.1
       Strict-Transport-Security:
       - max-age=0
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Frame-Options:
@@ -12595,5 +10543,5 @@ interactions:
       - 1; mode=block
     status:
       code: 200
-      message: OK
+      message: ''
 version: 1

--- a/test_volume/cassettes/surveyor.sra.metadata_is_gathered_correctly.yaml
+++ b/test_volume/cassettes/surveyor.sra.metadata_is_gathered_correctly.yaml
@@ -9,7 +9,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/DRR002116
   response:
@@ -42,7 +42,7 @@ interactions:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:43:10 GMT
+      - Wed, 17 May 2023 18:36:44 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -60,7 +60,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/DRX001563
   response:
@@ -116,7 +116,7 @@ interactions:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:43:10 GMT
+      - Wed, 17 May 2023 18:36:44 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -134,48 +134,42 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/DRS001521
   response:
     body:
       string: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<SAMPLE_SET>\n<SAMPLE accession=\"DRS001521\"
-        alias=\"SAMD00004104\" center_name=\"BioSample\" broker_name=\"DDBJ\">\n     <IDENTIFIERS>\n
-        \         <PRIMARY_ID>DRS001521</PRIMARY_ID>\n          <EXTERNAL_ID namespace=\"BioSample\">SAMD00004104</EXTERNAL_ID>\n
-        \    </IDENTIFIERS>\n     <TITLE>Gg_HH16_1_embryo_mRNAseq</TITLE>\n     <SAMPLE_NAME>\n
-        \         <TAXON_ID>9031</TAXON_ID>\n          <SCIENTIFIC_NAME>Gallus gallus</SCIENTIFIC_NAME>\n
-        \    </SAMPLE_NAME>\n     <SAMPLE_LINKS>\n          <SAMPLE_LINK>\n               <XREF_LINK>\n
-        \                   <DB>ENA-STUDY</DB>\n                    <ID>DRP000595</ID>\n
-        \              </XREF_LINK>\n          </SAMPLE_LINK>\n          <SAMPLE_LINK>\n
-        \              <XREF_LINK>\n                    <DB>ENA-EXPERIMENT</DB>\n
-        \                   <ID>DRX001563</ID>\n               </XREF_LINK>\n          </SAMPLE_LINK>\n
-        \         <SAMPLE_LINK>\n               <XREF_LINK>\n                    <DB>ENA-RUN</DB>\n
-        \                   <ID>DRR002116</ID>\n               </XREF_LINK>\n          </SAMPLE_LINK>\n
-        \         <SAMPLE_LINK>\n               <XREF_LINK>\n                    <DB>ENA-SUBMISSION</DB>\n
-        \                   <ID>DRA000567</ID>\n               </XREF_LINK>\n          </SAMPLE_LINK>\n
-        \         <SAMPLE_LINK>\n               <XREF_LINK>\n                    <DB>ENA-FASTQ-FILES</DB>\n
-        \                   <ID><![CDATA[https://www.ebi.ac.uk/ena/portal/api/filereport?accession=DRS001521&result=read_run&fields=run_accession,fastq_ftp,fastq_md5,fastq_bytes]]></ID>\n
-        \              </XREF_LINK>\n          </SAMPLE_LINK>\n          <SAMPLE_LINK>\n
-        \              <XREF_LINK>\n                    <DB>ENA-SUBMITTED-FILES</DB>\n
-        \                   <ID><![CDATA[https://www.ebi.ac.uk/ena/portal/api/filereport?accession=DRS001521&result=read_run&fields=run_accession,submitted_ftp,submitted_md5,submitted_bytes,submitted_format]]></ID>\n
-        \              </XREF_LINK>\n          </SAMPLE_LINK>\n     </SAMPLE_LINKS>\n
-        \    <SAMPLE_ATTRIBUTES>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>sample_name</TAG>\n
+        alias=\"SAMD00004104\" center_name=\"Group for Morphological Evolution, Center
+        for Developmental Biology, Kobe Institute, RIKEN\" broker_name=\"DDBJ\">\n
+        \    <IDENTIFIERS>\n          <PRIMARY_ID>DRS001521</PRIMARY_ID>\n          <EXTERNAL_ID
+        namespace=\"BioSample\">SAMD00004104</EXTERNAL_ID>\n     </IDENTIFIERS>\n
+        \    <TITLE>Gg_HH16_1_embryo_mRNAseq</TITLE>\n     <SAMPLE_NAME>\n          <TAXON_ID>9031</TAXON_ID>\n
+        \         <SCIENTIFIC_NAME>Gallus gallus</SCIENTIFIC_NAME>\n          <COMMON_NAME>chicken</COMMON_NAME>\n
+        \    </SAMPLE_NAME>\n     <SAMPLE_LINKS>\n    <SAMPLE_LINK>\n        <XREF_LINK>\n
+        \           <DB>ENA-FASTQ-FILES</DB>\n            <ID><![CDATA[https://www.ebi.ac.uk/ena/portal/api/filereport?accession=DRS001521&result=read_run&fields=run_accession,fastq_ftp,fastq_md5,fastq_bytes]]></ID>\n
+        \       </XREF_LINK>\n    </SAMPLE_LINK>\n    <SAMPLE_LINK>\n        <XREF_LINK>\n
+        \           <DB>ENA-SUBMITTED-FILES</DB>\n            <ID><![CDATA[https://www.ebi.ac.uk/ena/portal/api/filereport?accession=DRS001521&result=read_run&fields=run_accession,submitted_ftp,submitted_md5,submitted_bytes,submitted_format]]></ID>\n
+        \       </XREF_LINK>\n    </SAMPLE_LINK>\n</SAMPLE_LINKS>\n<SAMPLE_ATTRIBUTES>\n
+        \         <SAMPLE_ATTRIBUTE>\n               <TAG>INSDC secondary accession</TAG>\n
         \              <VALUE>DRS001521</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
-        \              <TAG>sample comment</TAG>\n               <VALUE>mRNAseq of
-        chicken at stage HH16 (biological replicate 1)</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
-        \         <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-SPOT-COUNT</TAG>\n               <VALUE>32568360</VALUE>\n
-        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-BASE-COUNT</TAG>\n
-        \              <VALUE>3256836000</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
-        \         <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-FIRST-PUBLIC</TAG>\n
-        \              <VALUE>2013-07-20</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
-        \         <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-LAST-UPDATE</TAG>\n
-        \              <VALUE>2015-08-24</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
+        \              <TAG>NCBI submission package</TAG>\n               <VALUE>Generic.1.0</VALUE>\n
+        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>organism</TAG>\n
+        \              <VALUE>Gallus gallus</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
+        \         <SAMPLE_ATTRIBUTE>\n               <TAG>sample comment</TAG>\n               <VALUE>mRNAseq
+        of chicken at stage HH16 (biological replicate 1)</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
+        \         <SAMPLE_ATTRIBUTE>\n               <TAG>sample name</TAG>\n               <VALUE>DRS001521</VALUE>\n
+        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>BioSampleModel</TAG>\n
+        \              <VALUE>Generic</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
+        \              <TAG>ENA-FIRST-PUBLIC</TAG>\n               <VALUE>2013-02-27</VALUE>\n
+        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-LAST-UPDATE</TAG>\n
+        \              <VALUE>2014-11-12</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
         \    </SAMPLE_ATTRIBUTES>\n</SAMPLE>\n</SAMPLE_SET>\n"
     headers:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:43:10 GMT
+      - Wed, 17 May 2023 18:36:44 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -193,7 +187,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/DRP000595
   response:
@@ -236,7 +230,7 @@ interactions:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:43:11 GMT
+      - Wed, 17 May 2023 18:36:44 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -254,7 +248,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/DRA000567
   response:
@@ -293,7 +287,7 @@ interactions:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:43:13 GMT
+      - Wed, 17 May 2023 18:36:45 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -301,66 +295,4 @@ interactions:
     status:
       code: 200
       message: ''
-- request:
-    body: acc=DRR002116&accept-proto=fasp&version=2.0
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '43'
-      User-Agent:
-      - python-requests/2.25.1
-    method: POST
-    uri: https://www.ncbi.nlm.nih.gov/Traces/names/names.cgi
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAAwzIsQ6CMBQF0J2vaOLAhLkttFBmdxPi5PZ40KBpbAM1xuR9vJ7xnMwZ1bFTfs9y
-        mSbAaO3EtKbrvRswiIFuG/QN2hvsaPVo7V0svOs4sPPwmpc5eLOSHYgogFiziHSAXF/xq+qtlHzU
-        Ku+pJE5RPQ5FMabPuqiQdlW2f6T5uXKpfgAAAP//AwDGlZjGjgAAAA==
-    headers:
-      Cache-Control:
-      - private
-      Connection:
-      - Keep-Alive
-      Content-Encoding:
-      - gzip
-      Content-Security-Policy:
-      - upgrade-insecure-requests
-      Content-Type:
-      - text/plain
-      Date:
-      - Wed, 28 Jul 2021 19:43:13 GMT
-      Keep-Alive:
-      - timeout=1, max=10
-      NCBI-PHID:
-      - C7A422B4101B35110000000000000001.m_1
-      NCBI-SID:
-      - C7A422B4101B3511_0000SID
-      Referrer-Policy:
-      - origin-when-cross-origin
-      Server:
-      - Apache
-      Set-Cookie:
-      - ncbi_sid=C7A422B4101B3511_0000SID; domain=.nih.gov; path=/; expires=Thu, 28
-        Jul 2022 19:43:13 GMT
-      SraNameServerOutputVersion:
-      - '2.0'
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains; preload
-      Transfer-Encoding:
-      - chunked
-      Vary:
-      - Accept-Encoding
-      X-UA-Compatible:
-      - IE=Edge
-      X-XSS-Protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
 version: 1

--- a/test_volume/cassettes/surveyor.sra.srp_survey.yaml
+++ b/test_volume/cassettes/surveyor.sra.srp_survey.yaml
@@ -9,7 +9,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/SRP068364
   response:
@@ -57,7 +57,7 @@ interactions:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:43:16 GMT
+      - Wed, 17 May 2023 18:36:48 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -75,7 +75,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/SRR3098579
   response:
@@ -119,7 +119,7 @@ interactions:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:43:17 GMT
+      - Wed, 17 May 2023 18:36:49 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -137,7 +137,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/SRX1528546
   response:
@@ -185,7 +185,7 @@ interactions:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:43:18 GMT
+      - Wed, 17 May 2023 18:36:49 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -203,52 +203,44 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/SRS1246178
   response:
     body:
       string: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<SAMPLE_SET>\n<SAMPLE accession=\"SRS1246178\"
-        alias=\"GSM2037738\" broker_name=\"NCBI\">\n     <IDENTIFIERS>\n          <PRIMARY_ID>SRS1246178</PRIMARY_ID>\n
+        alias=\"GSM2037738\" center_name=\"Michael Pack, Medicine/DIgestive Diseases,
+        University of Pennsylvania\" broker_name=\"NCBI\">\n     <IDENTIFIERS>\n          <PRIMARY_ID>SRS1246178</PRIMARY_ID>\n
         \         <EXTERNAL_ID namespace=\"BioSample\">SAMN04397505</EXTERNAL_ID>\n
-        \         <EXTERNAL_ID namespace=\"GEO\">GSM2037738</EXTERNAL_ID>\n          <SUBMITTER_ID
-        namespace=\"\">GSM2037738</SUBMITTER_ID>\n     </IDENTIFIERS>\n     <TITLE>Control
-        1</TITLE>\n     <SAMPLE_NAME>\n          <TAXON_ID>7955</TAXON_ID>\n          <SCIENTIFIC_NAME>Danio
-        rerio</SCIENTIFIC_NAME>\n          <COMMON_NAME>zebrafish</COMMON_NAME>\n
-        \    </SAMPLE_NAME>\n     <SAMPLE_LINKS>\n          <SAMPLE_LINK>\n               <XREF_LINK>\n
-        \                   <DB>ENA-STUDY</DB>\n                    <ID>SRP068364</ID>\n
-        \              </XREF_LINK>\n          </SAMPLE_LINK>\n          <SAMPLE_LINK>\n
-        \              <XREF_LINK>\n                    <DB>ENA-EXPERIMENT</DB>\n
-        \                   <ID>SRX1528546</ID>\n               </XREF_LINK>\n          </SAMPLE_LINK>\n
-        \         <SAMPLE_LINK>\n               <XREF_LINK>\n                    <DB>ENA-RUN</DB>\n
-        \                   <ID>SRR3098579</ID>\n               </XREF_LINK>\n          </SAMPLE_LINK>\n
-        \         <SAMPLE_LINK>\n               <XREF_LINK>\n                    <DB>ENA-SUBMISSION</DB>\n
-        \                   <ID>SRA333195</ID>\n               </XREF_LINK>\n          </SAMPLE_LINK>\n
-        \         <SAMPLE_LINK>\n               <XREF_LINK>\n                    <DB>ARRAYEXPRESS</DB>\n
-        \                   <ID>E-GEOD-76780</ID>\n               </XREF_LINK>\n          </SAMPLE_LINK>\n
-        \         <SAMPLE_LINK>\n               <XREF_LINK>\n                    <DB>ENA-FASTQ-FILES</DB>\n
-        \                   <ID><![CDATA[https://www.ebi.ac.uk/ena/portal/api/filereport?accession=SRS1246178&result=read_run&fields=run_accession,fastq_ftp,fastq_md5,fastq_bytes]]></ID>\n
-        \              </XREF_LINK>\n          </SAMPLE_LINK>\n          <SAMPLE_LINK>\n
-        \              <XREF_LINK>\n                    <DB>ENA-SUBMITTED-FILES</DB>\n
-        \                   <ID><![CDATA[https://www.ebi.ac.uk/ena/portal/api/filereport?accession=SRS1246178&result=read_run&fields=run_accession,submitted_ftp,submitted_md5,submitted_bytes,submitted_format]]></ID>\n
-        \              </XREF_LINK>\n          </SAMPLE_LINK>\n     </SAMPLE_LINKS>\n
-        \    <SAMPLE_ATTRIBUTES>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>source_name</TAG>\n
-        \              <VALUE>liver</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
-        \              <TAG>tissue</TAG>\n               <VALUE>liver</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
+        \         <SUBMITTER_ID namespace=\"Michael Pack, Medicine/DIgestive Diseases,
+        University of Pennsylvania\">GSM2037738</SUBMITTER_ID>\n     </IDENTIFIERS>\n
+        \    <TITLE>Control 1</TITLE>\n     <SAMPLE_NAME>\n          <TAXON_ID>7955</TAXON_ID>\n
+        \         <SCIENTIFIC_NAME>Danio rerio</SCIENTIFIC_NAME>\n          <COMMON_NAME>zebrafish</COMMON_NAME>\n
+        \    </SAMPLE_NAME>\n     <SAMPLE_LINKS>\n    <SAMPLE_LINK>\n        <XREF_LINK>\n
+        \           <DB>ENA-FASTQ-FILES</DB>\n            <ID><![CDATA[https://www.ebi.ac.uk/ena/portal/api/filereport?accession=SRS1246178&result=read_run&fields=run_accession,fastq_ftp,fastq_md5,fastq_bytes]]></ID>\n
+        \       </XREF_LINK>\n    </SAMPLE_LINK>\n    <SAMPLE_LINK>\n        <XREF_LINK>\n
+        \           <DB>ENA-SUBMITTED-FILES</DB>\n            <ID><![CDATA[https://www.ebi.ac.uk/ena/portal/api/filereport?accession=SRS1246178&result=read_run&fields=run_accession,submitted_ftp,submitted_md5,submitted_bytes,submitted_format]]></ID>\n
+        \       </XREF_LINK>\n    </SAMPLE_LINK>\n</SAMPLE_LINKS>\n<SAMPLE_ATTRIBUTES>\n
         \         <SAMPLE_ATTRIBUTE>\n               <TAG>treatment</TAG>\n               <VALUE>DMSO</VALUE>\n
-        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-SPOT-COUNT</TAG>\n
-        \              <VALUE>56576210</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
-        \              <TAG>ENA-BASE-COUNT</TAG>\n               <VALUE>11315242000</VALUE>\n
-        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-FIRST-PUBLIC</TAG>\n
-        \              <VALUE>2017-11-07</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
-        \         <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-LAST-UPDATE</TAG>\n
-        \              <VALUE>2017-11-07</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
+        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>INSDC
+        secondary accession</TAG>\n               <VALUE>SRS1246178</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
+        \         <SAMPLE_ATTRIBUTE>\n               <TAG>NCBI submission package</TAG>\n
+        \              <VALUE>Generic.1.0</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
+        \         <SAMPLE_ATTRIBUTE>\n               <TAG>organism</TAG>\n               <VALUE>Danio
+        rerio</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
+        \              <TAG>tissue</TAG>\n               <VALUE>liver</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
+        \         <SAMPLE_ATTRIBUTE>\n               <TAG>source_name</TAG>\n               <VALUE>liver</VALUE>\n
+        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>BioSampleModel</TAG>\n
+        \              <VALUE>Generic</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
+        \              <TAG>ENA-FIRST-PUBLIC</TAG>\n               <VALUE>2017-08-24</VALUE>\n
+        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-LAST-UPDATE</TAG>\n
+        \              <VALUE>2017-08-24</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
         \    </SAMPLE_ATTRIBUTES>\n</SAMPLE>\n</SAMPLE_SET>\n"
     headers:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:43:18 GMT
+      - Wed, 17 May 2023 18:36:50 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -266,7 +258,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/SRP068364
   response:
@@ -314,7 +306,7 @@ interactions:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:43:19 GMT
+      - Wed, 17 May 2023 18:36:50 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -332,7 +324,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/SRA333195
   response:
@@ -369,7 +361,7 @@ interactions:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:43:19 GMT
+      - Wed, 17 May 2023 18:36:50 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -377,68 +369,6 @@ interactions:
     status:
       code: 200
       message: ''
-- request:
-    body: acc=SRR3098579&accept-proto=fasp&version=2.0
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '44'
-      User-Agent:
-      - python-requests/2.25.1
-    method: POST
-    uri: https://www.ncbi.nlm.nih.gov/Traces/names/names.cgi
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAAwzISwrCMBAA0H1PEXDRVWXyz/QSQnXlrk0iVUITkogIc3h9y3cSZxhaXct7o+uy
-        SECnLZJBYxUCgiMB3EzAJy5uHGeJs5Z3sk4ZAxY8Omm3oHkwEnX0MirhPAYiUgB0OdKXjXvvpY2s
-        1Nyzz4k9G1tTyp8Y2CNX1vd/5O0VfR9+AAAA//8DANXTVuiPAAAA
-    headers:
-      Cache-Control:
-      - private
-      Connection:
-      - Keep-Alive
-      Content-Encoding:
-      - gzip
-      Content-Security-Policy:
-      - upgrade-insecure-requests
-      Content-Type:
-      - text/plain
-      Date:
-      - Wed, 28 Jul 2021 19:43:21 GMT
-      Keep-Alive:
-      - timeout=1, max=10
-      NCBI-PHID:
-      - C7A422DB101B35910000000000000001.m_1
-      NCBI-SID:
-      - C7A422DB101B3591_0000SID
-      Referrer-Policy:
-      - origin-when-cross-origin
-      Server:
-      - Apache
-      Set-Cookie:
-      - ncbi_sid=C7A422DB101B3591_0000SID; domain=.nih.gov; path=/; expires=Thu, 28
-        Jul 2022 19:43:21 GMT
-      SraNameServerOutputVersion:
-      - '2.0'
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains; preload
-      Transfer-Encoding:
-      - chunked
-      Vary:
-      - Accept-Encoding
-      X-UA-Compatible:
-      - IE=Edge
-      X-XSS-Protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
 - request:
     body: null
     headers:
@@ -449,7 +379,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://eutils.ncbi.nlm.nih.gov/entrez/eutils/esummary.fcgi?db=pubmed&id=27102575&retmode=json&tool=refinebio&email=hello@refine.bio
   response:
@@ -459,21 +389,21 @@ interactions:
         e3rSkyYYCHuy0EzgT4agAXJhHNGeoIAfsk6yjrB8nMFvATaKyqfmIHsHzR7qRVXW88Ucvoq/+qpH
         250UYMKhR58W1GX1JDZkIqR/dBW0qKooOA62S/iNDHpW/J3yYPAD27R3Ao1j0ncDstjetNsFy0tb
         ZJ0KzpO9RInx76Z3tqS9aDNtn1IdpXbieZVpXKPthvhIEi/rTOurVIqckZSfFqU7xDf2DzupR9Ti
-        I3PAhkXuoS2zaJdnAAAA///MVsty2yAU3fcrGK+SmdhGkm1ZziqvaZKpM5l02ekCIxTTIOEi5Kbp
-        5N97APlVJzPxrisJuId7uI8Dh/qZy4pcHgi61wbT5Pbh0KgIpWry8PlA2Lli0pCbQ0ky/kQ+lnG0
-        j2K1DRW+DbXSKl8IqrHMhipilZX6Web4ErTH/Bf7TRi3ciktfqqcoE+FWQqSC3goJSAW9ny1XC8E
-        l0UY64LYuSAzqSSa3ttVYWSxi/OG8YuYGVbIet7zvWnsitXjf8HKSZVWjY/5aICRrOvGDRInPOxR
-        QDI642zQzWjacYGuHp12CXwQ90qVTSV/NsKnYpzQOBuMwiZe+uKUdrMoyZxehaloGKfdJBnSoGsh
-        s986t+i2iilyZqzkCM93J5hcmxx5tY3jcN/MpiInXbDPxTP+Cm3I9Oryy83dVdhrbRoPHQcWtgpi
-        +6cj87aKYFmK3JH0MyAVIQZM+VOvVdeV4hqSa7ltn2zsI9qLKI37c7HoxeMRTXaBi5JvA8cb4P30
-        YhgPo5gOdhGlzN9B3N1cT7+m4whB3oWYdyFvn0YcaI9D7CKGGwTWujKfkM1xTqGXTc2NXFi/skX7
-        1PfqXNZW4450SdnOGvIt5NJnZute69OoH40JpRNKPa1dyFLW+4ikHw3fQTDOxcLuQwb9KH4HguvO
-        iJd9QJwQOnoLsC6wjwJgrdDSO4i0T8c4yQrh+6EQuHu5CPWM4Rs3fY+sngino8FRcjxJo7Tr2g/m
-        bTovdFm6K1xWrm1cvU3iNBlkWYw+qLQn4B0ya42cNdY77FyzmpyBs4EuufZE5rEn102FR02UnXSK
-        RqkfoY1bDd/QIkfnTFlZ4vFwQqZ579gJgtKcQfYqrx1osQnZ7yaERPOWONTN2zsdNZzrytFTqCbQ
-        A6GZ1k8rbYUJgiqbMvzj14bHWFAKgObCrPz/M92SD17ahPgALiDeVVPO3JPPzbAlk4rNlCiMLhuj
-        wuxqV6yIdgpH2GOLuc3ejvrGLZ8zlGjrxN0Yuy+9Ps3QFG2xBoNCmq37b/2uW7rD8EY5JWzj8vr6
-        +ukvAAAA//8DAF95z3y5CgAA
+        I3PAhkXuoS2zaJdnAAAA///MVk1z2yAQvfdXMD4lM7WNJNuynFOSdppk6kwmPXZ6wAhFNEi4CLlt
+        OvnvfYD8VScz8a0nCdi3+1h2Hxwbp5Q1+XAk6E4bTJOb+2OzIpRqyP2nI2EXiklDro8lyfgjeduJ
+        o30Ua2yo8F2olVb5QlCtZTZUEaut1L9kji9Be5Q/2W/CuJUrafFT5wR9KsxKkFwgQiUBsbDn6+Vm
+        KbgswlgXxJaCLKSSaHpvV4eRhRcXDeMnsTCskE058L1p7JrVw3/BykmVVq3P+WSEkWya1g0SJzzs
+        QUAyetNs1M9o2nOJrh+cdgl8kPdaVW0tf7TCH8U0oXE2mgQnXvrilPazKMmcXoWpaByn/SQZ06Br
+        4WS/9m7QbTVT5NxYyZGeb04wuTY5ztW2jsNdu5iLnPTBPhe/8FdoQ+YfP3y+vv0YfG1M47HjwIKr
+        ILZ/ejLvqgiWlcgdST8DUhFywJTf9UZ1XSluIJXcs59u7W+vr+Zf0mmEne9DlhV/BXI3vxzH4yim
+        owPEfpjxFoO1vsxnZIs9gyy1DTdyaf3KDpGzfb+5lrtek63XiA4iSuNhKZaDeDqhie+lUjZW4w5z
+        SdvNKs5DyJXP3M69M6TRMJoSSmeU+rj7kJVsDhHJMBq/gmCci6U9hIyGUfwKBNeREU+HgDghdPIS
+        YFMAbwXAWqHl9hDpkE6xkzXC12shcDdyEeoNwxdu4gFZX+Fnk9FJcjpLo7Tv2gPm3Xld6qpyV6ys
+        XVm70pvFaTLKshh1WmtPwAdk1hq5aK0P2LtiDTkHZwPdcO2DkoFPrtsaj44Raqlolfoe2qzT2C0t
+        cnLBlJUVLvf3ZJ4PTl3DKs0ZZKn2vY0qmpHDgkFKNO+IQ328vdM5w7muHT2FagI9EFpo/bjWPpgg
+        qbKtwj9+bXgshU4GqBRmHf+f6Y58iNIdiE/gEuJat9XCPcncDFsxqdhCicLoqjUqzK69YkV0U9jC
+        AVvMbX076tuwvGQo0S6IU/T9l9iQZmiKrliDQSHNzv20eXet3GZ4q5xSdXl5fn5+9xcAAP//AwCM
+        qqIyWQoAAA==
     headers:
       Access-Control-Allow-Origin:
       - '*'
@@ -488,18 +418,20 @@ interactions:
       Content-Type:
       - application/json; charset=UTF-8
       Date:
-      - Wed, 28 Jul 2021 19:43:20 GMT
+      - Wed, 17 May 2023 18:36:51 GMT
       Keep-Alive:
       - timeout=4, max=40
       NCBI-PHID:
-      - D0BD3D622C4BDF7500004EFC6D94BF07.1.1.m_1
+      - 322C36E9C9D0D90500005409C5B33DFE.1.1.m_1
       NCBI-SID:
-      - F6183D46F2126CAE_F0A8SID
+      - B9B997ADC5BB1F2E_0B63SID
+      Referrer-Policy:
+      - origin-when-cross-origin
       Server:
       - Finatra
       Set-Cookie:
-      - ncbi_sid=F6183D46F2126CAE_F0A8SID; domain=.nih.gov; path=/; expires=Thu, 28
-        Jul 2022 19:43:21 GMT
+      - ncbi_sid=B9B997ADC5BB1F2E_0B63SID; domain=.nih.gov; path=/; expires=Fri, 17
+        May 2024 18:36:51 GMT
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains; preload
       Transfer-Encoding:
@@ -527,29 +459,27 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/portal/api/filereport?accession=SRR3098579&result=read_run
   response:
     body:
-      string: "run_accession\tfastq_ftp\tfastq_bytes\tfastq_md5\tsubmitted_ftp\tsubmitted_bytes\tsubmitted_md5\tsra_ftp\tsra_bytes\tsra_md5\nSRR3098579\tftp.sra.ebi.ac.uk/vol1/fastq/SRR309/009/SRR3098579/SRR3098579_1.fastq.gz;ftp.sra.ebi.ac.uk/vol1/fastq/SRR309/009/SRR3098579/SRR3098579_2.fastq.gz\t3999026139;3956970849\t9dc519ddc6a0aed81998137fcefa16f2;e7c56cceed78f71188178b7a39204c87\t\t\t\t\t\t\n"
+      string: "run_accession\tfastq_ftp\tfastq_bytes\tfastq_md5\tbam_ftp\tbam_bytes\tbam_md5\tsubmitted_ftp\tsubmitted_bytes\tsubmitted_md5\tsra_ftp\tsra_bytes\tsra_md5\nSRR3098579\tftp.sra.ebi.ac.uk/vol1/fastq/SRR309/009/SRR3098579/SRR3098579_1.fastq.gz;ftp.sra.ebi.ac.uk/vol1/fastq/SRR309/009/SRR3098579/SRR3098579_2.fastq.gz\t3999026139;3956970849\t9dc519ddc6a0aed81998137fcefa16f2;e7c56cceed78f71188178b7a39204c87\t\t\t\t\t\t\tftp.sra.ebi.ac.uk/vol1/srr/SRR309/009/SRR3098579\t6967490908\t78466070c9837bd51d6395ec3e428c9d\n"
     headers:
       Cache-Control:
       - no-cache, no-store, max-age=0, must-revalidate
+      Content-Length:
+      - '486'
       Content-Type:
       - text/plain
       Date:
-      - Wed, 28 Jul 2021 19:43:21 GMT
+      - Wed, 17 May 2023 18:36:51 GMT
       Expires:
       - '0'
       Pragma:
       - no-cache
-      Server:
-      - Apache-Coyote/1.1
       Strict-Transport-Security:
       - max-age=0
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Frame-Options:
@@ -558,7 +488,7 @@ interactions:
       - 1; mode=block
     status:
       code: 200
-      message: OK
+      message: ''
 - request:
     body: null
     headers:
@@ -569,7 +499,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/SRR3098580
   response:
@@ -613,7 +543,7 @@ interactions:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:43:23 GMT
+      - Wed, 17 May 2023 18:36:51 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -631,7 +561,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/SRX1528547
   response:
@@ -679,7 +609,7 @@ interactions:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:43:23 GMT
+      - Wed, 17 May 2023 18:36:52 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -697,52 +627,44 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/SRS1246177
   response:
     body:
       string: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<SAMPLE_SET>\n<SAMPLE accession=\"SRS1246177\"
-        alias=\"GSM2037739\" broker_name=\"NCBI\">\n     <IDENTIFIERS>\n          <PRIMARY_ID>SRS1246177</PRIMARY_ID>\n
+        alias=\"GSM2037739\" center_name=\"Michael Pack, Medicine/DIgestive Diseases,
+        University of Pennsylvania\" broker_name=\"NCBI\">\n     <IDENTIFIERS>\n          <PRIMARY_ID>SRS1246177</PRIMARY_ID>\n
         \         <EXTERNAL_ID namespace=\"BioSample\">SAMN04397506</EXTERNAL_ID>\n
-        \         <EXTERNAL_ID namespace=\"GEO\">GSM2037739</EXTERNAL_ID>\n          <SUBMITTER_ID
-        namespace=\"\">GSM2037739</SUBMITTER_ID>\n     </IDENTIFIERS>\n     <TITLE>Control
-        2</TITLE>\n     <SAMPLE_NAME>\n          <TAXON_ID>7955</TAXON_ID>\n          <SCIENTIFIC_NAME>Danio
-        rerio</SCIENTIFIC_NAME>\n          <COMMON_NAME>zebrafish</COMMON_NAME>\n
-        \    </SAMPLE_NAME>\n     <SAMPLE_LINKS>\n          <SAMPLE_LINK>\n               <XREF_LINK>\n
-        \                   <DB>ENA-STUDY</DB>\n                    <ID>SRP068364</ID>\n
-        \              </XREF_LINK>\n          </SAMPLE_LINK>\n          <SAMPLE_LINK>\n
-        \              <XREF_LINK>\n                    <DB>ENA-EXPERIMENT</DB>\n
-        \                   <ID>SRX1528547</ID>\n               </XREF_LINK>\n          </SAMPLE_LINK>\n
-        \         <SAMPLE_LINK>\n               <XREF_LINK>\n                    <DB>ENA-RUN</DB>\n
-        \                   <ID>SRR3098580</ID>\n               </XREF_LINK>\n          </SAMPLE_LINK>\n
-        \         <SAMPLE_LINK>\n               <XREF_LINK>\n                    <DB>ENA-SUBMISSION</DB>\n
-        \                   <ID>SRA333195</ID>\n               </XREF_LINK>\n          </SAMPLE_LINK>\n
-        \         <SAMPLE_LINK>\n               <XREF_LINK>\n                    <DB>ARRAYEXPRESS</DB>\n
-        \                   <ID>E-GEOD-76780</ID>\n               </XREF_LINK>\n          </SAMPLE_LINK>\n
-        \         <SAMPLE_LINK>\n               <XREF_LINK>\n                    <DB>ENA-FASTQ-FILES</DB>\n
-        \                   <ID><![CDATA[https://www.ebi.ac.uk/ena/portal/api/filereport?accession=SRS1246177&result=read_run&fields=run_accession,fastq_ftp,fastq_md5,fastq_bytes]]></ID>\n
-        \              </XREF_LINK>\n          </SAMPLE_LINK>\n          <SAMPLE_LINK>\n
-        \              <XREF_LINK>\n                    <DB>ENA-SUBMITTED-FILES</DB>\n
-        \                   <ID><![CDATA[https://www.ebi.ac.uk/ena/portal/api/filereport?accession=SRS1246177&result=read_run&fields=run_accession,submitted_ftp,submitted_md5,submitted_bytes,submitted_format]]></ID>\n
-        \              </XREF_LINK>\n          </SAMPLE_LINK>\n     </SAMPLE_LINKS>\n
-        \    <SAMPLE_ATTRIBUTES>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>source_name</TAG>\n
-        \              <VALUE>liver</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
-        \              <TAG>tissue</TAG>\n               <VALUE>liver</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
+        \         <SUBMITTER_ID namespace=\"Michael Pack, Medicine/DIgestive Diseases,
+        University of Pennsylvania\">GSM2037739</SUBMITTER_ID>\n     </IDENTIFIERS>\n
+        \    <TITLE>Control 2</TITLE>\n     <SAMPLE_NAME>\n          <TAXON_ID>7955</TAXON_ID>\n
+        \         <SCIENTIFIC_NAME>Danio rerio</SCIENTIFIC_NAME>\n          <COMMON_NAME>zebrafish</COMMON_NAME>\n
+        \    </SAMPLE_NAME>\n     <SAMPLE_LINKS>\n    <SAMPLE_LINK>\n        <XREF_LINK>\n
+        \           <DB>ENA-FASTQ-FILES</DB>\n            <ID><![CDATA[https://www.ebi.ac.uk/ena/portal/api/filereport?accession=SRS1246177&result=read_run&fields=run_accession,fastq_ftp,fastq_md5,fastq_bytes]]></ID>\n
+        \       </XREF_LINK>\n    </SAMPLE_LINK>\n    <SAMPLE_LINK>\n        <XREF_LINK>\n
+        \           <DB>ENA-SUBMITTED-FILES</DB>\n            <ID><![CDATA[https://www.ebi.ac.uk/ena/portal/api/filereport?accession=SRS1246177&result=read_run&fields=run_accession,submitted_ftp,submitted_md5,submitted_bytes,submitted_format]]></ID>\n
+        \       </XREF_LINK>\n    </SAMPLE_LINK>\n</SAMPLE_LINKS>\n<SAMPLE_ATTRIBUTES>\n
         \         <SAMPLE_ATTRIBUTE>\n               <TAG>treatment</TAG>\n               <VALUE>DMSO</VALUE>\n
-        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-SPOT-COUNT</TAG>\n
-        \              <VALUE>55503963</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
-        \              <TAG>ENA-BASE-COUNT</TAG>\n               <VALUE>11100792600</VALUE>\n
-        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-FIRST-PUBLIC</TAG>\n
-        \              <VALUE>2017-11-07</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
-        \         <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-LAST-UPDATE</TAG>\n
-        \              <VALUE>2017-11-07</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
+        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>INSDC
+        secondary accession</TAG>\n               <VALUE>SRS1246177</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
+        \         <SAMPLE_ATTRIBUTE>\n               <TAG>NCBI submission package</TAG>\n
+        \              <VALUE>Generic.1.0</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
+        \         <SAMPLE_ATTRIBUTE>\n               <TAG>organism</TAG>\n               <VALUE>Danio
+        rerio</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
+        \              <TAG>tissue</TAG>\n               <VALUE>liver</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
+        \         <SAMPLE_ATTRIBUTE>\n               <TAG>source_name</TAG>\n               <VALUE>liver</VALUE>\n
+        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>BioSampleModel</TAG>\n
+        \              <VALUE>Generic</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
+        \              <TAG>ENA-FIRST-PUBLIC</TAG>\n               <VALUE>2017-08-24</VALUE>\n
+        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-LAST-UPDATE</TAG>\n
+        \              <VALUE>2017-08-24</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
         \    </SAMPLE_ATTRIBUTES>\n</SAMPLE>\n</SAMPLE_SET>\n"
     headers:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:43:23 GMT
+      - Wed, 17 May 2023 18:36:52 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -760,7 +682,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/SRP068364
   response:
@@ -808,7 +730,7 @@ interactions:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:43:24 GMT
+      - Wed, 17 May 2023 18:36:53 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -826,7 +748,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/SRA333195
   response:
@@ -863,7 +785,7 @@ interactions:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:43:24 GMT
+      - Wed, 17 May 2023 18:36:54 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -872,68 +794,6 @@ interactions:
       code: 200
       message: ''
 - request:
-    body: acc=SRR3098580&accept-proto=fasp&version=2.0
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '44'
-      User-Agent:
-      - python-requests/2.25.1
-    method: POST
-    uri: https://www.ncbi.nlm.nih.gov/Traces/names/names.cgi
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAAwzIsQ7CIBAA0L1fQeLQqeYOKBz9CZPq5Aa0TTVESMEYk/t4feM7yTN09fDlHfg6
-        zwocjQRsiKQhNDiyBDQD4IDyJmFCM2l7Z61Wr8PmXERNTlkvbTBBw0JkXViQmTUAX17pK/q9tVJ7
-        UY7ccsxJPKrwKeXPuogtH6Lt/8jhucbW/QAAAP//AwBpZSYsjwAAAA==
-    headers:
-      Cache-Control:
-      - private
-      Connection:
-      - Keep-Alive
-      Content-Encoding:
-      - gzip
-      Content-Security-Policy:
-      - upgrade-insecure-requests
-      Content-Type:
-      - text/plain
-      Date:
-      - Wed, 28 Jul 2021 19:43:25 GMT
-      Keep-Alive:
-      - timeout=1, max=10
-      NCBI-PHID:
-      - CC95F552101B35D10000000000000001.m_1
-      NCBI-SID:
-      - CC95F552101B35D1_0000SID
-      Referrer-Policy:
-      - origin-when-cross-origin
-      Server:
-      - Apache
-      Set-Cookie:
-      - ncbi_sid=CC95F552101B35D1_0000SID; domain=.nih.gov; path=/; expires=Thu, 28
-        Jul 2022 19:43:25 GMT
-      SraNameServerOutputVersion:
-      - '2.0'
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains; preload
-      Transfer-Encoding:
-      - chunked
-      Vary:
-      - Accept-Encoding
-      X-UA-Compatible:
-      - IE=Edge
-      X-XSS-Protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
-- request:
     body: null
     headers:
       Accept:
@@ -943,29 +803,27 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/portal/api/filereport?accession=SRR3098580&result=read_run
   response:
     body:
-      string: "run_accession\tfastq_ftp\tfastq_bytes\tfastq_md5\tsubmitted_ftp\tsubmitted_bytes\tsubmitted_md5\tsra_ftp\tsra_bytes\tsra_md5\nSRR3098580\tftp.sra.ebi.ac.uk/vol1/fastq/SRR309/000/SRR3098580/SRR3098580_1.fastq.gz;ftp.sra.ebi.ac.uk/vol1/fastq/SRR309/000/SRR3098580/SRR3098580_2.fastq.gz\t4061413779;4030359471\t6a7008ed2b0ed60d82d6a89e406b6c04;343eb987bbca5ec7001f2303c1570b2b\t\t\t\t\t\t\n"
+      string: "run_accession\tfastq_ftp\tfastq_bytes\tfastq_md5\tbam_ftp\tbam_bytes\tbam_md5\tsubmitted_ftp\tsubmitted_bytes\tsubmitted_md5\tsra_ftp\tsra_bytes\tsra_md5\nSRR3098580\tftp.sra.ebi.ac.uk/vol1/fastq/SRR309/000/SRR3098580/SRR3098580_1.fastq.gz;ftp.sra.ebi.ac.uk/vol1/fastq/SRR309/000/SRR3098580/SRR3098580_2.fastq.gz\t4061413779;4030359471\t6a7008ed2b0ed60d82d6a89e406b6c04;343eb987bbca5ec7001f2303c1570b2b\t\t\t\t\t\t\tftp.sra.ebi.ac.uk/vol1/srr/SRR309/000/SRR3098580\t6882681615\t43ea4bf99c148937a27b6b40d8879bd1\n"
     headers:
       Cache-Control:
       - no-cache, no-store, max-age=0, must-revalidate
+      Content-Length:
+      - '486'
       Content-Type:
       - text/plain
       Date:
-      - Wed, 28 Jul 2021 19:43:25 GMT
+      - Wed, 17 May 2023 18:36:54 GMT
       Expires:
       - '0'
       Pragma:
       - no-cache
-      Server:
-      - Apache-Coyote/1.1
       Strict-Transport-Security:
       - max-age=0
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Frame-Options:
@@ -974,7 +832,7 @@ interactions:
       - 1; mode=block
     status:
       code: 200
-      message: OK
+      message: ''
 - request:
     body: null
     headers:
@@ -985,7 +843,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/SRR3098581
   response:
@@ -1029,7 +887,7 @@ interactions:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:43:26 GMT
+      - Wed, 17 May 2023 18:36:54 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -1047,7 +905,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/SRX1528548
   response:
@@ -1095,7 +953,7 @@ interactions:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:43:27 GMT
+      - Wed, 17 May 2023 18:36:55 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -1113,52 +971,44 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/SRS1246176
   response:
     body:
       string: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<SAMPLE_SET>\n<SAMPLE accession=\"SRS1246176\"
-        alias=\"GSM2037740\" broker_name=\"NCBI\">\n     <IDENTIFIERS>\n          <PRIMARY_ID>SRS1246176</PRIMARY_ID>\n
+        alias=\"GSM2037740\" center_name=\"Michael Pack, Medicine/DIgestive Diseases,
+        University of Pennsylvania\" broker_name=\"NCBI\">\n     <IDENTIFIERS>\n          <PRIMARY_ID>SRS1246176</PRIMARY_ID>\n
         \         <EXTERNAL_ID namespace=\"BioSample\">SAMN04397507</EXTERNAL_ID>\n
-        \         <EXTERNAL_ID namespace=\"GEO\">GSM2037740</EXTERNAL_ID>\n          <SUBMITTER_ID
-        namespace=\"\">GSM2037740</SUBMITTER_ID>\n     </IDENTIFIERS>\n     <TITLE>Biliatresone
-        1</TITLE>\n     <SAMPLE_NAME>\n          <TAXON_ID>7955</TAXON_ID>\n          <SCIENTIFIC_NAME>Danio
-        rerio</SCIENTIFIC_NAME>\n          <COMMON_NAME>zebrafish</COMMON_NAME>\n
-        \    </SAMPLE_NAME>\n     <SAMPLE_LINKS>\n          <SAMPLE_LINK>\n               <XREF_LINK>\n
-        \                   <DB>ENA-STUDY</DB>\n                    <ID>SRP068364</ID>\n
-        \              </XREF_LINK>\n          </SAMPLE_LINK>\n          <SAMPLE_LINK>\n
-        \              <XREF_LINK>\n                    <DB>ENA-EXPERIMENT</DB>\n
-        \                   <ID>SRX1528548</ID>\n               </XREF_LINK>\n          </SAMPLE_LINK>\n
-        \         <SAMPLE_LINK>\n               <XREF_LINK>\n                    <DB>ENA-RUN</DB>\n
-        \                   <ID>SRR3098581</ID>\n               </XREF_LINK>\n          </SAMPLE_LINK>\n
-        \         <SAMPLE_LINK>\n               <XREF_LINK>\n                    <DB>ENA-SUBMISSION</DB>\n
-        \                   <ID>SRA333195</ID>\n               </XREF_LINK>\n          </SAMPLE_LINK>\n
-        \         <SAMPLE_LINK>\n               <XREF_LINK>\n                    <DB>ARRAYEXPRESS</DB>\n
-        \                   <ID>E-GEOD-76780</ID>\n               </XREF_LINK>\n          </SAMPLE_LINK>\n
-        \         <SAMPLE_LINK>\n               <XREF_LINK>\n                    <DB>ENA-FASTQ-FILES</DB>\n
-        \                   <ID><![CDATA[https://www.ebi.ac.uk/ena/portal/api/filereport?accession=SRS1246176&result=read_run&fields=run_accession,fastq_ftp,fastq_md5,fastq_bytes]]></ID>\n
-        \              </XREF_LINK>\n          </SAMPLE_LINK>\n          <SAMPLE_LINK>\n
-        \              <XREF_LINK>\n                    <DB>ENA-SUBMITTED-FILES</DB>\n
-        \                   <ID><![CDATA[https://www.ebi.ac.uk/ena/portal/api/filereport?accession=SRS1246176&result=read_run&fields=run_accession,submitted_ftp,submitted_md5,submitted_bytes,submitted_format]]></ID>\n
-        \              </XREF_LINK>\n          </SAMPLE_LINK>\n     </SAMPLE_LINKS>\n
-        \    <SAMPLE_ATTRIBUTES>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>source_name</TAG>\n
-        \              <VALUE>liver</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
-        \              <TAG>tissue</TAG>\n               <VALUE>liver</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
+        \         <SUBMITTER_ID namespace=\"Michael Pack, Medicine/DIgestive Diseases,
+        University of Pennsylvania\">GSM2037740</SUBMITTER_ID>\n     </IDENTIFIERS>\n
+        \    <TITLE>Biliatresone 1</TITLE>\n     <SAMPLE_NAME>\n          <TAXON_ID>7955</TAXON_ID>\n
+        \         <SCIENTIFIC_NAME>Danio rerio</SCIENTIFIC_NAME>\n          <COMMON_NAME>zebrafish</COMMON_NAME>\n
+        \    </SAMPLE_NAME>\n     <SAMPLE_LINKS>\n    <SAMPLE_LINK>\n        <XREF_LINK>\n
+        \           <DB>ENA-FASTQ-FILES</DB>\n            <ID><![CDATA[https://www.ebi.ac.uk/ena/portal/api/filereport?accession=SRS1246176&result=read_run&fields=run_accession,fastq_ftp,fastq_md5,fastq_bytes]]></ID>\n
+        \       </XREF_LINK>\n    </SAMPLE_LINK>\n    <SAMPLE_LINK>\n        <XREF_LINK>\n
+        \           <DB>ENA-SUBMITTED-FILES</DB>\n            <ID><![CDATA[https://www.ebi.ac.uk/ena/portal/api/filereport?accession=SRS1246176&result=read_run&fields=run_accession,submitted_ftp,submitted_md5,submitted_bytes,submitted_format]]></ID>\n
+        \       </XREF_LINK>\n    </SAMPLE_LINK>\n</SAMPLE_LINKS>\n<SAMPLE_ATTRIBUTES>\n
         \         <SAMPLE_ATTRIBUTE>\n               <TAG>treatment</TAG>\n               <VALUE>Biliatresone</VALUE>\n
-        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-SPOT-COUNT</TAG>\n
-        \              <VALUE>56284823</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
-        \              <TAG>ENA-BASE-COUNT</TAG>\n               <VALUE>11256964600</VALUE>\n
-        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-FIRST-PUBLIC</TAG>\n
-        \              <VALUE>2017-11-07</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
-        \         <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-LAST-UPDATE</TAG>\n
-        \              <VALUE>2017-11-07</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
+        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>INSDC
+        secondary accession</TAG>\n               <VALUE>SRS1246176</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
+        \         <SAMPLE_ATTRIBUTE>\n               <TAG>NCBI submission package</TAG>\n
+        \              <VALUE>Generic.1.0</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
+        \         <SAMPLE_ATTRIBUTE>\n               <TAG>organism</TAG>\n               <VALUE>Danio
+        rerio</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
+        \              <TAG>tissue</TAG>\n               <VALUE>liver</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
+        \         <SAMPLE_ATTRIBUTE>\n               <TAG>source_name</TAG>\n               <VALUE>liver</VALUE>\n
+        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>BioSampleModel</TAG>\n
+        \              <VALUE>Generic</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
+        \              <TAG>ENA-FIRST-PUBLIC</TAG>\n               <VALUE>2017-08-24</VALUE>\n
+        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-LAST-UPDATE</TAG>\n
+        \              <VALUE>2017-08-24</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
         \    </SAMPLE_ATTRIBUTES>\n</SAMPLE>\n</SAMPLE_SET>\n"
     headers:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:43:27 GMT
+      - Wed, 17 May 2023 18:36:55 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -1176,7 +1026,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/SRP068364
   response:
@@ -1224,7 +1074,7 @@ interactions:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:43:27 GMT
+      - Wed, 17 May 2023 18:36:55 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -1242,7 +1092,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/SRA333195
   response:
@@ -1279,7 +1129,7 @@ interactions:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:43:28 GMT
+      - Wed, 17 May 2023 18:36:55 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -1288,68 +1138,6 @@ interactions:
       code: 200
       message: ''
 - request:
-    body: acc=SRR3098581&accept-proto=fasp&version=2.0
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '44'
-      User-Agent:
-      - python-requests/2.25.1
-    method: POST
-    uri: https://www.ncbi.nlm.nih.gov/Traces/names/names.cgi
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAAwzKMQrDIBQA0D2nEDpkSvn6rdFcopB26qZGSYtUUUsp/MM36+OdxBmGVm35OLqt
-        K4LRF81JGSVnNWtEEsDVBHzi4s7NInEB8SDEaDYPKBC1PZbRPqKzKENEO2tPRBKAru/0Y+Pee2kj
-        KzX37HNiz8ZsSvkbNhZzZX0/ILtX8H34AwAA//8DANkLet6PAAAA
-    headers:
-      Cache-Control:
-      - private
-      Connection:
-      - Keep-Alive
-      Content-Encoding:
-      - gzip
-      Content-Security-Policy:
-      - upgrade-insecure-requests
-      Content-Type:
-      - text/plain
-      Date:
-      - Wed, 28 Jul 2021 19:43:29 GMT
-      Keep-Alive:
-      - timeout=1, max=10
-      NCBI-PHID:
-      - CC95F57C101B36110000000000000001.m_1
-      NCBI-SID:
-      - CC95F57C101B3611_0000SID
-      Referrer-Policy:
-      - origin-when-cross-origin
-      Server:
-      - Apache
-      Set-Cookie:
-      - ncbi_sid=CC95F57C101B3611_0000SID; domain=.nih.gov; path=/; expires=Thu, 28
-        Jul 2022 19:43:29 GMT
-      SraNameServerOutputVersion:
-      - '2.0'
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains; preload
-      Transfer-Encoding:
-      - chunked
-      Vary:
-      - Accept-Encoding
-      X-UA-Compatible:
-      - IE=Edge
-      X-XSS-Protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
-- request:
     body: null
     headers:
       Accept:
@@ -1359,29 +1147,27 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/portal/api/filereport?accession=SRR3098581&result=read_run
   response:
     body:
-      string: "run_accession\tfastq_ftp\tfastq_bytes\tfastq_md5\tsubmitted_ftp\tsubmitted_bytes\tsubmitted_md5\tsra_ftp\tsra_bytes\tsra_md5\nSRR3098581\tftp.sra.ebi.ac.uk/vol1/fastq/SRR309/001/SRR3098581/SRR3098581_1.fastq.gz;ftp.sra.ebi.ac.uk/vol1/fastq/SRR309/001/SRR3098581/SRR3098581_2.fastq.gz\t4144635913;4104985160\t08aeda9f65037f4ad5f509b7292fac64;2a49ff5629ed4f535f53bbec56cacac1\t\t\t\t\t\t\n"
+      string: "run_accession\tfastq_ftp\tfastq_bytes\tfastq_md5\tbam_ftp\tbam_bytes\tbam_md5\tsubmitted_ftp\tsubmitted_bytes\tsubmitted_md5\tsra_ftp\tsra_bytes\tsra_md5\nSRR3098581\tftp.sra.ebi.ac.uk/vol1/fastq/SRR309/001/SRR3098581/SRR3098581_1.fastq.gz;ftp.sra.ebi.ac.uk/vol1/fastq/SRR309/001/SRR3098581/SRR3098581_2.fastq.gz\t4144635913;4104985160\t08aeda9f65037f4ad5f509b7292fac64;2a49ff5629ed4f535f53bbec56cacac1\t\t\t\t\t\t\tftp.sra.ebi.ac.uk/vol1/srr/SRR309/001/SRR3098581\t6964767833\t33f9dc032338a83398cf3ba34ef3a78c\n"
     headers:
       Cache-Control:
       - no-cache, no-store, max-age=0, must-revalidate
+      Content-Length:
+      - '486'
       Content-Type:
       - text/plain
       Date:
-      - Wed, 28 Jul 2021 19:43:29 GMT
+      - Wed, 17 May 2023 18:36:56 GMT
       Expires:
       - '0'
       Pragma:
       - no-cache
-      Server:
-      - Apache-Coyote/1.1
       Strict-Transport-Security:
       - max-age=0
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Frame-Options:
@@ -1390,7 +1176,7 @@ interactions:
       - 1; mode=block
     status:
       code: 200
-      message: OK
+      message: ''
 - request:
     body: null
     headers:
@@ -1401,7 +1187,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/SRR3098582
   response:
@@ -1445,7 +1231,7 @@ interactions:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:43:30 GMT
+      - Wed, 17 May 2023 18:36:56 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -1463,7 +1249,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/SRX1528549
   response:
@@ -1511,7 +1297,7 @@ interactions:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:43:30 GMT
+      - Wed, 17 May 2023 18:36:57 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -1529,52 +1315,44 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/SRS1246175
   response:
     body:
       string: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<SAMPLE_SET>\n<SAMPLE accession=\"SRS1246175\"
-        alias=\"GSM2037741\" broker_name=\"NCBI\">\n     <IDENTIFIERS>\n          <PRIMARY_ID>SRS1246175</PRIMARY_ID>\n
+        alias=\"GSM2037741\" center_name=\"Michael Pack, Medicine/DIgestive Diseases,
+        University of Pennsylvania\" broker_name=\"NCBI\">\n     <IDENTIFIERS>\n          <PRIMARY_ID>SRS1246175</PRIMARY_ID>\n
         \         <EXTERNAL_ID namespace=\"BioSample\">SAMN04397508</EXTERNAL_ID>\n
-        \         <EXTERNAL_ID namespace=\"GEO\">GSM2037741</EXTERNAL_ID>\n          <SUBMITTER_ID
-        namespace=\"\">GSM2037741</SUBMITTER_ID>\n     </IDENTIFIERS>\n     <TITLE>Biliatresone
-        2</TITLE>\n     <SAMPLE_NAME>\n          <TAXON_ID>7955</TAXON_ID>\n          <SCIENTIFIC_NAME>Danio
-        rerio</SCIENTIFIC_NAME>\n          <COMMON_NAME>zebrafish</COMMON_NAME>\n
-        \    </SAMPLE_NAME>\n     <SAMPLE_LINKS>\n          <SAMPLE_LINK>\n               <XREF_LINK>\n
-        \                   <DB>ENA-STUDY</DB>\n                    <ID>SRP068364</ID>\n
-        \              </XREF_LINK>\n          </SAMPLE_LINK>\n          <SAMPLE_LINK>\n
-        \              <XREF_LINK>\n                    <DB>ENA-EXPERIMENT</DB>\n
-        \                   <ID>SRX1528549</ID>\n               </XREF_LINK>\n          </SAMPLE_LINK>\n
-        \         <SAMPLE_LINK>\n               <XREF_LINK>\n                    <DB>ENA-RUN</DB>\n
-        \                   <ID>SRR3098582</ID>\n               </XREF_LINK>\n          </SAMPLE_LINK>\n
-        \         <SAMPLE_LINK>\n               <XREF_LINK>\n                    <DB>ENA-SUBMISSION</DB>\n
-        \                   <ID>SRA333195</ID>\n               </XREF_LINK>\n          </SAMPLE_LINK>\n
-        \         <SAMPLE_LINK>\n               <XREF_LINK>\n                    <DB>ARRAYEXPRESS</DB>\n
-        \                   <ID>E-GEOD-76780</ID>\n               </XREF_LINK>\n          </SAMPLE_LINK>\n
-        \         <SAMPLE_LINK>\n               <XREF_LINK>\n                    <DB>ENA-FASTQ-FILES</DB>\n
-        \                   <ID><![CDATA[https://www.ebi.ac.uk/ena/portal/api/filereport?accession=SRS1246175&result=read_run&fields=run_accession,fastq_ftp,fastq_md5,fastq_bytes]]></ID>\n
-        \              </XREF_LINK>\n          </SAMPLE_LINK>\n          <SAMPLE_LINK>\n
-        \              <XREF_LINK>\n                    <DB>ENA-SUBMITTED-FILES</DB>\n
-        \                   <ID><![CDATA[https://www.ebi.ac.uk/ena/portal/api/filereport?accession=SRS1246175&result=read_run&fields=run_accession,submitted_ftp,submitted_md5,submitted_bytes,submitted_format]]></ID>\n
-        \              </XREF_LINK>\n          </SAMPLE_LINK>\n     </SAMPLE_LINKS>\n
-        \    <SAMPLE_ATTRIBUTES>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>source_name</TAG>\n
-        \              <VALUE>liver</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
-        \              <TAG>tissue</TAG>\n               <VALUE>liver</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
+        \         <SUBMITTER_ID namespace=\"Michael Pack, Medicine/DIgestive Diseases,
+        University of Pennsylvania\">GSM2037741</SUBMITTER_ID>\n     </IDENTIFIERS>\n
+        \    <TITLE>Biliatresone 2</TITLE>\n     <SAMPLE_NAME>\n          <TAXON_ID>7955</TAXON_ID>\n
+        \         <SCIENTIFIC_NAME>Danio rerio</SCIENTIFIC_NAME>\n          <COMMON_NAME>zebrafish</COMMON_NAME>\n
+        \    </SAMPLE_NAME>\n     <SAMPLE_LINKS>\n    <SAMPLE_LINK>\n        <XREF_LINK>\n
+        \           <DB>ENA-FASTQ-FILES</DB>\n            <ID><![CDATA[https://www.ebi.ac.uk/ena/portal/api/filereport?accession=SRS1246175&result=read_run&fields=run_accession,fastq_ftp,fastq_md5,fastq_bytes]]></ID>\n
+        \       </XREF_LINK>\n    </SAMPLE_LINK>\n    <SAMPLE_LINK>\n        <XREF_LINK>\n
+        \           <DB>ENA-SUBMITTED-FILES</DB>\n            <ID><![CDATA[https://www.ebi.ac.uk/ena/portal/api/filereport?accession=SRS1246175&result=read_run&fields=run_accession,submitted_ftp,submitted_md5,submitted_bytes,submitted_format]]></ID>\n
+        \       </XREF_LINK>\n    </SAMPLE_LINK>\n</SAMPLE_LINKS>\n<SAMPLE_ATTRIBUTES>\n
         \         <SAMPLE_ATTRIBUTE>\n               <TAG>treatment</TAG>\n               <VALUE>Biliatresone</VALUE>\n
-        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-SPOT-COUNT</TAG>\n
-        \              <VALUE>59107344</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
-        \              <TAG>ENA-BASE-COUNT</TAG>\n               <VALUE>11821468800</VALUE>\n
-        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-FIRST-PUBLIC</TAG>\n
-        \              <VALUE>2017-11-07</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
-        \         <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-LAST-UPDATE</TAG>\n
-        \              <VALUE>2017-11-07</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
+        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>INSDC
+        secondary accession</TAG>\n               <VALUE>SRS1246175</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
+        \         <SAMPLE_ATTRIBUTE>\n               <TAG>NCBI submission package</TAG>\n
+        \              <VALUE>Generic.1.0</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
+        \         <SAMPLE_ATTRIBUTE>\n               <TAG>organism</TAG>\n               <VALUE>Danio
+        rerio</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
+        \              <TAG>tissue</TAG>\n               <VALUE>liver</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
+        \         <SAMPLE_ATTRIBUTE>\n               <TAG>source_name</TAG>\n               <VALUE>liver</VALUE>\n
+        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>BioSampleModel</TAG>\n
+        \              <VALUE>Generic</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
+        \              <TAG>ENA-FIRST-PUBLIC</TAG>\n               <VALUE>2017-08-24</VALUE>\n
+        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-LAST-UPDATE</TAG>\n
+        \              <VALUE>2017-08-24</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
         \    </SAMPLE_ATTRIBUTES>\n</SAMPLE>\n</SAMPLE_SET>\n"
     headers:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:43:31 GMT
+      - Wed, 17 May 2023 18:36:57 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -1592,7 +1370,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/SRP068364
   response:
@@ -1640,7 +1418,7 @@ interactions:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:43:31 GMT
+      - Wed, 17 May 2023 18:36:57 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -1658,7 +1436,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/SRA333195
   response:
@@ -1695,7 +1473,7 @@ interactions:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:43:32 GMT
+      - Wed, 17 May 2023 18:36:58 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -1704,68 +1482,6 @@ interactions:
       code: 200
       message: ''
 - request:
-    body: acc=SRR3098582&accept-proto=fasp&version=2.0
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '44'
-      User-Agent:
-      - python-requests/2.25.1
-    method: POST
-    uri: https://www.ncbi.nlm.nih.gov/Traces/names/names.cgi
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAAwzISwrCMBAA0H1PEXDRVWVmMk2aXkKortxl+qFKMKWNiDCH17d8JzpDdexxe4te
-        h8FC6NqO1FtCJm47qwToGsAG6YahZ9sD3nWxjp2bPEVxwi3K7CcMwhJ9YIxWVRlAL6/0NfVaynbU
-        ZttzyWNO5nGYmFL+zJNZ8m7K+o8sz3ks1Q8AAP//AwAvJGGEjwAAAA==
-    headers:
-      Cache-Control:
-      - private
-      Connection:
-      - Keep-Alive
-      Content-Encoding:
-      - gzip
-      Content-Security-Policy:
-      - upgrade-insecure-requests
-      Content-Type:
-      - text/plain
-      Date:
-      - Wed, 28 Jul 2021 19:43:33 GMT
-      Keep-Alive:
-      - timeout=1, max=10
-      NCBI-PHID:
-      - C7A4234C101B36510000000000000001.m_1
-      NCBI-SID:
-      - C7A4234C101B3651_0000SID
-      Referrer-Policy:
-      - origin-when-cross-origin
-      Server:
-      - Apache
-      Set-Cookie:
-      - ncbi_sid=C7A4234C101B3651_0000SID; domain=.nih.gov; path=/; expires=Thu, 28
-        Jul 2022 19:43:33 GMT
-      SraNameServerOutputVersion:
-      - '2.0'
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains; preload
-      Transfer-Encoding:
-      - chunked
-      Vary:
-      - Accept-Encoding
-      X-UA-Compatible:
-      - IE=Edge
-      X-XSS-Protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
-- request:
     body: null
     headers:
       Accept:
@@ -1775,29 +1491,27 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/portal/api/filereport?accession=SRR3098582&result=read_run
   response:
     body:
-      string: "run_accession\tfastq_ftp\tfastq_bytes\tfastq_md5\tsubmitted_ftp\tsubmitted_bytes\tsubmitted_md5\tsra_ftp\tsra_bytes\tsra_md5\nSRR3098582\tftp.sra.ebi.ac.uk/vol1/fastq/SRR309/002/SRR3098582/SRR3098582_1.fastq.gz;ftp.sra.ebi.ac.uk/vol1/fastq/SRR309/002/SRR3098582/SRR3098582_2.fastq.gz\t4316824267;4279937658\tf6c81ae89ce3d6da48175926d4503547;6315f2371bc413220feb23c1ac030c46\t\t\t\t\t\t\n"
+      string: "run_accession\tfastq_ftp\tfastq_bytes\tfastq_md5\tbam_ftp\tbam_bytes\tbam_md5\tsubmitted_ftp\tsubmitted_bytes\tsubmitted_md5\tsra_ftp\tsra_bytes\tsra_md5\nSRR3098582\tftp.sra.ebi.ac.uk/vol1/fastq/SRR309/002/SRR3098582/SRR3098582_1.fastq.gz;ftp.sra.ebi.ac.uk/vol1/fastq/SRR309/002/SRR3098582/SRR3098582_2.fastq.gz\t4316824267;4279937658\tf6c81ae89ce3d6da48175926d4503547;6315f2371bc413220feb23c1ac030c46\t\t\t\t\t\t\tftp.sra.ebi.ac.uk/vol1/srr/SRR309/002/SRR3098582\t7321424583\tf36466d72ab6b451be7d19b4ba7941a3\n"
     headers:
       Cache-Control:
       - no-cache, no-store, max-age=0, must-revalidate
+      Content-Length:
+      - '486'
       Content-Type:
       - text/plain
       Date:
-      - Wed, 28 Jul 2021 19:43:33 GMT
+      - Wed, 17 May 2023 18:36:58 GMT
       Expires:
       - '0'
       Pragma:
       - no-cache
-      Server:
-      - Apache-Coyote/1.1
       Strict-Transport-Security:
       - max-age=0
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Frame-Options:
@@ -1806,7 +1520,7 @@ interactions:
       - 1; mode=block
     status:
       code: 200
-      message: OK
+      message: ''
 - request:
     body: null
     headers:
@@ -1817,7 +1531,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/SRP111553
   response:
@@ -1865,7 +1579,7 @@ interactions:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:43:35 GMT
+      - Wed, 17 May 2023 18:36:59 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -1883,7 +1597,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/SRR5818004
   response:
@@ -1924,7 +1638,7 @@ interactions:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:43:35 GMT
+      - Wed, 17 May 2023 18:36:59 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -1942,7 +1656,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/SRX2996258
   response:
@@ -1999,7 +1713,7 @@ interactions:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:43:36 GMT
+      - Wed, 17 May 2023 18:37:00 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -2017,54 +1731,40 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/SRS2347490
   response:
     body:
       string: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<SAMPLE_SET>\n<SAMPLE accession=\"SRS2347490\"
-        alias=\"GSM2700326\" broker_name=\"NCBI\">\n     <IDENTIFIERS>\n          <PRIMARY_ID>SRS2347490</PRIMARY_ID>\n
-        \         <EXTERNAL_ID namespace=\"BioSample\">SAMN07343034</EXTERNAL_ID>\n
-        \         <EXTERNAL_ID namespace=\"GEO\">GSM2700326</EXTERNAL_ID>\n          <SUBMITTER_ID
-        namespace=\"\">GSM2700326</SUBMITTER_ID>\n     </IDENTIFIERS>\n     <TITLE>wt1aGFP_1_neg</TITLE>\n
-        \    <SAMPLE_NAME>\n          <TAXON_ID>7955</TAXON_ID>\n          <SCIENTIFIC_NAME>Danio
-        rerio</SCIENTIFIC_NAME>\n          <COMMON_NAME>zebrafish</COMMON_NAME>\n
-        \    </SAMPLE_NAME>\n     <SAMPLE_LINKS>\n          <SAMPLE_LINK>\n               <XREF_LINK>\n
-        \                   <DB>ENA-STUDY</DB>\n                    <ID>SRP111553</ID>\n
-        \              </XREF_LINK>\n          </SAMPLE_LINK>\n          <SAMPLE_LINK>\n
-        \              <XREF_LINK>\n                    <DB>ENA-EXPERIMENT</DB>\n
-        \                   <ID>SRX2996258</ID>\n               </XREF_LINK>\n          </SAMPLE_LINK>\n
-        \         <SAMPLE_LINK>\n               <XREF_LINK>\n                    <DB>ENA-RUN</DB>\n
-        \                   <ID>SRR5818004-SRR5818005</ID>\n               </XREF_LINK>\n
-        \         </SAMPLE_LINK>\n          <SAMPLE_LINK>\n               <XREF_LINK>\n
-        \                   <DB>ENA-SUBMISSION</DB>\n                    <ID>SRA585736</ID>\n
-        \              </XREF_LINK>\n          </SAMPLE_LINK>\n          <SAMPLE_LINK>\n
-        \              <XREF_LINK>\n                    <DB>ARRAYEXPRESS</DB>\n                    <ID>E-GEOD-101204</ID>\n
-        \              </XREF_LINK>\n          </SAMPLE_LINK>\n          <SAMPLE_LINK>\n
-        \              <XREF_LINK>\n                    <DB>ENA-FASTQ-FILES</DB>\n
-        \                   <ID><![CDATA[https://www.ebi.ac.uk/ena/portal/api/filereport?accession=SRS2347490&result=read_run&fields=run_accession,fastq_ftp,fastq_md5,fastq_bytes]]></ID>\n
-        \              </XREF_LINK>\n          </SAMPLE_LINK>\n          <SAMPLE_LINK>\n
-        \              <XREF_LINK>\n                    <DB>ENA-SUBMITTED-FILES</DB>\n
-        \                   <ID><![CDATA[https://www.ebi.ac.uk/ena/portal/api/filereport?accession=SRS2347490&result=read_run&fields=run_accession,submitted_ftp,submitted_md5,submitted_bytes,submitted_format]]></ID>\n
-        \              </XREF_LINK>\n          </SAMPLE_LINK>\n     </SAMPLE_LINKS>\n
-        \    <SAMPLE_ATTRIBUTES>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>source_name</TAG>\n
+        alias=\"GSM2700326\" center_name=\"Bioinformatics Unit, CNIC\" broker_name=\"NCBI\">\n
+        \    <IDENTIFIERS>\n          <PRIMARY_ID>SRS2347490</PRIMARY_ID>\n          <EXTERNAL_ID
+        namespace=\"BioSample\">SAMN07343034</EXTERNAL_ID>\n          <SUBMITTER_ID
+        namespace=\"Bioinformatics Unit, CNIC\">GSM2700326</SUBMITTER_ID>\n     </IDENTIFIERS>\n
+        \    <TITLE>wt1aGFP_1_neg</TITLE>\n     <SAMPLE_NAME>\n          <TAXON_ID>7955</TAXON_ID>\n
+        \         <SCIENTIFIC_NAME>Danio rerio</SCIENTIFIC_NAME>\n          <COMMON_NAME>zebrafish</COMMON_NAME>\n
+        \    </SAMPLE_NAME>\n     <SAMPLE_LINKS>\n    <SAMPLE_LINK>\n        <XREF_LINK>\n
+        \           <DB>ENA-FASTQ-FILES</DB>\n            <ID><![CDATA[https://www.ebi.ac.uk/ena/portal/api/filereport?accession=SRS2347490&result=read_run&fields=run_accession,fastq_ftp,fastq_md5,fastq_bytes]]></ID>\n
+        \       </XREF_LINK>\n    </SAMPLE_LINK>\n    <SAMPLE_LINK>\n        <XREF_LINK>\n
+        \           <DB>ENA-SUBMITTED-FILES</DB>\n            <ID><![CDATA[https://www.ebi.ac.uk/ena/portal/api/filereport?accession=SRS2347490&result=read_run&fields=run_accession,submitted_ftp,submitted_md5,submitted_bytes,submitted_format]]></ID>\n
+        \       </XREF_LINK>\n    </SAMPLE_LINK>\n</SAMPLE_LINKS>\n<SAMPLE_ATTRIBUTES>\n
+        \         <SAMPLE_ATTRIBUTE>\n               <TAG>INSDC secondary accession</TAG>\n
+        \              <VALUE>SRS2347490</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
+        \         <SAMPLE_ATTRIBUTE>\n               <TAG>organism</TAG>\n               <VALUE>Danio
+        rerio</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
+        \              <TAG>pool</TAG>\n               <VALUE>1</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
+        \         <SAMPLE_ATTRIBUTE>\n               <TAG>cell type</TAG>\n               <VALUE>wt1a-</VALUE>\n
+        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>source_name</TAG>\n
         \              <VALUE>Heart</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
-        \              <TAG>cell type</TAG>\n               <VALUE>wt1a-</VALUE>\n
-        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>pool</TAG>\n
-        \              <VALUE>1</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
-        \              <TAG>ENA-SPOT-COUNT</TAG>\n               <VALUE>27406051</VALUE>\n
-        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-BASE-COUNT</TAG>\n
-        \              <VALUE>1671769111</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
-        \         <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-FIRST-PUBLIC</TAG>\n
-        \              <VALUE>2018-03-23</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
-        \         <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-LAST-UPDATE</TAG>\n
-        \              <VALUE>2018-04-04</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
+        \              <TAG>BioSampleModel</TAG>\n               <VALUE>Generic</VALUE>\n
+        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-FIRST-PUBLIC</TAG>\n
+        \              <VALUE>2018-03-22</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
         \    </SAMPLE_ATTRIBUTES>\n</SAMPLE>\n</SAMPLE_SET>\n"
     headers:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:43:36 GMT
+      - Wed, 17 May 2023 18:37:01 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -2082,7 +1782,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/SRP111553
   response:
@@ -2130,7 +1830,7 @@ interactions:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:43:37 GMT
+      - Wed, 17 May 2023 18:37:01 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -2148,7 +1848,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/SRA585736
   response:
@@ -2185,7 +1885,7 @@ interactions:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:43:37 GMT
+      - Wed, 17 May 2023 18:37:01 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -2193,68 +1893,6 @@ interactions:
     status:
       code: 200
       message: ''
-- request:
-    body: acc=SRR5818004&accept-proto=fasp&version=2.0
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '44'
-      User-Agent:
-      - python-requests/2.25.1
-    method: POST
-    uri: https://www.ncbi.nlm.nih.gov/Traces/names/names.cgi
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAAwzIwQrCMAwA0LtfUfCw0yRpujbbTwjTk7etpkwpdmwVEfLx+o7vaE9w2Ldpfc96
-        GceOkQGcOnbk2WNQCxhaCC3i1eJANHTupiQTkRXqepBkk8TeSWASbz3HxKiqDkDPr/w1zVLrujdm
-        3UotsWTz2M2Uc/nI3aSymbr8o8xPifXwAwAA//8DAAZ0mZuOAAAA
-    headers:
-      Cache-Control:
-      - private
-      Connection:
-      - Keep-Alive
-      Content-Encoding:
-      - gzip
-      Content-Security-Policy:
-      - upgrade-insecure-requests
-      Content-Type:
-      - text/plain
-      Date:
-      - Wed, 28 Jul 2021 19:43:38 GMT
-      Keep-Alive:
-      - timeout=1, max=10
-      NCBI-PHID:
-      - CC95F5C2101B36A10000000000000001.m_1
-      NCBI-SID:
-      - CC95F5C2101B36A1_0000SID
-      Referrer-Policy:
-      - origin-when-cross-origin
-      Server:
-      - Apache
-      Set-Cookie:
-      - ncbi_sid=CC95F5C2101B36A1_0000SID; domain=.nih.gov; path=/; expires=Thu, 28
-        Jul 2022 19:43:38 GMT
-      SraNameServerOutputVersion:
-      - '2.0'
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains; preload
-      Transfer-Encoding:
-      - chunked
-      Vary:
-      - Accept-Encoding
-      X-UA-Compatible:
-      - IE=Edge
-      X-XSS-Protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
 - request:
     body: null
     headers:
@@ -2265,7 +1903,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://eutils.ncbi.nlm.nih.gov/entrez/eutils/esummary.fcgi?db=pubmed&id=29610343&retmode=json&tool=refinebio&email=hello@refine.bio
   response:
@@ -2275,19 +1913,19 @@ interactions:
         unBhd+G/5P/OgLWkSjLmA/p9KzFH6bqmId5jhO+SnbImiMlZhh8RcjC1n8KdqhzmL7i6vkiT7DzD
         1+jn/e2H2qxE2HZvFflpYJWkV1C0DOll0OUfxiroznYsJvWJrYBH8hoKQRWUQsEzlFCEDHW+tjxx
         DGiomdLleDCiln18z2R6C3en2Om44tgImtCd85KPlOGyuX9LmrhS8ZqcV1oTbBZ+UIbZeGNZ7sZP
-        M1P+e96afjzowL+1juBh6fraOk+wXdi6YeP8YtaSlOmhklDsAumv8hcAAAD//7RW32/TMBB+56+w
-        +t7VbtMmLU8TTAK0VpMACWniwXGc1uDYxbErGNr/zp2dNunY0PaAVKnx5b77/Z3zHPA1N1tOvrwQ
-        tZZO4LiSzbOAMJMa+pjG5CHcK68R+wkGpVXSeFKr0tlWtQTG3OqDbMlB8SQt0Q5RhguvDtwDKeBA
-        /E6C7lYa6UBmtuROlo7Xqt0RoJXzF3GOnT+68v/PFbLV6hCrxNgcjqptQzwtkH18K4Eno4wVxThj
-        S2SkhhYghSX8QaWMboJRP4KMxcvndF7ki2QnbgA6zcdFNs2Qs0nE6JKNF9mSJnqnXtyOPgBzDQe6
-        Oq8E5P0V94awroJO+IBR3IRyLSsyhsQq+ROeauvI+urt9fvNVbJ1Up3OMQaeTKWd83ukqq7voNnI
-        CoOMEgiKQR24jomflg8OUA9Raqif9fosZ4uczbB6Z4jKniFmAwS9YDSfTfaGtxdPwfeNGMKLHn6z
-        fjNfMlpM83MEju/jiMdTki/Uh4jOEfMeAe/GqlqRPrbXkUc71XoLlwKWf9ifUwcGO3xCM/gRulhR
-        Gj0PAaCtlZEPEcVkRp9AAF+cvPuXizhhtXTSCJzyWzhz750qg4/n0Tvekkuw6IBUOI+QJQCEDQYu
-        swxmpg5af0tz260avHakrIBqLbF15N8mspGni0g2v1AO11H0etT5bJSHgf4IwSfhZQPrSHBkjbYi
-        WogEg6lakacGCHK1ouuWUD6icJc4IazBxDS0IyVaWvv9uF9ABcqrQpOe4dGn6zuRCkA76Y5RPBB3
-        aScvXaVHWNc9LDATmhI/ElDCD1xpXmpZO9sEp5P0aBXeyE4EKfwVLch62xh671bs+N4fneDWPP8w
-        wI6znFCKHU8KtXKD5f7YzX/AvETQuD+6Et3f37/6AwAA//8DAA15bML2CAAA
+        M1P+e96afjzowL+1juBh6fraOk+wXdi6YeP8YtaSlOmhklDsAumv8hcAAAD//7RV32/TMBB+56+w
+        +t7NbtMmLU8TTAK0VpNgEtLEg+M4rcGxh2NXMLT/nTs7adKNofGANGnx9b77/d29BHzFzY6Tz/+I
+        2kgncFzJ9kVAmEkNfUxj8hjuldeI/QSD0ippPKlV6WyrWgJjbvVBtuSgeJKWaIcow4VXB+6BFPAg
+        fi9BdyeNdCAzO3IvS8dr1e4J0Mr5szjHzveu/P9zhWy1OsQqMbaAp2rbEF9LZB/fSeDJJGNFMc3Y
+        ChmpoQVIYQn/oFJGN8Go70HG4uULuijyZbITNwCd5dMim2XI2SRidMWmy2xFE71TL24nH4C5hgNd
+        nVcC8v6Ce0NYV0EnfMAorkO5kRWZQmKV/AFftXVkc/n26v32Mtk6qs4WGANPptLO+TVRVdd30Gxk
+        hUFGCQTFoA5cx8SPywcHaIA0YqxfDPrXmzeLFaPFLH+CUCc+FgMGfpuqak0G7OtTcGXVGDofoIye
+        MZrPz+8Mb89YzpY5m2PnTn2rE3g2go8QUOG9ar2FpY3lGdfvWKHRjj2nGfwRulxTGt2NAaCtlZGP
+        EcX5nD6DgHl28v5vLuIE1NJJI3AKb+HNvXeqDD6+J+94Sy7AooOhx3mBsgJA2GDg2GRQtDpo/TXN
+        VbcK8CxIWQEVWmLryI9tZAtPh0I2P1EO5yJ67XVujPIwcB8h+CS8aGBdCI5Tra2IFiIBoHFr8lyP
+        IFcruhYJ5SMKue6EsAYT09COlGhp7bee/6AC5VWhSd/w6dN5TUMPoL10fRSPxF3ayUtX6QnW9Q4W
+        jAlNiUccJfzAleallrWzTXA6SXur8IvsRJDCk2hBNtjG0Ae3Ys/vfO8Et9rp4caOs5xQih1PCrVy
+        o+X7p8t8wLxE0MjvrkQPDw+vfgMAAP//AwCCvIZklggAAA==
     headers:
       Access-Control-Allow-Origin:
       - '*'
@@ -2302,18 +1940,20 @@ interactions:
       Content-Type:
       - application/json; charset=UTF-8
       Date:
-      - Wed, 28 Jul 2021 19:43:37 GMT
+      - Wed, 17 May 2023 18:37:01 GMT
       Keep-Alive:
       - timeout=4, max=40
       NCBI-PHID:
-      - 322C6078A1DD388500003FF99EA4C4D3.1.1.m_1
+      - 322C36E9C9D0D90500004709F0669592.1.1.m_1
       NCBI-SID:
-      - D07104C48ED79493_9AA1SID
+      - 15A7E4A692BBC304_4B15SID
+      Referrer-Policy:
+      - origin-when-cross-origin
       Server:
       - Finatra
       Set-Cookie:
-      - ncbi_sid=D07104C48ED79493_9AA1SID; domain=.nih.gov; path=/; expires=Thu, 28
-        Jul 2022 19:43:38 GMT
+      - ncbi_sid=15A7E4A692BBC304_4B15SID; domain=.nih.gov; path=/; expires=Fri, 17
+        May 2024 18:37:02 GMT
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains; preload
       Transfer-Encoding:
@@ -2341,29 +1981,27 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/portal/api/filereport?accession=SRR5818004&result=read_run
   response:
     body:
-      string: "run_accession\tfastq_ftp\tfastq_bytes\tfastq_md5\tsubmitted_ftp\tsubmitted_bytes\tsubmitted_md5\tsra_ftp\tsra_bytes\tsra_md5\nSRR5818004\tftp.sra.ebi.ac.uk/vol1/fastq/SRR581/004/SRR5818004/SRR5818004.fastq.gz\t672369314\tff777268831b4ce053e1320f3bd0994a\t\t\t\t\t\t\n"
+      string: "run_accession\tfastq_ftp\tfastq_bytes\tfastq_md5\tbam_ftp\tbam_bytes\tbam_md5\tsubmitted_ftp\tsubmitted_bytes\tsubmitted_md5\tsra_ftp\tsra_bytes\tsra_md5\nSRR5818004\tftp.sra.ebi.ac.uk/vol1/fastq/SRR581/004/SRR5818004/SRR5818004.fastq.gz\t672369314\tff777268831b4ce053e1320f3bd0994a\t\t\t\t\t\t\tftp.sra.ebi.ac.uk/vol1/srr/SRR581/004/SRR5818004\t484368617\t3ea332e3590ef2fec94e783e6268cf81\n"
     headers:
       Cache-Control:
       - no-cache, no-store, max-age=0, must-revalidate
+      Content-Length:
+      - '365'
       Content-Type:
       - text/plain
       Date:
-      - Wed, 28 Jul 2021 19:43:38 GMT
+      - Wed, 17 May 2023 18:37:02 GMT
       Expires:
       - '0'
       Pragma:
       - no-cache
-      Server:
-      - Apache-Coyote/1.1
       Strict-Transport-Security:
       - max-age=0
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Frame-Options:
@@ -2372,7 +2010,7 @@ interactions:
       - 1; mode=block
     status:
       code: 200
-      message: OK
+      message: ''
 - request:
     body: null
     headers:
@@ -2383,7 +2021,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/SRR5818005
   response:
@@ -2424,7 +2062,7 @@ interactions:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:43:40 GMT
+      - Wed, 17 May 2023 18:37:02 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -2442,7 +2080,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/SRX2996258
   response:
@@ -2499,7 +2137,7 @@ interactions:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:43:40 GMT
+      - Wed, 17 May 2023 18:37:02 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -2517,54 +2155,40 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/SRS2347490
   response:
     body:
       string: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<SAMPLE_SET>\n<SAMPLE accession=\"SRS2347490\"
-        alias=\"GSM2700326\" broker_name=\"NCBI\">\n     <IDENTIFIERS>\n          <PRIMARY_ID>SRS2347490</PRIMARY_ID>\n
-        \         <EXTERNAL_ID namespace=\"BioSample\">SAMN07343034</EXTERNAL_ID>\n
-        \         <EXTERNAL_ID namespace=\"GEO\">GSM2700326</EXTERNAL_ID>\n          <SUBMITTER_ID
-        namespace=\"\">GSM2700326</SUBMITTER_ID>\n     </IDENTIFIERS>\n     <TITLE>wt1aGFP_1_neg</TITLE>\n
-        \    <SAMPLE_NAME>\n          <TAXON_ID>7955</TAXON_ID>\n          <SCIENTIFIC_NAME>Danio
-        rerio</SCIENTIFIC_NAME>\n          <COMMON_NAME>zebrafish</COMMON_NAME>\n
-        \    </SAMPLE_NAME>\n     <SAMPLE_LINKS>\n          <SAMPLE_LINK>\n               <XREF_LINK>\n
-        \                   <DB>ENA-STUDY</DB>\n                    <ID>SRP111553</ID>\n
-        \              </XREF_LINK>\n          </SAMPLE_LINK>\n          <SAMPLE_LINK>\n
-        \              <XREF_LINK>\n                    <DB>ENA-EXPERIMENT</DB>\n
-        \                   <ID>SRX2996258</ID>\n               </XREF_LINK>\n          </SAMPLE_LINK>\n
-        \         <SAMPLE_LINK>\n               <XREF_LINK>\n                    <DB>ENA-RUN</DB>\n
-        \                   <ID>SRR5818004-SRR5818005</ID>\n               </XREF_LINK>\n
-        \         </SAMPLE_LINK>\n          <SAMPLE_LINK>\n               <XREF_LINK>\n
-        \                   <DB>ENA-SUBMISSION</DB>\n                    <ID>SRA585736</ID>\n
-        \              </XREF_LINK>\n          </SAMPLE_LINK>\n          <SAMPLE_LINK>\n
-        \              <XREF_LINK>\n                    <DB>ARRAYEXPRESS</DB>\n                    <ID>E-GEOD-101204</ID>\n
-        \              </XREF_LINK>\n          </SAMPLE_LINK>\n          <SAMPLE_LINK>\n
-        \              <XREF_LINK>\n                    <DB>ENA-FASTQ-FILES</DB>\n
-        \                   <ID><![CDATA[https://www.ebi.ac.uk/ena/portal/api/filereport?accession=SRS2347490&result=read_run&fields=run_accession,fastq_ftp,fastq_md5,fastq_bytes]]></ID>\n
-        \              </XREF_LINK>\n          </SAMPLE_LINK>\n          <SAMPLE_LINK>\n
-        \              <XREF_LINK>\n                    <DB>ENA-SUBMITTED-FILES</DB>\n
-        \                   <ID><![CDATA[https://www.ebi.ac.uk/ena/portal/api/filereport?accession=SRS2347490&result=read_run&fields=run_accession,submitted_ftp,submitted_md5,submitted_bytes,submitted_format]]></ID>\n
-        \              </XREF_LINK>\n          </SAMPLE_LINK>\n     </SAMPLE_LINKS>\n
-        \    <SAMPLE_ATTRIBUTES>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>source_name</TAG>\n
+        alias=\"GSM2700326\" center_name=\"Bioinformatics Unit, CNIC\" broker_name=\"NCBI\">\n
+        \    <IDENTIFIERS>\n          <PRIMARY_ID>SRS2347490</PRIMARY_ID>\n          <EXTERNAL_ID
+        namespace=\"BioSample\">SAMN07343034</EXTERNAL_ID>\n          <SUBMITTER_ID
+        namespace=\"Bioinformatics Unit, CNIC\">GSM2700326</SUBMITTER_ID>\n     </IDENTIFIERS>\n
+        \    <TITLE>wt1aGFP_1_neg</TITLE>\n     <SAMPLE_NAME>\n          <TAXON_ID>7955</TAXON_ID>\n
+        \         <SCIENTIFIC_NAME>Danio rerio</SCIENTIFIC_NAME>\n          <COMMON_NAME>zebrafish</COMMON_NAME>\n
+        \    </SAMPLE_NAME>\n     <SAMPLE_LINKS>\n    <SAMPLE_LINK>\n        <XREF_LINK>\n
+        \           <DB>ENA-FASTQ-FILES</DB>\n            <ID><![CDATA[https://www.ebi.ac.uk/ena/portal/api/filereport?accession=SRS2347490&result=read_run&fields=run_accession,fastq_ftp,fastq_md5,fastq_bytes]]></ID>\n
+        \       </XREF_LINK>\n    </SAMPLE_LINK>\n    <SAMPLE_LINK>\n        <XREF_LINK>\n
+        \           <DB>ENA-SUBMITTED-FILES</DB>\n            <ID><![CDATA[https://www.ebi.ac.uk/ena/portal/api/filereport?accession=SRS2347490&result=read_run&fields=run_accession,submitted_ftp,submitted_md5,submitted_bytes,submitted_format]]></ID>\n
+        \       </XREF_LINK>\n    </SAMPLE_LINK>\n</SAMPLE_LINKS>\n<SAMPLE_ATTRIBUTES>\n
+        \         <SAMPLE_ATTRIBUTE>\n               <TAG>INSDC secondary accession</TAG>\n
+        \              <VALUE>SRS2347490</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
+        \         <SAMPLE_ATTRIBUTE>\n               <TAG>organism</TAG>\n               <VALUE>Danio
+        rerio</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
+        \              <TAG>pool</TAG>\n               <VALUE>1</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
+        \         <SAMPLE_ATTRIBUTE>\n               <TAG>cell type</TAG>\n               <VALUE>wt1a-</VALUE>\n
+        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>source_name</TAG>\n
         \              <VALUE>Heart</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
-        \              <TAG>cell type</TAG>\n               <VALUE>wt1a-</VALUE>\n
-        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>pool</TAG>\n
-        \              <VALUE>1</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
-        \              <TAG>ENA-SPOT-COUNT</TAG>\n               <VALUE>27406051</VALUE>\n
-        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-BASE-COUNT</TAG>\n
-        \              <VALUE>1671769111</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
-        \         <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-FIRST-PUBLIC</TAG>\n
-        \              <VALUE>2018-03-23</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
-        \         <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-LAST-UPDATE</TAG>\n
-        \              <VALUE>2018-04-04</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
+        \              <TAG>BioSampleModel</TAG>\n               <VALUE>Generic</VALUE>\n
+        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-FIRST-PUBLIC</TAG>\n
+        \              <VALUE>2018-03-22</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
         \    </SAMPLE_ATTRIBUTES>\n</SAMPLE>\n</SAMPLE_SET>\n"
     headers:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:43:41 GMT
+      - Wed, 17 May 2023 18:37:02 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -2582,7 +2206,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/SRP111553
   response:
@@ -2630,7 +2254,7 @@ interactions:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:43:41 GMT
+      - Wed, 17 May 2023 18:37:04 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -2648,7 +2272,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/SRA585736
   response:
@@ -2685,7 +2309,7 @@ interactions:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:43:42 GMT
+      - Wed, 17 May 2023 18:37:04 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -2694,68 +2318,6 @@ interactions:
       code: 200
       message: ''
 - request:
-    body: acc=SRR5818005&accept-proto=fasp&version=2.0
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '44'
-      User-Agent:
-      - python-requests/2.25.1
-    method: POST
-    uri: https://www.ncbi.nlm.nih.gov/Traces/names/names.cgi
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAAwzIsQ7CIBAA0L1fQeLQqeYOOFr6EybVyY0CTTVECMUYk/t4feM7yTN0R3XlvfJ1
-        WWjCCYBYW21IktIsAccBxgHxJnFWaiZ5Zweb8sYaG5RGEzQQxRGtCQYVBArMrAH48kpf0e+tlaMX
-        peaWfU7icQiXUv7EILZcRdv/kddn9K37AQAA//8DAIZfTJCOAAAA
-    headers:
-      Cache-Control:
-      - private
-      Connection:
-      - Keep-Alive
-      Content-Encoding:
-      - gzip
-      Content-Security-Policy:
-      - upgrade-insecure-requests
-      Content-Type:
-      - text/plain
-      Date:
-      - Wed, 28 Jul 2021 19:43:42 GMT
-      Keep-Alive:
-      - timeout=1, max=10
-      NCBI-PHID:
-      - CC95F5E4101B36E10000000000000001.m_1
-      NCBI-SID:
-      - CC95F5E4101B36E1_0000SID
-      Referrer-Policy:
-      - origin-when-cross-origin
-      Server:
-      - Apache
-      Set-Cookie:
-      - ncbi_sid=CC95F5E4101B36E1_0000SID; domain=.nih.gov; path=/; expires=Thu, 28
-        Jul 2022 19:43:42 GMT
-      SraNameServerOutputVersion:
-      - '2.0'
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains; preload
-      Transfer-Encoding:
-      - chunked
-      Vary:
-      - Accept-Encoding
-      X-UA-Compatible:
-      - IE=Edge
-      X-XSS-Protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
-- request:
     body: null
     headers:
       Accept:
@@ -2765,29 +2327,27 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/portal/api/filereport?accession=SRR5818005&result=read_run
   response:
     body:
-      string: "run_accession\tfastq_ftp\tfastq_bytes\tfastq_md5\tsubmitted_ftp\tsubmitted_bytes\tsubmitted_md5\tsra_ftp\tsra_bytes\tsra_md5\nSRR5818005\tftp.sra.ebi.ac.uk/vol1/fastq/SRR581/005/SRR5818005/SRR5818005.fastq.gz\t686245154\t5ce51c7ad9cacdab4fb9f3961373eb99\t\t\t\t\t\t\n"
+      string: "run_accession\tfastq_ftp\tfastq_bytes\tfastq_md5\tbam_ftp\tbam_bytes\tbam_md5\tsubmitted_ftp\tsubmitted_bytes\tsubmitted_md5\tsra_ftp\tsra_bytes\tsra_md5\nSRR5818005\tftp.sra.ebi.ac.uk/vol1/fastq/SRR581/005/SRR5818005/SRR5818005.fastq.gz\t686245154\t5ce51c7ad9cacdab4fb9f3961373eb99\t\t\t\t\t\t\tftp.sra.ebi.ac.uk/vol1/srr/SRR581/005/SRR5818005\t494652534\ta0f3c6969d3416d4055e7196d6130d5d\n"
     headers:
       Cache-Control:
       - no-cache, no-store, max-age=0, must-revalidate
+      Content-Length:
+      - '365'
       Content-Type:
       - text/plain
       Date:
-      - Wed, 28 Jul 2021 19:43:43 GMT
+      - Wed, 17 May 2023 18:37:05 GMT
       Expires:
       - '0'
       Pragma:
       - no-cache
-      Server:
-      - Apache-Coyote/1.1
       Strict-Transport-Security:
       - max-age=0
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Frame-Options:
@@ -2796,7 +2356,7 @@ interactions:
       - 1; mode=block
     status:
       code: 200
-      message: OK
+      message: ''
 - request:
     body: null
     headers:
@@ -2807,7 +2367,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/SRR5818006
   response:
@@ -2848,7 +2408,7 @@ interactions:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:43:44 GMT
+      - Wed, 17 May 2023 18:37:05 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -2866,7 +2426,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/SRX2996259
   response:
@@ -2923,7 +2483,7 @@ interactions:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:43:44 GMT
+      - Wed, 17 May 2023 18:37:05 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -2941,54 +2501,40 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/SRS2347492
   response:
     body:
       string: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<SAMPLE_SET>\n<SAMPLE accession=\"SRS2347492\"
-        alias=\"GSM2700327\" broker_name=\"NCBI\">\n     <IDENTIFIERS>\n          <PRIMARY_ID>SRS2347492</PRIMARY_ID>\n
-        \         <EXTERNAL_ID namespace=\"BioSample\">SAMN07343033</EXTERNAL_ID>\n
-        \         <EXTERNAL_ID namespace=\"GEO\">GSM2700327</EXTERNAL_ID>\n          <SUBMITTER_ID
-        namespace=\"\">GSM2700327</SUBMITTER_ID>\n     </IDENTIFIERS>\n     <TITLE>wt1aGFP_1_pos</TITLE>\n
-        \    <SAMPLE_NAME>\n          <TAXON_ID>7955</TAXON_ID>\n          <SCIENTIFIC_NAME>Danio
-        rerio</SCIENTIFIC_NAME>\n          <COMMON_NAME>zebrafish</COMMON_NAME>\n
-        \    </SAMPLE_NAME>\n     <SAMPLE_LINKS>\n          <SAMPLE_LINK>\n               <XREF_LINK>\n
-        \                   <DB>ENA-STUDY</DB>\n                    <ID>SRP111553</ID>\n
-        \              </XREF_LINK>\n          </SAMPLE_LINK>\n          <SAMPLE_LINK>\n
-        \              <XREF_LINK>\n                    <DB>ENA-EXPERIMENT</DB>\n
-        \                   <ID>SRX2996259</ID>\n               </XREF_LINK>\n          </SAMPLE_LINK>\n
-        \         <SAMPLE_LINK>\n               <XREF_LINK>\n                    <DB>ENA-RUN</DB>\n
-        \                   <ID>SRR5818006-SRR5818007</ID>\n               </XREF_LINK>\n
-        \         </SAMPLE_LINK>\n          <SAMPLE_LINK>\n               <XREF_LINK>\n
-        \                   <DB>ENA-SUBMISSION</DB>\n                    <ID>SRA585736</ID>\n
-        \              </XREF_LINK>\n          </SAMPLE_LINK>\n          <SAMPLE_LINK>\n
-        \              <XREF_LINK>\n                    <DB>ARRAYEXPRESS</DB>\n                    <ID>E-GEOD-101204</ID>\n
-        \              </XREF_LINK>\n          </SAMPLE_LINK>\n          <SAMPLE_LINK>\n
-        \              <XREF_LINK>\n                    <DB>ENA-FASTQ-FILES</DB>\n
-        \                   <ID><![CDATA[https://www.ebi.ac.uk/ena/portal/api/filereport?accession=SRS2347492&result=read_run&fields=run_accession,fastq_ftp,fastq_md5,fastq_bytes]]></ID>\n
-        \              </XREF_LINK>\n          </SAMPLE_LINK>\n          <SAMPLE_LINK>\n
-        \              <XREF_LINK>\n                    <DB>ENA-SUBMITTED-FILES</DB>\n
-        \                   <ID><![CDATA[https://www.ebi.ac.uk/ena/portal/api/filereport?accession=SRS2347492&result=read_run&fields=run_accession,submitted_ftp,submitted_md5,submitted_bytes,submitted_format]]></ID>\n
-        \              </XREF_LINK>\n          </SAMPLE_LINK>\n     </SAMPLE_LINKS>\n
-        \    <SAMPLE_ATTRIBUTES>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>source_name</TAG>\n
+        alias=\"GSM2700327\" center_name=\"Bioinformatics Unit, CNIC\" broker_name=\"NCBI\">\n
+        \    <IDENTIFIERS>\n          <PRIMARY_ID>SRS2347492</PRIMARY_ID>\n          <EXTERNAL_ID
+        namespace=\"BioSample\">SAMN07343033</EXTERNAL_ID>\n          <SUBMITTER_ID
+        namespace=\"Bioinformatics Unit, CNIC\">GSM2700327</SUBMITTER_ID>\n     </IDENTIFIERS>\n
+        \    <TITLE>wt1aGFP_1_pos</TITLE>\n     <SAMPLE_NAME>\n          <TAXON_ID>7955</TAXON_ID>\n
+        \         <SCIENTIFIC_NAME>Danio rerio</SCIENTIFIC_NAME>\n          <COMMON_NAME>zebrafish</COMMON_NAME>\n
+        \    </SAMPLE_NAME>\n     <SAMPLE_LINKS>\n    <SAMPLE_LINK>\n        <XREF_LINK>\n
+        \           <DB>ENA-FASTQ-FILES</DB>\n            <ID><![CDATA[https://www.ebi.ac.uk/ena/portal/api/filereport?accession=SRS2347492&result=read_run&fields=run_accession,fastq_ftp,fastq_md5,fastq_bytes]]></ID>\n
+        \       </XREF_LINK>\n    </SAMPLE_LINK>\n    <SAMPLE_LINK>\n        <XREF_LINK>\n
+        \           <DB>ENA-SUBMITTED-FILES</DB>\n            <ID><![CDATA[https://www.ebi.ac.uk/ena/portal/api/filereport?accession=SRS2347492&result=read_run&fields=run_accession,submitted_ftp,submitted_md5,submitted_bytes,submitted_format]]></ID>\n
+        \       </XREF_LINK>\n    </SAMPLE_LINK>\n</SAMPLE_LINKS>\n<SAMPLE_ATTRIBUTES>\n
+        \         <SAMPLE_ATTRIBUTE>\n               <TAG>INSDC secondary accession</TAG>\n
+        \              <VALUE>SRS2347492</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
+        \         <SAMPLE_ATTRIBUTE>\n               <TAG>organism</TAG>\n               <VALUE>Danio
+        rerio</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
+        \              <TAG>pool</TAG>\n               <VALUE>1</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
+        \         <SAMPLE_ATTRIBUTE>\n               <TAG>cell type</TAG>\n               <VALUE>wt1a+</VALUE>\n
+        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>source_name</TAG>\n
         \              <VALUE>Heart</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
-        \              <TAG>cell type</TAG>\n               <VALUE>wt1a+</VALUE>\n
-        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>pool</TAG>\n
-        \              <VALUE>1</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
-        \              <TAG>ENA-SPOT-COUNT</TAG>\n               <VALUE>24149372</VALUE>\n
-        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-BASE-COUNT</TAG>\n
-        \              <VALUE>1473111692</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
-        \         <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-FIRST-PUBLIC</TAG>\n
-        \              <VALUE>2018-03-23</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
-        \         <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-LAST-UPDATE</TAG>\n
-        \              <VALUE>2018-04-04</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
+        \              <TAG>BioSampleModel</TAG>\n               <VALUE>Generic</VALUE>\n
+        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-FIRST-PUBLIC</TAG>\n
+        \              <VALUE>2018-03-22</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
         \    </SAMPLE_ATTRIBUTES>\n</SAMPLE>\n</SAMPLE_SET>\n"
     headers:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:43:45 GMT
+      - Wed, 17 May 2023 18:37:05 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -3006,7 +2552,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/SRP111553
   response:
@@ -3054,7 +2600,7 @@ interactions:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:43:45 GMT
+      - Wed, 17 May 2023 18:37:06 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -3072,7 +2618,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/SRA585736
   response:
@@ -3109,7 +2655,7 @@ interactions:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:43:46 GMT
+      - Wed, 17 May 2023 18:37:06 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -3118,68 +2664,6 @@ interactions:
       code: 200
       message: ''
 - request:
-    body: acc=SRR5818006&accept-proto=fasp&version=2.0
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '44'
-      User-Agent:
-      - python-requests/2.25.1
-    method: POST
-    uri: https://www.ncbi.nlm.nih.gov/Traces/names/names.cgi
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAAwzIsQ7CIBAA0L1fQeLQqeYOehT6EybVyQ0opBoiTcEYk/t4feM7yTN09XD72/N1
-        WcigAdA8SrKWFBBLwGmAaUC8SZyVmknfWRuwoH1Y0aNOFElK5RQYh0kZmhwzjwB8eeWv6LfW9tqL
-        /SithJLFowqXc/nEVaRyiLb9o/hnDK37AQAA//8DAJv5LpqOAAAA
-    headers:
-      Cache-Control:
-      - private
-      Connection:
-      - Keep-Alive
-      Content-Encoding:
-      - gzip
-      Content-Security-Policy:
-      - upgrade-insecure-requests
-      Content-Type:
-      - text/plain
-      Date:
-      - Wed, 28 Jul 2021 19:43:47 GMT
-      Keep-Alive:
-      - timeout=1, max=10
-      NCBI-PHID:
-      - C7A42429101B37310000000000000001.m_1
-      NCBI-SID:
-      - C7A42429101B3731_0000SID
-      Referrer-Policy:
-      - origin-when-cross-origin
-      Server:
-      - Apache
-      Set-Cookie:
-      - ncbi_sid=C7A42429101B3731_0000SID; domain=.nih.gov; path=/; expires=Thu, 28
-        Jul 2022 19:43:47 GMT
-      SraNameServerOutputVersion:
-      - '2.0'
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains; preload
-      Transfer-Encoding:
-      - chunked
-      Vary:
-      - Accept-Encoding
-      X-UA-Compatible:
-      - IE=Edge
-      X-XSS-Protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
-- request:
     body: null
     headers:
       Accept:
@@ -3189,29 +2673,27 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/portal/api/filereport?accession=SRR5818006&result=read_run
   response:
     body:
-      string: "run_accession\tfastq_ftp\tfastq_bytes\tfastq_md5\tsubmitted_ftp\tsubmitted_bytes\tsubmitted_md5\tsra_ftp\tsra_bytes\tsra_md5\nSRR5818006\tftp.sra.ebi.ac.uk/vol1/fastq/SRR581/006/SRR5818006/SRR5818006.fastq.gz\t625431044\te487dc5e2399d2144ad35a0fa0b126bc\t\t\t\t\t\t\n"
+      string: "run_accession\tfastq_ftp\tfastq_bytes\tfastq_md5\tbam_ftp\tbam_bytes\tbam_md5\tsubmitted_ftp\tsubmitted_bytes\tsubmitted_md5\tsra_ftp\tsra_bytes\tsra_md5\nSRR5818006\tftp.sra.ebi.ac.uk/vol1/fastq/SRR581/006/SRR5818006/SRR5818006.fastq.gz\t625431044\te487dc5e2399d2144ad35a0fa0b126bc\t\t\t\t\t\t\tftp.sra.ebi.ac.uk/vol1/srr/SRR581/006/SRR5818006\t425995305\t680906bcd1b16f5e5223a308a1f3857a\n"
     headers:
       Cache-Control:
       - no-cache, no-store, max-age=0, must-revalidate
+      Content-Length:
+      - '365'
       Content-Type:
       - text/plain
       Date:
-      - Wed, 28 Jul 2021 19:43:47 GMT
+      - Wed, 17 May 2023 18:37:06 GMT
       Expires:
       - '0'
       Pragma:
       - no-cache
-      Server:
-      - Apache-Coyote/1.1
       Strict-Transport-Security:
       - max-age=0
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Frame-Options:
@@ -3220,7 +2702,7 @@ interactions:
       - 1; mode=block
     status:
       code: 200
-      message: OK
+      message: ''
 - request:
     body: null
     headers:
@@ -3231,7 +2713,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/SRR5818007
   response:
@@ -3272,7 +2754,7 @@ interactions:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:43:48 GMT
+      - Wed, 17 May 2023 18:37:07 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -3290,7 +2772,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/SRX2996259
   response:
@@ -3347,7 +2829,7 @@ interactions:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:43:49 GMT
+      - Wed, 17 May 2023 18:37:07 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -3365,54 +2847,40 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/SRS2347492
   response:
     body:
       string: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<SAMPLE_SET>\n<SAMPLE accession=\"SRS2347492\"
-        alias=\"GSM2700327\" broker_name=\"NCBI\">\n     <IDENTIFIERS>\n          <PRIMARY_ID>SRS2347492</PRIMARY_ID>\n
-        \         <EXTERNAL_ID namespace=\"BioSample\">SAMN07343033</EXTERNAL_ID>\n
-        \         <EXTERNAL_ID namespace=\"GEO\">GSM2700327</EXTERNAL_ID>\n          <SUBMITTER_ID
-        namespace=\"\">GSM2700327</SUBMITTER_ID>\n     </IDENTIFIERS>\n     <TITLE>wt1aGFP_1_pos</TITLE>\n
-        \    <SAMPLE_NAME>\n          <TAXON_ID>7955</TAXON_ID>\n          <SCIENTIFIC_NAME>Danio
-        rerio</SCIENTIFIC_NAME>\n          <COMMON_NAME>zebrafish</COMMON_NAME>\n
-        \    </SAMPLE_NAME>\n     <SAMPLE_LINKS>\n          <SAMPLE_LINK>\n               <XREF_LINK>\n
-        \                   <DB>ENA-STUDY</DB>\n                    <ID>SRP111553</ID>\n
-        \              </XREF_LINK>\n          </SAMPLE_LINK>\n          <SAMPLE_LINK>\n
-        \              <XREF_LINK>\n                    <DB>ENA-EXPERIMENT</DB>\n
-        \                   <ID>SRX2996259</ID>\n               </XREF_LINK>\n          </SAMPLE_LINK>\n
-        \         <SAMPLE_LINK>\n               <XREF_LINK>\n                    <DB>ENA-RUN</DB>\n
-        \                   <ID>SRR5818006-SRR5818007</ID>\n               </XREF_LINK>\n
-        \         </SAMPLE_LINK>\n          <SAMPLE_LINK>\n               <XREF_LINK>\n
-        \                   <DB>ENA-SUBMISSION</DB>\n                    <ID>SRA585736</ID>\n
-        \              </XREF_LINK>\n          </SAMPLE_LINK>\n          <SAMPLE_LINK>\n
-        \              <XREF_LINK>\n                    <DB>ARRAYEXPRESS</DB>\n                    <ID>E-GEOD-101204</ID>\n
-        \              </XREF_LINK>\n          </SAMPLE_LINK>\n          <SAMPLE_LINK>\n
-        \              <XREF_LINK>\n                    <DB>ENA-FASTQ-FILES</DB>\n
-        \                   <ID><![CDATA[https://www.ebi.ac.uk/ena/portal/api/filereport?accession=SRS2347492&result=read_run&fields=run_accession,fastq_ftp,fastq_md5,fastq_bytes]]></ID>\n
-        \              </XREF_LINK>\n          </SAMPLE_LINK>\n          <SAMPLE_LINK>\n
-        \              <XREF_LINK>\n                    <DB>ENA-SUBMITTED-FILES</DB>\n
-        \                   <ID><![CDATA[https://www.ebi.ac.uk/ena/portal/api/filereport?accession=SRS2347492&result=read_run&fields=run_accession,submitted_ftp,submitted_md5,submitted_bytes,submitted_format]]></ID>\n
-        \              </XREF_LINK>\n          </SAMPLE_LINK>\n     </SAMPLE_LINKS>\n
-        \    <SAMPLE_ATTRIBUTES>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>source_name</TAG>\n
+        alias=\"GSM2700327\" center_name=\"Bioinformatics Unit, CNIC\" broker_name=\"NCBI\">\n
+        \    <IDENTIFIERS>\n          <PRIMARY_ID>SRS2347492</PRIMARY_ID>\n          <EXTERNAL_ID
+        namespace=\"BioSample\">SAMN07343033</EXTERNAL_ID>\n          <SUBMITTER_ID
+        namespace=\"Bioinformatics Unit, CNIC\">GSM2700327</SUBMITTER_ID>\n     </IDENTIFIERS>\n
+        \    <TITLE>wt1aGFP_1_pos</TITLE>\n     <SAMPLE_NAME>\n          <TAXON_ID>7955</TAXON_ID>\n
+        \         <SCIENTIFIC_NAME>Danio rerio</SCIENTIFIC_NAME>\n          <COMMON_NAME>zebrafish</COMMON_NAME>\n
+        \    </SAMPLE_NAME>\n     <SAMPLE_LINKS>\n    <SAMPLE_LINK>\n        <XREF_LINK>\n
+        \           <DB>ENA-FASTQ-FILES</DB>\n            <ID><![CDATA[https://www.ebi.ac.uk/ena/portal/api/filereport?accession=SRS2347492&result=read_run&fields=run_accession,fastq_ftp,fastq_md5,fastq_bytes]]></ID>\n
+        \       </XREF_LINK>\n    </SAMPLE_LINK>\n    <SAMPLE_LINK>\n        <XREF_LINK>\n
+        \           <DB>ENA-SUBMITTED-FILES</DB>\n            <ID><![CDATA[https://www.ebi.ac.uk/ena/portal/api/filereport?accession=SRS2347492&result=read_run&fields=run_accession,submitted_ftp,submitted_md5,submitted_bytes,submitted_format]]></ID>\n
+        \       </XREF_LINK>\n    </SAMPLE_LINK>\n</SAMPLE_LINKS>\n<SAMPLE_ATTRIBUTES>\n
+        \         <SAMPLE_ATTRIBUTE>\n               <TAG>INSDC secondary accession</TAG>\n
+        \              <VALUE>SRS2347492</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
+        \         <SAMPLE_ATTRIBUTE>\n               <TAG>organism</TAG>\n               <VALUE>Danio
+        rerio</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
+        \              <TAG>pool</TAG>\n               <VALUE>1</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
+        \         <SAMPLE_ATTRIBUTE>\n               <TAG>cell type</TAG>\n               <VALUE>wt1a+</VALUE>\n
+        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>source_name</TAG>\n
         \              <VALUE>Heart</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
-        \              <TAG>cell type</TAG>\n               <VALUE>wt1a+</VALUE>\n
-        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>pool</TAG>\n
-        \              <VALUE>1</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
-        \              <TAG>ENA-SPOT-COUNT</TAG>\n               <VALUE>24149372</VALUE>\n
-        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-BASE-COUNT</TAG>\n
-        \              <VALUE>1473111692</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
-        \         <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-FIRST-PUBLIC</TAG>\n
-        \              <VALUE>2018-03-23</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
-        \         <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-LAST-UPDATE</TAG>\n
-        \              <VALUE>2018-04-04</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
+        \              <TAG>BioSampleModel</TAG>\n               <VALUE>Generic</VALUE>\n
+        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-FIRST-PUBLIC</TAG>\n
+        \              <VALUE>2018-03-22</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
         \    </SAMPLE_ATTRIBUTES>\n</SAMPLE>\n</SAMPLE_SET>\n"
     headers:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:43:50 GMT
+      - Wed, 17 May 2023 18:37:07 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -3430,7 +2898,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/SRP111553
   response:
@@ -3478,7 +2946,7 @@ interactions:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:43:50 GMT
+      - Wed, 17 May 2023 18:37:09 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -3496,7 +2964,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/SRA585736
   response:
@@ -3533,7 +3001,7 @@ interactions:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:43:51 GMT
+      - Wed, 17 May 2023 18:37:08 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -3542,68 +3010,6 @@ interactions:
       code: 200
       message: ''
 - request:
-    body: acc=SRR5818007&accept-proto=fasp&version=2.0
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '44'
-      User-Agent:
-      - python-requests/2.25.1
-    method: POST
-    uri: https://www.ncbi.nlm.nih.gov/Traces/names/names.cgi
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAAwzISwrDIBAA0H1OIXSRVcr4mai5RCHtqjs1SlokSmIphTl885bvIq7QHburH0/3
-        eUbDDYAmJUd7EkACuB5AD5w/BJ8kn9A+yUtUaJLyUkShk0Qc0+K8dWiTDc4QkQKg25Z/rF9bq0fP
-        6l5aCSWz18FczuUbF5bKztp6RvHvGFr3BwAA//8DAAfy9XmOAAAA
-    headers:
-      Cache-Control:
-      - private
-      Connection:
-      - Keep-Alive
-      Content-Encoding:
-      - gzip
-      Content-Security-Policy:
-      - upgrade-insecure-requests
-      Content-Type:
-      - text/plain
-      Date:
-      - Wed, 28 Jul 2021 19:43:51 GMT
-      Keep-Alive:
-      - timeout=1, max=10
-      NCBI-PHID:
-      - CC95F61E101B37710000000000000001.m_1
-      NCBI-SID:
-      - CC95F61E101B3771_0000SID
-      Referrer-Policy:
-      - origin-when-cross-origin
-      Server:
-      - Apache
-      Set-Cookie:
-      - ncbi_sid=CC95F61E101B3771_0000SID; domain=.nih.gov; path=/; expires=Thu, 28
-        Jul 2022 19:43:51 GMT
-      SraNameServerOutputVersion:
-      - '2.0'
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains; preload
-      Transfer-Encoding:
-      - chunked
-      Vary:
-      - Accept-Encoding
-      X-UA-Compatible:
-      - IE=Edge
-      X-XSS-Protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
-- request:
     body: null
     headers:
       Accept:
@@ -3613,29 +3019,27 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/portal/api/filereport?accession=SRR5818007&result=read_run
   response:
     body:
-      string: "run_accession\tfastq_ftp\tfastq_bytes\tfastq_md5\tsubmitted_ftp\tsubmitted_bytes\tsubmitted_md5\tsra_ftp\tsra_bytes\tsra_md5\nSRR5818007\tftp.sra.ebi.ac.uk/vol1/fastq/SRR581/007/SRR5818007/SRR5818007.fastq.gz\t640925564\tadff66451ac81a93ba08a067ea78e492\t\t\t\t\t\t\n"
+      string: "run_accession\tfastq_ftp\tfastq_bytes\tfastq_md5\tbam_ftp\tbam_bytes\tbam_md5\tsubmitted_ftp\tsubmitted_bytes\tsubmitted_md5\tsra_ftp\tsra_bytes\tsra_md5\nSRR5818007\tftp.sra.ebi.ac.uk/vol1/fastq/SRR581/007/SRR5818007/SRR5818007.fastq.gz\t640925564\tadff66451ac81a93ba08a067ea78e492\t\t\t\t\t\t\tftp.sra.ebi.ac.uk/vol1/srr/SRR581/007/SRR5818007\t436999920\tb35458f4b32e27f3556fdab9a59f9ca8\n"
     headers:
       Cache-Control:
       - no-cache, no-store, max-age=0, must-revalidate
+      Content-Length:
+      - '365'
       Content-Type:
       - text/plain
       Date:
-      - Wed, 28 Jul 2021 19:43:52 GMT
+      - Wed, 17 May 2023 18:37:08 GMT
       Expires:
       - '0'
       Pragma:
       - no-cache
-      Server:
-      - Apache-Coyote/1.1
       Strict-Transport-Security:
       - max-age=0
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Frame-Options:
@@ -3644,7 +3048,7 @@ interactions:
       - 1; mode=block
     status:
       code: 200
-      message: OK
+      message: ''
 - request:
     body: null
     headers:
@@ -3655,7 +3059,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/SRR5818008
   response:
@@ -3696,7 +3100,7 @@ interactions:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:43:53 GMT
+      - Wed, 17 May 2023 18:37:10 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -3714,7 +3118,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/SRX2996260
   response:
@@ -3771,7 +3175,7 @@ interactions:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:43:53 GMT
+      - Wed, 17 May 2023 18:37:10 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -3789,54 +3193,40 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/SRS2347491
   response:
     body:
       string: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<SAMPLE_SET>\n<SAMPLE accession=\"SRS2347491\"
-        alias=\"GSM2700328\" broker_name=\"NCBI\">\n     <IDENTIFIERS>\n          <PRIMARY_ID>SRS2347491</PRIMARY_ID>\n
-        \         <EXTERNAL_ID namespace=\"BioSample\">SAMN07343032</EXTERNAL_ID>\n
-        \         <EXTERNAL_ID namespace=\"GEO\">GSM2700328</EXTERNAL_ID>\n          <SUBMITTER_ID
-        namespace=\"\">GSM2700328</SUBMITTER_ID>\n     </IDENTIFIERS>\n     <TITLE>wt1aGFP_2_neg</TITLE>\n
-        \    <SAMPLE_NAME>\n          <TAXON_ID>7955</TAXON_ID>\n          <SCIENTIFIC_NAME>Danio
-        rerio</SCIENTIFIC_NAME>\n          <COMMON_NAME>zebrafish</COMMON_NAME>\n
-        \    </SAMPLE_NAME>\n     <SAMPLE_LINKS>\n          <SAMPLE_LINK>\n               <XREF_LINK>\n
-        \                   <DB>ENA-STUDY</DB>\n                    <ID>SRP111553</ID>\n
-        \              </XREF_LINK>\n          </SAMPLE_LINK>\n          <SAMPLE_LINK>\n
-        \              <XREF_LINK>\n                    <DB>ENA-EXPERIMENT</DB>\n
-        \                   <ID>SRX2996260</ID>\n               </XREF_LINK>\n          </SAMPLE_LINK>\n
-        \         <SAMPLE_LINK>\n               <XREF_LINK>\n                    <DB>ENA-RUN</DB>\n
-        \                   <ID>SRR5818008-SRR5818009</ID>\n               </XREF_LINK>\n
-        \         </SAMPLE_LINK>\n          <SAMPLE_LINK>\n               <XREF_LINK>\n
-        \                   <DB>ENA-SUBMISSION</DB>\n                    <ID>SRA585736</ID>\n
-        \              </XREF_LINK>\n          </SAMPLE_LINK>\n          <SAMPLE_LINK>\n
-        \              <XREF_LINK>\n                    <DB>ARRAYEXPRESS</DB>\n                    <ID>E-GEOD-101204</ID>\n
-        \              </XREF_LINK>\n          </SAMPLE_LINK>\n          <SAMPLE_LINK>\n
-        \              <XREF_LINK>\n                    <DB>ENA-FASTQ-FILES</DB>\n
-        \                   <ID><![CDATA[https://www.ebi.ac.uk/ena/portal/api/filereport?accession=SRS2347491&result=read_run&fields=run_accession,fastq_ftp,fastq_md5,fastq_bytes]]></ID>\n
-        \              </XREF_LINK>\n          </SAMPLE_LINK>\n          <SAMPLE_LINK>\n
-        \              <XREF_LINK>\n                    <DB>ENA-SUBMITTED-FILES</DB>\n
-        \                   <ID><![CDATA[https://www.ebi.ac.uk/ena/portal/api/filereport?accession=SRS2347491&result=read_run&fields=run_accession,submitted_ftp,submitted_md5,submitted_bytes,submitted_format]]></ID>\n
-        \              </XREF_LINK>\n          </SAMPLE_LINK>\n     </SAMPLE_LINKS>\n
-        \    <SAMPLE_ATTRIBUTES>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>source_name</TAG>\n
+        alias=\"GSM2700328\" center_name=\"Bioinformatics Unit, CNIC\" broker_name=\"NCBI\">\n
+        \    <IDENTIFIERS>\n          <PRIMARY_ID>SRS2347491</PRIMARY_ID>\n          <EXTERNAL_ID
+        namespace=\"BioSample\">SAMN07343032</EXTERNAL_ID>\n          <SUBMITTER_ID
+        namespace=\"Bioinformatics Unit, CNIC\">GSM2700328</SUBMITTER_ID>\n     </IDENTIFIERS>\n
+        \    <TITLE>wt1aGFP_2_neg</TITLE>\n     <SAMPLE_NAME>\n          <TAXON_ID>7955</TAXON_ID>\n
+        \         <SCIENTIFIC_NAME>Danio rerio</SCIENTIFIC_NAME>\n          <COMMON_NAME>zebrafish</COMMON_NAME>\n
+        \    </SAMPLE_NAME>\n     <SAMPLE_LINKS>\n    <SAMPLE_LINK>\n        <XREF_LINK>\n
+        \           <DB>ENA-FASTQ-FILES</DB>\n            <ID><![CDATA[https://www.ebi.ac.uk/ena/portal/api/filereport?accession=SRS2347491&result=read_run&fields=run_accession,fastq_ftp,fastq_md5,fastq_bytes]]></ID>\n
+        \       </XREF_LINK>\n    </SAMPLE_LINK>\n    <SAMPLE_LINK>\n        <XREF_LINK>\n
+        \           <DB>ENA-SUBMITTED-FILES</DB>\n            <ID><![CDATA[https://www.ebi.ac.uk/ena/portal/api/filereport?accession=SRS2347491&result=read_run&fields=run_accession,submitted_ftp,submitted_md5,submitted_bytes,submitted_format]]></ID>\n
+        \       </XREF_LINK>\n    </SAMPLE_LINK>\n</SAMPLE_LINKS>\n<SAMPLE_ATTRIBUTES>\n
+        \         <SAMPLE_ATTRIBUTE>\n               <TAG>INSDC secondary accession</TAG>\n
+        \              <VALUE>SRS2347491</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
+        \         <SAMPLE_ATTRIBUTE>\n               <TAG>organism</TAG>\n               <VALUE>Danio
+        rerio</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
+        \              <TAG>pool</TAG>\n               <VALUE>2</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
+        \         <SAMPLE_ATTRIBUTE>\n               <TAG>cell type</TAG>\n               <VALUE>wt1a-</VALUE>\n
+        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>source_name</TAG>\n
         \              <VALUE>Heart</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
-        \              <TAG>cell type</TAG>\n               <VALUE>wt1a-</VALUE>\n
-        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>pool</TAG>\n
-        \              <VALUE>2</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
-        \              <TAG>ENA-SPOT-COUNT</TAG>\n               <VALUE>22896376</VALUE>\n
-        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-BASE-COUNT</TAG>\n
-        \              <VALUE>1396678936</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
-        \         <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-FIRST-PUBLIC</TAG>\n
-        \              <VALUE>2018-03-23</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
-        \         <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-LAST-UPDATE</TAG>\n
-        \              <VALUE>2018-04-04</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
+        \              <TAG>BioSampleModel</TAG>\n               <VALUE>Generic</VALUE>\n
+        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-FIRST-PUBLIC</TAG>\n
+        \              <VALUE>2018-03-22</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
         \    </SAMPLE_ATTRIBUTES>\n</SAMPLE>\n</SAMPLE_SET>\n"
     headers:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:43:54 GMT
+      - Wed, 17 May 2023 18:37:10 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -3854,7 +3244,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/SRP111553
   response:
@@ -3902,7 +3292,7 @@ interactions:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:43:54 GMT
+      - Wed, 17 May 2023 18:37:11 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -3920,7 +3310,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/SRA585736
   response:
@@ -3957,7 +3347,7 @@ interactions:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:43:55 GMT
+      - Wed, 17 May 2023 18:37:11 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -3966,68 +3356,6 @@ interactions:
       code: 200
       message: ''
 - request:
-    body: acc=SRR5818008&accept-proto=fasp&version=2.0
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '44'
-      User-Agent:
-      - python-requests/2.25.1
-    method: POST
-    uri: https://www.ncbi.nlm.nih.gov/Traces/names/names.cgi
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAAwzMOwrCQBAA0D6nWLBIFZmZ7GfMJYRoZbeTD1EWNyQrIszhTfuKd6IzVPsW14/o
-        re8dIwOwWmg944WdEmBoIDSId8Kuxc76h0JsJYgQkhMmS+LGOXg7I4uLNnjVYwC9vtPP1Esp616b
-        dcslDzmZ525iSvk7jWbOmynLAVle01CqPwAAAP//AwBuHZzBjgAAAA==
-    headers:
-      Cache-Control:
-      - private
-      Connection:
-      - Keep-Alive
-      Content-Encoding:
-      - gzip
-      Content-Security-Policy:
-      - upgrade-insecure-requests
-      Content-Type:
-      - text/plain
-      Date:
-      - Wed, 28 Jul 2021 19:44:01 GMT
-      Keep-Alive:
-      - timeout=1, max=10
-      NCBI-PHID:
-      - C7A4248D101B38110000000000000001.m_1
-      NCBI-SID:
-      - C7A4248D101B3811_0000SID
-      Referrer-Policy:
-      - origin-when-cross-origin
-      Server:
-      - Apache
-      Set-Cookie:
-      - ncbi_sid=C7A4248D101B3811_0000SID; domain=.nih.gov; path=/; expires=Thu, 28
-        Jul 2022 19:44:01 GMT
-      SraNameServerOutputVersion:
-      - '2.0'
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains; preload
-      Transfer-Encoding:
-      - chunked
-      Vary:
-      - Accept-Encoding
-      X-UA-Compatible:
-      - IE=Edge
-      X-XSS-Protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
-- request:
     body: null
     headers:
       Accept:
@@ -4037,29 +3365,27 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/portal/api/filereport?accession=SRR5818008&result=read_run
   response:
     body:
-      string: "run_accession\tfastq_ftp\tfastq_bytes\tfastq_md5\tsubmitted_ftp\tsubmitted_bytes\tsubmitted_md5\tsra_ftp\tsra_bytes\tsra_md5\nSRR5818008\tftp.sra.ebi.ac.uk/vol1/fastq/SRR581/008/SRR5818008/SRR5818008.fastq.gz\t560733863\t3d0e7b490a27a68b25c95af49f959a88\t\t\t\t\t\t\n"
+      string: "run_accession\tfastq_ftp\tfastq_bytes\tfastq_md5\tbam_ftp\tbam_bytes\tbam_md5\tsubmitted_ftp\tsubmitted_bytes\tsubmitted_md5\tsra_ftp\tsra_bytes\tsra_md5\nSRR5818008\tftp.sra.ebi.ac.uk/vol1/fastq/SRR581/008/SRR5818008/SRR5818008.fastq.gz\t560733863\t3d0e7b490a27a68b25c95af49f959a88\t\t\t\t\t\t\tftp.sra.ebi.ac.uk/vol1/srr/SRR581/008/SRR5818008\t403681985\t0a3b7bb2125b8242b5df764f18b5a476\n"
     headers:
       Cache-Control:
       - no-cache, no-store, max-age=0, must-revalidate
+      Content-Length:
+      - '365'
       Content-Type:
       - text/plain
       Date:
-      - Wed, 28 Jul 2021 19:44:01 GMT
+      - Wed, 17 May 2023 18:37:12 GMT
       Expires:
       - '0'
       Pragma:
       - no-cache
-      Server:
-      - Apache-Coyote/1.1
       Strict-Transport-Security:
       - max-age=0
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Frame-Options:
@@ -4068,7 +3394,7 @@ interactions:
       - 1; mode=block
     status:
       code: 200
-      message: OK
+      message: ''
 - request:
     body: null
     headers:
@@ -4079,7 +3405,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/SRR5818009
   response:
@@ -4120,7 +3446,7 @@ interactions:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:44:02 GMT
+      - Wed, 17 May 2023 18:37:12 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -4138,7 +3464,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/SRX2996260
   response:
@@ -4195,7 +3521,7 @@ interactions:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:44:02 GMT
+      - Wed, 17 May 2023 18:37:12 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -4213,54 +3539,40 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/SRS2347491
   response:
     body:
       string: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<SAMPLE_SET>\n<SAMPLE accession=\"SRS2347491\"
-        alias=\"GSM2700328\" broker_name=\"NCBI\">\n     <IDENTIFIERS>\n          <PRIMARY_ID>SRS2347491</PRIMARY_ID>\n
-        \         <EXTERNAL_ID namespace=\"BioSample\">SAMN07343032</EXTERNAL_ID>\n
-        \         <EXTERNAL_ID namespace=\"GEO\">GSM2700328</EXTERNAL_ID>\n          <SUBMITTER_ID
-        namespace=\"\">GSM2700328</SUBMITTER_ID>\n     </IDENTIFIERS>\n     <TITLE>wt1aGFP_2_neg</TITLE>\n
-        \    <SAMPLE_NAME>\n          <TAXON_ID>7955</TAXON_ID>\n          <SCIENTIFIC_NAME>Danio
-        rerio</SCIENTIFIC_NAME>\n          <COMMON_NAME>zebrafish</COMMON_NAME>\n
-        \    </SAMPLE_NAME>\n     <SAMPLE_LINKS>\n          <SAMPLE_LINK>\n               <XREF_LINK>\n
-        \                   <DB>ENA-STUDY</DB>\n                    <ID>SRP111553</ID>\n
-        \              </XREF_LINK>\n          </SAMPLE_LINK>\n          <SAMPLE_LINK>\n
-        \              <XREF_LINK>\n                    <DB>ENA-EXPERIMENT</DB>\n
-        \                   <ID>SRX2996260</ID>\n               </XREF_LINK>\n          </SAMPLE_LINK>\n
-        \         <SAMPLE_LINK>\n               <XREF_LINK>\n                    <DB>ENA-RUN</DB>\n
-        \                   <ID>SRR5818008-SRR5818009</ID>\n               </XREF_LINK>\n
-        \         </SAMPLE_LINK>\n          <SAMPLE_LINK>\n               <XREF_LINK>\n
-        \                   <DB>ENA-SUBMISSION</DB>\n                    <ID>SRA585736</ID>\n
-        \              </XREF_LINK>\n          </SAMPLE_LINK>\n          <SAMPLE_LINK>\n
-        \              <XREF_LINK>\n                    <DB>ARRAYEXPRESS</DB>\n                    <ID>E-GEOD-101204</ID>\n
-        \              </XREF_LINK>\n          </SAMPLE_LINK>\n          <SAMPLE_LINK>\n
-        \              <XREF_LINK>\n                    <DB>ENA-FASTQ-FILES</DB>\n
-        \                   <ID><![CDATA[https://www.ebi.ac.uk/ena/portal/api/filereport?accession=SRS2347491&result=read_run&fields=run_accession,fastq_ftp,fastq_md5,fastq_bytes]]></ID>\n
-        \              </XREF_LINK>\n          </SAMPLE_LINK>\n          <SAMPLE_LINK>\n
-        \              <XREF_LINK>\n                    <DB>ENA-SUBMITTED-FILES</DB>\n
-        \                   <ID><![CDATA[https://www.ebi.ac.uk/ena/portal/api/filereport?accession=SRS2347491&result=read_run&fields=run_accession,submitted_ftp,submitted_md5,submitted_bytes,submitted_format]]></ID>\n
-        \              </XREF_LINK>\n          </SAMPLE_LINK>\n     </SAMPLE_LINKS>\n
-        \    <SAMPLE_ATTRIBUTES>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>source_name</TAG>\n
+        alias=\"GSM2700328\" center_name=\"Bioinformatics Unit, CNIC\" broker_name=\"NCBI\">\n
+        \    <IDENTIFIERS>\n          <PRIMARY_ID>SRS2347491</PRIMARY_ID>\n          <EXTERNAL_ID
+        namespace=\"BioSample\">SAMN07343032</EXTERNAL_ID>\n          <SUBMITTER_ID
+        namespace=\"Bioinformatics Unit, CNIC\">GSM2700328</SUBMITTER_ID>\n     </IDENTIFIERS>\n
+        \    <TITLE>wt1aGFP_2_neg</TITLE>\n     <SAMPLE_NAME>\n          <TAXON_ID>7955</TAXON_ID>\n
+        \         <SCIENTIFIC_NAME>Danio rerio</SCIENTIFIC_NAME>\n          <COMMON_NAME>zebrafish</COMMON_NAME>\n
+        \    </SAMPLE_NAME>\n     <SAMPLE_LINKS>\n    <SAMPLE_LINK>\n        <XREF_LINK>\n
+        \           <DB>ENA-FASTQ-FILES</DB>\n            <ID><![CDATA[https://www.ebi.ac.uk/ena/portal/api/filereport?accession=SRS2347491&result=read_run&fields=run_accession,fastq_ftp,fastq_md5,fastq_bytes]]></ID>\n
+        \       </XREF_LINK>\n    </SAMPLE_LINK>\n    <SAMPLE_LINK>\n        <XREF_LINK>\n
+        \           <DB>ENA-SUBMITTED-FILES</DB>\n            <ID><![CDATA[https://www.ebi.ac.uk/ena/portal/api/filereport?accession=SRS2347491&result=read_run&fields=run_accession,submitted_ftp,submitted_md5,submitted_bytes,submitted_format]]></ID>\n
+        \       </XREF_LINK>\n    </SAMPLE_LINK>\n</SAMPLE_LINKS>\n<SAMPLE_ATTRIBUTES>\n
+        \         <SAMPLE_ATTRIBUTE>\n               <TAG>INSDC secondary accession</TAG>\n
+        \              <VALUE>SRS2347491</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
+        \         <SAMPLE_ATTRIBUTE>\n               <TAG>organism</TAG>\n               <VALUE>Danio
+        rerio</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
+        \              <TAG>pool</TAG>\n               <VALUE>2</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
+        \         <SAMPLE_ATTRIBUTE>\n               <TAG>cell type</TAG>\n               <VALUE>wt1a-</VALUE>\n
+        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>source_name</TAG>\n
         \              <VALUE>Heart</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
-        \              <TAG>cell type</TAG>\n               <VALUE>wt1a-</VALUE>\n
-        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>pool</TAG>\n
-        \              <VALUE>2</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
-        \              <TAG>ENA-SPOT-COUNT</TAG>\n               <VALUE>22896376</VALUE>\n
-        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-BASE-COUNT</TAG>\n
-        \              <VALUE>1396678936</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
-        \         <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-FIRST-PUBLIC</TAG>\n
-        \              <VALUE>2018-03-23</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
-        \         <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-LAST-UPDATE</TAG>\n
-        \              <VALUE>2018-04-04</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
+        \              <TAG>BioSampleModel</TAG>\n               <VALUE>Generic</VALUE>\n
+        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-FIRST-PUBLIC</TAG>\n
+        \              <VALUE>2018-03-22</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
         \    </SAMPLE_ATTRIBUTES>\n</SAMPLE>\n</SAMPLE_SET>\n"
     headers:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:44:03 GMT
+      - Wed, 17 May 2023 18:37:12 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -4278,7 +3590,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/SRP111553
   response:
@@ -4326,7 +3638,7 @@ interactions:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:44:09 GMT
+      - Wed, 17 May 2023 18:37:13 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -4344,7 +3656,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/SRA585736
   response:
@@ -4381,7 +3693,7 @@ interactions:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:44:09 GMT
+      - Wed, 17 May 2023 18:37:13 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -4390,68 +3702,6 @@ interactions:
       code: 200
       message: ''
 - request:
-    body: acc=SRR5818009&accept-proto=fasp&version=2.0
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '44'
-      User-Agent:
-      - python-requests/2.25.1
-    method: POST
-    uri: https://www.ncbi.nlm.nih.gov/Traces/names/names.cgi
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAAwzIwQrCMAwA0LtfUfCw0yRJ26zbTwjTk7dmrkwpdmwVEfLx+o7vSCc47Ftc36KX
-        cfQBA0CvDi16YNcrAXYtdC3ilXCwdnB8U0YvKUZiGyUESj0TBSteeE5OgFXVAej5lb+mWWpd98as
-        W6llKtk8dhNzLp/5blLZTF3+UeQ5T/XwAwAA//8DAFjevJKOAAAA
-    headers:
-      Cache-Control:
-      - private
-      Connection:
-      - Keep-Alive
-      Content-Encoding:
-      - gzip
-      Content-Security-Policy:
-      - upgrade-insecure-requests
-      Content-Type:
-      - text/plain
-      Date:
-      - Wed, 28 Jul 2021 19:44:10 GMT
-      Keep-Alive:
-      - timeout=1, max=10
-      NCBI-PHID:
-      - C7A42541101B38A10000000000000001.m_1
-      NCBI-SID:
-      - C7A42541101B38A1_0000SID
-      Referrer-Policy:
-      - origin-when-cross-origin
-      Server:
-      - Apache
-      Set-Cookie:
-      - ncbi_sid=C7A42541101B38A1_0000SID; domain=.nih.gov; path=/; expires=Thu, 28
-        Jul 2022 19:44:10 GMT
-      SraNameServerOutputVersion:
-      - '2.0'
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains; preload
-      Transfer-Encoding:
-      - chunked
-      Vary:
-      - Accept-Encoding
-      X-UA-Compatible:
-      - IE=Edge
-      X-XSS-Protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
-- request:
     body: null
     headers:
       Accept:
@@ -4461,29 +3711,27 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/portal/api/filereport?accession=SRR5818009&result=read_run
   response:
     body:
-      string: "run_accession\tfastq_ftp\tfastq_bytes\tfastq_md5\tsubmitted_ftp\tsubmitted_bytes\tsubmitted_md5\tsra_ftp\tsra_bytes\tsra_md5\nSRR5818009\tftp.sra.ebi.ac.uk/vol1/fastq/SRR581/009/SRR5818009/SRR5818009.fastq.gz\t573562587\t8a669d361beb0a193e85aec0e2c63792\t\t\t\t\t\t\n"
+      string: "run_accession\tfastq_ftp\tfastq_bytes\tfastq_md5\tbam_ftp\tbam_bytes\tbam_md5\tsubmitted_ftp\tsubmitted_bytes\tsubmitted_md5\tsra_ftp\tsra_bytes\tsra_md5\nSRR5818009\tftp.sra.ebi.ac.uk/vol1/fastq/SRR581/009/SRR5818009/SRR5818009.fastq.gz\t573562587\t8a669d361beb0a193e85aec0e2c63792\t\t\t\t\t\t\tftp.sra.ebi.ac.uk/vol1/srr/SRR581/009/SRR5818009\t413150649\t615bfaa263ab882f962283b5b6ef4b06\n"
     headers:
       Cache-Control:
       - no-cache, no-store, max-age=0, must-revalidate
+      Content-Length:
+      - '365'
       Content-Type:
       - text/plain
       Date:
-      - Wed, 28 Jul 2021 19:44:11 GMT
+      - Wed, 17 May 2023 18:37:14 GMT
       Expires:
       - '0'
       Pragma:
       - no-cache
-      Server:
-      - Apache-Coyote/1.1
       Strict-Transport-Security:
       - max-age=0
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Frame-Options:
@@ -4492,7 +3740,7 @@ interactions:
       - 1; mode=block
     status:
       code: 200
-      message: OK
+      message: ''
 - request:
     body: null
     headers:
@@ -4503,7 +3751,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/SRR5818010
   response:
@@ -4544,7 +3792,7 @@ interactions:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:44:11 GMT
+      - Wed, 17 May 2023 18:37:14 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -4562,7 +3810,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/SRX2996261
   response:
@@ -4619,7 +3867,7 @@ interactions:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:44:11 GMT
+      - Wed, 17 May 2023 18:37:14 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -4637,54 +3885,40 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/SRS2347493
   response:
     body:
       string: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<SAMPLE_SET>\n<SAMPLE accession=\"SRS2347493\"
-        alias=\"GSM2700329\" broker_name=\"NCBI\">\n     <IDENTIFIERS>\n          <PRIMARY_ID>SRS2347493</PRIMARY_ID>\n
-        \         <EXTERNAL_ID namespace=\"BioSample\">SAMN07343031</EXTERNAL_ID>\n
-        \         <EXTERNAL_ID namespace=\"GEO\">GSM2700329</EXTERNAL_ID>\n          <SUBMITTER_ID
-        namespace=\"\">GSM2700329</SUBMITTER_ID>\n     </IDENTIFIERS>\n     <TITLE>wt1aGFP_2_pos</TITLE>\n
-        \    <SAMPLE_NAME>\n          <TAXON_ID>7955</TAXON_ID>\n          <SCIENTIFIC_NAME>Danio
-        rerio</SCIENTIFIC_NAME>\n          <COMMON_NAME>zebrafish</COMMON_NAME>\n
-        \    </SAMPLE_NAME>\n     <SAMPLE_LINKS>\n          <SAMPLE_LINK>\n               <XREF_LINK>\n
-        \                   <DB>ENA-STUDY</DB>\n                    <ID>SRP111553</ID>\n
-        \              </XREF_LINK>\n          </SAMPLE_LINK>\n          <SAMPLE_LINK>\n
-        \              <XREF_LINK>\n                    <DB>ENA-EXPERIMENT</DB>\n
-        \                   <ID>SRX2996261</ID>\n               </XREF_LINK>\n          </SAMPLE_LINK>\n
-        \         <SAMPLE_LINK>\n               <XREF_LINK>\n                    <DB>ENA-RUN</DB>\n
-        \                   <ID>SRR5818010-SRR5818011</ID>\n               </XREF_LINK>\n
-        \         </SAMPLE_LINK>\n          <SAMPLE_LINK>\n               <XREF_LINK>\n
-        \                   <DB>ENA-SUBMISSION</DB>\n                    <ID>SRA585736</ID>\n
-        \              </XREF_LINK>\n          </SAMPLE_LINK>\n          <SAMPLE_LINK>\n
-        \              <XREF_LINK>\n                    <DB>ARRAYEXPRESS</DB>\n                    <ID>E-GEOD-101204</ID>\n
-        \              </XREF_LINK>\n          </SAMPLE_LINK>\n          <SAMPLE_LINK>\n
-        \              <XREF_LINK>\n                    <DB>ENA-FASTQ-FILES</DB>\n
-        \                   <ID><![CDATA[https://www.ebi.ac.uk/ena/portal/api/filereport?accession=SRS2347493&result=read_run&fields=run_accession,fastq_ftp,fastq_md5,fastq_bytes]]></ID>\n
-        \              </XREF_LINK>\n          </SAMPLE_LINK>\n          <SAMPLE_LINK>\n
-        \              <XREF_LINK>\n                    <DB>ENA-SUBMITTED-FILES</DB>\n
-        \                   <ID><![CDATA[https://www.ebi.ac.uk/ena/portal/api/filereport?accession=SRS2347493&result=read_run&fields=run_accession,submitted_ftp,submitted_md5,submitted_bytes,submitted_format]]></ID>\n
-        \              </XREF_LINK>\n          </SAMPLE_LINK>\n     </SAMPLE_LINKS>\n
-        \    <SAMPLE_ATTRIBUTES>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>source_name</TAG>\n
+        alias=\"GSM2700329\" center_name=\"Bioinformatics Unit, CNIC\" broker_name=\"NCBI\">\n
+        \    <IDENTIFIERS>\n          <PRIMARY_ID>SRS2347493</PRIMARY_ID>\n          <EXTERNAL_ID
+        namespace=\"BioSample\">SAMN07343031</EXTERNAL_ID>\n          <SUBMITTER_ID
+        namespace=\"Bioinformatics Unit, CNIC\">GSM2700329</SUBMITTER_ID>\n     </IDENTIFIERS>\n
+        \    <TITLE>wt1aGFP_2_pos</TITLE>\n     <SAMPLE_NAME>\n          <TAXON_ID>7955</TAXON_ID>\n
+        \         <SCIENTIFIC_NAME>Danio rerio</SCIENTIFIC_NAME>\n          <COMMON_NAME>zebrafish</COMMON_NAME>\n
+        \    </SAMPLE_NAME>\n     <SAMPLE_LINKS>\n    <SAMPLE_LINK>\n        <XREF_LINK>\n
+        \           <DB>ENA-FASTQ-FILES</DB>\n            <ID><![CDATA[https://www.ebi.ac.uk/ena/portal/api/filereport?accession=SRS2347493&result=read_run&fields=run_accession,fastq_ftp,fastq_md5,fastq_bytes]]></ID>\n
+        \       </XREF_LINK>\n    </SAMPLE_LINK>\n    <SAMPLE_LINK>\n        <XREF_LINK>\n
+        \           <DB>ENA-SUBMITTED-FILES</DB>\n            <ID><![CDATA[https://www.ebi.ac.uk/ena/portal/api/filereport?accession=SRS2347493&result=read_run&fields=run_accession,submitted_ftp,submitted_md5,submitted_bytes,submitted_format]]></ID>\n
+        \       </XREF_LINK>\n    </SAMPLE_LINK>\n</SAMPLE_LINKS>\n<SAMPLE_ATTRIBUTES>\n
+        \         <SAMPLE_ATTRIBUTE>\n               <TAG>INSDC secondary accession</TAG>\n
+        \              <VALUE>SRS2347493</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
+        \         <SAMPLE_ATTRIBUTE>\n               <TAG>organism</TAG>\n               <VALUE>Danio
+        rerio</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
+        \              <TAG>pool</TAG>\n               <VALUE>2</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
+        \         <SAMPLE_ATTRIBUTE>\n               <TAG>cell type</TAG>\n               <VALUE>wt1a+</VALUE>\n
+        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>source_name</TAG>\n
         \              <VALUE>Heart</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
-        \              <TAG>cell type</TAG>\n               <VALUE>wt1a+</VALUE>\n
-        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>pool</TAG>\n
-        \              <VALUE>2</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
-        \              <TAG>ENA-SPOT-COUNT</TAG>\n               <VALUE>24971267</VALUE>\n
-        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-BASE-COUNT</TAG>\n
-        \              <VALUE>1523247287</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
-        \         <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-FIRST-PUBLIC</TAG>\n
-        \              <VALUE>2018-03-23</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
-        \         <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-LAST-UPDATE</TAG>\n
-        \              <VALUE>2018-04-04</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
+        \              <TAG>BioSampleModel</TAG>\n               <VALUE>Generic</VALUE>\n
+        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-FIRST-PUBLIC</TAG>\n
+        \              <VALUE>2018-03-22</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
         \    </SAMPLE_ATTRIBUTES>\n</SAMPLE>\n</SAMPLE_SET>\n"
     headers:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:44:12 GMT
+      - Wed, 17 May 2023 18:37:14 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -4702,7 +3936,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/SRP111553
   response:
@@ -4750,7 +3984,7 @@ interactions:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:44:13 GMT
+      - Wed, 17 May 2023 18:37:15 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -4768,7 +4002,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/SRA585736
   response:
@@ -4805,7 +4039,7 @@ interactions:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:44:13 GMT
+      - Wed, 17 May 2023 18:37:15 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -4814,68 +4048,6 @@ interactions:
       code: 200
       message: ''
 - request:
-    body: acc=SRR5818010&accept-proto=fasp&version=2.0
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '44'
-      User-Agent:
-      - python-requests/2.25.1
-    method: POST
-    uri: https://www.ncbi.nlm.nih.gov/Traces/names/names.cgi
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAAwzIsQrCMBAA0L1fEXDoVLlLk/TanxCqk1ub5KgSTGgjItzH6xvfSZ+hOfalvFe5
-        zrMlJEAQY9ASOWtEAw4dDB3iTePU6wnwLpqC7RlG0wf2wbILMTDxSI6tceRFxADI5ZW+qt1qLUer
-        yp5r9jmpx6GWlPInBsV5V3X7R16f0dfmBwAA//8DADOotuKOAAAA
-    headers:
-      Cache-Control:
-      - private
-      Connection:
-      - Keep-Alive
-      Content-Encoding:
-      - gzip
-      Content-Security-Policy:
-      - upgrade-insecure-requests
-      Content-Type:
-      - text/plain
-      Date:
-      - Wed, 28 Jul 2021 19:44:14 GMT
-      Keep-Alive:
-      - timeout=1, max=10
-      NCBI-PHID:
-      - CC95F705101B38E10000000000000001.m_1
-      NCBI-SID:
-      - CC95F705101B38E1_0000SID
-      Referrer-Policy:
-      - origin-when-cross-origin
-      Server:
-      - Apache
-      Set-Cookie:
-      - ncbi_sid=CC95F705101B38E1_0000SID; domain=.nih.gov; path=/; expires=Thu, 28
-        Jul 2022 19:44:14 GMT
-      SraNameServerOutputVersion:
-      - '2.0'
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains; preload
-      Transfer-Encoding:
-      - chunked
-      Vary:
-      - Accept-Encoding
-      X-UA-Compatible:
-      - IE=Edge
-      X-XSS-Protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
-- request:
     body: null
     headers:
       Accept:
@@ -4885,29 +4057,27 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/portal/api/filereport?accession=SRR5818010&result=read_run
   response:
     body:
-      string: "run_accession\tfastq_ftp\tfastq_bytes\tfastq_md5\tsubmitted_ftp\tsubmitted_bytes\tsubmitted_md5\tsra_ftp\tsra_bytes\tsra_md5\nSRR5818010\tftp.sra.ebi.ac.uk/vol1/fastq/SRR581/000/SRR5818010/SRR5818010.fastq.gz\t648541432\tfc630cc3bad9750ba9269c4c0301b770\t\t\t\t\t\t\n"
+      string: "run_accession\tfastq_ftp\tfastq_bytes\tfastq_md5\tbam_ftp\tbam_bytes\tbam_md5\tsubmitted_ftp\tsubmitted_bytes\tsubmitted_md5\tsra_ftp\tsra_bytes\tsra_md5\nSRR5818010\tftp.sra.ebi.ac.uk/vol1/fastq/SRR581/000/SRR5818010/SRR5818010.fastq.gz\t648541432\tfc630cc3bad9750ba9269c4c0301b770\t\t\t\t\t\t\tftp.sra.ebi.ac.uk/vol1/srr/SRR581/000/SRR5818010\t441588654\t28d53f0943dfcd5f6dedf8f986f5468c\n"
     headers:
       Cache-Control:
       - no-cache, no-store, max-age=0, must-revalidate
+      Content-Length:
+      - '365'
       Content-Type:
       - text/plain
       Date:
-      - Wed, 28 Jul 2021 19:44:14 GMT
+      - Wed, 17 May 2023 18:37:16 GMT
       Expires:
       - '0'
       Pragma:
       - no-cache
-      Server:
-      - Apache-Coyote/1.1
       Strict-Transport-Security:
       - max-age=0
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Frame-Options:
@@ -4916,7 +4086,7 @@ interactions:
       - 1; mode=block
     status:
       code: 200
-      message: OK
+      message: ''
 - request:
     body: null
     headers:
@@ -4927,7 +4097,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/SRR5818011
   response:
@@ -4968,7 +4138,7 @@ interactions:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:44:14 GMT
+      - Wed, 17 May 2023 18:37:17 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -4986,7 +4156,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/SRX2996261
   response:
@@ -5043,7 +4213,7 @@ interactions:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:44:15 GMT
+      - Wed, 17 May 2023 18:37:17 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -5061,54 +4231,40 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/SRS2347493
   response:
     body:
       string: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<SAMPLE_SET>\n<SAMPLE accession=\"SRS2347493\"
-        alias=\"GSM2700329\" broker_name=\"NCBI\">\n     <IDENTIFIERS>\n          <PRIMARY_ID>SRS2347493</PRIMARY_ID>\n
-        \         <EXTERNAL_ID namespace=\"BioSample\">SAMN07343031</EXTERNAL_ID>\n
-        \         <EXTERNAL_ID namespace=\"GEO\">GSM2700329</EXTERNAL_ID>\n          <SUBMITTER_ID
-        namespace=\"\">GSM2700329</SUBMITTER_ID>\n     </IDENTIFIERS>\n     <TITLE>wt1aGFP_2_pos</TITLE>\n
-        \    <SAMPLE_NAME>\n          <TAXON_ID>7955</TAXON_ID>\n          <SCIENTIFIC_NAME>Danio
-        rerio</SCIENTIFIC_NAME>\n          <COMMON_NAME>zebrafish</COMMON_NAME>\n
-        \    </SAMPLE_NAME>\n     <SAMPLE_LINKS>\n          <SAMPLE_LINK>\n               <XREF_LINK>\n
-        \                   <DB>ENA-STUDY</DB>\n                    <ID>SRP111553</ID>\n
-        \              </XREF_LINK>\n          </SAMPLE_LINK>\n          <SAMPLE_LINK>\n
-        \              <XREF_LINK>\n                    <DB>ENA-EXPERIMENT</DB>\n
-        \                   <ID>SRX2996261</ID>\n               </XREF_LINK>\n          </SAMPLE_LINK>\n
-        \         <SAMPLE_LINK>\n               <XREF_LINK>\n                    <DB>ENA-RUN</DB>\n
-        \                   <ID>SRR5818010-SRR5818011</ID>\n               </XREF_LINK>\n
-        \         </SAMPLE_LINK>\n          <SAMPLE_LINK>\n               <XREF_LINK>\n
-        \                   <DB>ENA-SUBMISSION</DB>\n                    <ID>SRA585736</ID>\n
-        \              </XREF_LINK>\n          </SAMPLE_LINK>\n          <SAMPLE_LINK>\n
-        \              <XREF_LINK>\n                    <DB>ARRAYEXPRESS</DB>\n                    <ID>E-GEOD-101204</ID>\n
-        \              </XREF_LINK>\n          </SAMPLE_LINK>\n          <SAMPLE_LINK>\n
-        \              <XREF_LINK>\n                    <DB>ENA-FASTQ-FILES</DB>\n
-        \                   <ID><![CDATA[https://www.ebi.ac.uk/ena/portal/api/filereport?accession=SRS2347493&result=read_run&fields=run_accession,fastq_ftp,fastq_md5,fastq_bytes]]></ID>\n
-        \              </XREF_LINK>\n          </SAMPLE_LINK>\n          <SAMPLE_LINK>\n
-        \              <XREF_LINK>\n                    <DB>ENA-SUBMITTED-FILES</DB>\n
-        \                   <ID><![CDATA[https://www.ebi.ac.uk/ena/portal/api/filereport?accession=SRS2347493&result=read_run&fields=run_accession,submitted_ftp,submitted_md5,submitted_bytes,submitted_format]]></ID>\n
-        \              </XREF_LINK>\n          </SAMPLE_LINK>\n     </SAMPLE_LINKS>\n
-        \    <SAMPLE_ATTRIBUTES>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>source_name</TAG>\n
+        alias=\"GSM2700329\" center_name=\"Bioinformatics Unit, CNIC\" broker_name=\"NCBI\">\n
+        \    <IDENTIFIERS>\n          <PRIMARY_ID>SRS2347493</PRIMARY_ID>\n          <EXTERNAL_ID
+        namespace=\"BioSample\">SAMN07343031</EXTERNAL_ID>\n          <SUBMITTER_ID
+        namespace=\"Bioinformatics Unit, CNIC\">GSM2700329</SUBMITTER_ID>\n     </IDENTIFIERS>\n
+        \    <TITLE>wt1aGFP_2_pos</TITLE>\n     <SAMPLE_NAME>\n          <TAXON_ID>7955</TAXON_ID>\n
+        \         <SCIENTIFIC_NAME>Danio rerio</SCIENTIFIC_NAME>\n          <COMMON_NAME>zebrafish</COMMON_NAME>\n
+        \    </SAMPLE_NAME>\n     <SAMPLE_LINKS>\n    <SAMPLE_LINK>\n        <XREF_LINK>\n
+        \           <DB>ENA-FASTQ-FILES</DB>\n            <ID><![CDATA[https://www.ebi.ac.uk/ena/portal/api/filereport?accession=SRS2347493&result=read_run&fields=run_accession,fastq_ftp,fastq_md5,fastq_bytes]]></ID>\n
+        \       </XREF_LINK>\n    </SAMPLE_LINK>\n    <SAMPLE_LINK>\n        <XREF_LINK>\n
+        \           <DB>ENA-SUBMITTED-FILES</DB>\n            <ID><![CDATA[https://www.ebi.ac.uk/ena/portal/api/filereport?accession=SRS2347493&result=read_run&fields=run_accession,submitted_ftp,submitted_md5,submitted_bytes,submitted_format]]></ID>\n
+        \       </XREF_LINK>\n    </SAMPLE_LINK>\n</SAMPLE_LINKS>\n<SAMPLE_ATTRIBUTES>\n
+        \         <SAMPLE_ATTRIBUTE>\n               <TAG>INSDC secondary accession</TAG>\n
+        \              <VALUE>SRS2347493</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
+        \         <SAMPLE_ATTRIBUTE>\n               <TAG>organism</TAG>\n               <VALUE>Danio
+        rerio</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
+        \              <TAG>pool</TAG>\n               <VALUE>2</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
+        \         <SAMPLE_ATTRIBUTE>\n               <TAG>cell type</TAG>\n               <VALUE>wt1a+</VALUE>\n
+        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>source_name</TAG>\n
         \              <VALUE>Heart</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
-        \              <TAG>cell type</TAG>\n               <VALUE>wt1a+</VALUE>\n
-        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>pool</TAG>\n
-        \              <VALUE>2</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
-        \              <TAG>ENA-SPOT-COUNT</TAG>\n               <VALUE>24971267</VALUE>\n
-        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-BASE-COUNT</TAG>\n
-        \              <VALUE>1523247287</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
-        \         <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-FIRST-PUBLIC</TAG>\n
-        \              <VALUE>2018-03-23</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
-        \         <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-LAST-UPDATE</TAG>\n
-        \              <VALUE>2018-04-04</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
+        \              <TAG>BioSampleModel</TAG>\n               <VALUE>Generic</VALUE>\n
+        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-FIRST-PUBLIC</TAG>\n
+        \              <VALUE>2018-03-22</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
         \    </SAMPLE_ATTRIBUTES>\n</SAMPLE>\n</SAMPLE_SET>\n"
     headers:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:44:16 GMT
+      - Wed, 17 May 2023 18:37:17 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -5126,7 +4282,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/SRP111553
   response:
@@ -5174,7 +4330,7 @@ interactions:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:44:17 GMT
+      - Wed, 17 May 2023 18:37:18 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -5192,7 +4348,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/SRA585736
   response:
@@ -5229,7 +4385,7 @@ interactions:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:44:17 GMT
+      - Wed, 17 May 2023 18:37:18 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -5238,68 +4394,6 @@ interactions:
       code: 200
       message: ''
 - request:
-    body: acc=SRR5818011&accept-proto=fasp&version=2.0
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '44'
-      User-Agent:
-      - python-requests/2.25.1
-    method: POST
-    uri: https://www.ncbi.nlm.nih.gov/Traces/names/names.cgi
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAAwzISwrCMBAA0H1PEXDRVWVmmm8vIVRX7pqaUiU0IYmIMIfXt3wnOkNXy5Lfnq/z
-        rCxaQGSpRhiVsY4J0AxgBsQb4TTSBPbOWjtPagGQLsgNViQ0TiESSL1ZL5lZAvDliF/R763l2otc
-        UktriuJZxRJj+oSH2FIRbf9H8q+wtu4HAAD//wMAPDVhvI4AAAA=
-    headers:
-      Cache-Control:
-      - private
-      Connection:
-      - Keep-Alive
-      Content-Encoding:
-      - gzip
-      Content-Security-Policy:
-      - upgrade-insecure-requests
-      Content-Type:
-      - text/plain
-      Date:
-      - Wed, 28 Jul 2021 19:44:18 GMT
-      Keep-Alive:
-      - timeout=1, max=10
-      NCBI-PHID:
-      - CC95F721101B39210000000000000001.m_1
-      NCBI-SID:
-      - CC95F721101B3921_0000SID
-      Referrer-Policy:
-      - origin-when-cross-origin
-      Server:
-      - Apache
-      Set-Cookie:
-      - ncbi_sid=CC95F721101B3921_0000SID; domain=.nih.gov; path=/; expires=Thu, 28
-        Jul 2022 19:44:18 GMT
-      SraNameServerOutputVersion:
-      - '2.0'
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains; preload
-      Transfer-Encoding:
-      - chunked
-      Vary:
-      - Accept-Encoding
-      X-UA-Compatible:
-      - IE=Edge
-      X-XSS-Protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
-- request:
     body: null
     headers:
       Accept:
@@ -5309,29 +4403,27 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/portal/api/filereport?accession=SRR5818011&result=read_run
   response:
     body:
-      string: "run_accession\tfastq_ftp\tfastq_bytes\tfastq_md5\tsubmitted_ftp\tsubmitted_bytes\tsubmitted_md5\tsra_ftp\tsra_bytes\tsra_md5\nSRR5818011\tftp.sra.ebi.ac.uk/vol1/fastq/SRR581/001/SRR5818011/SRR5818011.fastq.gz\t664607333\ta10130c4bf552c08705fe4965c086543\t\t\t\t\t\t\n"
+      string: "run_accession\tfastq_ftp\tfastq_bytes\tfastq_md5\tbam_ftp\tbam_bytes\tbam_md5\tsubmitted_ftp\tsubmitted_bytes\tsubmitted_md5\tsra_ftp\tsra_bytes\tsra_md5\nSRR5818011\tftp.sra.ebi.ac.uk/vol1/fastq/SRR581/001/SRR5818011/SRR5818011.fastq.gz\t664607333\ta10130c4bf552c08705fe4965c086543\t\t\t\t\t\t\tftp.sra.ebi.ac.uk/vol1/srr/SRR581/001/SRR5818011\t453035789\t669b25a0049e4f0c121795112046f8b4\n"
     headers:
       Cache-Control:
       - no-cache, no-store, max-age=0, must-revalidate
+      Content-Length:
+      - '365'
       Content-Type:
       - text/plain
       Date:
-      - Wed, 28 Jul 2021 19:44:18 GMT
+      - Wed, 17 May 2023 18:37:19 GMT
       Expires:
       - '0'
       Pragma:
       - no-cache
-      Server:
-      - Apache-Coyote/1.1
       Strict-Transport-Security:
       - max-age=0
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Frame-Options:
@@ -5340,7 +4432,7 @@ interactions:
       - 1; mode=block
     status:
       code: 200
-      message: OK
+      message: ''
 - request:
     body: null
     headers:
@@ -5351,7 +4443,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/SRR5818012
   response:
@@ -5392,7 +4484,7 @@ interactions:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:44:19 GMT
+      - Wed, 17 May 2023 18:37:19 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -5410,7 +4502,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/SRX2996262
   response:
@@ -5467,7 +4559,7 @@ interactions:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:44:20 GMT
+      - Wed, 17 May 2023 18:37:19 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -5485,54 +4577,40 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/SRS2347494
   response:
     body:
       string: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<SAMPLE_SET>\n<SAMPLE accession=\"SRS2347494\"
-        alias=\"GSM2700330\" broker_name=\"NCBI\">\n     <IDENTIFIERS>\n          <PRIMARY_ID>SRS2347494</PRIMARY_ID>\n
-        \         <EXTERNAL_ID namespace=\"BioSample\">SAMN07343030</EXTERNAL_ID>\n
-        \         <EXTERNAL_ID namespace=\"GEO\">GSM2700330</EXTERNAL_ID>\n          <SUBMITTER_ID
-        namespace=\"\">GSM2700330</SUBMITTER_ID>\n     </IDENTIFIERS>\n     <TITLE>wt1aGFP_3_neg</TITLE>\n
-        \    <SAMPLE_NAME>\n          <TAXON_ID>7955</TAXON_ID>\n          <SCIENTIFIC_NAME>Danio
-        rerio</SCIENTIFIC_NAME>\n          <COMMON_NAME>zebrafish</COMMON_NAME>\n
-        \    </SAMPLE_NAME>\n     <SAMPLE_LINKS>\n          <SAMPLE_LINK>\n               <XREF_LINK>\n
-        \                   <DB>ENA-STUDY</DB>\n                    <ID>SRP111553</ID>\n
-        \              </XREF_LINK>\n          </SAMPLE_LINK>\n          <SAMPLE_LINK>\n
-        \              <XREF_LINK>\n                    <DB>ENA-EXPERIMENT</DB>\n
-        \                   <ID>SRX2996262</ID>\n               </XREF_LINK>\n          </SAMPLE_LINK>\n
-        \         <SAMPLE_LINK>\n               <XREF_LINK>\n                    <DB>ENA-RUN</DB>\n
-        \                   <ID>SRR5818012-SRR5818013</ID>\n               </XREF_LINK>\n
-        \         </SAMPLE_LINK>\n          <SAMPLE_LINK>\n               <XREF_LINK>\n
-        \                   <DB>ENA-SUBMISSION</DB>\n                    <ID>SRA585736</ID>\n
-        \              </XREF_LINK>\n          </SAMPLE_LINK>\n          <SAMPLE_LINK>\n
-        \              <XREF_LINK>\n                    <DB>ARRAYEXPRESS</DB>\n                    <ID>E-GEOD-101204</ID>\n
-        \              </XREF_LINK>\n          </SAMPLE_LINK>\n          <SAMPLE_LINK>\n
-        \              <XREF_LINK>\n                    <DB>ENA-FASTQ-FILES</DB>\n
-        \                   <ID><![CDATA[https://www.ebi.ac.uk/ena/portal/api/filereport?accession=SRS2347494&result=read_run&fields=run_accession,fastq_ftp,fastq_md5,fastq_bytes]]></ID>\n
-        \              </XREF_LINK>\n          </SAMPLE_LINK>\n          <SAMPLE_LINK>\n
-        \              <XREF_LINK>\n                    <DB>ENA-SUBMITTED-FILES</DB>\n
-        \                   <ID><![CDATA[https://www.ebi.ac.uk/ena/portal/api/filereport?accession=SRS2347494&result=read_run&fields=run_accession,submitted_ftp,submitted_md5,submitted_bytes,submitted_format]]></ID>\n
-        \              </XREF_LINK>\n          </SAMPLE_LINK>\n     </SAMPLE_LINKS>\n
-        \    <SAMPLE_ATTRIBUTES>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>source_name</TAG>\n
+        alias=\"GSM2700330\" center_name=\"Bioinformatics Unit, CNIC\" broker_name=\"NCBI\">\n
+        \    <IDENTIFIERS>\n          <PRIMARY_ID>SRS2347494</PRIMARY_ID>\n          <EXTERNAL_ID
+        namespace=\"BioSample\">SAMN07343030</EXTERNAL_ID>\n          <SUBMITTER_ID
+        namespace=\"Bioinformatics Unit, CNIC\">GSM2700330</SUBMITTER_ID>\n     </IDENTIFIERS>\n
+        \    <TITLE>wt1aGFP_3_neg</TITLE>\n     <SAMPLE_NAME>\n          <TAXON_ID>7955</TAXON_ID>\n
+        \         <SCIENTIFIC_NAME>Danio rerio</SCIENTIFIC_NAME>\n          <COMMON_NAME>zebrafish</COMMON_NAME>\n
+        \    </SAMPLE_NAME>\n     <SAMPLE_LINKS>\n    <SAMPLE_LINK>\n        <XREF_LINK>\n
+        \           <DB>ENA-FASTQ-FILES</DB>\n            <ID><![CDATA[https://www.ebi.ac.uk/ena/portal/api/filereport?accession=SRS2347494&result=read_run&fields=run_accession,fastq_ftp,fastq_md5,fastq_bytes]]></ID>\n
+        \       </XREF_LINK>\n    </SAMPLE_LINK>\n    <SAMPLE_LINK>\n        <XREF_LINK>\n
+        \           <DB>ENA-SUBMITTED-FILES</DB>\n            <ID><![CDATA[https://www.ebi.ac.uk/ena/portal/api/filereport?accession=SRS2347494&result=read_run&fields=run_accession,submitted_ftp,submitted_md5,submitted_bytes,submitted_format]]></ID>\n
+        \       </XREF_LINK>\n    </SAMPLE_LINK>\n</SAMPLE_LINKS>\n<SAMPLE_ATTRIBUTES>\n
+        \         <SAMPLE_ATTRIBUTE>\n               <TAG>INSDC secondary accession</TAG>\n
+        \              <VALUE>SRS2347494</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
+        \         <SAMPLE_ATTRIBUTE>\n               <TAG>organism</TAG>\n               <VALUE>Danio
+        rerio</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
+        \              <TAG>pool</TAG>\n               <VALUE>3</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
+        \         <SAMPLE_ATTRIBUTE>\n               <TAG>cell type</TAG>\n               <VALUE>wt1a-</VALUE>\n
+        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>source_name</TAG>\n
         \              <VALUE>Heart</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
-        \              <TAG>cell type</TAG>\n               <VALUE>wt1a-</VALUE>\n
-        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>pool</TAG>\n
-        \              <VALUE>3</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
-        \              <TAG>ENA-SPOT-COUNT</TAG>\n               <VALUE>24020655</VALUE>\n
-        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-BASE-COUNT</TAG>\n
-        \              <VALUE>1465259955</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
-        \         <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-FIRST-PUBLIC</TAG>\n
-        \              <VALUE>2018-03-23</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
-        \         <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-LAST-UPDATE</TAG>\n
-        \              <VALUE>2018-04-04</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
+        \              <TAG>BioSampleModel</TAG>\n               <VALUE>Generic</VALUE>\n
+        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-FIRST-PUBLIC</TAG>\n
+        \              <VALUE>2018-03-22</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
         \    </SAMPLE_ATTRIBUTES>\n</SAMPLE>\n</SAMPLE_SET>\n"
     headers:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:44:20 GMT
+      - Wed, 17 May 2023 18:37:19 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -5550,7 +4628,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/SRP111553
   response:
@@ -5598,7 +4676,7 @@ interactions:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:44:21 GMT
+      - Wed, 17 May 2023 18:37:20 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -5616,7 +4694,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/SRA585736
   response:
@@ -5653,7 +4731,7 @@ interactions:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:44:21 GMT
+      - Wed, 17 May 2023 18:37:20 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -5662,68 +4740,6 @@ interactions:
       code: 200
       message: ''
 - request:
-    body: acc=SRR5818012&accept-proto=fasp&version=2.0
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '44'
-      User-Agent:
-      - python-requests/2.25.1
-    method: POST
-    uri: https://www.ncbi.nlm.nih.gov/Traces/names/names.cgi
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAAwzISw7CIBAA0H1PQeKiq5oBhl8vYVJduSsUUg0RQjHGZA6vb/lO4gzD0db69nRd
-        FmW5BS4IBQI6tIYEcDOBmTi/CT5LMYO9UwQVg5MgN6O9ljpJFb1CF1JSTktLRAhAl1f+snHvvR4j
-        q630Ekpmj4OtOZdP3FgqjfX9H8U/Y+jDDwAA//8DABfQB9eOAAAA
-    headers:
-      Cache-Control:
-      - private
-      Connection:
-      - Keep-Alive
-      Content-Encoding:
-      - gzip
-      Content-Security-Policy:
-      - upgrade-insecure-requests
-      Content-Type:
-      - text/plain
-      Date:
-      - Wed, 28 Jul 2021 19:44:22 GMT
-      Keep-Alive:
-      - timeout=1, max=10
-      NCBI-PHID:
-      - C7A428B6101B39610000000000000001.m_1
-      NCBI-SID:
-      - C7A428B6101B3961_0000SID
-      Referrer-Policy:
-      - origin-when-cross-origin
-      Server:
-      - Apache
-      Set-Cookie:
-      - ncbi_sid=C7A428B6101B3961_0000SID; domain=.nih.gov; path=/; expires=Thu, 28
-        Jul 2022 19:44:22 GMT
-      SraNameServerOutputVersion:
-      - '2.0'
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains; preload
-      Transfer-Encoding:
-      - chunked
-      Vary:
-      - Accept-Encoding
-      X-UA-Compatible:
-      - IE=Edge
-      X-XSS-Protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
-- request:
     body: null
     headers:
       Accept:
@@ -5733,29 +4749,27 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/portal/api/filereport?accession=SRR5818012&result=read_run
   response:
     body:
-      string: "run_accession\tfastq_ftp\tfastq_bytes\tfastq_md5\tsubmitted_ftp\tsubmitted_bytes\tsubmitted_md5\tsra_ftp\tsra_bytes\tsra_md5\nSRR5818012\tftp.sra.ebi.ac.uk/vol1/fastq/SRR581/002/SRR5818012/SRR5818012.fastq.gz\t596873240\t34bb91a39c5c162acd96838f5271558a\t\t\t\t\t\t\n"
+      string: "run_accession\tfastq_ftp\tfastq_bytes\tfastq_md5\tbam_ftp\tbam_bytes\tbam_md5\tsubmitted_ftp\tsubmitted_bytes\tsubmitted_md5\tsra_ftp\tsra_bytes\tsra_md5\nSRR5818012\tftp.sra.ebi.ac.uk/vol1/fastq/SRR581/002/SRR5818012/SRR5818012.fastq.gz\t596873240\t34bb91a39c5c162acd96838f5271558a\t\t\t\t\t\t\tftp.sra.ebi.ac.uk/vol1/srr/SRR581/002/SRR5818012\t424049487\te05ec9303d76b636f35eb549cff59638\n"
     headers:
       Cache-Control:
       - no-cache, no-store, max-age=0, must-revalidate
+      Content-Length:
+      - '365'
       Content-Type:
       - text/plain
       Date:
-      - Wed, 28 Jul 2021 19:44:22 GMT
+      - Wed, 17 May 2023 18:37:20 GMT
       Expires:
       - '0'
       Pragma:
       - no-cache
-      Server:
-      - Apache-Coyote/1.1
       Strict-Transport-Security:
       - max-age=0
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Frame-Options:
@@ -5764,7 +4778,7 @@ interactions:
       - 1; mode=block
     status:
       code: 200
-      message: OK
+      message: ''
 - request:
     body: null
     headers:
@@ -5775,7 +4789,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/SRR5818013
   response:
@@ -5816,7 +4830,7 @@ interactions:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:44:23 GMT
+      - Wed, 17 May 2023 18:37:21 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -5834,7 +4848,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/SRX2996262
   response:
@@ -5891,7 +4905,7 @@ interactions:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:44:24 GMT
+      - Wed, 17 May 2023 18:37:21 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -5909,54 +4923,40 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/SRS2347494
   response:
     body:
       string: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<SAMPLE_SET>\n<SAMPLE accession=\"SRS2347494\"
-        alias=\"GSM2700330\" broker_name=\"NCBI\">\n     <IDENTIFIERS>\n          <PRIMARY_ID>SRS2347494</PRIMARY_ID>\n
-        \         <EXTERNAL_ID namespace=\"BioSample\">SAMN07343030</EXTERNAL_ID>\n
-        \         <EXTERNAL_ID namespace=\"GEO\">GSM2700330</EXTERNAL_ID>\n          <SUBMITTER_ID
-        namespace=\"\">GSM2700330</SUBMITTER_ID>\n     </IDENTIFIERS>\n     <TITLE>wt1aGFP_3_neg</TITLE>\n
-        \    <SAMPLE_NAME>\n          <TAXON_ID>7955</TAXON_ID>\n          <SCIENTIFIC_NAME>Danio
-        rerio</SCIENTIFIC_NAME>\n          <COMMON_NAME>zebrafish</COMMON_NAME>\n
-        \    </SAMPLE_NAME>\n     <SAMPLE_LINKS>\n          <SAMPLE_LINK>\n               <XREF_LINK>\n
-        \                   <DB>ENA-STUDY</DB>\n                    <ID>SRP111553</ID>\n
-        \              </XREF_LINK>\n          </SAMPLE_LINK>\n          <SAMPLE_LINK>\n
-        \              <XREF_LINK>\n                    <DB>ENA-EXPERIMENT</DB>\n
-        \                   <ID>SRX2996262</ID>\n               </XREF_LINK>\n          </SAMPLE_LINK>\n
-        \         <SAMPLE_LINK>\n               <XREF_LINK>\n                    <DB>ENA-RUN</DB>\n
-        \                   <ID>SRR5818012-SRR5818013</ID>\n               </XREF_LINK>\n
-        \         </SAMPLE_LINK>\n          <SAMPLE_LINK>\n               <XREF_LINK>\n
-        \                   <DB>ENA-SUBMISSION</DB>\n                    <ID>SRA585736</ID>\n
-        \              </XREF_LINK>\n          </SAMPLE_LINK>\n          <SAMPLE_LINK>\n
-        \              <XREF_LINK>\n                    <DB>ARRAYEXPRESS</DB>\n                    <ID>E-GEOD-101204</ID>\n
-        \              </XREF_LINK>\n          </SAMPLE_LINK>\n          <SAMPLE_LINK>\n
-        \              <XREF_LINK>\n                    <DB>ENA-FASTQ-FILES</DB>\n
-        \                   <ID><![CDATA[https://www.ebi.ac.uk/ena/portal/api/filereport?accession=SRS2347494&result=read_run&fields=run_accession,fastq_ftp,fastq_md5,fastq_bytes]]></ID>\n
-        \              </XREF_LINK>\n          </SAMPLE_LINK>\n          <SAMPLE_LINK>\n
-        \              <XREF_LINK>\n                    <DB>ENA-SUBMITTED-FILES</DB>\n
-        \                   <ID><![CDATA[https://www.ebi.ac.uk/ena/portal/api/filereport?accession=SRS2347494&result=read_run&fields=run_accession,submitted_ftp,submitted_md5,submitted_bytes,submitted_format]]></ID>\n
-        \              </XREF_LINK>\n          </SAMPLE_LINK>\n     </SAMPLE_LINKS>\n
-        \    <SAMPLE_ATTRIBUTES>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>source_name</TAG>\n
+        alias=\"GSM2700330\" center_name=\"Bioinformatics Unit, CNIC\" broker_name=\"NCBI\">\n
+        \    <IDENTIFIERS>\n          <PRIMARY_ID>SRS2347494</PRIMARY_ID>\n          <EXTERNAL_ID
+        namespace=\"BioSample\">SAMN07343030</EXTERNAL_ID>\n          <SUBMITTER_ID
+        namespace=\"Bioinformatics Unit, CNIC\">GSM2700330</SUBMITTER_ID>\n     </IDENTIFIERS>\n
+        \    <TITLE>wt1aGFP_3_neg</TITLE>\n     <SAMPLE_NAME>\n          <TAXON_ID>7955</TAXON_ID>\n
+        \         <SCIENTIFIC_NAME>Danio rerio</SCIENTIFIC_NAME>\n          <COMMON_NAME>zebrafish</COMMON_NAME>\n
+        \    </SAMPLE_NAME>\n     <SAMPLE_LINKS>\n    <SAMPLE_LINK>\n        <XREF_LINK>\n
+        \           <DB>ENA-FASTQ-FILES</DB>\n            <ID><![CDATA[https://www.ebi.ac.uk/ena/portal/api/filereport?accession=SRS2347494&result=read_run&fields=run_accession,fastq_ftp,fastq_md5,fastq_bytes]]></ID>\n
+        \       </XREF_LINK>\n    </SAMPLE_LINK>\n    <SAMPLE_LINK>\n        <XREF_LINK>\n
+        \           <DB>ENA-SUBMITTED-FILES</DB>\n            <ID><![CDATA[https://www.ebi.ac.uk/ena/portal/api/filereport?accession=SRS2347494&result=read_run&fields=run_accession,submitted_ftp,submitted_md5,submitted_bytes,submitted_format]]></ID>\n
+        \       </XREF_LINK>\n    </SAMPLE_LINK>\n</SAMPLE_LINKS>\n<SAMPLE_ATTRIBUTES>\n
+        \         <SAMPLE_ATTRIBUTE>\n               <TAG>INSDC secondary accession</TAG>\n
+        \              <VALUE>SRS2347494</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
+        \         <SAMPLE_ATTRIBUTE>\n               <TAG>organism</TAG>\n               <VALUE>Danio
+        rerio</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
+        \              <TAG>pool</TAG>\n               <VALUE>3</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
+        \         <SAMPLE_ATTRIBUTE>\n               <TAG>cell type</TAG>\n               <VALUE>wt1a-</VALUE>\n
+        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>source_name</TAG>\n
         \              <VALUE>Heart</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
-        \              <TAG>cell type</TAG>\n               <VALUE>wt1a-</VALUE>\n
-        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>pool</TAG>\n
-        \              <VALUE>3</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
-        \              <TAG>ENA-SPOT-COUNT</TAG>\n               <VALUE>24020655</VALUE>\n
-        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-BASE-COUNT</TAG>\n
-        \              <VALUE>1465259955</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
-        \         <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-FIRST-PUBLIC</TAG>\n
-        \              <VALUE>2018-03-23</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
-        \         <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-LAST-UPDATE</TAG>\n
-        \              <VALUE>2018-04-04</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
+        \              <TAG>BioSampleModel</TAG>\n               <VALUE>Generic</VALUE>\n
+        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-FIRST-PUBLIC</TAG>\n
+        \              <VALUE>2018-03-22</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
         \    </SAMPLE_ATTRIBUTES>\n</SAMPLE>\n</SAMPLE_SET>\n"
     headers:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:44:24 GMT
+      - Wed, 17 May 2023 18:37:22 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -5974,7 +4974,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/SRP111553
   response:
@@ -6022,7 +5022,7 @@ interactions:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:44:25 GMT
+      - Wed, 17 May 2023 18:37:22 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -6040,7 +5040,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/SRA585736
   response:
@@ -6077,7 +5077,7 @@ interactions:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:44:25 GMT
+      - Wed, 17 May 2023 18:37:22 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -6086,68 +5086,6 @@ interactions:
       code: 200
       message: ''
 - request:
-    body: acc=SRR5818013&accept-proto=fasp&version=2.0
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '44'
-      User-Agent:
-      - python-requests/2.25.1
-    method: POST
-    uri: https://www.ncbi.nlm.nih.gov/Traces/names/names.cgi
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAAwzISwrCMBAA0H1PEXDRVWVmMmnaXkKortw1P6oEU9qICHN4fct3ojM0x75sbyfX
-        eTYDDoBaWBvoexxZCNB2YDvEG+GkcTJ8FzbOYEiEo7eRyFmNPBJjBEMhxSAiDCCXV/6qdq11O1q1
-        7aUWX7J6HGrJuXxiUKnsqq7/KO4ZfW1+AAAA//8DAL7QTpeOAAAA
-    headers:
-      Cache-Control:
-      - private
-      Connection:
-      - Keep-Alive
-      Content-Encoding:
-      - gzip
-      Content-Security-Policy:
-      - upgrade-insecure-requests
-      Content-Type:
-      - text/plain
-      Date:
-      - Wed, 28 Jul 2021 19:44:26 GMT
-      Keep-Alive:
-      - timeout=1, max=10
-      NCBI-PHID:
-      - CC95F75F101B39A10000000000000001.m_1
-      NCBI-SID:
-      - CC95F75F101B39A1_0000SID
-      Referrer-Policy:
-      - origin-when-cross-origin
-      Server:
-      - Apache
-      Set-Cookie:
-      - ncbi_sid=CC95F75F101B39A1_0000SID; domain=.nih.gov; path=/; expires=Thu, 28
-        Jul 2022 19:44:26 GMT
-      SraNameServerOutputVersion:
-      - '2.0'
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains; preload
-      Transfer-Encoding:
-      - chunked
-      Vary:
-      - Accept-Encoding
-      X-UA-Compatible:
-      - IE=Edge
-      X-XSS-Protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
-- request:
     body: null
     headers:
       Accept:
@@ -6157,29 +5095,27 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/portal/api/filereport?accession=SRR5818013&result=read_run
   response:
     body:
-      string: "run_accession\tfastq_ftp\tfastq_bytes\tfastq_md5\tsubmitted_ftp\tsubmitted_bytes\tsubmitted_md5\tsra_ftp\tsra_bytes\tsra_md5\nSRR5818013\tftp.sra.ebi.ac.uk/vol1/fastq/SRR581/003/SRR5818013/SRR5818013.fastq.gz\t611906971\tce77ccfd2bc4c23e9ee5501ca3e9243e\t\t\t\t\t\t\n"
+      string: "run_accession\tfastq_ftp\tfastq_bytes\tfastq_md5\tbam_ftp\tbam_bytes\tbam_md5\tsubmitted_ftp\tsubmitted_bytes\tsubmitted_md5\tsra_ftp\tsra_bytes\tsra_md5\nSRR5818013\tftp.sra.ebi.ac.uk/vol1/fastq/SRR581/003/SRR5818013/SRR5818013.fastq.gz\t611906971\tce77ccfd2bc4c23e9ee5501ca3e9243e\t\t\t\t\t\t\tftp.sra.ebi.ac.uk/vol1/srr/SRR581/003/SRR5818013\t435066194\t45b51df219c7e22b73149241e052dfed\n"
     headers:
       Cache-Control:
       - no-cache, no-store, max-age=0, must-revalidate
+      Content-Length:
+      - '365'
       Content-Type:
       - text/plain
       Date:
-      - Wed, 28 Jul 2021 19:44:26 GMT
+      - Wed, 17 May 2023 18:37:24 GMT
       Expires:
       - '0'
       Pragma:
       - no-cache
-      Server:
-      - Apache-Coyote/1.1
       Strict-Transport-Security:
       - max-age=0
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Frame-Options:
@@ -6188,7 +5124,7 @@ interactions:
       - 1; mode=block
     status:
       code: 200
-      message: OK
+      message: ''
 - request:
     body: null
     headers:
@@ -6199,7 +5135,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/SRR5818014
   response:
@@ -6240,7 +5176,7 @@ interactions:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:44:27 GMT
+      - Wed, 17 May 2023 18:37:24 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -6258,7 +5194,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/SRX2996263
   response:
@@ -6315,7 +5251,7 @@ interactions:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:44:28 GMT
+      - Wed, 17 May 2023 18:37:24 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -6333,54 +5269,40 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/SRS2347495
   response:
     body:
       string: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<SAMPLE_SET>\n<SAMPLE accession=\"SRS2347495\"
-        alias=\"GSM2700331\" broker_name=\"NCBI\">\n     <IDENTIFIERS>\n          <PRIMARY_ID>SRS2347495</PRIMARY_ID>\n
-        \         <EXTERNAL_ID namespace=\"BioSample\">SAMN07343029</EXTERNAL_ID>\n
-        \         <EXTERNAL_ID namespace=\"GEO\">GSM2700331</EXTERNAL_ID>\n          <SUBMITTER_ID
-        namespace=\"\">GSM2700331</SUBMITTER_ID>\n     </IDENTIFIERS>\n     <TITLE>wt1aGFP_3_pos</TITLE>\n
-        \    <SAMPLE_NAME>\n          <TAXON_ID>7955</TAXON_ID>\n          <SCIENTIFIC_NAME>Danio
-        rerio</SCIENTIFIC_NAME>\n          <COMMON_NAME>zebrafish</COMMON_NAME>\n
-        \    </SAMPLE_NAME>\n     <SAMPLE_LINKS>\n          <SAMPLE_LINK>\n               <XREF_LINK>\n
-        \                   <DB>ENA-STUDY</DB>\n                    <ID>SRP111553</ID>\n
-        \              </XREF_LINK>\n          </SAMPLE_LINK>\n          <SAMPLE_LINK>\n
-        \              <XREF_LINK>\n                    <DB>ENA-EXPERIMENT</DB>\n
-        \                   <ID>SRX2996263</ID>\n               </XREF_LINK>\n          </SAMPLE_LINK>\n
-        \         <SAMPLE_LINK>\n               <XREF_LINK>\n                    <DB>ENA-RUN</DB>\n
-        \                   <ID>SRR5818014-SRR5818015</ID>\n               </XREF_LINK>\n
-        \         </SAMPLE_LINK>\n          <SAMPLE_LINK>\n               <XREF_LINK>\n
-        \                   <DB>ENA-SUBMISSION</DB>\n                    <ID>SRA585736</ID>\n
-        \              </XREF_LINK>\n          </SAMPLE_LINK>\n          <SAMPLE_LINK>\n
-        \              <XREF_LINK>\n                    <DB>ARRAYEXPRESS</DB>\n                    <ID>E-GEOD-101204</ID>\n
-        \              </XREF_LINK>\n          </SAMPLE_LINK>\n          <SAMPLE_LINK>\n
-        \              <XREF_LINK>\n                    <DB>ENA-FASTQ-FILES</DB>\n
-        \                   <ID><![CDATA[https://www.ebi.ac.uk/ena/portal/api/filereport?accession=SRS2347495&result=read_run&fields=run_accession,fastq_ftp,fastq_md5,fastq_bytes]]></ID>\n
-        \              </XREF_LINK>\n          </SAMPLE_LINK>\n          <SAMPLE_LINK>\n
-        \              <XREF_LINK>\n                    <DB>ENA-SUBMITTED-FILES</DB>\n
-        \                   <ID><![CDATA[https://www.ebi.ac.uk/ena/portal/api/filereport?accession=SRS2347495&result=read_run&fields=run_accession,submitted_ftp,submitted_md5,submitted_bytes,submitted_format]]></ID>\n
-        \              </XREF_LINK>\n          </SAMPLE_LINK>\n     </SAMPLE_LINKS>\n
-        \    <SAMPLE_ATTRIBUTES>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>source_name</TAG>\n
+        alias=\"GSM2700331\" center_name=\"Bioinformatics Unit, CNIC\" broker_name=\"NCBI\">\n
+        \    <IDENTIFIERS>\n          <PRIMARY_ID>SRS2347495</PRIMARY_ID>\n          <EXTERNAL_ID
+        namespace=\"BioSample\">SAMN07343029</EXTERNAL_ID>\n          <SUBMITTER_ID
+        namespace=\"Bioinformatics Unit, CNIC\">GSM2700331</SUBMITTER_ID>\n     </IDENTIFIERS>\n
+        \    <TITLE>wt1aGFP_3_pos</TITLE>\n     <SAMPLE_NAME>\n          <TAXON_ID>7955</TAXON_ID>\n
+        \         <SCIENTIFIC_NAME>Danio rerio</SCIENTIFIC_NAME>\n          <COMMON_NAME>zebrafish</COMMON_NAME>\n
+        \    </SAMPLE_NAME>\n     <SAMPLE_LINKS>\n    <SAMPLE_LINK>\n        <XREF_LINK>\n
+        \           <DB>ENA-FASTQ-FILES</DB>\n            <ID><![CDATA[https://www.ebi.ac.uk/ena/portal/api/filereport?accession=SRS2347495&result=read_run&fields=run_accession,fastq_ftp,fastq_md5,fastq_bytes]]></ID>\n
+        \       </XREF_LINK>\n    </SAMPLE_LINK>\n    <SAMPLE_LINK>\n        <XREF_LINK>\n
+        \           <DB>ENA-SUBMITTED-FILES</DB>\n            <ID><![CDATA[https://www.ebi.ac.uk/ena/portal/api/filereport?accession=SRS2347495&result=read_run&fields=run_accession,submitted_ftp,submitted_md5,submitted_bytes,submitted_format]]></ID>\n
+        \       </XREF_LINK>\n    </SAMPLE_LINK>\n</SAMPLE_LINKS>\n<SAMPLE_ATTRIBUTES>\n
+        \         <SAMPLE_ATTRIBUTE>\n               <TAG>INSDC secondary accession</TAG>\n
+        \              <VALUE>SRS2347495</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
+        \         <SAMPLE_ATTRIBUTE>\n               <TAG>organism</TAG>\n               <VALUE>Danio
+        rerio</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
+        \              <TAG>pool</TAG>\n               <VALUE>3</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
+        \         <SAMPLE_ATTRIBUTE>\n               <TAG>cell type</TAG>\n               <VALUE>wt1a+</VALUE>\n
+        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>source_name</TAG>\n
         \              <VALUE>Heart</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
-        \              <TAG>cell type</TAG>\n               <VALUE>wt1a+</VALUE>\n
-        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>pool</TAG>\n
-        \              <VALUE>3</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
-        \              <TAG>ENA-SPOT-COUNT</TAG>\n               <VALUE>25570895</VALUE>\n
-        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-BASE-COUNT</TAG>\n
-        \              <VALUE>1559824595</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
-        \         <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-FIRST-PUBLIC</TAG>\n
-        \              <VALUE>2018-03-23</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
-        \         <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-LAST-UPDATE</TAG>\n
-        \              <VALUE>2018-04-04</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
+        \              <TAG>BioSampleModel</TAG>\n               <VALUE>Generic</VALUE>\n
+        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-FIRST-PUBLIC</TAG>\n
+        \              <VALUE>2018-03-22</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
         \    </SAMPLE_ATTRIBUTES>\n</SAMPLE>\n</SAMPLE_SET>\n"
     headers:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:44:29 GMT
+      - Wed, 17 May 2023 18:37:25 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -6398,7 +5320,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/SRP111553
   response:
@@ -6446,7 +5368,7 @@ interactions:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:44:29 GMT
+      - Wed, 17 May 2023 18:37:25 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -6464,7 +5386,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/SRA585736
   response:
@@ -6501,7 +5423,7 @@ interactions:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:44:30 GMT
+      - Wed, 17 May 2023 18:37:25 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -6510,68 +5432,6 @@ interactions:
       code: 200
       message: ''
 - request:
-    body: acc=SRR5818014&accept-proto=fasp&version=2.0
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '44'
-      User-Agent:
-      - python-requests/2.25.1
-    method: POST
-    uri: https://www.ncbi.nlm.nih.gov/Traces/names/names.cgi
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAAwzIsQrCMBAA0L1fEXDoVLm73JHYnxCqk1ubVKqEJrQREe7j7fKGd6IzNPs2ls+k
-        t2EQjx6QlYWtt+JBCdB14DrEO2FvqWd5aLSOHI2RA7IEwDh7LzGAvUxCBKCqfHhd08+0S61lb03Z
-        cs0hJ/PazZhS/s7RPPNm6nJEnt5zqM0fAAD//wMALJ4MxY4AAAA=
-    headers:
-      Cache-Control:
-      - private
-      Connection:
-      - Keep-Alive
-      Content-Encoding:
-      - gzip
-      Content-Security-Policy:
-      - upgrade-insecure-requests
-      Content-Type:
-      - text/plain
-      Date:
-      - Wed, 28 Jul 2021 19:44:30 GMT
-      Keep-Alive:
-      - timeout=1, max=10
-      NCBI-PHID:
-      - C7A42964101B39E10000000000000001.m_1
-      NCBI-SID:
-      - C7A42964101B39E1_0000SID
-      Referrer-Policy:
-      - origin-when-cross-origin
-      Server:
-      - Apache
-      Set-Cookie:
-      - ncbi_sid=C7A42964101B39E1_0000SID; domain=.nih.gov; path=/; expires=Thu, 28
-        Jul 2022 19:44:30 GMT
-      SraNameServerOutputVersion:
-      - '2.0'
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains; preload
-      Transfer-Encoding:
-      - chunked
-      Vary:
-      - Accept-Encoding
-      X-UA-Compatible:
-      - IE=Edge
-      X-XSS-Protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
-- request:
     body: null
     headers:
       Accept:
@@ -6581,29 +5441,27 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/portal/api/filereport?accession=SRR5818014&result=read_run
   response:
     body:
-      string: "run_accession\tfastq_ftp\tfastq_bytes\tfastq_md5\tsubmitted_ftp\tsubmitted_bytes\tsubmitted_md5\tsra_ftp\tsra_bytes\tsra_md5\nSRR5818014\tftp.sra.ebi.ac.uk/vol1/fastq/SRR581/004/SRR5818014/SRR5818014.fastq.gz\t653073940\t8ce9ecf3ee5c145072e81fdf9f4410b3\t\t\t\t\t\t\n"
+      string: "run_accession\tfastq_ftp\tfastq_bytes\tfastq_md5\tbam_ftp\tbam_bytes\tbam_md5\tsubmitted_ftp\tsubmitted_bytes\tsubmitted_md5\tsra_ftp\tsra_bytes\tsra_md5\nSRR5818014\tftp.sra.ebi.ac.uk/vol1/fastq/SRR581/004/SRR5818014/SRR5818014.fastq.gz\t653073940\t8ce9ecf3ee5c145072e81fdf9f4410b3\t\t\t\t\t\t\tftp.sra.ebi.ac.uk/vol1/srr/SRR581/004/SRR5818014\t454383580\td37272ad4c145c01de885dc039b52200\n"
     headers:
       Cache-Control:
       - no-cache, no-store, max-age=0, must-revalidate
+      Content-Length:
+      - '365'
       Content-Type:
       - text/plain
       Date:
-      - Wed, 28 Jul 2021 19:44:31 GMT
+      - Wed, 17 May 2023 18:37:25 GMT
       Expires:
       - '0'
       Pragma:
       - no-cache
-      Server:
-      - Apache-Coyote/1.1
       Strict-Transport-Security:
       - max-age=0
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Frame-Options:
@@ -6612,7 +5470,7 @@ interactions:
       - 1; mode=block
     status:
       code: 200
-      message: OK
+      message: ''
 - request:
     body: null
     headers:
@@ -6623,7 +5481,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/SRR5818015
   response:
@@ -6664,7 +5522,7 @@ interactions:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:44:32 GMT
+      - Wed, 17 May 2023 18:37:26 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -6682,7 +5540,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/SRX2996263
   response:
@@ -6739,7 +5597,7 @@ interactions:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:44:32 GMT
+      - Wed, 17 May 2023 18:37:26 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -6757,54 +5615,40 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/SRS2347495
   response:
     body:
       string: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<SAMPLE_SET>\n<SAMPLE accession=\"SRS2347495\"
-        alias=\"GSM2700331\" broker_name=\"NCBI\">\n     <IDENTIFIERS>\n          <PRIMARY_ID>SRS2347495</PRIMARY_ID>\n
-        \         <EXTERNAL_ID namespace=\"BioSample\">SAMN07343029</EXTERNAL_ID>\n
-        \         <EXTERNAL_ID namespace=\"GEO\">GSM2700331</EXTERNAL_ID>\n          <SUBMITTER_ID
-        namespace=\"\">GSM2700331</SUBMITTER_ID>\n     </IDENTIFIERS>\n     <TITLE>wt1aGFP_3_pos</TITLE>\n
-        \    <SAMPLE_NAME>\n          <TAXON_ID>7955</TAXON_ID>\n          <SCIENTIFIC_NAME>Danio
-        rerio</SCIENTIFIC_NAME>\n          <COMMON_NAME>zebrafish</COMMON_NAME>\n
-        \    </SAMPLE_NAME>\n     <SAMPLE_LINKS>\n          <SAMPLE_LINK>\n               <XREF_LINK>\n
-        \                   <DB>ENA-STUDY</DB>\n                    <ID>SRP111553</ID>\n
-        \              </XREF_LINK>\n          </SAMPLE_LINK>\n          <SAMPLE_LINK>\n
-        \              <XREF_LINK>\n                    <DB>ENA-EXPERIMENT</DB>\n
-        \                   <ID>SRX2996263</ID>\n               </XREF_LINK>\n          </SAMPLE_LINK>\n
-        \         <SAMPLE_LINK>\n               <XREF_LINK>\n                    <DB>ENA-RUN</DB>\n
-        \                   <ID>SRR5818014-SRR5818015</ID>\n               </XREF_LINK>\n
-        \         </SAMPLE_LINK>\n          <SAMPLE_LINK>\n               <XREF_LINK>\n
-        \                   <DB>ENA-SUBMISSION</DB>\n                    <ID>SRA585736</ID>\n
-        \              </XREF_LINK>\n          </SAMPLE_LINK>\n          <SAMPLE_LINK>\n
-        \              <XREF_LINK>\n                    <DB>ARRAYEXPRESS</DB>\n                    <ID>E-GEOD-101204</ID>\n
-        \              </XREF_LINK>\n          </SAMPLE_LINK>\n          <SAMPLE_LINK>\n
-        \              <XREF_LINK>\n                    <DB>ENA-FASTQ-FILES</DB>\n
-        \                   <ID><![CDATA[https://www.ebi.ac.uk/ena/portal/api/filereport?accession=SRS2347495&result=read_run&fields=run_accession,fastq_ftp,fastq_md5,fastq_bytes]]></ID>\n
-        \              </XREF_LINK>\n          </SAMPLE_LINK>\n          <SAMPLE_LINK>\n
-        \              <XREF_LINK>\n                    <DB>ENA-SUBMITTED-FILES</DB>\n
-        \                   <ID><![CDATA[https://www.ebi.ac.uk/ena/portal/api/filereport?accession=SRS2347495&result=read_run&fields=run_accession,submitted_ftp,submitted_md5,submitted_bytes,submitted_format]]></ID>\n
-        \              </XREF_LINK>\n          </SAMPLE_LINK>\n     </SAMPLE_LINKS>\n
-        \    <SAMPLE_ATTRIBUTES>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>source_name</TAG>\n
+        alias=\"GSM2700331\" center_name=\"Bioinformatics Unit, CNIC\" broker_name=\"NCBI\">\n
+        \    <IDENTIFIERS>\n          <PRIMARY_ID>SRS2347495</PRIMARY_ID>\n          <EXTERNAL_ID
+        namespace=\"BioSample\">SAMN07343029</EXTERNAL_ID>\n          <SUBMITTER_ID
+        namespace=\"Bioinformatics Unit, CNIC\">GSM2700331</SUBMITTER_ID>\n     </IDENTIFIERS>\n
+        \    <TITLE>wt1aGFP_3_pos</TITLE>\n     <SAMPLE_NAME>\n          <TAXON_ID>7955</TAXON_ID>\n
+        \         <SCIENTIFIC_NAME>Danio rerio</SCIENTIFIC_NAME>\n          <COMMON_NAME>zebrafish</COMMON_NAME>\n
+        \    </SAMPLE_NAME>\n     <SAMPLE_LINKS>\n    <SAMPLE_LINK>\n        <XREF_LINK>\n
+        \           <DB>ENA-FASTQ-FILES</DB>\n            <ID><![CDATA[https://www.ebi.ac.uk/ena/portal/api/filereport?accession=SRS2347495&result=read_run&fields=run_accession,fastq_ftp,fastq_md5,fastq_bytes]]></ID>\n
+        \       </XREF_LINK>\n    </SAMPLE_LINK>\n    <SAMPLE_LINK>\n        <XREF_LINK>\n
+        \           <DB>ENA-SUBMITTED-FILES</DB>\n            <ID><![CDATA[https://www.ebi.ac.uk/ena/portal/api/filereport?accession=SRS2347495&result=read_run&fields=run_accession,submitted_ftp,submitted_md5,submitted_bytes,submitted_format]]></ID>\n
+        \       </XREF_LINK>\n    </SAMPLE_LINK>\n</SAMPLE_LINKS>\n<SAMPLE_ATTRIBUTES>\n
+        \         <SAMPLE_ATTRIBUTE>\n               <TAG>INSDC secondary accession</TAG>\n
+        \              <VALUE>SRS2347495</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
+        \         <SAMPLE_ATTRIBUTE>\n               <TAG>organism</TAG>\n               <VALUE>Danio
+        rerio</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
+        \              <TAG>pool</TAG>\n               <VALUE>3</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
+        \         <SAMPLE_ATTRIBUTE>\n               <TAG>cell type</TAG>\n               <VALUE>wt1a+</VALUE>\n
+        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>source_name</TAG>\n
         \              <VALUE>Heart</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
-        \              <TAG>cell type</TAG>\n               <VALUE>wt1a+</VALUE>\n
-        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>pool</TAG>\n
-        \              <VALUE>3</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
-        \              <TAG>ENA-SPOT-COUNT</TAG>\n               <VALUE>25570895</VALUE>\n
-        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-BASE-COUNT</TAG>\n
-        \              <VALUE>1559824595</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
-        \         <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-FIRST-PUBLIC</TAG>\n
-        \              <VALUE>2018-03-23</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
-        \         <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-LAST-UPDATE</TAG>\n
-        \              <VALUE>2018-04-04</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
+        \              <TAG>BioSampleModel</TAG>\n               <VALUE>Generic</VALUE>\n
+        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-FIRST-PUBLIC</TAG>\n
+        \              <VALUE>2018-03-22</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
         \    </SAMPLE_ATTRIBUTES>\n</SAMPLE>\n</SAMPLE_SET>\n"
     headers:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:44:33 GMT
+      - Wed, 17 May 2023 18:37:27 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -6822,7 +5666,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/SRP111553
   response:
@@ -6870,7 +5714,7 @@ interactions:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:44:34 GMT
+      - Wed, 17 May 2023 18:37:27 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -6888,7 +5732,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/SRA585736
   response:
@@ -6925,7 +5769,7 @@ interactions:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:44:34 GMT
+      - Wed, 17 May 2023 18:37:27 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -6934,68 +5778,6 @@ interactions:
       code: 200
       message: ''
 - request:
-    body: acc=SRR5818015&accept-proto=fasp&version=2.0
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '44'
-      User-Agent:
-      - python-requests/2.25.1
-    method: POST
-    uri: https://www.ncbi.nlm.nih.gov/Traces/names/names.cgi
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAAwzISwrCMBAA0H1PEXDRVWUm//QSQnXlLl+qBFPaiAhzeH3Ld+JnGI7db+9A12VR
-        Fi2gIqklOqGcIw5oJjAT4o3jLPiM7k6pZBt9FDIIpSH5Igwa6bBoy8ErT0QSgC6v+mXj2vt2jGzb
-        W2+xVfY4mK+1fXJipe2sr/9o4ZljH34AAAD//wMAgDyOdI4AAAA=
-    headers:
-      Cache-Control:
-      - private
-      Connection:
-      - Keep-Alive
-      Content-Encoding:
-      - gzip
-      Content-Security-Policy:
-      - upgrade-insecure-requests
-      Content-Type:
-      - text/plain
-      Date:
-      - Wed, 28 Jul 2021 19:44:35 GMT
-      Keep-Alive:
-      - timeout=1, max=10
-      NCBI-PHID:
-      - CC95F7B9101B3A310000000000000001.m_1
-      NCBI-SID:
-      - CC95F7B9101B3A31_0000SID
-      Referrer-Policy:
-      - origin-when-cross-origin
-      Server:
-      - Apache
-      Set-Cookie:
-      - ncbi_sid=CC95F7B9101B3A31_0000SID; domain=.nih.gov; path=/; expires=Thu, 28
-        Jul 2022 19:44:35 GMT
-      SraNameServerOutputVersion:
-      - '2.0'
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains; preload
-      Transfer-Encoding:
-      - chunked
-      Vary:
-      - Accept-Encoding
-      X-UA-Compatible:
-      - IE=Edge
-      X-XSS-Protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
-- request:
     body: null
     headers:
       Accept:
@@ -7005,29 +5787,27 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/portal/api/filereport?accession=SRR5818015&result=read_run
   response:
     body:
-      string: "run_accession\tfastq_ftp\tfastq_bytes\tfastq_md5\tsubmitted_ftp\tsubmitted_bytes\tsubmitted_md5\tsra_ftp\tsra_bytes\tsra_md5\nSRR5818015\tftp.sra.ebi.ac.uk/vol1/fastq/SRR581/005/SRR5818015/SRR5818015.fastq.gz\t666679070\tcc72fb436d98e3577b504400bcc72c86\t\t\t\t\t\t\n"
+      string: "run_accession\tfastq_ftp\tfastq_bytes\tfastq_md5\tbam_ftp\tbam_bytes\tbam_md5\tsubmitted_ftp\tsubmitted_bytes\tsubmitted_md5\tsra_ftp\tsra_bytes\tsra_md5\nSRR5818015\tftp.sra.ebi.ac.uk/vol1/fastq/SRR581/005/SRR5818015/SRR5818015.fastq.gz\t666679070\tcc72fb436d98e3577b504400bcc72c86\t\t\t\t\t\t\tftp.sra.ebi.ac.uk/vol1/srr/SRR581/005/SRR5818015\t464193599\tdfe8cac34b3560daf3717491f6820a5a\n"
     headers:
       Cache-Control:
       - no-cache, no-store, max-age=0, must-revalidate
+      Content-Length:
+      - '365'
       Content-Type:
       - text/plain
       Date:
-      - Wed, 28 Jul 2021 19:44:35 GMT
+      - Wed, 17 May 2023 18:37:28 GMT
       Expires:
       - '0'
       Pragma:
       - no-cache
-      Server:
-      - Apache-Coyote/1.1
       Strict-Transport-Security:
       - max-age=0
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Frame-Options:
@@ -7036,7 +5816,7 @@ interactions:
       - 1; mode=block
     status:
       code: 200
-      message: OK
+      message: ''
 - request:
     body: null
     headers:
@@ -7047,7 +5827,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/SRR5818016
   response:
@@ -7088,7 +5868,7 @@ interactions:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:44:36 GMT
+      - Wed, 17 May 2023 18:37:28 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -7106,7 +5886,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/SRX2996264
   response:
@@ -7163,7 +5943,7 @@ interactions:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:44:37 GMT
+      - Wed, 17 May 2023 18:37:29 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -7181,54 +5961,40 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/SRS2347496
   response:
     body:
       string: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<SAMPLE_SET>\n<SAMPLE accession=\"SRS2347496\"
-        alias=\"GSM2700332\" broker_name=\"NCBI\">\n     <IDENTIFIERS>\n          <PRIMARY_ID>SRS2347496</PRIMARY_ID>\n
-        \         <EXTERNAL_ID namespace=\"BioSample\">SAMN07343037</EXTERNAL_ID>\n
-        \         <EXTERNAL_ID namespace=\"GEO\">GSM2700332</EXTERNAL_ID>\n          <SUBMITTER_ID
-        namespace=\"\">GSM2700332</SUBMITTER_ID>\n     </IDENTIFIERS>\n     <TITLE>wt1aGFP_4_neg</TITLE>\n
-        \    <SAMPLE_NAME>\n          <TAXON_ID>7955</TAXON_ID>\n          <SCIENTIFIC_NAME>Danio
-        rerio</SCIENTIFIC_NAME>\n          <COMMON_NAME>zebrafish</COMMON_NAME>\n
-        \    </SAMPLE_NAME>\n     <SAMPLE_LINKS>\n          <SAMPLE_LINK>\n               <XREF_LINK>\n
-        \                   <DB>ENA-STUDY</DB>\n                    <ID>SRP111553</ID>\n
-        \              </XREF_LINK>\n          </SAMPLE_LINK>\n          <SAMPLE_LINK>\n
-        \              <XREF_LINK>\n                    <DB>ENA-EXPERIMENT</DB>\n
-        \                   <ID>SRX2996264</ID>\n               </XREF_LINK>\n          </SAMPLE_LINK>\n
-        \         <SAMPLE_LINK>\n               <XREF_LINK>\n                    <DB>ENA-RUN</DB>\n
-        \                   <ID>SRR5818016-SRR5818017</ID>\n               </XREF_LINK>\n
-        \         </SAMPLE_LINK>\n          <SAMPLE_LINK>\n               <XREF_LINK>\n
-        \                   <DB>ENA-SUBMISSION</DB>\n                    <ID>SRA585736</ID>\n
-        \              </XREF_LINK>\n          </SAMPLE_LINK>\n          <SAMPLE_LINK>\n
-        \              <XREF_LINK>\n                    <DB>ARRAYEXPRESS</DB>\n                    <ID>E-GEOD-101204</ID>\n
-        \              </XREF_LINK>\n          </SAMPLE_LINK>\n          <SAMPLE_LINK>\n
-        \              <XREF_LINK>\n                    <DB>ENA-FASTQ-FILES</DB>\n
-        \                   <ID><![CDATA[https://www.ebi.ac.uk/ena/portal/api/filereport?accession=SRS2347496&result=read_run&fields=run_accession,fastq_ftp,fastq_md5,fastq_bytes]]></ID>\n
-        \              </XREF_LINK>\n          </SAMPLE_LINK>\n          <SAMPLE_LINK>\n
-        \              <XREF_LINK>\n                    <DB>ENA-SUBMITTED-FILES</DB>\n
-        \                   <ID><![CDATA[https://www.ebi.ac.uk/ena/portal/api/filereport?accession=SRS2347496&result=read_run&fields=run_accession,submitted_ftp,submitted_md5,submitted_bytes,submitted_format]]></ID>\n
-        \              </XREF_LINK>\n          </SAMPLE_LINK>\n     </SAMPLE_LINKS>\n
-        \    <SAMPLE_ATTRIBUTES>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>source_name</TAG>\n
+        alias=\"GSM2700332\" center_name=\"Bioinformatics Unit, CNIC\" broker_name=\"NCBI\">\n
+        \    <IDENTIFIERS>\n          <PRIMARY_ID>SRS2347496</PRIMARY_ID>\n          <EXTERNAL_ID
+        namespace=\"BioSample\">SAMN07343037</EXTERNAL_ID>\n          <SUBMITTER_ID
+        namespace=\"Bioinformatics Unit, CNIC\">GSM2700332</SUBMITTER_ID>\n     </IDENTIFIERS>\n
+        \    <TITLE>wt1aGFP_4_neg</TITLE>\n     <SAMPLE_NAME>\n          <TAXON_ID>7955</TAXON_ID>\n
+        \         <SCIENTIFIC_NAME>Danio rerio</SCIENTIFIC_NAME>\n          <COMMON_NAME>zebrafish</COMMON_NAME>\n
+        \    </SAMPLE_NAME>\n     <SAMPLE_LINKS>\n    <SAMPLE_LINK>\n        <XREF_LINK>\n
+        \           <DB>ENA-FASTQ-FILES</DB>\n            <ID><![CDATA[https://www.ebi.ac.uk/ena/portal/api/filereport?accession=SRS2347496&result=read_run&fields=run_accession,fastq_ftp,fastq_md5,fastq_bytes]]></ID>\n
+        \       </XREF_LINK>\n    </SAMPLE_LINK>\n    <SAMPLE_LINK>\n        <XREF_LINK>\n
+        \           <DB>ENA-SUBMITTED-FILES</DB>\n            <ID><![CDATA[https://www.ebi.ac.uk/ena/portal/api/filereport?accession=SRS2347496&result=read_run&fields=run_accession,submitted_ftp,submitted_md5,submitted_bytes,submitted_format]]></ID>\n
+        \       </XREF_LINK>\n    </SAMPLE_LINK>\n</SAMPLE_LINKS>\n<SAMPLE_ATTRIBUTES>\n
+        \         <SAMPLE_ATTRIBUTE>\n               <TAG>INSDC secondary accession</TAG>\n
+        \              <VALUE>SRS2347496</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
+        \         <SAMPLE_ATTRIBUTE>\n               <TAG>organism</TAG>\n               <VALUE>Danio
+        rerio</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
+        \              <TAG>pool</TAG>\n               <VALUE>4</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
+        \         <SAMPLE_ATTRIBUTE>\n               <TAG>cell type</TAG>\n               <VALUE>wt1a-</VALUE>\n
+        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>source_name</TAG>\n
         \              <VALUE>Heart</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
-        \              <TAG>cell type</TAG>\n               <VALUE>wt1a-</VALUE>\n
-        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>pool</TAG>\n
-        \              <VALUE>4</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
-        \              <TAG>ENA-SPOT-COUNT</TAG>\n               <VALUE>28010081</VALUE>\n
-        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-BASE-COUNT</TAG>\n
-        \              <VALUE>1708614941</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
-        \         <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-FIRST-PUBLIC</TAG>\n
-        \              <VALUE>2018-03-23</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
-        \         <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-LAST-UPDATE</TAG>\n
-        \              <VALUE>2018-04-04</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
+        \              <TAG>BioSampleModel</TAG>\n               <VALUE>Generic</VALUE>\n
+        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-FIRST-PUBLIC</TAG>\n
+        \              <VALUE>2018-03-22</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
         \    </SAMPLE_ATTRIBUTES>\n</SAMPLE>\n</SAMPLE_SET>\n"
     headers:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:44:37 GMT
+      - Wed, 17 May 2023 18:37:29 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -7246,7 +6012,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/SRP111553
   response:
@@ -7294,7 +6060,7 @@ interactions:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:44:38 GMT
+      - Wed, 17 May 2023 18:37:29 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -7312,7 +6078,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/SRA585736
   response:
@@ -7349,7 +6115,7 @@ interactions:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:44:38 GMT
+      - Wed, 17 May 2023 18:37:30 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -7358,68 +6124,6 @@ interactions:
       code: 200
       message: ''
 - request:
-    body: acc=SRR5818016&accept-proto=fasp&version=2.0
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '44'
-      User-Agent:
-      - python-requests/2.25.1
-    method: POST
-    uri: https://www.ncbi.nlm.nih.gov/Traces/names/names.cgi
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAAwzISwrCMBAA0H1PEXDRVSUzmebTSwjVlbskbakSTEgjIszh9S3fCc+yO6ov78DX
-        eR4tWAmayREp1NoySjCDNAPADWFSNI3uzls0ALSOZGFzxpGNAZWOC5oQVfCemUlKvrzSV/R7a+Xo
-        Ram55ZiTeBzCp5Q/6yK2XEXb/5HDc42t+wEAAP//AwCQxTb0jgAAAA==
-    headers:
-      Cache-Control:
-      - private
-      Connection:
-      - Keep-Alive
-      Content-Encoding:
-      - gzip
-      Content-Security-Policy:
-      - upgrade-insecure-requests
-      Content-Type:
-      - text/plain
-      Date:
-      - Wed, 28 Jul 2021 19:44:39 GMT
-      Keep-Alive:
-      - timeout=1, max=10
-      NCBI-PHID:
-      - C7A429C2101B3A710000000000000001.m_1
-      NCBI-SID:
-      - C7A429C2101B3A71_0000SID
-      Referrer-Policy:
-      - origin-when-cross-origin
-      Server:
-      - Apache
-      Set-Cookie:
-      - ncbi_sid=C7A429C2101B3A71_0000SID; domain=.nih.gov; path=/; expires=Thu, 28
-        Jul 2022 19:44:39 GMT
-      SraNameServerOutputVersion:
-      - '2.0'
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains; preload
-      Transfer-Encoding:
-      - chunked
-      Vary:
-      - Accept-Encoding
-      X-UA-Compatible:
-      - IE=Edge
-      X-XSS-Protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
-- request:
     body: null
     headers:
       Accept:
@@ -7429,29 +6133,27 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/portal/api/filereport?accession=SRR5818016&result=read_run
   response:
     body:
-      string: "run_accession\tfastq_ftp\tfastq_bytes\tfastq_md5\tsubmitted_ftp\tsubmitted_bytes\tsubmitted_md5\tsra_ftp\tsra_bytes\tsra_md5\nSRR5818016\tftp.sra.ebi.ac.uk/vol1/fastq/SRR581/006/SRR5818016/SRR5818016.fastq.gz\t692367575\ta4efd28f613dbea313df0ca2f608dd1c\t\t\t\t\t\t\n"
+      string: "run_accession\tfastq_ftp\tfastq_bytes\tfastq_md5\tbam_ftp\tbam_bytes\tbam_md5\tsubmitted_ftp\tsubmitted_bytes\tsubmitted_md5\tsra_ftp\tsra_bytes\tsra_md5\nSRR5818016\tftp.sra.ebi.ac.uk/vol1/fastq/SRR581/006/SRR5818016/SRR5818016.fastq.gz\t692367575\ta4efd28f613dbea313df0ca2f608dd1c\t\t\t\t\t\t\tftp.sra.ebi.ac.uk/vol1/srr/SRR581/006/SRR5818016\t494432668\tfc7114e5481f97948cb236cd27bc3baa\n"
     headers:
       Cache-Control:
       - no-cache, no-store, max-age=0, must-revalidate
+      Content-Length:
+      - '365'
       Content-Type:
       - text/plain
       Date:
-      - Wed, 28 Jul 2021 19:44:39 GMT
+      - Wed, 17 May 2023 18:37:31 GMT
       Expires:
       - '0'
       Pragma:
       - no-cache
-      Server:
-      - Apache-Coyote/1.1
       Strict-Transport-Security:
       - max-age=0
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Frame-Options:
@@ -7460,7 +6162,7 @@ interactions:
       - 1; mode=block
     status:
       code: 200
-      message: OK
+      message: ''
 - request:
     body: null
     headers:
@@ -7471,7 +6173,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/SRR5818017
   response:
@@ -7512,7 +6214,7 @@ interactions:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:44:40 GMT
+      - Wed, 17 May 2023 18:37:30 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -7530,7 +6232,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/SRX2996264
   response:
@@ -7587,7 +6289,7 @@ interactions:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:44:41 GMT
+      - Wed, 17 May 2023 18:37:31 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -7605,54 +6307,40 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/SRS2347496
   response:
     body:
       string: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<SAMPLE_SET>\n<SAMPLE accession=\"SRS2347496\"
-        alias=\"GSM2700332\" broker_name=\"NCBI\">\n     <IDENTIFIERS>\n          <PRIMARY_ID>SRS2347496</PRIMARY_ID>\n
-        \         <EXTERNAL_ID namespace=\"BioSample\">SAMN07343037</EXTERNAL_ID>\n
-        \         <EXTERNAL_ID namespace=\"GEO\">GSM2700332</EXTERNAL_ID>\n          <SUBMITTER_ID
-        namespace=\"\">GSM2700332</SUBMITTER_ID>\n     </IDENTIFIERS>\n     <TITLE>wt1aGFP_4_neg</TITLE>\n
-        \    <SAMPLE_NAME>\n          <TAXON_ID>7955</TAXON_ID>\n          <SCIENTIFIC_NAME>Danio
-        rerio</SCIENTIFIC_NAME>\n          <COMMON_NAME>zebrafish</COMMON_NAME>\n
-        \    </SAMPLE_NAME>\n     <SAMPLE_LINKS>\n          <SAMPLE_LINK>\n               <XREF_LINK>\n
-        \                   <DB>ENA-STUDY</DB>\n                    <ID>SRP111553</ID>\n
-        \              </XREF_LINK>\n          </SAMPLE_LINK>\n          <SAMPLE_LINK>\n
-        \              <XREF_LINK>\n                    <DB>ENA-EXPERIMENT</DB>\n
-        \                   <ID>SRX2996264</ID>\n               </XREF_LINK>\n          </SAMPLE_LINK>\n
-        \         <SAMPLE_LINK>\n               <XREF_LINK>\n                    <DB>ENA-RUN</DB>\n
-        \                   <ID>SRR5818016-SRR5818017</ID>\n               </XREF_LINK>\n
-        \         </SAMPLE_LINK>\n          <SAMPLE_LINK>\n               <XREF_LINK>\n
-        \                   <DB>ENA-SUBMISSION</DB>\n                    <ID>SRA585736</ID>\n
-        \              </XREF_LINK>\n          </SAMPLE_LINK>\n          <SAMPLE_LINK>\n
-        \              <XREF_LINK>\n                    <DB>ARRAYEXPRESS</DB>\n                    <ID>E-GEOD-101204</ID>\n
-        \              </XREF_LINK>\n          </SAMPLE_LINK>\n          <SAMPLE_LINK>\n
-        \              <XREF_LINK>\n                    <DB>ENA-FASTQ-FILES</DB>\n
-        \                   <ID><![CDATA[https://www.ebi.ac.uk/ena/portal/api/filereport?accession=SRS2347496&result=read_run&fields=run_accession,fastq_ftp,fastq_md5,fastq_bytes]]></ID>\n
-        \              </XREF_LINK>\n          </SAMPLE_LINK>\n          <SAMPLE_LINK>\n
-        \              <XREF_LINK>\n                    <DB>ENA-SUBMITTED-FILES</DB>\n
-        \                   <ID><![CDATA[https://www.ebi.ac.uk/ena/portal/api/filereport?accession=SRS2347496&result=read_run&fields=run_accession,submitted_ftp,submitted_md5,submitted_bytes,submitted_format]]></ID>\n
-        \              </XREF_LINK>\n          </SAMPLE_LINK>\n     </SAMPLE_LINKS>\n
-        \    <SAMPLE_ATTRIBUTES>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>source_name</TAG>\n
+        alias=\"GSM2700332\" center_name=\"Bioinformatics Unit, CNIC\" broker_name=\"NCBI\">\n
+        \    <IDENTIFIERS>\n          <PRIMARY_ID>SRS2347496</PRIMARY_ID>\n          <EXTERNAL_ID
+        namespace=\"BioSample\">SAMN07343037</EXTERNAL_ID>\n          <SUBMITTER_ID
+        namespace=\"Bioinformatics Unit, CNIC\">GSM2700332</SUBMITTER_ID>\n     </IDENTIFIERS>\n
+        \    <TITLE>wt1aGFP_4_neg</TITLE>\n     <SAMPLE_NAME>\n          <TAXON_ID>7955</TAXON_ID>\n
+        \         <SCIENTIFIC_NAME>Danio rerio</SCIENTIFIC_NAME>\n          <COMMON_NAME>zebrafish</COMMON_NAME>\n
+        \    </SAMPLE_NAME>\n     <SAMPLE_LINKS>\n    <SAMPLE_LINK>\n        <XREF_LINK>\n
+        \           <DB>ENA-FASTQ-FILES</DB>\n            <ID><![CDATA[https://www.ebi.ac.uk/ena/portal/api/filereport?accession=SRS2347496&result=read_run&fields=run_accession,fastq_ftp,fastq_md5,fastq_bytes]]></ID>\n
+        \       </XREF_LINK>\n    </SAMPLE_LINK>\n    <SAMPLE_LINK>\n        <XREF_LINK>\n
+        \           <DB>ENA-SUBMITTED-FILES</DB>\n            <ID><![CDATA[https://www.ebi.ac.uk/ena/portal/api/filereport?accession=SRS2347496&result=read_run&fields=run_accession,submitted_ftp,submitted_md5,submitted_bytes,submitted_format]]></ID>\n
+        \       </XREF_LINK>\n    </SAMPLE_LINK>\n</SAMPLE_LINKS>\n<SAMPLE_ATTRIBUTES>\n
+        \         <SAMPLE_ATTRIBUTE>\n               <TAG>INSDC secondary accession</TAG>\n
+        \              <VALUE>SRS2347496</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
+        \         <SAMPLE_ATTRIBUTE>\n               <TAG>organism</TAG>\n               <VALUE>Danio
+        rerio</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
+        \              <TAG>pool</TAG>\n               <VALUE>4</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
+        \         <SAMPLE_ATTRIBUTE>\n               <TAG>cell type</TAG>\n               <VALUE>wt1a-</VALUE>\n
+        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>source_name</TAG>\n
         \              <VALUE>Heart</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
-        \              <TAG>cell type</TAG>\n               <VALUE>wt1a-</VALUE>\n
-        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>pool</TAG>\n
-        \              <VALUE>4</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
-        \              <TAG>ENA-SPOT-COUNT</TAG>\n               <VALUE>28010081</VALUE>\n
-        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-BASE-COUNT</TAG>\n
-        \              <VALUE>1708614941</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
-        \         <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-FIRST-PUBLIC</TAG>\n
-        \              <VALUE>2018-03-23</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
-        \         <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-LAST-UPDATE</TAG>\n
-        \              <VALUE>2018-04-04</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
+        \              <TAG>BioSampleModel</TAG>\n               <VALUE>Generic</VALUE>\n
+        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-FIRST-PUBLIC</TAG>\n
+        \              <VALUE>2018-03-22</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
         \    </SAMPLE_ATTRIBUTES>\n</SAMPLE>\n</SAMPLE_SET>\n"
     headers:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:44:41 GMT
+      - Wed, 17 May 2023 18:37:32 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -7670,7 +6358,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/SRP111553
   response:
@@ -7718,7 +6406,7 @@ interactions:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:44:43 GMT
+      - Wed, 17 May 2023 18:37:32 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -7736,7 +6424,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/SRA585736
   response:
@@ -7773,7 +6461,7 @@ interactions:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:44:43 GMT
+      - Wed, 17 May 2023 18:37:32 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -7782,68 +6470,6 @@ interactions:
       code: 200
       message: ''
 - request:
-    body: acc=SRR5818017&accept-proto=fasp&version=2.0
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '44'
-      User-Agent:
-      - python-requests/2.25.1
-    method: POST
-    uri: https://www.ncbi.nlm.nih.gov/Traces/names/names.cgi
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAAwzIsQ7CIBAA0L1fQeLQqeYOOCj9CZPq5EYLphoihGKMyX28Hd87yTN0e/Xls/B1
-        nmnEEdAygbUwKlQsDw5gB8SbxEnRpOWdUbvgSEUNRi5Bq0AUDKE3zhoZV8XMGoAv7/QT/dZa2XtR
-        am55zUk8d+FTyt8YxCNX0bYj8vKKa+v+AAAA//8DAOFojYaOAAAA
-    headers:
-      Cache-Control:
-      - private
-      Connection:
-      - Keep-Alive
-      Content-Encoding:
-      - gzip
-      Content-Security-Policy:
-      - upgrade-insecure-requests
-      Content-Type:
-      - text/plain
-      Date:
-      - Wed, 28 Jul 2021 19:44:44 GMT
-      Keep-Alive:
-      - timeout=1, max=10
-      NCBI-PHID:
-      - CC95F819101B3AC10000000000000001.m_1
-      NCBI-SID:
-      - CC95F819101B3AC1_0000SID
-      Referrer-Policy:
-      - origin-when-cross-origin
-      Server:
-      - Apache
-      Set-Cookie:
-      - ncbi_sid=CC95F819101B3AC1_0000SID; domain=.nih.gov; path=/; expires=Thu, 28
-        Jul 2022 19:44:44 GMT
-      SraNameServerOutputVersion:
-      - '2.0'
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains; preload
-      Transfer-Encoding:
-      - chunked
-      Vary:
-      - Accept-Encoding
-      X-UA-Compatible:
-      - IE=Edge
-      X-XSS-Protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
-- request:
     body: null
     headers:
       Accept:
@@ -7853,29 +6479,27 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/portal/api/filereport?accession=SRR5818017&result=read_run
   response:
     body:
-      string: "run_accession\tfastq_ftp\tfastq_bytes\tfastq_md5\tsubmitted_ftp\tsubmitted_bytes\tsubmitted_md5\tsra_ftp\tsra_bytes\tsra_md5\nSRR5818017\tftp.sra.ebi.ac.uk/vol1/fastq/SRR581/007/SRR5818017/SRR5818017.fastq.gz\t710518408\te4f4e0e59f8d282d8b307e33e2cef0e1\t\t\t\t\t\t\n"
+      string: "run_accession\tfastq_ftp\tfastq_bytes\tfastq_md5\tbam_ftp\tbam_bytes\tbam_md5\tsubmitted_ftp\tsubmitted_bytes\tsubmitted_md5\tsra_ftp\tsra_bytes\tsra_md5\nSRR5818017\tftp.sra.ebi.ac.uk/vol1/fastq/SRR581/007/SRR5818017/SRR5818017.fastq.gz\t710518408\te4f4e0e59f8d282d8b307e33e2cef0e1\t\t\t\t\t\t\tftp.sra.ebi.ac.uk/vol1/srr/SRR581/007/SRR5818017\t507708313\t149d953e4062bd43d55d651a69762ec3\n"
     headers:
       Cache-Control:
       - no-cache, no-store, max-age=0, must-revalidate
+      Content-Length:
+      - '365'
       Content-Type:
       - text/plain
       Date:
-      - Wed, 28 Jul 2021 19:44:45 GMT
+      - Wed, 17 May 2023 18:37:32 GMT
       Expires:
       - '0'
       Pragma:
       - no-cache
-      Server:
-      - Apache-Coyote/1.1
       Strict-Transport-Security:
       - max-age=0
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Frame-Options:
@@ -7884,7 +6508,7 @@ interactions:
       - 1; mode=block
     status:
       code: 200
-      message: OK
+      message: ''
 - request:
     body: null
     headers:
@@ -7895,7 +6519,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/SRR5818018
   response:
@@ -7936,7 +6560,7 @@ interactions:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:44:45 GMT
+      - Wed, 17 May 2023 18:37:33 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -7954,7 +6578,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/SRX2996265
   response:
@@ -8011,7 +6635,7 @@ interactions:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:44:45 GMT
+      - Wed, 17 May 2023 18:37:34 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -8029,54 +6653,40 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/SRS2347497
   response:
     body:
       string: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<SAMPLE_SET>\n<SAMPLE accession=\"SRS2347497\"
-        alias=\"GSM2700333\" broker_name=\"NCBI\">\n     <IDENTIFIERS>\n          <PRIMARY_ID>SRS2347497</PRIMARY_ID>\n
-        \         <EXTERNAL_ID namespace=\"BioSample\">SAMN07343036</EXTERNAL_ID>\n
-        \         <EXTERNAL_ID namespace=\"GEO\">GSM2700333</EXTERNAL_ID>\n          <SUBMITTER_ID
-        namespace=\"\">GSM2700333</SUBMITTER_ID>\n     </IDENTIFIERS>\n     <TITLE>wt1aGFP_4_pos</TITLE>\n
-        \    <SAMPLE_NAME>\n          <TAXON_ID>7955</TAXON_ID>\n          <SCIENTIFIC_NAME>Danio
-        rerio</SCIENTIFIC_NAME>\n          <COMMON_NAME>zebrafish</COMMON_NAME>\n
-        \    </SAMPLE_NAME>\n     <SAMPLE_LINKS>\n          <SAMPLE_LINK>\n               <XREF_LINK>\n
-        \                   <DB>ENA-STUDY</DB>\n                    <ID>SRP111553</ID>\n
-        \              </XREF_LINK>\n          </SAMPLE_LINK>\n          <SAMPLE_LINK>\n
-        \              <XREF_LINK>\n                    <DB>ENA-EXPERIMENT</DB>\n
-        \                   <ID>SRX2996265</ID>\n               </XREF_LINK>\n          </SAMPLE_LINK>\n
-        \         <SAMPLE_LINK>\n               <XREF_LINK>\n                    <DB>ENA-RUN</DB>\n
-        \                   <ID>SRR5818018-SRR5818019</ID>\n               </XREF_LINK>\n
-        \         </SAMPLE_LINK>\n          <SAMPLE_LINK>\n               <XREF_LINK>\n
-        \                   <DB>ENA-SUBMISSION</DB>\n                    <ID>SRA585736</ID>\n
-        \              </XREF_LINK>\n          </SAMPLE_LINK>\n          <SAMPLE_LINK>\n
-        \              <XREF_LINK>\n                    <DB>ARRAYEXPRESS</DB>\n                    <ID>E-GEOD-101204</ID>\n
-        \              </XREF_LINK>\n          </SAMPLE_LINK>\n          <SAMPLE_LINK>\n
-        \              <XREF_LINK>\n                    <DB>ENA-FASTQ-FILES</DB>\n
-        \                   <ID><![CDATA[https://www.ebi.ac.uk/ena/portal/api/filereport?accession=SRS2347497&result=read_run&fields=run_accession,fastq_ftp,fastq_md5,fastq_bytes]]></ID>\n
-        \              </XREF_LINK>\n          </SAMPLE_LINK>\n          <SAMPLE_LINK>\n
-        \              <XREF_LINK>\n                    <DB>ENA-SUBMITTED-FILES</DB>\n
-        \                   <ID><![CDATA[https://www.ebi.ac.uk/ena/portal/api/filereport?accession=SRS2347497&result=read_run&fields=run_accession,submitted_ftp,submitted_md5,submitted_bytes,submitted_format]]></ID>\n
-        \              </XREF_LINK>\n          </SAMPLE_LINK>\n     </SAMPLE_LINKS>\n
-        \    <SAMPLE_ATTRIBUTES>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>source_name</TAG>\n
+        alias=\"GSM2700333\" center_name=\"Bioinformatics Unit, CNIC\" broker_name=\"NCBI\">\n
+        \    <IDENTIFIERS>\n          <PRIMARY_ID>SRS2347497</PRIMARY_ID>\n          <EXTERNAL_ID
+        namespace=\"BioSample\">SAMN07343036</EXTERNAL_ID>\n          <SUBMITTER_ID
+        namespace=\"Bioinformatics Unit, CNIC\">GSM2700333</SUBMITTER_ID>\n     </IDENTIFIERS>\n
+        \    <TITLE>wt1aGFP_4_pos</TITLE>\n     <SAMPLE_NAME>\n          <TAXON_ID>7955</TAXON_ID>\n
+        \         <SCIENTIFIC_NAME>Danio rerio</SCIENTIFIC_NAME>\n          <COMMON_NAME>zebrafish</COMMON_NAME>\n
+        \    </SAMPLE_NAME>\n     <SAMPLE_LINKS>\n    <SAMPLE_LINK>\n        <XREF_LINK>\n
+        \           <DB>ENA-FASTQ-FILES</DB>\n            <ID><![CDATA[https://www.ebi.ac.uk/ena/portal/api/filereport?accession=SRS2347497&result=read_run&fields=run_accession,fastq_ftp,fastq_md5,fastq_bytes]]></ID>\n
+        \       </XREF_LINK>\n    </SAMPLE_LINK>\n    <SAMPLE_LINK>\n        <XREF_LINK>\n
+        \           <DB>ENA-SUBMITTED-FILES</DB>\n            <ID><![CDATA[https://www.ebi.ac.uk/ena/portal/api/filereport?accession=SRS2347497&result=read_run&fields=run_accession,submitted_ftp,submitted_md5,submitted_bytes,submitted_format]]></ID>\n
+        \       </XREF_LINK>\n    </SAMPLE_LINK>\n</SAMPLE_LINKS>\n<SAMPLE_ATTRIBUTES>\n
+        \         <SAMPLE_ATTRIBUTE>\n               <TAG>INSDC secondary accession</TAG>\n
+        \              <VALUE>SRS2347497</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
+        \         <SAMPLE_ATTRIBUTE>\n               <TAG>organism</TAG>\n               <VALUE>Danio
+        rerio</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
+        \              <TAG>pool</TAG>\n               <VALUE>4</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
+        \         <SAMPLE_ATTRIBUTE>\n               <TAG>cell type</TAG>\n               <VALUE>wt1a+</VALUE>\n
+        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>source_name</TAG>\n
         \              <VALUE>Heart</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
-        \              <TAG>cell type</TAG>\n               <VALUE>wt1a+</VALUE>\n
-        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>pool</TAG>\n
-        \              <VALUE>4</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
-        \              <TAG>ENA-SPOT-COUNT</TAG>\n               <VALUE>23930206</VALUE>\n
-        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-BASE-COUNT</TAG>\n
-        \              <VALUE>1459742566</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
-        \         <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-FIRST-PUBLIC</TAG>\n
-        \              <VALUE>2018-03-23</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
-        \         <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-LAST-UPDATE</TAG>\n
-        \              <VALUE>2018-04-04</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
+        \              <TAG>BioSampleModel</TAG>\n               <VALUE>Generic</VALUE>\n
+        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-FIRST-PUBLIC</TAG>\n
+        \              <VALUE>2018-03-22</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
         \    </SAMPLE_ATTRIBUTES>\n</SAMPLE>\n</SAMPLE_SET>\n"
     headers:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:44:47 GMT
+      - Wed, 17 May 2023 18:37:33 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -8094,7 +6704,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/SRP111553
   response:
@@ -8142,7 +6752,7 @@ interactions:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:44:47 GMT
+      - Wed, 17 May 2023 18:37:34 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -8160,7 +6770,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/SRA585736
   response:
@@ -8197,7 +6807,7 @@ interactions:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:44:47 GMT
+      - Wed, 17 May 2023 18:37:35 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -8206,68 +6816,6 @@ interactions:
       code: 200
       message: ''
 - request:
-    body: acc=SRR5818018&accept-proto=fasp&version=2.0
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '44'
-      User-Agent:
-      - python-requests/2.25.1
-    method: POST
-    uri: https://www.ncbi.nlm.nih.gov/Traces/names/names.cgi
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAAwzISw6CMBAA0D2naOKCFWY+lI5cwgRduaMtBE1DCdQYkzm8vuU70RmqYx+3t9fb
-        MFhBARRtiTsRx6IE6BpwDeKdsGfq2T6UHaK4GVuEYIm9D/7SWSaJPMXYiaq2AHpd09fUSynbUZtt
-        zyWHnMzzMGNK+TNFM+fdlOUf2b+mUKofAAAA//8DAOFuAHyOAAAA
-    headers:
-      Cache-Control:
-      - private
-      Connection:
-      - Keep-Alive
-      Content-Encoding:
-      - gzip
-      Content-Security-Policy:
-      - upgrade-insecure-requests
-      Content-Type:
-      - text/plain
-      Date:
-      - Wed, 28 Jul 2021 19:44:48 GMT
-      Keep-Alive:
-      - timeout=1, max=10
-      NCBI-PHID:
-      - C7A42A14101B3B010000000000000001.m_1
-      NCBI-SID:
-      - C7A42A14101B3B01_0000SID
-      Referrer-Policy:
-      - origin-when-cross-origin
-      Server:
-      - Apache
-      Set-Cookie:
-      - ncbi_sid=C7A42A14101B3B01_0000SID; domain=.nih.gov; path=/; expires=Thu, 28
-        Jul 2022 19:44:48 GMT
-      SraNameServerOutputVersion:
-      - '2.0'
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains; preload
-      Transfer-Encoding:
-      - chunked
-      Vary:
-      - Accept-Encoding
-      X-UA-Compatible:
-      - IE=Edge
-      X-XSS-Protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
-- request:
     body: null
     headers:
       Accept:
@@ -8277,29 +6825,27 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/portal/api/filereport?accession=SRR5818018&result=read_run
   response:
     body:
-      string: "run_accession\tfastq_ftp\tfastq_bytes\tfastq_md5\tsubmitted_ftp\tsubmitted_bytes\tsubmitted_md5\tsra_ftp\tsra_bytes\tsra_md5\nSRR5818018\tftp.sra.ebi.ac.uk/vol1/fastq/SRR581/008/SRR5818018/SRR5818018.fastq.gz\t616926968\tad76198d7a162b845f421ab477807d57\t\t\t\t\t\t\n"
+      string: "run_accession\tfastq_ftp\tfastq_bytes\tfastq_md5\tbam_ftp\tbam_bytes\tbam_md5\tsubmitted_ftp\tsubmitted_bytes\tsubmitted_md5\tsra_ftp\tsra_bytes\tsra_md5\nSRR5818018\tftp.sra.ebi.ac.uk/vol1/fastq/SRR581/008/SRR5818018/SRR5818018.fastq.gz\t616926968\tad76198d7a162b845f421ab477807d57\t\t\t\t\t\t\tftp.sra.ebi.ac.uk/vol1/srr/SRR581/008/SRR5818018\t423688738\t371187f1410c523bbcb965328d3edd68\n"
     headers:
       Cache-Control:
       - no-cache, no-store, max-age=0, must-revalidate
+      Content-Length:
+      - '365'
       Content-Type:
       - text/plain
       Date:
-      - Wed, 28 Jul 2021 19:44:49 GMT
+      - Wed, 17 May 2023 18:37:35 GMT
       Expires:
       - '0'
       Pragma:
       - no-cache
-      Server:
-      - Apache-Coyote/1.1
       Strict-Transport-Security:
       - max-age=0
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Frame-Options:
@@ -8308,7 +6854,7 @@ interactions:
       - 1; mode=block
     status:
       code: 200
-      message: OK
+      message: ''
 - request:
     body: null
     headers:
@@ -8319,7 +6865,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/SRR5818019
   response:
@@ -8360,7 +6906,7 @@ interactions:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:44:49 GMT
+      - Wed, 17 May 2023 18:37:36 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -8378,7 +6924,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/SRX2996265
   response:
@@ -8435,7 +6981,7 @@ interactions:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:44:49 GMT
+      - Wed, 17 May 2023 18:37:35 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -8453,54 +6999,40 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/SRS2347497
   response:
     body:
       string: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<SAMPLE_SET>\n<SAMPLE accession=\"SRS2347497\"
-        alias=\"GSM2700333\" broker_name=\"NCBI\">\n     <IDENTIFIERS>\n          <PRIMARY_ID>SRS2347497</PRIMARY_ID>\n
-        \         <EXTERNAL_ID namespace=\"BioSample\">SAMN07343036</EXTERNAL_ID>\n
-        \         <EXTERNAL_ID namespace=\"GEO\">GSM2700333</EXTERNAL_ID>\n          <SUBMITTER_ID
-        namespace=\"\">GSM2700333</SUBMITTER_ID>\n     </IDENTIFIERS>\n     <TITLE>wt1aGFP_4_pos</TITLE>\n
-        \    <SAMPLE_NAME>\n          <TAXON_ID>7955</TAXON_ID>\n          <SCIENTIFIC_NAME>Danio
-        rerio</SCIENTIFIC_NAME>\n          <COMMON_NAME>zebrafish</COMMON_NAME>\n
-        \    </SAMPLE_NAME>\n     <SAMPLE_LINKS>\n          <SAMPLE_LINK>\n               <XREF_LINK>\n
-        \                   <DB>ENA-STUDY</DB>\n                    <ID>SRP111553</ID>\n
-        \              </XREF_LINK>\n          </SAMPLE_LINK>\n          <SAMPLE_LINK>\n
-        \              <XREF_LINK>\n                    <DB>ENA-EXPERIMENT</DB>\n
-        \                   <ID>SRX2996265</ID>\n               </XREF_LINK>\n          </SAMPLE_LINK>\n
-        \         <SAMPLE_LINK>\n               <XREF_LINK>\n                    <DB>ENA-RUN</DB>\n
-        \                   <ID>SRR5818018-SRR5818019</ID>\n               </XREF_LINK>\n
-        \         </SAMPLE_LINK>\n          <SAMPLE_LINK>\n               <XREF_LINK>\n
-        \                   <DB>ENA-SUBMISSION</DB>\n                    <ID>SRA585736</ID>\n
-        \              </XREF_LINK>\n          </SAMPLE_LINK>\n          <SAMPLE_LINK>\n
-        \              <XREF_LINK>\n                    <DB>ARRAYEXPRESS</DB>\n                    <ID>E-GEOD-101204</ID>\n
-        \              </XREF_LINK>\n          </SAMPLE_LINK>\n          <SAMPLE_LINK>\n
-        \              <XREF_LINK>\n                    <DB>ENA-FASTQ-FILES</DB>\n
-        \                   <ID><![CDATA[https://www.ebi.ac.uk/ena/portal/api/filereport?accession=SRS2347497&result=read_run&fields=run_accession,fastq_ftp,fastq_md5,fastq_bytes]]></ID>\n
-        \              </XREF_LINK>\n          </SAMPLE_LINK>\n          <SAMPLE_LINK>\n
-        \              <XREF_LINK>\n                    <DB>ENA-SUBMITTED-FILES</DB>\n
-        \                   <ID><![CDATA[https://www.ebi.ac.uk/ena/portal/api/filereport?accession=SRS2347497&result=read_run&fields=run_accession,submitted_ftp,submitted_md5,submitted_bytes,submitted_format]]></ID>\n
-        \              </XREF_LINK>\n          </SAMPLE_LINK>\n     </SAMPLE_LINKS>\n
-        \    <SAMPLE_ATTRIBUTES>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>source_name</TAG>\n
+        alias=\"GSM2700333\" center_name=\"Bioinformatics Unit, CNIC\" broker_name=\"NCBI\">\n
+        \    <IDENTIFIERS>\n          <PRIMARY_ID>SRS2347497</PRIMARY_ID>\n          <EXTERNAL_ID
+        namespace=\"BioSample\">SAMN07343036</EXTERNAL_ID>\n          <SUBMITTER_ID
+        namespace=\"Bioinformatics Unit, CNIC\">GSM2700333</SUBMITTER_ID>\n     </IDENTIFIERS>\n
+        \    <TITLE>wt1aGFP_4_pos</TITLE>\n     <SAMPLE_NAME>\n          <TAXON_ID>7955</TAXON_ID>\n
+        \         <SCIENTIFIC_NAME>Danio rerio</SCIENTIFIC_NAME>\n          <COMMON_NAME>zebrafish</COMMON_NAME>\n
+        \    </SAMPLE_NAME>\n     <SAMPLE_LINKS>\n    <SAMPLE_LINK>\n        <XREF_LINK>\n
+        \           <DB>ENA-FASTQ-FILES</DB>\n            <ID><![CDATA[https://www.ebi.ac.uk/ena/portal/api/filereport?accession=SRS2347497&result=read_run&fields=run_accession,fastq_ftp,fastq_md5,fastq_bytes]]></ID>\n
+        \       </XREF_LINK>\n    </SAMPLE_LINK>\n    <SAMPLE_LINK>\n        <XREF_LINK>\n
+        \           <DB>ENA-SUBMITTED-FILES</DB>\n            <ID><![CDATA[https://www.ebi.ac.uk/ena/portal/api/filereport?accession=SRS2347497&result=read_run&fields=run_accession,submitted_ftp,submitted_md5,submitted_bytes,submitted_format]]></ID>\n
+        \       </XREF_LINK>\n    </SAMPLE_LINK>\n</SAMPLE_LINKS>\n<SAMPLE_ATTRIBUTES>\n
+        \         <SAMPLE_ATTRIBUTE>\n               <TAG>INSDC secondary accession</TAG>\n
+        \              <VALUE>SRS2347497</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
+        \         <SAMPLE_ATTRIBUTE>\n               <TAG>organism</TAG>\n               <VALUE>Danio
+        rerio</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
+        \              <TAG>pool</TAG>\n               <VALUE>4</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
+        \         <SAMPLE_ATTRIBUTE>\n               <TAG>cell type</TAG>\n               <VALUE>wt1a+</VALUE>\n
+        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>source_name</TAG>\n
         \              <VALUE>Heart</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
-        \              <TAG>cell type</TAG>\n               <VALUE>wt1a+</VALUE>\n
-        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>pool</TAG>\n
-        \              <VALUE>4</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
-        \              <TAG>ENA-SPOT-COUNT</TAG>\n               <VALUE>23930206</VALUE>\n
-        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-BASE-COUNT</TAG>\n
-        \              <VALUE>1459742566</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
-        \         <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-FIRST-PUBLIC</TAG>\n
-        \              <VALUE>2018-03-23</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
-        \         <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-LAST-UPDATE</TAG>\n
-        \              <VALUE>2018-04-04</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
+        \              <TAG>BioSampleModel</TAG>\n               <VALUE>Generic</VALUE>\n
+        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-FIRST-PUBLIC</TAG>\n
+        \              <VALUE>2018-03-22</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
         \    </SAMPLE_ATTRIBUTES>\n</SAMPLE>\n</SAMPLE_SET>\n"
     headers:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:44:51 GMT
+      - Wed, 17 May 2023 18:37:36 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -8518,7 +7050,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/SRP111553
   response:
@@ -8566,7 +7098,7 @@ interactions:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:44:51 GMT
+      - Wed, 17 May 2023 18:37:37 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -8584,7 +7116,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/SRA585736
   response:
@@ -8621,7 +7153,7 @@ interactions:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:44:52 GMT
+      - Wed, 17 May 2023 18:37:37 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -8630,68 +7162,6 @@ interactions:
       code: 200
       message: ''
 - request:
-    body: acc=SRR5818019&accept-proto=fasp&version=2.0
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '44'
-      User-Agent:
-      - python-requests/2.25.1
-    method: POST
-    uri: https://www.ncbi.nlm.nih.gov/Traces/names/names.cgi
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAAwzISwrCMBAA0H1PEXDRVWVmkpimlxCqK3f5lSqhCW1EhDm8vuU70Rm6Y3f17fk2
-        z3rEEdCykoq0NUYzAZoBzIB4J5wkTTA+2Cm/BLxE7zxGtRiyQWlNSQar0UZkZgXA1y1/Rb+2Vo9e
-        1L20EkoWz0O4nMsnRbGUXbT1H8W/UmjdDwAA//8DALIzE9+OAAAA
-    headers:
-      Cache-Control:
-      - private
-      Connection:
-      - Keep-Alive
-      Content-Encoding:
-      - gzip
-      Content-Security-Policy:
-      - upgrade-insecure-requests
-      Content-Type:
-      - text/plain
-      Date:
-      - Wed, 28 Jul 2021 19:44:52 GMT
-      Keep-Alive:
-      - timeout=1, max=10
-      NCBI-PHID:
-      - C7A42A3F101B3B410000000000000001.m_1
-      NCBI-SID:
-      - C7A42A3F101B3B41_0000SID
-      Referrer-Policy:
-      - origin-when-cross-origin
-      Server:
-      - Apache
-      Set-Cookie:
-      - ncbi_sid=C7A42A3F101B3B41_0000SID; domain=.nih.gov; path=/; expires=Thu, 28
-        Jul 2022 19:44:52 GMT
-      SraNameServerOutputVersion:
-      - '2.0'
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains; preload
-      Transfer-Encoding:
-      - chunked
-      Vary:
-      - Accept-Encoding
-      X-UA-Compatible:
-      - IE=Edge
-      X-XSS-Protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
-- request:
     body: null
     headers:
       Accept:
@@ -8701,29 +7171,27 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/portal/api/filereport?accession=SRR5818019&result=read_run
   response:
     body:
-      string: "run_accession\tfastq_ftp\tfastq_bytes\tfastq_md5\tsubmitted_ftp\tsubmitted_bytes\tsubmitted_md5\tsra_ftp\tsra_bytes\tsra_md5\nSRR5818019\tftp.sra.ebi.ac.uk/vol1/fastq/SRR581/009/SRR5818019/SRR5818019.fastq.gz\t631703792\t4b04c53f6f028dc9fad6338662a5f1bc\t\t\t\t\t\t\n"
+      string: "run_accession\tfastq_ftp\tfastq_bytes\tfastq_md5\tbam_ftp\tbam_bytes\tbam_md5\tsubmitted_ftp\tsubmitted_bytes\tsubmitted_md5\tsra_ftp\tsra_bytes\tsra_md5\nSRR5818019\tftp.sra.ebi.ac.uk/vol1/fastq/SRR581/009/SRR5818019/SRR5818019.fastq.gz\t631703792\t4b04c53f6f028dc9fad6338662a5f1bc\t\t\t\t\t\t\tftp.sra.ebi.ac.uk/vol1/srr/SRR581/009/SRR5818019\t434259775\ta4bfc16dbab1d4f729c4552e3c9519d1\n"
     headers:
       Cache-Control:
       - no-cache, no-store, max-age=0, must-revalidate
+      Content-Length:
+      - '365'
       Content-Type:
       - text/plain
       Date:
-      - Wed, 28 Jul 2021 19:44:52 GMT
+      - Wed, 17 May 2023 18:37:38 GMT
       Expires:
       - '0'
       Pragma:
       - no-cache
-      Server:
-      - Apache-Coyote/1.1
       Strict-Transport-Security:
       - max-age=0
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Frame-Options:
@@ -8732,7 +7200,7 @@ interactions:
       - 1; mode=block
     status:
       code: 200
-      message: OK
+      message: ''
 - request:
     body: null
     headers:
@@ -8743,7 +7211,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/DRP003977
   response:
@@ -8751,14 +7219,16 @@ interactions:
       string: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<STUDY_SET>\n<STUDY accession=\"DRP003977\"
         alias=\"DRP003977\" center_name=\"NIG\" broker_name=\"DDBJ\">\n     <IDENTIFIERS>\n
         \         <PRIMARY_ID>DRP003977</PRIMARY_ID>\n          <SECONDARY_ID>PRJDB4470</SECONDARY_ID>\n
-        \         <EXTERNAL_ID label=\"primary\" namespace=\"BioProject\">PRJDB4470</EXTERNAL_ID>\n
+        \         <EXTERNAL_ID label=\"BioProject ID\" namespace=\"BioProject\">PRJDB4470</EXTERNAL_ID>\n
         \         <SUBMITTER_ID namespace=\"NIG\">DRP003977</SUBMITTER_ID>\n     </IDENTIFIERS>\n
         \    <DESCRIPTOR>\n          <STUDY_TITLE>Gene expression analysis of the
-        zebrafish brain</STUDY_TITLE>\n          <STUDY_TYPE existing_study_type=\"Transcriptome
-        Analysis\"/>\n          <STUDY_ABSTRACT>Gene expression profiling by RNA-seq
-        of specific regions and subpopulations of neurons in the zebrafish brain that
-        control behaviors.</STUDY_ABSTRACT>\n     </DESCRIPTOR>\n     <STUDY_LINKS>\n
-        \         <STUDY_LINK>\n               <XREF_LINK>\n                    <DB>ENA-SAMPLE</DB>\n
+        zebrafish brain</STUDY_TITLE>\n          <STUDY_TYPE existing_study_type=\"Other\"/>\n
+        \         <STUDY_ABSTRACT>Gene expression profiling by RNA-seq of specific
+        regions and subpopulations of neurons in the zebrafish brain that control
+        behaviors.</STUDY_ABSTRACT>\n          <STUDY_DESCRIPTION>Gene expression
+        profiling by RNA-seq of specific regions and subpopulations of neurons in
+        the zebrafish brain that control behaviors.</STUDY_DESCRIPTION>\n     </DESCRIPTOR>\n
+        \    <STUDY_LINKS>\n          <STUDY_LINK>\n               <XREF_LINK>\n                    <DB>ENA-SAMPLE</DB>\n
         \                   <ID>DRS057265-DRS057267,DRS057269-DRS057272,DRS057274-DRS057275</ID>\n
         \              </XREF_LINK>\n          </STUDY_LINK>\n          <STUDY_LINK>\n
         \              <XREF_LINK>\n                    <DB>ENA-EXPERIMENT</DB>\n
@@ -8767,7 +7237,7 @@ interactions:
         \                   <DB>ENA-RUN</DB>\n                    <ID>DRR051059-DRR051067</ID>\n
         \              </XREF_LINK>\n          </STUDY_LINK>\n          <STUDY_LINK>\n
         \              <XREF_LINK>\n                    <DB>ENA-SUBMISSION</DB>\n
-        \                   <ID>DRA004276</ID>\n               </XREF_LINK>\n          </STUDY_LINK>\n
+        \                   <ID>DRA008860</ID>\n               </XREF_LINK>\n          </STUDY_LINK>\n
         \         <STUDY_LINK>\n               <XREF_LINK>\n                    <DB>ENA-FASTQ-FILES</DB>\n
         \                   <ID><![CDATA[https://www.ebi.ac.uk/ena/portal/api/filereport?accession=DRP003977&result=read_run&fields=run_accession,fastq_ftp,fastq_md5,fastq_bytes]]></ID>\n
         \              </XREF_LINK>\n          </STUDY_LINK>\n          <STUDY_LINK>\n
@@ -8779,13 +7249,13 @@ interactions:
         \              <TAG>ENA-BASE-COUNT</TAG>\n               <VALUE>182690550386</VALUE>\n
         \         </STUDY_ATTRIBUTE>\n          <STUDY_ATTRIBUTE>\n               <TAG>ENA-FIRST-PUBLIC</TAG>\n
         \              <VALUE>2018-01-08</VALUE>\n          </STUDY_ATTRIBUTE>\n          <STUDY_ATTRIBUTE>\n
-        \              <TAG>ENA-LAST-UPDATE</TAG>\n               <VALUE>2018-01-08</VALUE>\n
+        \              <TAG>ENA-LAST-UPDATE</TAG>\n               <VALUE>2021-08-11</VALUE>\n
         \         </STUDY_ATTRIBUTE>\n     </STUDY_ATTRIBUTES>\n</STUDY>\n</STUDY_SET>\n"
     headers:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:44:53 GMT
+      - Wed, 17 May 2023 18:37:37 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -8803,7 +7273,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/DRR051059
   response:
@@ -8837,7 +7307,7 @@ interactions:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:44:54 GMT
+      - Wed, 17 May 2023 18:37:38 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -8855,7 +7325,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/DRX045951
   response:
@@ -8911,7 +7381,7 @@ interactions:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:44:54 GMT
+      - Wed, 17 May 2023 18:37:39 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -8929,55 +7399,43 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/DRS057270
   response:
     body:
       string: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<SAMPLE_SET>\n<SAMPLE accession=\"DRS057270\"
-        alias=\"DRS057270\" center_name=\"NIG\" broker_name=\"DDBJ\">\n     <IDENTIFIERS>\n
-        \         <PRIMARY_ID>DRS057270</PRIMARY_ID>\n          <EXTERNAL_ID label=\"BioSample
-        ID\" namespace=\"BioSample\">SAMD00044993</EXTERNAL_ID>\n          <SUBMITTER_ID
-        namespace=\"NIG\">DRS057270</SUBMITTER_ID>\n     </IDENTIFIERS>\n     <TITLE>Danio
-        rerio</TITLE>\n     <SAMPLE_NAME>\n          <TAXON_ID>7955</TAXON_ID>\n          <SCIENTIFIC_NAME>Danio
-        rerio</SCIENTIFIC_NAME>\n          <COMMON_NAME>zebrafish</COMMON_NAME>\n
-        \    </SAMPLE_NAME>\n     <SAMPLE_LINKS>\n          <SAMPLE_LINK>\n               <XREF_LINK>\n
-        \                   <DB>ENA-STUDY</DB>\n                    <ID>DRP003977</ID>\n
-        \              </XREF_LINK>\n          </SAMPLE_LINK>\n          <SAMPLE_LINK>\n
-        \              <XREF_LINK>\n                    <DB>ENA-EXPERIMENT</DB>\n
-        \                   <ID>DRX045951</ID>\n               </XREF_LINK>\n          </SAMPLE_LINK>\n
-        \         <SAMPLE_LINK>\n               <XREF_LINK>\n                    <DB>ENA-RUN</DB>\n
-        \                   <ID>DRR051059</ID>\n               </XREF_LINK>\n          </SAMPLE_LINK>\n
-        \         <SAMPLE_LINK>\n               <XREF_LINK>\n                    <DB>ENA-SUBMISSION</DB>\n
-        \                   <ID>DRA004269</ID>\n               </XREF_LINK>\n          </SAMPLE_LINK>\n
-        \         <SAMPLE_LINK>\n               <XREF_LINK>\n                    <DB>ENA-FASTQ-FILES</DB>\n
-        \                   <ID><![CDATA[https://www.ebi.ac.uk/ena/portal/api/filereport?accession=DRS057270&result=read_run&fields=run_accession,fastq_ftp,fastq_md5,fastq_bytes]]></ID>\n
-        \              </XREF_LINK>\n          </SAMPLE_LINK>\n          <SAMPLE_LINK>\n
-        \              <XREF_LINK>\n                    <DB>ENA-SUBMITTED-FILES</DB>\n
-        \                   <ID><![CDATA[https://www.ebi.ac.uk/ena/portal/api/filereport?accession=DRS057270&result=read_run&fields=run_accession,submitted_ftp,submitted_md5,submitted_bytes,submitted_format]]></ID>\n
-        \              </XREF_LINK>\n          </SAMPLE_LINK>\n     </SAMPLE_LINKS>\n
-        \    <SAMPLE_ATTRIBUTES>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>description</TAG>\n
-        \              <VALUE>Whole brain of adult zebrafish</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
-        \         <SAMPLE_ATTRIBUTE>\n               <TAG>bioproject_id</TAG>\n               <VALUE>PRJDB4470</VALUE>\n
-        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>sample_name</TAG>\n
-        \              <VALUE>WB</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
-        \              <TAG>sample_title</TAG>\n               <VALUE>zebrafish whole
-        brain</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
-        \              <TAG>genotype</TAG>\n               <VALUE>WT</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
-        \         <SAMPLE_ATTRIBUTE>\n               <TAG>tissue_type</TAG>\n               <VALUE>brain</VALUE>\n
-        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-SPOT-COUNT</TAG>\n
-        \              <VALUE>125165088</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
-        \              <TAG>ENA-BASE-COUNT</TAG>\n               <VALUE>25283347776</VALUE>\n
-        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-FIRST-PUBLIC</TAG>\n
-        \              <VALUE>2018-01-07</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
-        \         <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-LAST-UPDATE</TAG>\n
-        \              <VALUE>2018-01-07</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
+        alias=\"SAMD00044993\" center_name=\"National Institute of Genetics (Japan)\"
+        broker_name=\"DDBJ\">\n     <IDENTIFIERS>\n          <PRIMARY_ID>DRS057270</PRIMARY_ID>\n
+        \         <EXTERNAL_ID namespace=\"BioSample\">SAMD00044993</EXTERNAL_ID>\n
+        \    </IDENTIFIERS>\n     <TITLE>zebrafish whole brain</TITLE>\n     <SAMPLE_NAME>\n
+        \         <TAXON_ID>7955</TAXON_ID>\n          <SCIENTIFIC_NAME>Danio rerio</SCIENTIFIC_NAME>\n
+        \         <COMMON_NAME>zebrafish</COMMON_NAME>\n     </SAMPLE_NAME>\n     <DESCRIPTION>Whole
+        brain of adult zebrafish</DESCRIPTION>\n     <SAMPLE_LINKS>\n    <SAMPLE_LINK>\n
+        \       <XREF_LINK>\n            <DB>ENA-FASTQ-FILES</DB>\n            <ID><![CDATA[https://www.ebi.ac.uk/ena/portal/api/filereport?accession=DRS057270&result=read_run&fields=run_accession,fastq_ftp,fastq_md5,fastq_bytes]]></ID>\n
+        \       </XREF_LINK>\n    </SAMPLE_LINK>\n    <SAMPLE_LINK>\n        <XREF_LINK>\n
+        \           <DB>ENA-SUBMITTED-FILES</DB>\n            <ID><![CDATA[https://www.ebi.ac.uk/ena/portal/api/filereport?accession=DRS057270&result=read_run&fields=run_accession,submitted_ftp,submitted_md5,submitted_bytes,submitted_format]]></ID>\n
+        \       </XREF_LINK>\n    </SAMPLE_LINK>\n</SAMPLE_LINKS>\n<SAMPLE_ATTRIBUTES>\n
+        \         <SAMPLE_ATTRIBUTE>\n               <TAG>INSDC secondary accession</TAG>\n
+        \              <VALUE>DRS057270</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
+        \              <TAG>NCBI submission package</TAG>\n               <VALUE>Generic.1.0</VALUE>\n
+        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>organism</TAG>\n
+        \              <VALUE>Danio rerio</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
+        \         <SAMPLE_ATTRIBUTE>\n               <TAG>tissue type</TAG>\n               <VALUE>brain</VALUE>\n
+        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>sample
+        name</TAG>\n               <VALUE>WB</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
+        \         <SAMPLE_ATTRIBUTE>\n               <TAG>genotype</TAG>\n               <VALUE>WT</VALUE>\n
+        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>BioSampleModel</TAG>\n
+        \              <VALUE>Generic</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
+        \              <TAG>ENA-FIRST-PUBLIC</TAG>\n               <VALUE>2018-01-06</VALUE>\n
+        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-LAST-UPDATE</TAG>\n
+        \              <VALUE>2018-01-06</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
         \    </SAMPLE_ATTRIBUTES>\n</SAMPLE>\n</SAMPLE_SET>\n"
     headers:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:44:55 GMT
+      - Wed, 17 May 2023 18:37:39 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -8995,7 +7453,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/DRP003977
   response:
@@ -9003,14 +7461,16 @@ interactions:
       string: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<STUDY_SET>\n<STUDY accession=\"DRP003977\"
         alias=\"DRP003977\" center_name=\"NIG\" broker_name=\"DDBJ\">\n     <IDENTIFIERS>\n
         \         <PRIMARY_ID>DRP003977</PRIMARY_ID>\n          <SECONDARY_ID>PRJDB4470</SECONDARY_ID>\n
-        \         <EXTERNAL_ID label=\"primary\" namespace=\"BioProject\">PRJDB4470</EXTERNAL_ID>\n
+        \         <EXTERNAL_ID label=\"BioProject ID\" namespace=\"BioProject\">PRJDB4470</EXTERNAL_ID>\n
         \         <SUBMITTER_ID namespace=\"NIG\">DRP003977</SUBMITTER_ID>\n     </IDENTIFIERS>\n
         \    <DESCRIPTOR>\n          <STUDY_TITLE>Gene expression analysis of the
-        zebrafish brain</STUDY_TITLE>\n          <STUDY_TYPE existing_study_type=\"Transcriptome
-        Analysis\"/>\n          <STUDY_ABSTRACT>Gene expression profiling by RNA-seq
-        of specific regions and subpopulations of neurons in the zebrafish brain that
-        control behaviors.</STUDY_ABSTRACT>\n     </DESCRIPTOR>\n     <STUDY_LINKS>\n
-        \         <STUDY_LINK>\n               <XREF_LINK>\n                    <DB>ENA-SAMPLE</DB>\n
+        zebrafish brain</STUDY_TITLE>\n          <STUDY_TYPE existing_study_type=\"Other\"/>\n
+        \         <STUDY_ABSTRACT>Gene expression profiling by RNA-seq of specific
+        regions and subpopulations of neurons in the zebrafish brain that control
+        behaviors.</STUDY_ABSTRACT>\n          <STUDY_DESCRIPTION>Gene expression
+        profiling by RNA-seq of specific regions and subpopulations of neurons in
+        the zebrafish brain that control behaviors.</STUDY_DESCRIPTION>\n     </DESCRIPTOR>\n
+        \    <STUDY_LINKS>\n          <STUDY_LINK>\n               <XREF_LINK>\n                    <DB>ENA-SAMPLE</DB>\n
         \                   <ID>DRS057265-DRS057267,DRS057269-DRS057272,DRS057274-DRS057275</ID>\n
         \              </XREF_LINK>\n          </STUDY_LINK>\n          <STUDY_LINK>\n
         \              <XREF_LINK>\n                    <DB>ENA-EXPERIMENT</DB>\n
@@ -9019,7 +7479,7 @@ interactions:
         \                   <DB>ENA-RUN</DB>\n                    <ID>DRR051059-DRR051067</ID>\n
         \              </XREF_LINK>\n          </STUDY_LINK>\n          <STUDY_LINK>\n
         \              <XREF_LINK>\n                    <DB>ENA-SUBMISSION</DB>\n
-        \                   <ID>DRA004276</ID>\n               </XREF_LINK>\n          </STUDY_LINK>\n
+        \                   <ID>DRA008860</ID>\n               </XREF_LINK>\n          </STUDY_LINK>\n
         \         <STUDY_LINK>\n               <XREF_LINK>\n                    <DB>ENA-FASTQ-FILES</DB>\n
         \                   <ID><![CDATA[https://www.ebi.ac.uk/ena/portal/api/filereport?accession=DRP003977&result=read_run&fields=run_accession,fastq_ftp,fastq_md5,fastq_bytes]]></ID>\n
         \              </XREF_LINK>\n          </STUDY_LINK>\n          <STUDY_LINK>\n
@@ -9031,13 +7491,13 @@ interactions:
         \              <TAG>ENA-BASE-COUNT</TAG>\n               <VALUE>182690550386</VALUE>\n
         \         </STUDY_ATTRIBUTE>\n          <STUDY_ATTRIBUTE>\n               <TAG>ENA-FIRST-PUBLIC</TAG>\n
         \              <VALUE>2018-01-08</VALUE>\n          </STUDY_ATTRIBUTE>\n          <STUDY_ATTRIBUTE>\n
-        \              <TAG>ENA-LAST-UPDATE</TAG>\n               <VALUE>2018-01-08</VALUE>\n
+        \              <TAG>ENA-LAST-UPDATE</TAG>\n               <VALUE>2021-08-11</VALUE>\n
         \         </STUDY_ATTRIBUTE>\n     </STUDY_ATTRIBUTES>\n</STUDY>\n</STUDY_SET>\n"
     headers:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:44:55 GMT
+      - Wed, 17 May 2023 18:37:40 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -9055,7 +7515,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/DRA004269
   response:
@@ -9089,7 +7549,7 @@ interactions:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:44:56 GMT
+      - Wed, 17 May 2023 18:37:40 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -9098,68 +7558,6 @@ interactions:
       code: 200
       message: ''
 - request:
-    body: acc=DRR051059&accept-proto=fasp&version=2.0
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '43'
-      User-Agent:
-      - python-requests/2.25.1
-    method: POST
-    uri: https://www.ncbi.nlm.nih.gov/Traces/names/names.cgi
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAAwzJuwrCMBQA0L1fEXDoVLk3ryad3YXi5JbElCrBhCQiwv14u55z4mcYWnXl4+my
-        rqAQlCWcZ2ulAK6ROKCZACfQNzSLFIvid9JmlsGI44OOUYCVm3DaK8M5BiENEUkAur7Tj41776WN
-        rNTcc8iJPRtzKeVvfLAtV9b3A7J/xdCHPwAAAP//AwD5xduojwAAAA==
-    headers:
-      Cache-Control:
-      - private
-      Connection:
-      - Keep-Alive
-      Content-Encoding:
-      - gzip
-      Content-Security-Policy:
-      - upgrade-insecure-requests
-      Content-Type:
-      - text/plain
-      Date:
-      - Wed, 28 Jul 2021 19:44:57 GMT
-      Keep-Alive:
-      - timeout=1, max=10
-      NCBI-PHID:
-      - CC95F88E101B3B910000000000000001.m_1
-      NCBI-SID:
-      - CC95F88E101B3B91_0000SID
-      Referrer-Policy:
-      - origin-when-cross-origin
-      Server:
-      - Apache
-      Set-Cookie:
-      - ncbi_sid=CC95F88E101B3B91_0000SID; domain=.nih.gov; path=/; expires=Thu, 28
-        Jul 2022 19:44:57 GMT
-      SraNameServerOutputVersion:
-      - '2.0'
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains; preload
-      Transfer-Encoding:
-      - chunked
-      Vary:
-      - Accept-Encoding
-      X-UA-Compatible:
-      - IE=Edge
-      X-XSS-Protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
-- request:
     body: null
     headers:
       Accept:
@@ -9169,29 +7567,27 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/portal/api/filereport?accession=DRR051059&result=read_run
   response:
     body:
-      string: "run_accession\tfastq_ftp\tfastq_bytes\tfastq_md5\tsubmitted_ftp\tsubmitted_bytes\tsubmitted_md5\tsra_ftp\tsra_bytes\tsra_md5\nDRR051059\tftp.sra.ebi.ac.uk/vol1/fastq/DRR051/DRR051059/DRR051059_1.fastq.gz;ftp.sra.ebi.ac.uk/vol1/fastq/DRR051/DRR051059/DRR051059_2.fastq.gz\t11191882751;11504627040\t5437a4dd2fe03230513793d9a5e1c999;5bc99fce97935ae4b0950745beeed48c\t\t\t\t\t\t\n"
+      string: "run_accession\tfastq_ftp\tfastq_bytes\tfastq_md5\tbam_ftp\tbam_bytes\tbam_md5\tsubmitted_ftp\tsubmitted_bytes\tsubmitted_md5\tsra_ftp\tsra_bytes\tsra_md5\nDRR051059\tftp.sra.ebi.ac.uk/vol1/fastq/DRR051/DRR051059/DRR051059_1.fastq.gz;ftp.sra.ebi.ac.uk/vol1/fastq/DRR051/DRR051059/DRR051059_2.fastq.gz\t11191882751;11504627040\t5437a4dd2fe03230513793d9a5e1c999;5bc99fce97935ae4b0950745beeed48c\t\t\t\t\t\t\tftp.sra.ebi.ac.uk/vol1/drr/DRR051/DRR051059\t17799430261\t6874c83261c6ee3094f3a6b58221c348\n"
     headers:
       Cache-Control:
       - no-cache, no-store, max-age=0, must-revalidate
+      Content-Length:
+      - '471'
       Content-Type:
       - text/plain
       Date:
-      - Wed, 28 Jul 2021 19:44:58 GMT
+      - Wed, 17 May 2023 18:37:41 GMT
       Expires:
       - '0'
       Pragma:
       - no-cache
-      Server:
-      - Apache-Coyote/1.1
       Strict-Transport-Security:
       - max-age=0
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Frame-Options:
@@ -9200,7 +7596,7 @@ interactions:
       - 1; mode=block
     status:
       code: 200
-      message: OK
+      message: ''
 - request:
     body: null
     headers:
@@ -9211,7 +7607,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/DRR051060
   response:
@@ -9245,7 +7641,7 @@ interactions:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:44:59 GMT
+      - Wed, 17 May 2023 18:37:41 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -9263,7 +7659,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/DRX045952
   response:
@@ -9319,7 +7715,7 @@ interactions:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:44:59 GMT
+      - Wed, 17 May 2023 18:37:41 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -9337,55 +7733,43 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/DRS057269
   response:
     body:
       string: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<SAMPLE_SET>\n<SAMPLE accession=\"DRS057269\"
-        alias=\"DRS057269\" center_name=\"NIG\" broker_name=\"DDBJ\">\n     <IDENTIFIERS>\n
-        \         <PRIMARY_ID>DRS057269</PRIMARY_ID>\n          <EXTERNAL_ID label=\"BioSample
-        ID\" namespace=\"BioSample\">SAMD00044992</EXTERNAL_ID>\n          <SUBMITTER_ID
-        namespace=\"NIG\">DRS057269</SUBMITTER_ID>\n     </IDENTIFIERS>\n     <TITLE>Danio
-        rerio</TITLE>\n     <SAMPLE_NAME>\n          <TAXON_ID>7955</TAXON_ID>\n          <SCIENTIFIC_NAME>Danio
-        rerio</SCIENTIFIC_NAME>\n          <COMMON_NAME>zebrafish</COMMON_NAME>\n
-        \    </SAMPLE_NAME>\n     <SAMPLE_LINKS>\n          <SAMPLE_LINK>\n               <XREF_LINK>\n
-        \                   <DB>ENA-STUDY</DB>\n                    <ID>DRP003977</ID>\n
-        \              </XREF_LINK>\n          </SAMPLE_LINK>\n          <SAMPLE_LINK>\n
-        \              <XREF_LINK>\n                    <DB>ENA-EXPERIMENT</DB>\n
-        \                   <ID>DRX045952</ID>\n               </XREF_LINK>\n          </SAMPLE_LINK>\n
-        \         <SAMPLE_LINK>\n               <XREF_LINK>\n                    <DB>ENA-RUN</DB>\n
-        \                   <ID>DRR051060</ID>\n               </XREF_LINK>\n          </SAMPLE_LINK>\n
-        \         <SAMPLE_LINK>\n               <XREF_LINK>\n                    <DB>ENA-SUBMISSION</DB>\n
-        \                   <ID>DRA004270</ID>\n               </XREF_LINK>\n          </SAMPLE_LINK>\n
-        \         <SAMPLE_LINK>\n               <XREF_LINK>\n                    <DB>ENA-FASTQ-FILES</DB>\n
-        \                   <ID><![CDATA[https://www.ebi.ac.uk/ena/portal/api/filereport?accession=DRS057269&result=read_run&fields=run_accession,fastq_ftp,fastq_md5,fastq_bytes]]></ID>\n
-        \              </XREF_LINK>\n          </SAMPLE_LINK>\n          <SAMPLE_LINK>\n
-        \              <XREF_LINK>\n                    <DB>ENA-SUBMITTED-FILES</DB>\n
-        \                   <ID><![CDATA[https://www.ebi.ac.uk/ena/portal/api/filereport?accession=DRS057269&result=read_run&fields=run_accession,submitted_ftp,submitted_md5,submitted_bytes,submitted_format]]></ID>\n
-        \              </XREF_LINK>\n          </SAMPLE_LINK>\n     </SAMPLE_LINKS>\n
-        \    <SAMPLE_ATTRIBUTES>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>description</TAG>\n
-        \              <VALUE>Telencephalon of adult zebrafrish barin</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
-        \         <SAMPLE_ATTRIBUTE>\n               <TAG>bioproject_id</TAG>\n               <VALUE>PRJDB4470</VALUE>\n
-        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>sample_name</TAG>\n
-        \              <VALUE>Tel</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
-        \              <TAG>sample_title</TAG>\n               <VALUE>zebrafihsh telencephalon</VALUE>\n
-        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>genotype</TAG>\n
-        \              <VALUE>WT</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
-        \              <TAG>tissue_type</TAG>\n               <VALUE>brain</VALUE>\n
-        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-SPOT-COUNT</TAG>\n
-        \              <VALUE>99040238</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
-        \              <TAG>ENA-BASE-COUNT</TAG>\n               <VALUE>20006128076</VALUE>\n
-        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-FIRST-PUBLIC</TAG>\n
-        \              <VALUE>2018-01-07</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
-        \         <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-LAST-UPDATE</TAG>\n
-        \              <VALUE>2018-01-07</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
+        alias=\"SAMD00044992\" center_name=\"National Institute of Genetics (Japan)\"
+        broker_name=\"DDBJ\">\n     <IDENTIFIERS>\n          <PRIMARY_ID>DRS057269</PRIMARY_ID>\n
+        \         <EXTERNAL_ID namespace=\"BioSample\">SAMD00044992</EXTERNAL_ID>\n
+        \    </IDENTIFIERS>\n     <TITLE>zebrafihsh telencephalon</TITLE>\n     <SAMPLE_NAME>\n
+        \         <TAXON_ID>7955</TAXON_ID>\n          <SCIENTIFIC_NAME>Danio rerio</SCIENTIFIC_NAME>\n
+        \         <COMMON_NAME>zebrafish</COMMON_NAME>\n     </SAMPLE_NAME>\n     <DESCRIPTION>Telencephalon
+        of adult zebrafrish barin</DESCRIPTION>\n     <SAMPLE_LINKS>\n    <SAMPLE_LINK>\n
+        \       <XREF_LINK>\n            <DB>ENA-FASTQ-FILES</DB>\n            <ID><![CDATA[https://www.ebi.ac.uk/ena/portal/api/filereport?accession=DRS057269&result=read_run&fields=run_accession,fastq_ftp,fastq_md5,fastq_bytes]]></ID>\n
+        \       </XREF_LINK>\n    </SAMPLE_LINK>\n    <SAMPLE_LINK>\n        <XREF_LINK>\n
+        \           <DB>ENA-SUBMITTED-FILES</DB>\n            <ID><![CDATA[https://www.ebi.ac.uk/ena/portal/api/filereport?accession=DRS057269&result=read_run&fields=run_accession,submitted_ftp,submitted_md5,submitted_bytes,submitted_format]]></ID>\n
+        \       </XREF_LINK>\n    </SAMPLE_LINK>\n</SAMPLE_LINKS>\n<SAMPLE_ATTRIBUTES>\n
+        \         <SAMPLE_ATTRIBUTE>\n               <TAG>INSDC secondary accession</TAG>\n
+        \              <VALUE>DRS057269</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
+        \              <TAG>NCBI submission package</TAG>\n               <VALUE>Generic.1.0</VALUE>\n
+        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>organism</TAG>\n
+        \              <VALUE>Danio rerio</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
+        \         <SAMPLE_ATTRIBUTE>\n               <TAG>tissue type</TAG>\n               <VALUE>brain</VALUE>\n
+        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>sample
+        name</TAG>\n               <VALUE>Tel</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
+        \         <SAMPLE_ATTRIBUTE>\n               <TAG>genotype</TAG>\n               <VALUE>WT</VALUE>\n
+        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>BioSampleModel</TAG>\n
+        \              <VALUE>Generic</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
+        \              <TAG>ENA-FIRST-PUBLIC</TAG>\n               <VALUE>2018-01-06</VALUE>\n
+        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-LAST-UPDATE</TAG>\n
+        \              <VALUE>2018-01-06</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
         \    </SAMPLE_ATTRIBUTES>\n</SAMPLE>\n</SAMPLE_SET>\n"
     headers:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:44:59 GMT
+      - Wed, 17 May 2023 18:37:41 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -9403,7 +7787,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/DRP003977
   response:
@@ -9411,14 +7795,16 @@ interactions:
       string: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<STUDY_SET>\n<STUDY accession=\"DRP003977\"
         alias=\"DRP003977\" center_name=\"NIG\" broker_name=\"DDBJ\">\n     <IDENTIFIERS>\n
         \         <PRIMARY_ID>DRP003977</PRIMARY_ID>\n          <SECONDARY_ID>PRJDB4470</SECONDARY_ID>\n
-        \         <EXTERNAL_ID label=\"primary\" namespace=\"BioProject\">PRJDB4470</EXTERNAL_ID>\n
+        \         <EXTERNAL_ID label=\"BioProject ID\" namespace=\"BioProject\">PRJDB4470</EXTERNAL_ID>\n
         \         <SUBMITTER_ID namespace=\"NIG\">DRP003977</SUBMITTER_ID>\n     </IDENTIFIERS>\n
         \    <DESCRIPTOR>\n          <STUDY_TITLE>Gene expression analysis of the
-        zebrafish brain</STUDY_TITLE>\n          <STUDY_TYPE existing_study_type=\"Transcriptome
-        Analysis\"/>\n          <STUDY_ABSTRACT>Gene expression profiling by RNA-seq
-        of specific regions and subpopulations of neurons in the zebrafish brain that
-        control behaviors.</STUDY_ABSTRACT>\n     </DESCRIPTOR>\n     <STUDY_LINKS>\n
-        \         <STUDY_LINK>\n               <XREF_LINK>\n                    <DB>ENA-SAMPLE</DB>\n
+        zebrafish brain</STUDY_TITLE>\n          <STUDY_TYPE existing_study_type=\"Other\"/>\n
+        \         <STUDY_ABSTRACT>Gene expression profiling by RNA-seq of specific
+        regions and subpopulations of neurons in the zebrafish brain that control
+        behaviors.</STUDY_ABSTRACT>\n          <STUDY_DESCRIPTION>Gene expression
+        profiling by RNA-seq of specific regions and subpopulations of neurons in
+        the zebrafish brain that control behaviors.</STUDY_DESCRIPTION>\n     </DESCRIPTOR>\n
+        \    <STUDY_LINKS>\n          <STUDY_LINK>\n               <XREF_LINK>\n                    <DB>ENA-SAMPLE</DB>\n
         \                   <ID>DRS057265-DRS057267,DRS057269-DRS057272,DRS057274-DRS057275</ID>\n
         \              </XREF_LINK>\n          </STUDY_LINK>\n          <STUDY_LINK>\n
         \              <XREF_LINK>\n                    <DB>ENA-EXPERIMENT</DB>\n
@@ -9427,7 +7813,7 @@ interactions:
         \                   <DB>ENA-RUN</DB>\n                    <ID>DRR051059-DRR051067</ID>\n
         \              </XREF_LINK>\n          </STUDY_LINK>\n          <STUDY_LINK>\n
         \              <XREF_LINK>\n                    <DB>ENA-SUBMISSION</DB>\n
-        \                   <ID>DRA004276</ID>\n               </XREF_LINK>\n          </STUDY_LINK>\n
+        \                   <ID>DRA008860</ID>\n               </XREF_LINK>\n          </STUDY_LINK>\n
         \         <STUDY_LINK>\n               <XREF_LINK>\n                    <DB>ENA-FASTQ-FILES</DB>\n
         \                   <ID><![CDATA[https://www.ebi.ac.uk/ena/portal/api/filereport?accession=DRP003977&result=read_run&fields=run_accession,fastq_ftp,fastq_md5,fastq_bytes]]></ID>\n
         \              </XREF_LINK>\n          </STUDY_LINK>\n          <STUDY_LINK>\n
@@ -9439,13 +7825,13 @@ interactions:
         \              <TAG>ENA-BASE-COUNT</TAG>\n               <VALUE>182690550386</VALUE>\n
         \         </STUDY_ATTRIBUTE>\n          <STUDY_ATTRIBUTE>\n               <TAG>ENA-FIRST-PUBLIC</TAG>\n
         \              <VALUE>2018-01-08</VALUE>\n          </STUDY_ATTRIBUTE>\n          <STUDY_ATTRIBUTE>\n
-        \              <TAG>ENA-LAST-UPDATE</TAG>\n               <VALUE>2018-01-08</VALUE>\n
+        \              <TAG>ENA-LAST-UPDATE</TAG>\n               <VALUE>2021-08-11</VALUE>\n
         \         </STUDY_ATTRIBUTE>\n     </STUDY_ATTRIBUTES>\n</STUDY>\n</STUDY_SET>\n"
     headers:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:45:00 GMT
+      - Wed, 17 May 2023 18:37:42 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -9463,7 +7849,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/DRA004270
   response:
@@ -9497,7 +7883,7 @@ interactions:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:45:01 GMT
+      - Wed, 17 May 2023 18:37:43 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -9506,68 +7892,6 @@ interactions:
       code: 200
       message: ''
 - request:
-    body: acc=DRR051060&accept-proto=fasp&version=2.0
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '43'
-      User-Agent:
-      - python-requests/2.25.1
-    method: POST
-    uri: https://www.ncbi.nlm.nih.gov/Traces/names/names.cgi
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAAwzIsQrDIBAA0D1fIXTIlHKn0Wrm7oXQqZsaJS1SRS2lcB/fjO+d+BmGVm35OLqu
-        K0gEBYQzaKHxACcOqCfACdQd9SLUgvJBXqsguMQQLXijHDfiYiK33s6blaiIaAag2zv92Lj3XtrI
-        Ss09+5zYszGbUv6GjcVcWd+PyO4VfB/+AAAA//8DAGeGt82PAAAA
-    headers:
-      Cache-Control:
-      - private
-      Connection:
-      - Keep-Alive
-      Content-Encoding:
-      - gzip
-      Content-Security-Policy:
-      - upgrade-insecure-requests
-      Content-Type:
-      - text/plain
-      Date:
-      - Wed, 28 Jul 2021 19:45:01 GMT
-      Keep-Alive:
-      - timeout=1, max=10
-      NCBI-PHID:
-      - CC95F912101B3BD10000000000000001.m_1
-      NCBI-SID:
-      - CC95F912101B3BD1_0000SID
-      Referrer-Policy:
-      - origin-when-cross-origin
-      Server:
-      - Apache
-      Set-Cookie:
-      - ncbi_sid=CC95F912101B3BD1_0000SID; domain=.nih.gov; path=/; expires=Thu, 28
-        Jul 2022 19:45:01 GMT
-      SraNameServerOutputVersion:
-      - '2.0'
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains; preload
-      Transfer-Encoding:
-      - chunked
-      Vary:
-      - Accept-Encoding
-      X-UA-Compatible:
-      - IE=Edge
-      X-XSS-Protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
-- request:
     body: null
     headers:
       Accept:
@@ -9577,29 +7901,27 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/portal/api/filereport?accession=DRR051060&result=read_run
   response:
     body:
-      string: "run_accession\tfastq_ftp\tfastq_bytes\tfastq_md5\tsubmitted_ftp\tsubmitted_bytes\tsubmitted_md5\tsra_ftp\tsra_bytes\tsra_md5\nDRR051060\tftp.sra.ebi.ac.uk/vol1/fastq/DRR051/DRR051060/DRR051060_1.fastq.gz;ftp.sra.ebi.ac.uk/vol1/fastq/DRR051/DRR051060/DRR051060_2.fastq.gz\t8860709458;9122863611\tb02f28ce177a28116323c9d9b85086f3;41a443250ebd3dcf3d9c19e3a6bf4ea9\t\t\t\t\t\t\n"
+      string: "run_accession\tfastq_ftp\tfastq_bytes\tfastq_md5\tbam_ftp\tbam_bytes\tbam_md5\tsubmitted_ftp\tsubmitted_bytes\tsubmitted_md5\tsra_ftp\tsra_bytes\tsra_md5\nDRR051060\tftp.sra.ebi.ac.uk/vol1/fastq/DRR051/DRR051060/DRR051060_1.fastq.gz;ftp.sra.ebi.ac.uk/vol1/fastq/DRR051/DRR051060/DRR051060_2.fastq.gz\t8860709458;9122863611\tb02f28ce177a28116323c9d9b85086f3;41a443250ebd3dcf3d9c19e3a6bf4ea9\t\t\t\t\t\t\tftp.sra.ebi.ac.uk/vol1/drr/DRR051/DRR051060\t14083815102\tc86e3251efa0c96b29379f2aca4da516\n"
     headers:
       Cache-Control:
       - no-cache, no-store, max-age=0, must-revalidate
+      Content-Length:
+      - '469'
       Content-Type:
       - text/plain
       Date:
-      - Wed, 28 Jul 2021 19:45:02 GMT
+      - Wed, 17 May 2023 18:37:43 GMT
       Expires:
       - '0'
       Pragma:
       - no-cache
-      Server:
-      - Apache-Coyote/1.1
       Strict-Transport-Security:
       - max-age=0
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Frame-Options:
@@ -9608,7 +7930,7 @@ interactions:
       - 1; mode=block
     status:
       code: 200
-      message: OK
+      message: ''
 - request:
     body: null
     headers:
@@ -9619,7 +7941,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/DRR051061
   response:
@@ -9653,7 +7975,7 @@ interactions:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:45:02 GMT
+      - Wed, 17 May 2023 18:37:44 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -9671,7 +7993,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/DRX045953
   response:
@@ -9728,7 +8050,7 @@ interactions:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:45:03 GMT
+      - Wed, 17 May 2023 18:37:44 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -9746,57 +8068,44 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/DRS057274
   response:
     body:
       string: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<SAMPLE_SET>\n<SAMPLE accession=\"DRS057274\"
-        alias=\"DRS057274\" center_name=\"NIG\" broker_name=\"DDBJ\">\n     <IDENTIFIERS>\n
-        \         <PRIMARY_ID>DRS057274</PRIMARY_ID>\n          <EXTERNAL_ID label=\"BioSample
-        ID\" namespace=\"BioSample\">SAMD00044989</EXTERNAL_ID>\n          <SUBMITTER_ID
-        namespace=\"NIG\">DRS057274</SUBMITTER_ID>\n     </IDENTIFIERS>\n     <TITLE>Danio
-        rerio</TITLE>\n     <SAMPLE_NAME>\n          <TAXON_ID>7955</TAXON_ID>\n          <SCIENTIFIC_NAME>Danio
-        rerio</SCIENTIFIC_NAME>\n          <COMMON_NAME>zebrafish</COMMON_NAME>\n
-        \    </SAMPLE_NAME>\n     <SAMPLE_LINKS>\n          <SAMPLE_LINK>\n               <XREF_LINK>\n
-        \                   <DB>ENA-STUDY</DB>\n                    <ID>DRP003977</ID>\n
-        \              </XREF_LINK>\n          </SAMPLE_LINK>\n          <SAMPLE_LINK>\n
-        \              <XREF_LINK>\n                    <DB>ENA-EXPERIMENT</DB>\n
-        \                   <ID>DRX045953</ID>\n               </XREF_LINK>\n          </SAMPLE_LINK>\n
-        \         <SAMPLE_LINK>\n               <XREF_LINK>\n                    <DB>ENA-RUN</DB>\n
-        \                   <ID>DRR051061</ID>\n               </XREF_LINK>\n          </SAMPLE_LINK>\n
-        \         <SAMPLE_LINK>\n               <XREF_LINK>\n                    <DB>ENA-SUBMISSION</DB>\n
-        \                   <ID>DRA004271</ID>\n               </XREF_LINK>\n          </SAMPLE_LINK>\n
-        \         <SAMPLE_LINK>\n               <XREF_LINK>\n                    <DB>ENA-FASTQ-FILES</DB>\n
-        \                   <ID><![CDATA[https://www.ebi.ac.uk/ena/portal/api/filereport?accession=DRS057274&result=read_run&fields=run_accession,fastq_ftp,fastq_md5,fastq_bytes]]></ID>\n
-        \              </XREF_LINK>\n          </SAMPLE_LINK>\n          <SAMPLE_LINK>\n
-        \              <XREF_LINK>\n                    <DB>ENA-SUBMITTED-FILES</DB>\n
-        \                   <ID><![CDATA[https://www.ebi.ac.uk/ena/portal/api/filereport?accession=DRS057274&result=read_run&fields=run_accession,submitted_ftp,submitted_md5,submitted_bytes,submitted_format]]></ID>\n
-        \              </XREF_LINK>\n          </SAMPLE_LINK>\n     </SAMPLE_LINKS>\n
-        \    <SAMPLE_ATTRIBUTES>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>description</TAG>\n
-        \              <VALUE>Collected from 10 adult fish by using FACS</VALUE>\n
-        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>bioproject_id</TAG>\n
-        \              <VALUE>PRJDB4470</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
-        \              <TAG>sample_name</TAG>\n               <VALUE>231A_GFP_plus_WB</VALUE>\n
-        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>sample_title</TAG>\n
-        \              <VALUE>GFP+ cells from whole brain of SAGFF(LF)231A;UAS:GFP
-        transgenic zebrafish</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
-        \              <TAG>genotype</TAG>\n               <VALUE>SAGFF(LF)231A;UAS:GFP</VALUE>\n
-        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>tissue_type</TAG>\n
-        \              <VALUE>brain</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
-        \              <TAG>ENA-SPOT-COUNT</TAG>\n               <VALUE>136153270</VALUE>\n
-        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-BASE-COUNT</TAG>\n
-        \              <VALUE>27230654000</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
-        \         <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-FIRST-PUBLIC</TAG>\n
-        \              <VALUE>2018-01-07</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
-        \         <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-LAST-UPDATE</TAG>\n
-        \              <VALUE>2018-01-07</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
+        alias=\"SAMD00044989\" center_name=\"National Institute of Genetics (Japan)\"
+        broker_name=\"DDBJ\">\n     <IDENTIFIERS>\n          <PRIMARY_ID>DRS057274</PRIMARY_ID>\n
+        \         <EXTERNAL_ID namespace=\"BioSample\">SAMD00044989</EXTERNAL_ID>\n
+        \    </IDENTIFIERS>\n     <TITLE>GFP+ cells from whole brain of SAGFF(LF)231A;UAS:GFP
+        transgenic zebrafish</TITLE>\n     <SAMPLE_NAME>\n          <TAXON_ID>7955</TAXON_ID>\n
+        \         <SCIENTIFIC_NAME>Danio rerio</SCIENTIFIC_NAME>\n          <COMMON_NAME>zebrafish</COMMON_NAME>\n
+        \    </SAMPLE_NAME>\n     <DESCRIPTION>Collected from 10 adult fish by using
+        FACS</DESCRIPTION>\n     <SAMPLE_LINKS>\n    <SAMPLE_LINK>\n        <XREF_LINK>\n
+        \           <DB>ENA-FASTQ-FILES</DB>\n            <ID><![CDATA[https://www.ebi.ac.uk/ena/portal/api/filereport?accession=DRS057274&result=read_run&fields=run_accession,fastq_ftp,fastq_md5,fastq_bytes]]></ID>\n
+        \       </XREF_LINK>\n    </SAMPLE_LINK>\n    <SAMPLE_LINK>\n        <XREF_LINK>\n
+        \           <DB>ENA-SUBMITTED-FILES</DB>\n            <ID><![CDATA[https://www.ebi.ac.uk/ena/portal/api/filereport?accession=DRS057274&result=read_run&fields=run_accession,submitted_ftp,submitted_md5,submitted_bytes,submitted_format]]></ID>\n
+        \       </XREF_LINK>\n    </SAMPLE_LINK>\n</SAMPLE_LINKS>\n<SAMPLE_ATTRIBUTES>\n
+        \         <SAMPLE_ATTRIBUTE>\n               <TAG>INSDC secondary accession</TAG>\n
+        \              <VALUE>DRS057274</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
+        \              <TAG>NCBI submission package</TAG>\n               <VALUE>Generic.1.0</VALUE>\n
+        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>organism</TAG>\n
+        \              <VALUE>Danio rerio</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
+        \         <SAMPLE_ATTRIBUTE>\n               <TAG>tissue type</TAG>\n               <VALUE>brain</VALUE>\n
+        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>sample
+        name</TAG>\n               <VALUE>231A_GFP_plus_WB</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
+        \         <SAMPLE_ATTRIBUTE>\n               <TAG>genotype</TAG>\n               <VALUE>SAGFF(LF)231A;UAS:GFP</VALUE>\n
+        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>BioSampleModel</TAG>\n
+        \              <VALUE>Generic</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
+        \              <TAG>ENA-FIRST-PUBLIC</TAG>\n               <VALUE>2018-01-06</VALUE>\n
+        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-LAST-UPDATE</TAG>\n
+        \              <VALUE>2018-01-06</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
         \    </SAMPLE_ATTRIBUTES>\n</SAMPLE>\n</SAMPLE_SET>\n"
     headers:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:45:04 GMT
+      - Wed, 17 May 2023 18:37:44 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -9814,7 +8123,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/DRP003977
   response:
@@ -9822,14 +8131,16 @@ interactions:
       string: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<STUDY_SET>\n<STUDY accession=\"DRP003977\"
         alias=\"DRP003977\" center_name=\"NIG\" broker_name=\"DDBJ\">\n     <IDENTIFIERS>\n
         \         <PRIMARY_ID>DRP003977</PRIMARY_ID>\n          <SECONDARY_ID>PRJDB4470</SECONDARY_ID>\n
-        \         <EXTERNAL_ID label=\"primary\" namespace=\"BioProject\">PRJDB4470</EXTERNAL_ID>\n
+        \         <EXTERNAL_ID label=\"BioProject ID\" namespace=\"BioProject\">PRJDB4470</EXTERNAL_ID>\n
         \         <SUBMITTER_ID namespace=\"NIG\">DRP003977</SUBMITTER_ID>\n     </IDENTIFIERS>\n
         \    <DESCRIPTOR>\n          <STUDY_TITLE>Gene expression analysis of the
-        zebrafish brain</STUDY_TITLE>\n          <STUDY_TYPE existing_study_type=\"Transcriptome
-        Analysis\"/>\n          <STUDY_ABSTRACT>Gene expression profiling by RNA-seq
-        of specific regions and subpopulations of neurons in the zebrafish brain that
-        control behaviors.</STUDY_ABSTRACT>\n     </DESCRIPTOR>\n     <STUDY_LINKS>\n
-        \         <STUDY_LINK>\n               <XREF_LINK>\n                    <DB>ENA-SAMPLE</DB>\n
+        zebrafish brain</STUDY_TITLE>\n          <STUDY_TYPE existing_study_type=\"Other\"/>\n
+        \         <STUDY_ABSTRACT>Gene expression profiling by RNA-seq of specific
+        regions and subpopulations of neurons in the zebrafish brain that control
+        behaviors.</STUDY_ABSTRACT>\n          <STUDY_DESCRIPTION>Gene expression
+        profiling by RNA-seq of specific regions and subpopulations of neurons in
+        the zebrafish brain that control behaviors.</STUDY_DESCRIPTION>\n     </DESCRIPTOR>\n
+        \    <STUDY_LINKS>\n          <STUDY_LINK>\n               <XREF_LINK>\n                    <DB>ENA-SAMPLE</DB>\n
         \                   <ID>DRS057265-DRS057267,DRS057269-DRS057272,DRS057274-DRS057275</ID>\n
         \              </XREF_LINK>\n          </STUDY_LINK>\n          <STUDY_LINK>\n
         \              <XREF_LINK>\n                    <DB>ENA-EXPERIMENT</DB>\n
@@ -9838,7 +8149,7 @@ interactions:
         \                   <DB>ENA-RUN</DB>\n                    <ID>DRR051059-DRR051067</ID>\n
         \              </XREF_LINK>\n          </STUDY_LINK>\n          <STUDY_LINK>\n
         \              <XREF_LINK>\n                    <DB>ENA-SUBMISSION</DB>\n
-        \                   <ID>DRA004276</ID>\n               </XREF_LINK>\n          </STUDY_LINK>\n
+        \                   <ID>DRA008860</ID>\n               </XREF_LINK>\n          </STUDY_LINK>\n
         \         <STUDY_LINK>\n               <XREF_LINK>\n                    <DB>ENA-FASTQ-FILES</DB>\n
         \                   <ID><![CDATA[https://www.ebi.ac.uk/ena/portal/api/filereport?accession=DRP003977&result=read_run&fields=run_accession,fastq_ftp,fastq_md5,fastq_bytes]]></ID>\n
         \              </XREF_LINK>\n          </STUDY_LINK>\n          <STUDY_LINK>\n
@@ -9850,13 +8161,13 @@ interactions:
         \              <TAG>ENA-BASE-COUNT</TAG>\n               <VALUE>182690550386</VALUE>\n
         \         </STUDY_ATTRIBUTE>\n          <STUDY_ATTRIBUTE>\n               <TAG>ENA-FIRST-PUBLIC</TAG>\n
         \              <VALUE>2018-01-08</VALUE>\n          </STUDY_ATTRIBUTE>\n          <STUDY_ATTRIBUTE>\n
-        \              <TAG>ENA-LAST-UPDATE</TAG>\n               <VALUE>2018-01-08</VALUE>\n
+        \              <TAG>ENA-LAST-UPDATE</TAG>\n               <VALUE>2021-08-11</VALUE>\n
         \         </STUDY_ATTRIBUTE>\n     </STUDY_ATTRIBUTES>\n</STUDY>\n</STUDY_SET>\n"
     headers:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:45:04 GMT
+      - Wed, 17 May 2023 18:37:45 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -9874,7 +8185,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/DRA004271
   response:
@@ -9908,7 +8219,7 @@ interactions:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:45:05 GMT
+      - Wed, 17 May 2023 18:37:46 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -9917,68 +8228,6 @@ interactions:
       code: 200
       message: ''
 - request:
-    body: acc=DRR051061&accept-proto=fasp&version=2.0
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '43'
-      User-Agent:
-      - python-requests/2.25.1
-    method: POST
-    uri: https://www.ncbi.nlm.nih.gov/Traces/names/names.cgi
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAAwzJvQrCMBAA4L1PEXDoVLm7/Lazu1Cc3NIkUiWYkkZEuIe36/ed6AzdXv32Wfgy
-        z6ARDDJaqcGZUTpgAnQD4ADmhm5SeiJ5ZyJvZPIKQMdRaTIxJQwq2mBRRtLMfBxf3/kn+rW1be/F
-        VksroWTx3IXPuXxTFI9SRVsPKMsrhdb9AQAA//8DAB+PMvSPAAAA
-    headers:
-      Cache-Control:
-      - private
-      Connection:
-      - Keep-Alive
-      Content-Encoding:
-      - gzip
-      Content-Security-Policy:
-      - upgrade-insecure-requests
-      Content-Type:
-      - text/plain
-      Date:
-      - Wed, 28 Jul 2021 19:45:05 GMT
-      Keep-Alive:
-      - timeout=1, max=10
-      NCBI-PHID:
-      - C7A42B00101B3C110000000000000001.m_1
-      NCBI-SID:
-      - C7A42B00101B3C11_0000SID
-      Referrer-Policy:
-      - origin-when-cross-origin
-      Server:
-      - Apache
-      Set-Cookie:
-      - ncbi_sid=C7A42B00101B3C11_0000SID; domain=.nih.gov; path=/; expires=Thu, 28
-        Jul 2022 19:45:05 GMT
-      SraNameServerOutputVersion:
-      - '2.0'
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains; preload
-      Transfer-Encoding:
-      - chunked
-      Vary:
-      - Accept-Encoding
-      X-UA-Compatible:
-      - IE=Edge
-      X-XSS-Protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
-- request:
     body: null
     headers:
       Accept:
@@ -9988,29 +8237,27 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/portal/api/filereport?accession=DRR051061&result=read_run
   response:
     body:
-      string: "run_accession\tfastq_ftp\tfastq_bytes\tfastq_md5\tsubmitted_ftp\tsubmitted_bytes\tsubmitted_md5\tsra_ftp\tsra_bytes\tsra_md5\nDRR051061\tftp.sra.ebi.ac.uk/vol1/fastq/DRR051/DRR051061/DRR051061_1.fastq.gz;ftp.sra.ebi.ac.uk/vol1/fastq/DRR051/DRR051061/DRR051061_2.fastq.gz\t10995619492;10855326022\t4f996689219b960f252308db99f7be3b;dffc1260802754bb0bb1102f3351bec8\t\t\t\t\t\t\n"
+      string: "run_accession\tfastq_ftp\tfastq_bytes\tfastq_md5\tbam_ftp\tbam_bytes\tbam_md5\tsubmitted_ftp\tsubmitted_bytes\tsubmitted_md5\tsra_ftp\tsra_bytes\tsra_md5\nDRR051061\tftp.sra.ebi.ac.uk/vol1/fastq/DRR051/DRR051061/DRR051061_1.fastq.gz;ftp.sra.ebi.ac.uk/vol1/fastq/DRR051/DRR051061/DRR051061_2.fastq.gz\t10995619492;10855326022\t4f996689219b960f252308db99f7be3b;dffc1260802754bb0bb1102f3351bec8\t\t\t\t\t\t\tftp.sra.ebi.ac.uk/vol1/drr/DRR051/DRR051061\t17350869380\t22a63ea4005d94526dee1c4d7c713d25\n"
     headers:
       Cache-Control:
       - no-cache, no-store, max-age=0, must-revalidate
+      Content-Length:
+      - '471'
       Content-Type:
       - text/plain
       Date:
-      - Wed, 28 Jul 2021 19:45:05 GMT
+      - Wed, 17 May 2023 18:37:45 GMT
       Expires:
       - '0'
       Pragma:
       - no-cache
-      Server:
-      - Apache-Coyote/1.1
       Strict-Transport-Security:
       - max-age=0
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Frame-Options:
@@ -10019,7 +8266,7 @@ interactions:
       - 1; mode=block
     status:
       code: 200
-      message: OK
+      message: ''
 - request:
     body: null
     headers:
@@ -10030,7 +8277,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/DRR051062
   response:
@@ -10064,7 +8311,7 @@ interactions:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:45:06 GMT
+      - Wed, 17 May 2023 18:37:46 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -10082,7 +8329,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/DRX045954
   response:
@@ -10139,7 +8386,7 @@ interactions:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:45:06 GMT
+      - Wed, 17 May 2023 18:37:47 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -10157,57 +8404,44 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/DRS057271
   response:
     body:
       string: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<SAMPLE_SET>\n<SAMPLE accession=\"DRS057271\"
-        alias=\"DRS057271\" center_name=\"NIG\" broker_name=\"DDBJ\">\n     <IDENTIFIERS>\n
-        \         <PRIMARY_ID>DRS057271</PRIMARY_ID>\n          <EXTERNAL_ID label=\"BioSample
-        ID\" namespace=\"BioSample\">SAMD00044988</EXTERNAL_ID>\n          <SUBMITTER_ID
-        namespace=\"NIG\">DRS057271</SUBMITTER_ID>\n     </IDENTIFIERS>\n     <TITLE>Danio
-        rerio</TITLE>\n     <SAMPLE_NAME>\n          <TAXON_ID>7955</TAXON_ID>\n          <SCIENTIFIC_NAME>Danio
-        rerio</SCIENTIFIC_NAME>\n          <COMMON_NAME>zebrafish</COMMON_NAME>\n
-        \    </SAMPLE_NAME>\n     <SAMPLE_LINKS>\n          <SAMPLE_LINK>\n               <XREF_LINK>\n
-        \                   <DB>ENA-STUDY</DB>\n                    <ID>DRP003977</ID>\n
-        \              </XREF_LINK>\n          </SAMPLE_LINK>\n          <SAMPLE_LINK>\n
-        \              <XREF_LINK>\n                    <DB>ENA-EXPERIMENT</DB>\n
-        \                   <ID>DRX045954</ID>\n               </XREF_LINK>\n          </SAMPLE_LINK>\n
-        \         <SAMPLE_LINK>\n               <XREF_LINK>\n                    <DB>ENA-RUN</DB>\n
-        \                   <ID>DRR051062</ID>\n               </XREF_LINK>\n          </SAMPLE_LINK>\n
-        \         <SAMPLE_LINK>\n               <XREF_LINK>\n                    <DB>ENA-SUBMISSION</DB>\n
-        \                   <ID>DRA004272</ID>\n               </XREF_LINK>\n          </SAMPLE_LINK>\n
-        \         <SAMPLE_LINK>\n               <XREF_LINK>\n                    <DB>ENA-FASTQ-FILES</DB>\n
-        \                   <ID><![CDATA[https://www.ebi.ac.uk/ena/portal/api/filereport?accession=DRS057271&result=read_run&fields=run_accession,fastq_ftp,fastq_md5,fastq_bytes]]></ID>\n
-        \              </XREF_LINK>\n          </SAMPLE_LINK>\n          <SAMPLE_LINK>\n
-        \              <XREF_LINK>\n                    <DB>ENA-SUBMITTED-FILES</DB>\n
-        \                   <ID><![CDATA[https://www.ebi.ac.uk/ena/portal/api/filereport?accession=DRS057271&result=read_run&fields=run_accession,submitted_ftp,submitted_md5,submitted_bytes,submitted_format]]></ID>\n
-        \              </XREF_LINK>\n          </SAMPLE_LINK>\n     </SAMPLE_LINKS>\n
-        \    <SAMPLE_ATTRIBUTES>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>description</TAG>\n
-        \              <VALUE>Collected from 40 adult fish by using FACS</VALUE>\n
-        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>bioproject_id</TAG>\n
-        \              <VALUE>PRJDB4470</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
-        \              <TAG>sample_name</TAG>\n               <VALUE>120A_GFP_plus_Tel</VALUE>\n
-        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>sample_title</TAG>\n
-        \              <VALUE>GFP+ cells from telencephalon of SAGFF(LF)120A;UAS:GFP
-        transgenic zebrafish</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
-        \              <TAG>genotype</TAG>\n               <VALUE>SAGFF(LF)120A;UAS:GFP</VALUE>\n
-        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>tissue_type</TAG>\n
-        \              <VALUE>brain</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
-        \              <TAG>ENA-SPOT-COUNT</TAG>\n               <VALUE>49090307</VALUE>\n
-        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-BASE-COUNT</TAG>\n
-        \              <VALUE>9916242014</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
-        \         <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-FIRST-PUBLIC</TAG>\n
-        \              <VALUE>2018-01-07</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
-        \         <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-LAST-UPDATE</TAG>\n
-        \              <VALUE>2018-01-07</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
+        alias=\"SAMD00044988\" center_name=\"National Institute of Genetics (Japan)\"
+        broker_name=\"DDBJ\">\n     <IDENTIFIERS>\n          <PRIMARY_ID>DRS057271</PRIMARY_ID>\n
+        \         <EXTERNAL_ID namespace=\"BioSample\">SAMD00044988</EXTERNAL_ID>\n
+        \    </IDENTIFIERS>\n     <TITLE>GFP+ cells from telencephalon of SAGFF(LF)120A;UAS:GFP
+        transgenic zebrafish</TITLE>\n     <SAMPLE_NAME>\n          <TAXON_ID>7955</TAXON_ID>\n
+        \         <SCIENTIFIC_NAME>Danio rerio</SCIENTIFIC_NAME>\n          <COMMON_NAME>zebrafish</COMMON_NAME>\n
+        \    </SAMPLE_NAME>\n     <DESCRIPTION>Collected from 40 adult fish by using
+        FACS</DESCRIPTION>\n     <SAMPLE_LINKS>\n    <SAMPLE_LINK>\n        <XREF_LINK>\n
+        \           <DB>ENA-FASTQ-FILES</DB>\n            <ID><![CDATA[https://www.ebi.ac.uk/ena/portal/api/filereport?accession=DRS057271&result=read_run&fields=run_accession,fastq_ftp,fastq_md5,fastq_bytes]]></ID>\n
+        \       </XREF_LINK>\n    </SAMPLE_LINK>\n    <SAMPLE_LINK>\n        <XREF_LINK>\n
+        \           <DB>ENA-SUBMITTED-FILES</DB>\n            <ID><![CDATA[https://www.ebi.ac.uk/ena/portal/api/filereport?accession=DRS057271&result=read_run&fields=run_accession,submitted_ftp,submitted_md5,submitted_bytes,submitted_format]]></ID>\n
+        \       </XREF_LINK>\n    </SAMPLE_LINK>\n</SAMPLE_LINKS>\n<SAMPLE_ATTRIBUTES>\n
+        \         <SAMPLE_ATTRIBUTE>\n               <TAG>INSDC secondary accession</TAG>\n
+        \              <VALUE>DRS057271</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
+        \              <TAG>NCBI submission package</TAG>\n               <VALUE>Generic.1.0</VALUE>\n
+        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>organism</TAG>\n
+        \              <VALUE>Danio rerio</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
+        \         <SAMPLE_ATTRIBUTE>\n               <TAG>tissue type</TAG>\n               <VALUE>brain</VALUE>\n
+        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>sample
+        name</TAG>\n               <VALUE>120A_GFP_plus_Tel</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
+        \         <SAMPLE_ATTRIBUTE>\n               <TAG>genotype</TAG>\n               <VALUE>SAGFF(LF)120A;UAS:GFP</VALUE>\n
+        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>BioSampleModel</TAG>\n
+        \              <VALUE>Generic</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
+        \              <TAG>ENA-FIRST-PUBLIC</TAG>\n               <VALUE>2018-01-06</VALUE>\n
+        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-LAST-UPDATE</TAG>\n
+        \              <VALUE>2018-01-06</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
         \    </SAMPLE_ATTRIBUTES>\n</SAMPLE>\n</SAMPLE_SET>\n"
     headers:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:45:08 GMT
+      - Wed, 17 May 2023 18:37:47 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -10225,7 +8459,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/DRP003977
   response:
@@ -10233,14 +8467,16 @@ interactions:
       string: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<STUDY_SET>\n<STUDY accession=\"DRP003977\"
         alias=\"DRP003977\" center_name=\"NIG\" broker_name=\"DDBJ\">\n     <IDENTIFIERS>\n
         \         <PRIMARY_ID>DRP003977</PRIMARY_ID>\n          <SECONDARY_ID>PRJDB4470</SECONDARY_ID>\n
-        \         <EXTERNAL_ID label=\"primary\" namespace=\"BioProject\">PRJDB4470</EXTERNAL_ID>\n
+        \         <EXTERNAL_ID label=\"BioProject ID\" namespace=\"BioProject\">PRJDB4470</EXTERNAL_ID>\n
         \         <SUBMITTER_ID namespace=\"NIG\">DRP003977</SUBMITTER_ID>\n     </IDENTIFIERS>\n
         \    <DESCRIPTOR>\n          <STUDY_TITLE>Gene expression analysis of the
-        zebrafish brain</STUDY_TITLE>\n          <STUDY_TYPE existing_study_type=\"Transcriptome
-        Analysis\"/>\n          <STUDY_ABSTRACT>Gene expression profiling by RNA-seq
-        of specific regions and subpopulations of neurons in the zebrafish brain that
-        control behaviors.</STUDY_ABSTRACT>\n     </DESCRIPTOR>\n     <STUDY_LINKS>\n
-        \         <STUDY_LINK>\n               <XREF_LINK>\n                    <DB>ENA-SAMPLE</DB>\n
+        zebrafish brain</STUDY_TITLE>\n          <STUDY_TYPE existing_study_type=\"Other\"/>\n
+        \         <STUDY_ABSTRACT>Gene expression profiling by RNA-seq of specific
+        regions and subpopulations of neurons in the zebrafish brain that control
+        behaviors.</STUDY_ABSTRACT>\n          <STUDY_DESCRIPTION>Gene expression
+        profiling by RNA-seq of specific regions and subpopulations of neurons in
+        the zebrafish brain that control behaviors.</STUDY_DESCRIPTION>\n     </DESCRIPTOR>\n
+        \    <STUDY_LINKS>\n          <STUDY_LINK>\n               <XREF_LINK>\n                    <DB>ENA-SAMPLE</DB>\n
         \                   <ID>DRS057265-DRS057267,DRS057269-DRS057272,DRS057274-DRS057275</ID>\n
         \              </XREF_LINK>\n          </STUDY_LINK>\n          <STUDY_LINK>\n
         \              <XREF_LINK>\n                    <DB>ENA-EXPERIMENT</DB>\n
@@ -10249,7 +8485,7 @@ interactions:
         \                   <DB>ENA-RUN</DB>\n                    <ID>DRR051059-DRR051067</ID>\n
         \              </XREF_LINK>\n          </STUDY_LINK>\n          <STUDY_LINK>\n
         \              <XREF_LINK>\n                    <DB>ENA-SUBMISSION</DB>\n
-        \                   <ID>DRA004276</ID>\n               </XREF_LINK>\n          </STUDY_LINK>\n
+        \                   <ID>DRA008860</ID>\n               </XREF_LINK>\n          </STUDY_LINK>\n
         \         <STUDY_LINK>\n               <XREF_LINK>\n                    <DB>ENA-FASTQ-FILES</DB>\n
         \                   <ID><![CDATA[https://www.ebi.ac.uk/ena/portal/api/filereport?accession=DRP003977&result=read_run&fields=run_accession,fastq_ftp,fastq_md5,fastq_bytes]]></ID>\n
         \              </XREF_LINK>\n          </STUDY_LINK>\n          <STUDY_LINK>\n
@@ -10261,13 +8497,13 @@ interactions:
         \              <TAG>ENA-BASE-COUNT</TAG>\n               <VALUE>182690550386</VALUE>\n
         \         </STUDY_ATTRIBUTE>\n          <STUDY_ATTRIBUTE>\n               <TAG>ENA-FIRST-PUBLIC</TAG>\n
         \              <VALUE>2018-01-08</VALUE>\n          </STUDY_ATTRIBUTE>\n          <STUDY_ATTRIBUTE>\n
-        \              <TAG>ENA-LAST-UPDATE</TAG>\n               <VALUE>2018-01-08</VALUE>\n
+        \              <TAG>ENA-LAST-UPDATE</TAG>\n               <VALUE>2021-08-11</VALUE>\n
         \         </STUDY_ATTRIBUTE>\n     </STUDY_ATTRIBUTES>\n</STUDY>\n</STUDY_SET>\n"
     headers:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:45:08 GMT
+      - Wed, 17 May 2023 18:37:48 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -10285,7 +8521,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/DRA004272
   response:
@@ -10319,7 +8555,7 @@ interactions:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:45:09 GMT
+      - Wed, 17 May 2023 18:37:48 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -10328,68 +8564,6 @@ interactions:
       code: 200
       message: ''
 - request:
-    body: acc=DRR051062&accept-proto=fasp&version=2.0
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '43'
-      User-Agent:
-      - python-requests/2.25.1
-    method: POST
-    uri: https://www.ncbi.nlm.nih.gov/Traces/names/names.cgi
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAAwzIuwrCMBQA0L1fEXDoVLk3iUnT2V0oTm7NiyqhCUlEhPvxesZz4mcYWt3K29J1
-        XeGCoDgpqbVRIJUgDjhPgBOoO84LNwuaB0XUoEwIczRSeO2M9oHLaL1F51EgEUkAuh3py8a999JG
-        Vmru2eXEno1tKeVP8Czmyvr+j2xfwfXhBwAA//8DAKZ6JjGOAAAA
-    headers:
-      Cache-Control:
-      - private
-      Connection:
-      - Keep-Alive
-      Content-Encoding:
-      - gzip
-      Content-Security-Policy:
-      - upgrade-insecure-requests
-      Content-Type:
-      - text/plain
-      Date:
-      - Wed, 28 Jul 2021 19:45:09 GMT
-      Keep-Alive:
-      - timeout=1, max=10
-      NCBI-PHID:
-      - C7A42B19101B3C510000000000000001.m_1
-      NCBI-SID:
-      - C7A42B19101B3C51_0000SID
-      Referrer-Policy:
-      - origin-when-cross-origin
-      Server:
-      - Apache
-      Set-Cookie:
-      - ncbi_sid=C7A42B19101B3C51_0000SID; domain=.nih.gov; path=/; expires=Thu, 28
-        Jul 2022 19:45:09 GMT
-      SraNameServerOutputVersion:
-      - '2.0'
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains; preload
-      Transfer-Encoding:
-      - chunked
-      Vary:
-      - Accept-Encoding
-      X-UA-Compatible:
-      - IE=Edge
-      X-XSS-Protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
-- request:
     body: null
     headers:
       Accept:
@@ -10399,29 +8573,27 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/portal/api/filereport?accession=DRR051062&result=read_run
   response:
     body:
-      string: "run_accession\tfastq_ftp\tfastq_bytes\tfastq_md5\tsubmitted_ftp\tsubmitted_bytes\tsubmitted_md5\tsra_ftp\tsra_bytes\tsra_md5\nDRR051062\tftp.sra.ebi.ac.uk/vol1/fastq/DRR051/DRR051062/DRR051062_1.fastq.gz;ftp.sra.ebi.ac.uk/vol1/fastq/DRR051/DRR051062/DRR051062_2.fastq.gz\t4036117683;4092158762\t9460e5da5ad16eb9e9dfb035acf4cfac;8ca9d614ef67f2cf435a3afb136d6b89\t\t\t\t\t\t\n"
+      string: "run_accession\tfastq_ftp\tfastq_bytes\tfastq_md5\tbam_ftp\tbam_bytes\tbam_md5\tsubmitted_ftp\tsubmitted_bytes\tsubmitted_md5\tsra_ftp\tsra_bytes\tsra_md5\nDRR051062\tftp.sra.ebi.ac.uk/vol1/fastq/DRR051/DRR051062/DRR051062_1.fastq.gz;ftp.sra.ebi.ac.uk/vol1/fastq/DRR051/DRR051062/DRR051062_2.fastq.gz\t4036117683;4092158762\t9460e5da5ad16eb9e9dfb035acf4cfac;8ca9d614ef67f2cf435a3afb136d6b89\t\t\t\t\t\t\tftp.sra.ebi.ac.uk/vol1/drr/DRR051/DRR051062\t6477960463\tf17069ee8f943d7c97de24fbdb1cd131\n"
     headers:
       Cache-Control:
       - no-cache, no-store, max-age=0, must-revalidate
+      Content-Length:
+      - '468'
       Content-Type:
       - text/plain
       Date:
-      - Wed, 28 Jul 2021 19:45:09 GMT
+      - Wed, 17 May 2023 18:37:49 GMT
       Expires:
       - '0'
       Pragma:
       - no-cache
-      Server:
-      - Apache-Coyote/1.1
       Strict-Transport-Security:
       - max-age=0
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Frame-Options:
@@ -10430,7 +8602,7 @@ interactions:
       - 1; mode=block
     status:
       code: 200
-      message: OK
+      message: ''
 - request:
     body: null
     headers:
@@ -10441,7 +8613,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/DRR051063
   response:
@@ -10475,7 +8647,7 @@ interactions:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:45:10 GMT
+      - Wed, 17 May 2023 18:37:48 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -10493,7 +8665,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/DRX045955
   response:
@@ -10550,7 +8722,7 @@ interactions:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:45:11 GMT
+      - Wed, 17 May 2023 18:37:49 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -10568,57 +8740,44 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/DRS057266
   response:
     body:
       string: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<SAMPLE_SET>\n<SAMPLE accession=\"DRS057266\"
-        alias=\"DRS057266\" center_name=\"NIG\" broker_name=\"DDBJ\">\n     <IDENTIFIERS>\n
-        \         <PRIMARY_ID>DRS057266</PRIMARY_ID>\n          <EXTERNAL_ID label=\"BioSample
-        ID\" namespace=\"BioSample\">SAMD00044987</EXTERNAL_ID>\n          <SUBMITTER_ID
-        namespace=\"NIG\">DRS057266</SUBMITTER_ID>\n     </IDENTIFIERS>\n     <TITLE>Danio
-        rerio</TITLE>\n     <SAMPLE_NAME>\n          <TAXON_ID>7955</TAXON_ID>\n          <SCIENTIFIC_NAME>Danio
-        rerio</SCIENTIFIC_NAME>\n          <COMMON_NAME>zebrafish</COMMON_NAME>\n
-        \    </SAMPLE_NAME>\n     <SAMPLE_LINKS>\n          <SAMPLE_LINK>\n               <XREF_LINK>\n
-        \                   <DB>ENA-STUDY</DB>\n                    <ID>DRP003977</ID>\n
-        \              </XREF_LINK>\n          </SAMPLE_LINK>\n          <SAMPLE_LINK>\n
-        \              <XREF_LINK>\n                    <DB>ENA-EXPERIMENT</DB>\n
-        \                   <ID>DRX045955</ID>\n               </XREF_LINK>\n          </SAMPLE_LINK>\n
-        \         <SAMPLE_LINK>\n               <XREF_LINK>\n                    <DB>ENA-RUN</DB>\n
-        \                   <ID>DRR051063</ID>\n               </XREF_LINK>\n          </SAMPLE_LINK>\n
-        \         <SAMPLE_LINK>\n               <XREF_LINK>\n                    <DB>ENA-SUBMISSION</DB>\n
-        \                   <ID>DRA004273</ID>\n               </XREF_LINK>\n          </SAMPLE_LINK>\n
-        \         <SAMPLE_LINK>\n               <XREF_LINK>\n                    <DB>ENA-FASTQ-FILES</DB>\n
-        \                   <ID><![CDATA[https://www.ebi.ac.uk/ena/portal/api/filereport?accession=DRS057266&result=read_run&fields=run_accession,fastq_ftp,fastq_md5,fastq_bytes]]></ID>\n
-        \              </XREF_LINK>\n          </SAMPLE_LINK>\n          <SAMPLE_LINK>\n
-        \              <XREF_LINK>\n                    <DB>ENA-SUBMITTED-FILES</DB>\n
-        \                   <ID><![CDATA[https://www.ebi.ac.uk/ena/portal/api/filereport?accession=DRS057266&result=read_run&fields=run_accession,submitted_ftp,submitted_md5,submitted_bytes,submitted_format]]></ID>\n
-        \              </XREF_LINK>\n          </SAMPLE_LINK>\n     </SAMPLE_LINKS>\n
-        \    <SAMPLE_ATTRIBUTES>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>description</TAG>\n
-        \              <VALUE>These cells are from the same fish as 120A_GFP_plus_Tel</VALUE>\n
-        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>bioproject_id</TAG>\n
-        \              <VALUE>PRJDB4470</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
-        \              <TAG>sample_name</TAG>\n               <VALUE>120A_GFP_minus_Tel</VALUE>\n
-        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>sample_title</TAG>\n
-        \              <VALUE>GFP- cells from telencephalon of SAGFF(LF)120A;UAS:GFP
-        transgenic zebrafish</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
-        \              <TAG>genotype</TAG>\n               <VALUE>SAGFF(LF)120A;UAS:GFP</VALUE>\n
-        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>tissue_type</TAG>\n
-        \              <VALUE>brain</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
-        \              <TAG>ENA-SPOT-COUNT</TAG>\n               <VALUE>76294060</VALUE>\n
-        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-BASE-COUNT</TAG>\n
-        \              <VALUE>15411400120</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
-        \         <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-FIRST-PUBLIC</TAG>\n
-        \              <VALUE>2018-01-07</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
-        \         <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-LAST-UPDATE</TAG>\n
-        \              <VALUE>2018-01-07</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
+        alias=\"SAMD00044987\" center_name=\"National Institute of Genetics (Japan)\"
+        broker_name=\"DDBJ\">\n     <IDENTIFIERS>\n          <PRIMARY_ID>DRS057266</PRIMARY_ID>\n
+        \         <EXTERNAL_ID namespace=\"BioSample\">SAMD00044987</EXTERNAL_ID>\n
+        \    </IDENTIFIERS>\n     <TITLE>GFP- cells from telencephalon of SAGFF(LF)120A;UAS:GFP
+        transgenic zebrafish</TITLE>\n     <SAMPLE_NAME>\n          <TAXON_ID>7955</TAXON_ID>\n
+        \         <SCIENTIFIC_NAME>Danio rerio</SCIENTIFIC_NAME>\n          <COMMON_NAME>zebrafish</COMMON_NAME>\n
+        \    </SAMPLE_NAME>\n     <DESCRIPTION>These cells are from the same fish
+        as 120A_GFP_plus_Tel</DESCRIPTION>\n     <SAMPLE_LINKS>\n    <SAMPLE_LINK>\n
+        \       <XREF_LINK>\n            <DB>ENA-FASTQ-FILES</DB>\n            <ID><![CDATA[https://www.ebi.ac.uk/ena/portal/api/filereport?accession=DRS057266&result=read_run&fields=run_accession,fastq_ftp,fastq_md5,fastq_bytes]]></ID>\n
+        \       </XREF_LINK>\n    </SAMPLE_LINK>\n    <SAMPLE_LINK>\n        <XREF_LINK>\n
+        \           <DB>ENA-SUBMITTED-FILES</DB>\n            <ID><![CDATA[https://www.ebi.ac.uk/ena/portal/api/filereport?accession=DRS057266&result=read_run&fields=run_accession,submitted_ftp,submitted_md5,submitted_bytes,submitted_format]]></ID>\n
+        \       </XREF_LINK>\n    </SAMPLE_LINK>\n</SAMPLE_LINKS>\n<SAMPLE_ATTRIBUTES>\n
+        \         <SAMPLE_ATTRIBUTE>\n               <TAG>INSDC secondary accession</TAG>\n
+        \              <VALUE>DRS057266</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
+        \              <TAG>NCBI submission package</TAG>\n               <VALUE>Generic.1.0</VALUE>\n
+        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>organism</TAG>\n
+        \              <VALUE>Danio rerio</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
+        \         <SAMPLE_ATTRIBUTE>\n               <TAG>tissue type</TAG>\n               <VALUE>brain</VALUE>\n
+        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>sample
+        name</TAG>\n               <VALUE>120A_GFP_minus_Tel</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
+        \         <SAMPLE_ATTRIBUTE>\n               <TAG>genotype</TAG>\n               <VALUE>SAGFF(LF)120A;UAS:GFP</VALUE>\n
+        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>BioSampleModel</TAG>\n
+        \              <VALUE>Generic</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
+        \              <TAG>ENA-FIRST-PUBLIC</TAG>\n               <VALUE>2018-01-06</VALUE>\n
+        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-LAST-UPDATE</TAG>\n
+        \              <VALUE>2018-01-06</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
         \    </SAMPLE_ATTRIBUTES>\n</SAMPLE>\n</SAMPLE_SET>\n"
     headers:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:45:11 GMT
+      - Wed, 17 May 2023 18:37:49 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -10636,7 +8795,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/DRP003977
   response:
@@ -10644,14 +8803,16 @@ interactions:
       string: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<STUDY_SET>\n<STUDY accession=\"DRP003977\"
         alias=\"DRP003977\" center_name=\"NIG\" broker_name=\"DDBJ\">\n     <IDENTIFIERS>\n
         \         <PRIMARY_ID>DRP003977</PRIMARY_ID>\n          <SECONDARY_ID>PRJDB4470</SECONDARY_ID>\n
-        \         <EXTERNAL_ID label=\"primary\" namespace=\"BioProject\">PRJDB4470</EXTERNAL_ID>\n
+        \         <EXTERNAL_ID label=\"BioProject ID\" namespace=\"BioProject\">PRJDB4470</EXTERNAL_ID>\n
         \         <SUBMITTER_ID namespace=\"NIG\">DRP003977</SUBMITTER_ID>\n     </IDENTIFIERS>\n
         \    <DESCRIPTOR>\n          <STUDY_TITLE>Gene expression analysis of the
-        zebrafish brain</STUDY_TITLE>\n          <STUDY_TYPE existing_study_type=\"Transcriptome
-        Analysis\"/>\n          <STUDY_ABSTRACT>Gene expression profiling by RNA-seq
-        of specific regions and subpopulations of neurons in the zebrafish brain that
-        control behaviors.</STUDY_ABSTRACT>\n     </DESCRIPTOR>\n     <STUDY_LINKS>\n
-        \         <STUDY_LINK>\n               <XREF_LINK>\n                    <DB>ENA-SAMPLE</DB>\n
+        zebrafish brain</STUDY_TITLE>\n          <STUDY_TYPE existing_study_type=\"Other\"/>\n
+        \         <STUDY_ABSTRACT>Gene expression profiling by RNA-seq of specific
+        regions and subpopulations of neurons in the zebrafish brain that control
+        behaviors.</STUDY_ABSTRACT>\n          <STUDY_DESCRIPTION>Gene expression
+        profiling by RNA-seq of specific regions and subpopulations of neurons in
+        the zebrafish brain that control behaviors.</STUDY_DESCRIPTION>\n     </DESCRIPTOR>\n
+        \    <STUDY_LINKS>\n          <STUDY_LINK>\n               <XREF_LINK>\n                    <DB>ENA-SAMPLE</DB>\n
         \                   <ID>DRS057265-DRS057267,DRS057269-DRS057272,DRS057274-DRS057275</ID>\n
         \              </XREF_LINK>\n          </STUDY_LINK>\n          <STUDY_LINK>\n
         \              <XREF_LINK>\n                    <DB>ENA-EXPERIMENT</DB>\n
@@ -10660,7 +8821,7 @@ interactions:
         \                   <DB>ENA-RUN</DB>\n                    <ID>DRR051059-DRR051067</ID>\n
         \              </XREF_LINK>\n          </STUDY_LINK>\n          <STUDY_LINK>\n
         \              <XREF_LINK>\n                    <DB>ENA-SUBMISSION</DB>\n
-        \                   <ID>DRA004276</ID>\n               </XREF_LINK>\n          </STUDY_LINK>\n
+        \                   <ID>DRA008860</ID>\n               </XREF_LINK>\n          </STUDY_LINK>\n
         \         <STUDY_LINK>\n               <XREF_LINK>\n                    <DB>ENA-FASTQ-FILES</DB>\n
         \                   <ID><![CDATA[https://www.ebi.ac.uk/ena/portal/api/filereport?accession=DRP003977&result=read_run&fields=run_accession,fastq_ftp,fastq_md5,fastq_bytes]]></ID>\n
         \              </XREF_LINK>\n          </STUDY_LINK>\n          <STUDY_LINK>\n
@@ -10672,13 +8833,13 @@ interactions:
         \              <TAG>ENA-BASE-COUNT</TAG>\n               <VALUE>182690550386</VALUE>\n
         \         </STUDY_ATTRIBUTE>\n          <STUDY_ATTRIBUTE>\n               <TAG>ENA-FIRST-PUBLIC</TAG>\n
         \              <VALUE>2018-01-08</VALUE>\n          </STUDY_ATTRIBUTE>\n          <STUDY_ATTRIBUTE>\n
-        \              <TAG>ENA-LAST-UPDATE</TAG>\n               <VALUE>2018-01-08</VALUE>\n
+        \              <TAG>ENA-LAST-UPDATE</TAG>\n               <VALUE>2021-08-11</VALUE>\n
         \         </STUDY_ATTRIBUTE>\n     </STUDY_ATTRIBUTES>\n</STUDY>\n</STUDY_SET>\n"
     headers:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:45:12 GMT
+      - Wed, 17 May 2023 18:37:50 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -10696,7 +8857,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/DRA004273
   response:
@@ -10730,7 +8891,7 @@ interactions:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:45:12 GMT
+      - Wed, 17 May 2023 18:37:50 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -10739,68 +8900,6 @@ interactions:
       code: 200
       message: ''
 - request:
-    body: acc=DRR051063&accept-proto=fasp&version=2.0
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '43'
-      User-Agent:
-      - python-requests/2.25.1
-    method: POST
-    uri: https://www.ncbi.nlm.nih.gov/Traces/names/names.cgi
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAAwzIvQ6CMBQG0J2naOLAhPl6L94Cs7sJcXLjpw2ahhKoMSb34fWM50RnFMc+bO9R
-        r32Pi4WwWhADTqRmJdimgq0gd7JdjQ7uoQ01AgljYBIgzGgde4Z1TEStd6paA3pb49eUS87bUZpt
-        TzlNKZrnYYYY08fPJqTd5OUfaXz5KRc/AAAA//8DAK2QvEGPAAAA
-    headers:
-      Cache-Control:
-      - private
-      Connection:
-      - Keep-Alive
-      Content-Encoding:
-      - gzip
-      Content-Security-Policy:
-      - upgrade-insecure-requests
-      Content-Type:
-      - text/plain
-      Date:
-      - Wed, 28 Jul 2021 19:45:13 GMT
-      Keep-Alive:
-      - timeout=1, max=10
-      NCBI-PHID:
-      - CC95F9C7101B3C910000000000000001.m_1
-      NCBI-SID:
-      - CC95F9C7101B3C91_0000SID
-      Referrer-Policy:
-      - origin-when-cross-origin
-      Server:
-      - Apache
-      Set-Cookie:
-      - ncbi_sid=CC95F9C7101B3C91_0000SID; domain=.nih.gov; path=/; expires=Thu, 28
-        Jul 2022 19:45:13 GMT
-      SraNameServerOutputVersion:
-      - '2.0'
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains; preload
-      Transfer-Encoding:
-      - chunked
-      Vary:
-      - Accept-Encoding
-      X-UA-Compatible:
-      - IE=Edge
-      X-XSS-Protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
-- request:
     body: null
     headers:
       Accept:
@@ -10810,29 +8909,27 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/portal/api/filereport?accession=DRR051063&result=read_run
   response:
     body:
-      string: "run_accession\tfastq_ftp\tfastq_bytes\tfastq_md5\tsubmitted_ftp\tsubmitted_bytes\tsubmitted_md5\tsra_ftp\tsra_bytes\tsra_md5\nDRR051063\tftp.sra.ebi.ac.uk/vol1/fastq/DRR051/DRR051063/DRR051063_1.fastq.gz;ftp.sra.ebi.ac.uk/vol1/fastq/DRR051/DRR051063/DRR051063_2.fastq.gz\t6390520397;6493698053\t9b523f167fd92adc999437039674b9c6;3fb87f88aeaa094df7a854fed0266eb5\t\t\t\t\t\t\n"
+      string: "run_accession\tfastq_ftp\tfastq_bytes\tfastq_md5\tbam_ftp\tbam_bytes\tbam_md5\tsubmitted_ftp\tsubmitted_bytes\tsubmitted_md5\tsra_ftp\tsra_bytes\tsra_md5\nDRR051063\tftp.sra.ebi.ac.uk/vol1/fastq/DRR051/DRR051063/DRR051063_1.fastq.gz;ftp.sra.ebi.ac.uk/vol1/fastq/DRR051/DRR051063/DRR051063_2.fastq.gz\t6390520397;6493698053\t9b523f167fd92adc999437039674b9c6;3fb87f88aeaa094df7a854fed0266eb5\t\t\t\t\t\t\tftp.sra.ebi.ac.uk/vol1/drr/DRR051/DRR051063\t10230076643\t828606fbf32600fd0973e301732229e7\n"
     headers:
       Cache-Control:
       - no-cache, no-store, max-age=0, must-revalidate
+      Content-Length:
+      - '469'
       Content-Type:
       - text/plain
       Date:
-      - Wed, 28 Jul 2021 19:45:13 GMT
+      - Wed, 17 May 2023 18:37:51 GMT
       Expires:
       - '0'
       Pragma:
       - no-cache
-      Server:
-      - Apache-Coyote/1.1
       Strict-Transport-Security:
       - max-age=0
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Frame-Options:
@@ -10841,7 +8938,7 @@ interactions:
       - 1; mode=block
     status:
       code: 200
-      message: OK
+      message: ''
 - request:
     body: null
     headers:
@@ -10852,7 +8949,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/DRR051064
   response:
@@ -10886,7 +8983,7 @@ interactions:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:45:14 GMT
+      - Wed, 17 May 2023 18:37:51 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -10904,7 +9001,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/DRX045956
   response:
@@ -10960,7 +9057,7 @@ interactions:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:45:14 GMT
+      - Wed, 17 May 2023 18:37:52 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -10978,56 +9075,45 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/DRS057265
   response:
     body:
       string: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<SAMPLE_SET>\n<SAMPLE accession=\"DRS057265\"
-        alias=\"DRS057265\" center_name=\"NIG\" broker_name=\"DDBJ\">\n     <IDENTIFIERS>\n
-        \         <PRIMARY_ID>DRS057265</PRIMARY_ID>\n          <EXTERNAL_ID label=\"BioSample
-        ID\" namespace=\"BioSample\">SAMD00044991</EXTERNAL_ID>\n          <SUBMITTER_ID
-        namespace=\"NIG\">DRS057265</SUBMITTER_ID>\n     </IDENTIFIERS>\n     <TITLE>Danio
-        rerio</TITLE>\n     <SAMPLE_NAME>\n          <TAXON_ID>7955</TAXON_ID>\n          <SCIENTIFIC_NAME>Danio
+        alias=\"SAMD00044991\" center_name=\"National Institute of Genetics (Japan)\"
+        broker_name=\"DDBJ\">\n     <IDENTIFIERS>\n          <PRIMARY_ID>DRS057265</PRIMARY_ID>\n
+        \         <EXTERNAL_ID namespace=\"BioSample\">SAMD00044991</EXTERNAL_ID>\n
+        \    </IDENTIFIERS>\n     <TITLE>CS_telencephalon_30 min after TWAA</TITLE>\n
+        \    <SAMPLE_NAME>\n          <TAXON_ID>7955</TAXON_ID>\n          <SCIENTIFIC_NAME>Danio
         rerio</SCIENTIFIC_NAME>\n          <COMMON_NAME>zebrafish</COMMON_NAME>\n
-        \    </SAMPLE_NAME>\n     <SAMPLE_LINKS>\n          <SAMPLE_LINK>\n               <XREF_LINK>\n
-        \                   <DB>ENA-STUDY</DB>\n                    <ID>DRP003977</ID>\n
-        \              </XREF_LINK>\n          </SAMPLE_LINK>\n          <SAMPLE_LINK>\n
-        \              <XREF_LINK>\n                    <DB>ENA-EXPERIMENT</DB>\n
-        \                   <ID>DRX045956</ID>\n               </XREF_LINK>\n          </SAMPLE_LINK>\n
-        \         <SAMPLE_LINK>\n               <XREF_LINK>\n                    <DB>ENA-RUN</DB>\n
-        \                   <ID>DRR051064</ID>\n               </XREF_LINK>\n          </SAMPLE_LINK>\n
-        \         <SAMPLE_LINK>\n               <XREF_LINK>\n                    <DB>ENA-SUBMISSION</DB>\n
-        \                   <ID>DRA004274</ID>\n               </XREF_LINK>\n          </SAMPLE_LINK>\n
-        \         <SAMPLE_LINK>\n               <XREF_LINK>\n                    <DB>ENA-FASTQ-FILES</DB>\n
-        \                   <ID><![CDATA[https://www.ebi.ac.uk/ena/portal/api/filereport?accession=DRS057265&result=read_run&fields=run_accession,fastq_ftp,fastq_md5,fastq_bytes]]></ID>\n
-        \              </XREF_LINK>\n          </SAMPLE_LINK>\n          <SAMPLE_LINK>\n
-        \              <XREF_LINK>\n                    <DB>ENA-SUBMITTED-FILES</DB>\n
-        \                   <ID><![CDATA[https://www.ebi.ac.uk/ena/portal/api/filereport?accession=DRS057265&result=read_run&fields=run_accession,submitted_ftp,submitted_md5,submitted_bytes,submitted_format]]></ID>\n
-        \              </XREF_LINK>\n          </SAMPLE_LINK>\n     </SAMPLE_LINKS>\n
-        \    <SAMPLE_ATTRIBUTES>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>description</TAG>\n
-        \              <VALUE>Telencephalon from adult zebrafrish, 30 min after light
-        stimulation in Two-Way Active Avoidance coditioning</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
-        \         <SAMPLE_ATTRIBUTE>\n               <TAG>bioproject_id</TAG>\n               <VALUE>PRJDB4470</VALUE>\n
-        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>sample_name</TAG>\n
-        \              <VALUE>CS_Tel_30</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
-        \              <TAG>sample_title</TAG>\n               <VALUE>CS_telencephalon_30
-        min after TWAA</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
-        \              <TAG>genotype</TAG>\n               <VALUE>WT</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
-        \         <SAMPLE_ATTRIBUTE>\n               <TAG>tissue_type</TAG>\n               <VALUE>brain</VALUE>\n
-        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-SPOT-COUNT</TAG>\n
-        \              <VALUE>146341598</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
-        \              <TAG>ENA-BASE-COUNT</TAG>\n               <VALUE>29268319600</VALUE>\n
-        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-FIRST-PUBLIC</TAG>\n
-        \              <VALUE>2018-01-07</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
-        \         <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-LAST-UPDATE</TAG>\n
-        \              <VALUE>2018-01-07</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
+        \    </SAMPLE_NAME>\n     <DESCRIPTION>Telencephalon from adult zebrafrish,
+        30 min after light stimulation in Two-Way Active Avoidance coditioning</DESCRIPTION>\n
+        \    <SAMPLE_LINKS>\n    <SAMPLE_LINK>\n        <XREF_LINK>\n            <DB>ENA-FASTQ-FILES</DB>\n
+        \           <ID><![CDATA[https://www.ebi.ac.uk/ena/portal/api/filereport?accession=DRS057265&result=read_run&fields=run_accession,fastq_ftp,fastq_md5,fastq_bytes]]></ID>\n
+        \       </XREF_LINK>\n    </SAMPLE_LINK>\n    <SAMPLE_LINK>\n        <XREF_LINK>\n
+        \           <DB>ENA-SUBMITTED-FILES</DB>\n            <ID><![CDATA[https://www.ebi.ac.uk/ena/portal/api/filereport?accession=DRS057265&result=read_run&fields=run_accession,submitted_ftp,submitted_md5,submitted_bytes,submitted_format]]></ID>\n
+        \       </XREF_LINK>\n    </SAMPLE_LINK>\n</SAMPLE_LINKS>\n<SAMPLE_ATTRIBUTES>\n
+        \         <SAMPLE_ATTRIBUTE>\n               <TAG>INSDC secondary accession</TAG>\n
+        \              <VALUE>DRS057265</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
+        \              <TAG>NCBI submission package</TAG>\n               <VALUE>Generic.1.0</VALUE>\n
+        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>organism</TAG>\n
+        \              <VALUE>Danio rerio</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
+        \         <SAMPLE_ATTRIBUTE>\n               <TAG>tissue type</TAG>\n               <VALUE>brain</VALUE>\n
+        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>sample
+        name</TAG>\n               <VALUE>CS_Tel_30</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
+        \         <SAMPLE_ATTRIBUTE>\n               <TAG>genotype</TAG>\n               <VALUE>WT</VALUE>\n
+        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>BioSampleModel</TAG>\n
+        \              <VALUE>Generic</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
+        \              <TAG>ENA-FIRST-PUBLIC</TAG>\n               <VALUE>2018-01-06</VALUE>\n
+        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-LAST-UPDATE</TAG>\n
+        \              <VALUE>2018-01-06</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
         \    </SAMPLE_ATTRIBUTES>\n</SAMPLE>\n</SAMPLE_SET>\n"
     headers:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:45:15 GMT
+      - Wed, 17 May 2023 18:37:52 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -11045,7 +9131,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/DRP003977
   response:
@@ -11053,14 +9139,16 @@ interactions:
       string: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<STUDY_SET>\n<STUDY accession=\"DRP003977\"
         alias=\"DRP003977\" center_name=\"NIG\" broker_name=\"DDBJ\">\n     <IDENTIFIERS>\n
         \         <PRIMARY_ID>DRP003977</PRIMARY_ID>\n          <SECONDARY_ID>PRJDB4470</SECONDARY_ID>\n
-        \         <EXTERNAL_ID label=\"primary\" namespace=\"BioProject\">PRJDB4470</EXTERNAL_ID>\n
+        \         <EXTERNAL_ID label=\"BioProject ID\" namespace=\"BioProject\">PRJDB4470</EXTERNAL_ID>\n
         \         <SUBMITTER_ID namespace=\"NIG\">DRP003977</SUBMITTER_ID>\n     </IDENTIFIERS>\n
         \    <DESCRIPTOR>\n          <STUDY_TITLE>Gene expression analysis of the
-        zebrafish brain</STUDY_TITLE>\n          <STUDY_TYPE existing_study_type=\"Transcriptome
-        Analysis\"/>\n          <STUDY_ABSTRACT>Gene expression profiling by RNA-seq
-        of specific regions and subpopulations of neurons in the zebrafish brain that
-        control behaviors.</STUDY_ABSTRACT>\n     </DESCRIPTOR>\n     <STUDY_LINKS>\n
-        \         <STUDY_LINK>\n               <XREF_LINK>\n                    <DB>ENA-SAMPLE</DB>\n
+        zebrafish brain</STUDY_TITLE>\n          <STUDY_TYPE existing_study_type=\"Other\"/>\n
+        \         <STUDY_ABSTRACT>Gene expression profiling by RNA-seq of specific
+        regions and subpopulations of neurons in the zebrafish brain that control
+        behaviors.</STUDY_ABSTRACT>\n          <STUDY_DESCRIPTION>Gene expression
+        profiling by RNA-seq of specific regions and subpopulations of neurons in
+        the zebrafish brain that control behaviors.</STUDY_DESCRIPTION>\n     </DESCRIPTOR>\n
+        \    <STUDY_LINKS>\n          <STUDY_LINK>\n               <XREF_LINK>\n                    <DB>ENA-SAMPLE</DB>\n
         \                   <ID>DRS057265-DRS057267,DRS057269-DRS057272,DRS057274-DRS057275</ID>\n
         \              </XREF_LINK>\n          </STUDY_LINK>\n          <STUDY_LINK>\n
         \              <XREF_LINK>\n                    <DB>ENA-EXPERIMENT</DB>\n
@@ -11069,7 +9157,7 @@ interactions:
         \                   <DB>ENA-RUN</DB>\n                    <ID>DRR051059-DRR051067</ID>\n
         \              </XREF_LINK>\n          </STUDY_LINK>\n          <STUDY_LINK>\n
         \              <XREF_LINK>\n                    <DB>ENA-SUBMISSION</DB>\n
-        \                   <ID>DRA004276</ID>\n               </XREF_LINK>\n          </STUDY_LINK>\n
+        \                   <ID>DRA008860</ID>\n               </XREF_LINK>\n          </STUDY_LINK>\n
         \         <STUDY_LINK>\n               <XREF_LINK>\n                    <DB>ENA-FASTQ-FILES</DB>\n
         \                   <ID><![CDATA[https://www.ebi.ac.uk/ena/portal/api/filereport?accession=DRP003977&result=read_run&fields=run_accession,fastq_ftp,fastq_md5,fastq_bytes]]></ID>\n
         \              </XREF_LINK>\n          </STUDY_LINK>\n          <STUDY_LINK>\n
@@ -11081,13 +9169,13 @@ interactions:
         \              <TAG>ENA-BASE-COUNT</TAG>\n               <VALUE>182690550386</VALUE>\n
         \         </STUDY_ATTRIBUTE>\n          <STUDY_ATTRIBUTE>\n               <TAG>ENA-FIRST-PUBLIC</TAG>\n
         \              <VALUE>2018-01-08</VALUE>\n          </STUDY_ATTRIBUTE>\n          <STUDY_ATTRIBUTE>\n
-        \              <TAG>ENA-LAST-UPDATE</TAG>\n               <VALUE>2018-01-08</VALUE>\n
+        \              <TAG>ENA-LAST-UPDATE</TAG>\n               <VALUE>2021-08-11</VALUE>\n
         \         </STUDY_ATTRIBUTE>\n     </STUDY_ATTRIBUTES>\n</STUDY>\n</STUDY_SET>\n"
     headers:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:45:15 GMT
+      - Wed, 17 May 2023 18:37:52 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -11105,7 +9193,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/DRA004274
   response:
@@ -11139,7 +9227,7 @@ interactions:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:45:17 GMT
+      - Wed, 17 May 2023 18:37:53 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -11148,68 +9236,6 @@ interactions:
       code: 200
       message: ''
 - request:
-    body: acc=DRR051064&accept-proto=fasp&version=2.0
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '43'
-      User-Agent:
-      - python-requests/2.25.1
-    method: POST
-    uri: https://www.ncbi.nlm.nih.gov/Traces/names/names.cgi
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAAwzIsQqDMBQF0N2vCHRwsty8vJjo3L0gnboZTbElNKIppfA+vm6Hc6Izqn0b10+Q
-        yzDAarQsBE8EOGJ3WPsGukF7075n6o29i4kdDLMDacvsTQwek7PjTDG0nWERYUCu7/RT9VLKutdq
-        3XLJU07quasxpfyNs3rkTZXliBxecSrVHwAA//8DAFGgQi2PAAAA
-    headers:
-      Cache-Control:
-      - private
-      Connection:
-      - Keep-Alive
-      Content-Encoding:
-      - gzip
-      Content-Security-Policy:
-      - upgrade-insecure-requests
-      Content-Type:
-      - text/plain
-      Date:
-      - Wed, 28 Jul 2021 19:45:17 GMT
-      Keep-Alive:
-      - timeout=1, max=10
-      NCBI-PHID:
-      - CC95F9F3101B3CD10000000000000001.m_1
-      NCBI-SID:
-      - CC95F9F3101B3CD1_0000SID
-      Referrer-Policy:
-      - origin-when-cross-origin
-      Server:
-      - Apache
-      Set-Cookie:
-      - ncbi_sid=CC95F9F3101B3CD1_0000SID; domain=.nih.gov; path=/; expires=Thu, 28
-        Jul 2022 19:45:17 GMT
-      SraNameServerOutputVersion:
-      - '2.0'
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains; preload
-      Transfer-Encoding:
-      - chunked
-      Vary:
-      - Accept-Encoding
-      X-UA-Compatible:
-      - IE=Edge
-      X-XSS-Protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
-- request:
     body: null
     headers:
       Accept:
@@ -11219,29 +9245,27 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/portal/api/filereport?accession=DRR051064&result=read_run
   response:
     body:
-      string: "run_accession\tfastq_ftp\tfastq_bytes\tfastq_md5\tsubmitted_ftp\tsubmitted_bytes\tsubmitted_md5\tsra_ftp\tsra_bytes\tsra_md5\nDRR051064\tftp.sra.ebi.ac.uk/vol1/fastq/DRR051/DRR051064/DRR051064_1.fastq.gz;ftp.sra.ebi.ac.uk/vol1/fastq/DRR051/DRR051064/DRR051064_2.fastq.gz\t13204439635;13344814940\t6e64a0d4d298ff5b1e3c23e8c50f3a60;8d5a6f4e83fa1afdd2276cf0a7124c51\t\t\t\t\t\t\n"
+      string: "run_accession\tfastq_ftp\tfastq_bytes\tfastq_md5\tbam_ftp\tbam_bytes\tbam_md5\tsubmitted_ftp\tsubmitted_bytes\tsubmitted_md5\tsra_ftp\tsra_bytes\tsra_md5\nDRR051064\tftp.sra.ebi.ac.uk/vol1/fastq/DRR051/DRR051064/DRR051064_1.fastq.gz;ftp.sra.ebi.ac.uk/vol1/fastq/DRR051/DRR051064/DRR051064_2.fastq.gz\t13204439635;13344814940\t6e64a0d4d298ff5b1e3c23e8c50f3a60;8d5a6f4e83fa1afdd2276cf0a7124c51\t\t\t\t\t\t\tftp.sra.ebi.ac.uk/vol1/drr/DRR051/DRR051064\t20822007247\t3e90344702154483eb80c75ad2eb6934\n"
     headers:
       Cache-Control:
       - no-cache, no-store, max-age=0, must-revalidate
+      Content-Length:
+      - '471'
       Content-Type:
       - text/plain
       Date:
-      - Wed, 28 Jul 2021 19:45:17 GMT
+      - Wed, 17 May 2023 18:37:54 GMT
       Expires:
       - '0'
       Pragma:
       - no-cache
-      Server:
-      - Apache-Coyote/1.1
       Strict-Transport-Security:
       - max-age=0
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Frame-Options:
@@ -11250,7 +9274,7 @@ interactions:
       - 1; mode=block
     status:
       code: 200
-      message: OK
+      message: ''
 - request:
     body: null
     headers:
@@ -11261,7 +9285,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/DRR051065
   response:
@@ -11295,7 +9319,7 @@ interactions:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:45:19 GMT
+      - Wed, 17 May 2023 18:37:54 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -11313,7 +9337,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/DRX045957
   response:
@@ -11369,7 +9393,7 @@ interactions:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:45:19 GMT
+      - Wed, 17 May 2023 18:37:54 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -11387,57 +9411,45 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/DRS057272
   response:
     body:
       string: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<SAMPLE_SET>\n<SAMPLE accession=\"DRS057272\"
-        alias=\"DRS057272\" center_name=\"NIG\" broker_name=\"DDBJ\">\n     <IDENTIFIERS>\n
-        \         <PRIMARY_ID>DRS057272</PRIMARY_ID>\n          <EXTERNAL_ID label=\"BioSample
-        ID\" namespace=\"BioSample\">SAMD00044990</EXTERNAL_ID>\n          <SUBMITTER_ID
-        namespace=\"NIG\">DRS057272</SUBMITTER_ID>\n     </IDENTIFIERS>\n     <TITLE>Danio
-        rerio</TITLE>\n     <SAMPLE_NAME>\n          <TAXON_ID>7955</TAXON_ID>\n          <SCIENTIFIC_NAME>Danio
+        alias=\"SAMD00044990\" center_name=\"National Institute of Genetics (Japan)\"
+        broker_name=\"DDBJ\">\n     <IDENTIFIERS>\n          <PRIMARY_ID>DRS057272</PRIMARY_ID>\n
+        \         <EXTERNAL_ID namespace=\"BioSample\">SAMD00044990</EXTERNAL_ID>\n
+        \    </IDENTIFIERS>\n     <TITLE>CS+US_telencephalon_30 min after TWAA</TITLE>\n
+        \    <SAMPLE_NAME>\n          <TAXON_ID>7955</TAXON_ID>\n          <SCIENTIFIC_NAME>Danio
         rerio</SCIENTIFIC_NAME>\n          <COMMON_NAME>zebrafish</COMMON_NAME>\n
-        \    </SAMPLE_NAME>\n     <SAMPLE_LINKS>\n          <SAMPLE_LINK>\n               <XREF_LINK>\n
-        \                   <DB>ENA-STUDY</DB>\n                    <ID>DRP003977</ID>\n
-        \              </XREF_LINK>\n          </SAMPLE_LINK>\n          <SAMPLE_LINK>\n
-        \              <XREF_LINK>\n                    <DB>ENA-EXPERIMENT</DB>\n
-        \                   <ID>DRX045957</ID>\n               </XREF_LINK>\n          </SAMPLE_LINK>\n
-        \         <SAMPLE_LINK>\n               <XREF_LINK>\n                    <DB>ENA-RUN</DB>\n
-        \                   <ID>DRR051065</ID>\n               </XREF_LINK>\n          </SAMPLE_LINK>\n
-        \         <SAMPLE_LINK>\n               <XREF_LINK>\n                    <DB>ENA-SUBMISSION</DB>\n
-        \                   <ID>DRA004275</ID>\n               </XREF_LINK>\n          </SAMPLE_LINK>\n
-        \         <SAMPLE_LINK>\n               <XREF_LINK>\n                    <DB>ENA-FASTQ-FILES</DB>\n
-        \                   <ID><![CDATA[https://www.ebi.ac.uk/ena/portal/api/filereport?accession=DRS057272&result=read_run&fields=run_accession,fastq_ftp,fastq_md5,fastq_bytes]]></ID>\n
-        \              </XREF_LINK>\n          </SAMPLE_LINK>\n          <SAMPLE_LINK>\n
-        \              <XREF_LINK>\n                    <DB>ENA-SUBMITTED-FILES</DB>\n
-        \                   <ID><![CDATA[https://www.ebi.ac.uk/ena/portal/api/filereport?accession=DRS057272&result=read_run&fields=run_accession,submitted_ftp,submitted_md5,submitted_bytes,submitted_format]]></ID>\n
-        \              </XREF_LINK>\n          </SAMPLE_LINK>\n     </SAMPLE_LINKS>\n
-        \    <SAMPLE_ATTRIBUTES>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>description</TAG>\n
-        \              <VALUE>Telencephalon from adult zebrafrish, 30 min after light
-        and electrical shock association in non-trace Two-Way Active Avoidance conditioning</VALUE>\n
-        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>bioproject_id</TAG>\n
-        \              <VALUE>PRJDB4470</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
-        \              <TAG>sample_name</TAG>\n               <VALUE>CS+US_Tel_30</VALUE>\n
-        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>sample_title</TAG>\n
-        \              <VALUE>CS+US_telencephalon_30 min after TWAA</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
+        \    </SAMPLE_NAME>\n     <DESCRIPTION>Telencephalon from adult zebrafrish,
+        30 min after light and electrical shock association in non-trace Two-Way Active
+        Avoidance conditioning</DESCRIPTION>\n     <SAMPLE_LINKS>\n    <SAMPLE_LINK>\n
+        \       <XREF_LINK>\n            <DB>ENA-FASTQ-FILES</DB>\n            <ID><![CDATA[https://www.ebi.ac.uk/ena/portal/api/filereport?accession=DRS057272&result=read_run&fields=run_accession,fastq_ftp,fastq_md5,fastq_bytes]]></ID>\n
+        \       </XREF_LINK>\n    </SAMPLE_LINK>\n    <SAMPLE_LINK>\n        <XREF_LINK>\n
+        \           <DB>ENA-SUBMITTED-FILES</DB>\n            <ID><![CDATA[https://www.ebi.ac.uk/ena/portal/api/filereport?accession=DRS057272&result=read_run&fields=run_accession,submitted_ftp,submitted_md5,submitted_bytes,submitted_format]]></ID>\n
+        \       </XREF_LINK>\n    </SAMPLE_LINK>\n</SAMPLE_LINKS>\n<SAMPLE_ATTRIBUTES>\n
+        \         <SAMPLE_ATTRIBUTE>\n               <TAG>INSDC secondary accession</TAG>\n
+        \              <VALUE>DRS057272</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
+        \              <TAG>NCBI submission package</TAG>\n               <VALUE>Generic.1.0</VALUE>\n
+        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>organism</TAG>\n
+        \              <VALUE>Danio rerio</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
+        \         <SAMPLE_ATTRIBUTE>\n               <TAG>tissue type</TAG>\n               <VALUE>brain</VALUE>\n
+        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>sample
+        name</TAG>\n               <VALUE>CS+US_Tel_30</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
         \         <SAMPLE_ATTRIBUTE>\n               <TAG>genotype</TAG>\n               <VALUE>WT</VALUE>\n
-        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>tissue_type</TAG>\n
-        \              <VALUE>brain</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
-        \              <TAG>ENA-SPOT-COUNT</TAG>\n               <VALUE>101196646</VALUE>\n
-        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-BASE-COUNT</TAG>\n
-        \              <VALUE>20239329200</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
-        \         <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-FIRST-PUBLIC</TAG>\n
-        \              <VALUE>2018-01-07</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
-        \         <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-LAST-UPDATE</TAG>\n
-        \              <VALUE>2018-01-07</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
+        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>BioSampleModel</TAG>\n
+        \              <VALUE>Generic</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
+        \              <TAG>ENA-FIRST-PUBLIC</TAG>\n               <VALUE>2018-01-06</VALUE>\n
+        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-LAST-UPDATE</TAG>\n
+        \              <VALUE>2018-01-06</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
         \    </SAMPLE_ATTRIBUTES>\n</SAMPLE>\n</SAMPLE_SET>\n"
     headers:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:45:20 GMT
+      - Wed, 17 May 2023 18:37:54 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -11455,7 +9467,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/DRP003977
   response:
@@ -11463,14 +9475,16 @@ interactions:
       string: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<STUDY_SET>\n<STUDY accession=\"DRP003977\"
         alias=\"DRP003977\" center_name=\"NIG\" broker_name=\"DDBJ\">\n     <IDENTIFIERS>\n
         \         <PRIMARY_ID>DRP003977</PRIMARY_ID>\n          <SECONDARY_ID>PRJDB4470</SECONDARY_ID>\n
-        \         <EXTERNAL_ID label=\"primary\" namespace=\"BioProject\">PRJDB4470</EXTERNAL_ID>\n
+        \         <EXTERNAL_ID label=\"BioProject ID\" namespace=\"BioProject\">PRJDB4470</EXTERNAL_ID>\n
         \         <SUBMITTER_ID namespace=\"NIG\">DRP003977</SUBMITTER_ID>\n     </IDENTIFIERS>\n
         \    <DESCRIPTOR>\n          <STUDY_TITLE>Gene expression analysis of the
-        zebrafish brain</STUDY_TITLE>\n          <STUDY_TYPE existing_study_type=\"Transcriptome
-        Analysis\"/>\n          <STUDY_ABSTRACT>Gene expression profiling by RNA-seq
-        of specific regions and subpopulations of neurons in the zebrafish brain that
-        control behaviors.</STUDY_ABSTRACT>\n     </DESCRIPTOR>\n     <STUDY_LINKS>\n
-        \         <STUDY_LINK>\n               <XREF_LINK>\n                    <DB>ENA-SAMPLE</DB>\n
+        zebrafish brain</STUDY_TITLE>\n          <STUDY_TYPE existing_study_type=\"Other\"/>\n
+        \         <STUDY_ABSTRACT>Gene expression profiling by RNA-seq of specific
+        regions and subpopulations of neurons in the zebrafish brain that control
+        behaviors.</STUDY_ABSTRACT>\n          <STUDY_DESCRIPTION>Gene expression
+        profiling by RNA-seq of specific regions and subpopulations of neurons in
+        the zebrafish brain that control behaviors.</STUDY_DESCRIPTION>\n     </DESCRIPTOR>\n
+        \    <STUDY_LINKS>\n          <STUDY_LINK>\n               <XREF_LINK>\n                    <DB>ENA-SAMPLE</DB>\n
         \                   <ID>DRS057265-DRS057267,DRS057269-DRS057272,DRS057274-DRS057275</ID>\n
         \              </XREF_LINK>\n          </STUDY_LINK>\n          <STUDY_LINK>\n
         \              <XREF_LINK>\n                    <DB>ENA-EXPERIMENT</DB>\n
@@ -11479,7 +9493,7 @@ interactions:
         \                   <DB>ENA-RUN</DB>\n                    <ID>DRR051059-DRR051067</ID>\n
         \              </XREF_LINK>\n          </STUDY_LINK>\n          <STUDY_LINK>\n
         \              <XREF_LINK>\n                    <DB>ENA-SUBMISSION</DB>\n
-        \                   <ID>DRA004276</ID>\n               </XREF_LINK>\n          </STUDY_LINK>\n
+        \                   <ID>DRA008860</ID>\n               </XREF_LINK>\n          </STUDY_LINK>\n
         \         <STUDY_LINK>\n               <XREF_LINK>\n                    <DB>ENA-FASTQ-FILES</DB>\n
         \                   <ID><![CDATA[https://www.ebi.ac.uk/ena/portal/api/filereport?accession=DRP003977&result=read_run&fields=run_accession,fastq_ftp,fastq_md5,fastq_bytes]]></ID>\n
         \              </XREF_LINK>\n          </STUDY_LINK>\n          <STUDY_LINK>\n
@@ -11491,13 +9505,13 @@ interactions:
         \              <TAG>ENA-BASE-COUNT</TAG>\n               <VALUE>182690550386</VALUE>\n
         \         </STUDY_ATTRIBUTE>\n          <STUDY_ATTRIBUTE>\n               <TAG>ENA-FIRST-PUBLIC</TAG>\n
         \              <VALUE>2018-01-08</VALUE>\n          </STUDY_ATTRIBUTE>\n          <STUDY_ATTRIBUTE>\n
-        \              <TAG>ENA-LAST-UPDATE</TAG>\n               <VALUE>2018-01-08</VALUE>\n
+        \              <TAG>ENA-LAST-UPDATE</TAG>\n               <VALUE>2021-08-11</VALUE>\n
         \         </STUDY_ATTRIBUTE>\n     </STUDY_ATTRIBUTES>\n</STUDY>\n</STUDY_SET>\n"
     headers:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:45:20 GMT
+      - Wed, 17 May 2023 18:37:55 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -11515,7 +9529,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/DRA004275
   response:
@@ -11549,7 +9563,7 @@ interactions:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:45:21 GMT
+      - Wed, 17 May 2023 18:37:55 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -11558,68 +9572,6 @@ interactions:
       code: 200
       message: ''
 - request:
-    body: acc=DRR051065&accept-proto=fasp&version=2.0
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '43'
-      User-Agent:
-      - python-requests/2.25.1
-    method: POST
-    uri: https://www.ncbi.nlm.nih.gov/Traces/names/names.cgi
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAAwzLuwrCMBQA0L1fEXDoVLk3ryad3YXi5JbElCrBhCQiwv14ux44J36GoVVXPp4u
-        6woKQStCKayWMEupiAOaCXACfeO4SL4g3MlsYVYxaOe5scGiF8J75XTUKh7PEpEEoOs7/di4917a
-        yErNPYec2LMxl1L+xgfbcmV9PyD7Vwx9+AMAAP//AwB4C0SvjwAAAA==
-    headers:
-      Cache-Control:
-      - private
-      Connection:
-      - Keep-Alive
-      Content-Encoding:
-      - gzip
-      Content-Security-Policy:
-      - upgrade-insecure-requests
-      Content-Type:
-      - text/plain
-      Date:
-      - Wed, 28 Jul 2021 19:45:21 GMT
-      Keep-Alive:
-      - timeout=1, max=10
-      NCBI-PHID:
-      - CC95FC16101B3D110000000000000001.m_1
-      NCBI-SID:
-      - CC95FC16101B3D11_0000SID
-      Referrer-Policy:
-      - origin-when-cross-origin
-      Server:
-      - Apache
-      Set-Cookie:
-      - ncbi_sid=CC95FC16101B3D11_0000SID; domain=.nih.gov; path=/; expires=Thu, 28
-        Jul 2022 19:45:21 GMT
-      SraNameServerOutputVersion:
-      - '2.0'
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains; preload
-      Transfer-Encoding:
-      - chunked
-      Vary:
-      - Accept-Encoding
-      X-UA-Compatible:
-      - IE=Edge
-      X-XSS-Protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
-- request:
     body: null
     headers:
       Accept:
@@ -11629,29 +9581,27 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/portal/api/filereport?accession=DRR051065&result=read_run
   response:
     body:
-      string: "run_accession\tfastq_ftp\tfastq_bytes\tfastq_md5\tsubmitted_ftp\tsubmitted_bytes\tsubmitted_md5\tsra_ftp\tsra_bytes\tsra_md5\nDRR051065\tftp.sra.ebi.ac.uk/vol1/fastq/DRR051/DRR051065/DRR051065_1.fastq.gz;ftp.sra.ebi.ac.uk/vol1/fastq/DRR051/DRR051065/DRR051065_2.fastq.gz\t9138934313;9235518567\t41d11e8c26bcb996af0be3b8eaa6b82b;21fbcb1077cbdcd82e3b5e81deb3495f\t\t\t\t\t\t\n"
+      string: "run_accession\tfastq_ftp\tfastq_bytes\tfastq_md5\tbam_ftp\tbam_bytes\tbam_md5\tsubmitted_ftp\tsubmitted_bytes\tsubmitted_md5\tsra_ftp\tsra_bytes\tsra_md5\nDRR051065\tftp.sra.ebi.ac.uk/vol1/fastq/DRR051/DRR051065/DRR051065_1.fastq.gz;ftp.sra.ebi.ac.uk/vol1/fastq/DRR051/DRR051065/DRR051065_2.fastq.gz\t9138934313;9235518567\t41d11e8c26bcb996af0be3b8eaa6b82b;21fbcb1077cbdcd82e3b5e81deb3495f\t\t\t\t\t\t\tftp.sra.ebi.ac.uk/vol1/drr/DRR051/DRR051065\t14396407445\t8fc75ec6ab289c91b33bb5a6e65e4079\n"
     headers:
       Cache-Control:
       - no-cache, no-store, max-age=0, must-revalidate
+      Content-Length:
+      - '469'
       Content-Type:
       - text/plain
       Date:
-      - Wed, 28 Jul 2021 19:45:22 GMT
+      - Wed, 17 May 2023 18:37:56 GMT
       Expires:
       - '0'
       Pragma:
       - no-cache
-      Server:
-      - Apache-Coyote/1.1
       Strict-Transport-Security:
       - max-age=0
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Frame-Options:
@@ -11660,7 +9610,7 @@ interactions:
       - 1; mode=block
     status:
       code: 200
-      message: OK
+      message: ''
 - request:
     body: null
     headers:
@@ -11671,7 +9621,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/DRR051066
   response:
@@ -11705,7 +9655,7 @@ interactions:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:45:23 GMT
+      - Wed, 17 May 2023 18:37:56 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -11723,7 +9673,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/DRX045958
   response:
@@ -11780,7 +9730,7 @@ interactions:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:45:23 GMT
+      - Wed, 17 May 2023 18:37:56 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -11798,57 +9748,44 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/DRS057275
   response:
     body:
       string: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<SAMPLE_SET>\n<SAMPLE accession=\"DRS057275\"
-        alias=\"DRS057275\" center_name=\"NIG\" broker_name=\"DDBJ\">\n     <IDENTIFIERS>\n
-        \         <PRIMARY_ID>DRS057275</PRIMARY_ID>\n          <EXTERNAL_ID label=\"BioSample
-        ID\" namespace=\"BioSample\">SAMD00044995</EXTERNAL_ID>\n          <SUBMITTER_ID
-        namespace=\"NIG\">DRS057275</SUBMITTER_ID>\n     </IDENTIFIERS>\n     <TITLE>Danio
-        rerio</TITLE>\n     <SAMPLE_NAME>\n          <TAXON_ID>7955</TAXON_ID>\n          <SCIENTIFIC_NAME>Danio
-        rerio</SCIENTIFIC_NAME>\n          <COMMON_NAME>zebrafish</COMMON_NAME>\n
-        \    </SAMPLE_NAME>\n     <SAMPLE_LINKS>\n          <SAMPLE_LINK>\n               <XREF_LINK>\n
-        \                   <DB>ENA-STUDY</DB>\n                    <ID>DRP003977</ID>\n
-        \              </XREF_LINK>\n          </SAMPLE_LINK>\n          <SAMPLE_LINK>\n
-        \              <XREF_LINK>\n                    <DB>ENA-EXPERIMENT</DB>\n
-        \                   <ID>DRX045958</ID>\n               </XREF_LINK>\n          </SAMPLE_LINK>\n
-        \         <SAMPLE_LINK>\n               <XREF_LINK>\n                    <DB>ENA-RUN</DB>\n
-        \                   <ID>DRR051066</ID>\n               </XREF_LINK>\n          </SAMPLE_LINK>\n
-        \         <SAMPLE_LINK>\n               <XREF_LINK>\n                    <DB>ENA-SUBMISSION</DB>\n
-        \                   <ID>DRA004276</ID>\n               </XREF_LINK>\n          </SAMPLE_LINK>\n
-        \         <SAMPLE_LINK>\n               <XREF_LINK>\n                    <DB>ENA-FASTQ-FILES</DB>\n
-        \                   <ID><![CDATA[https://www.ebi.ac.uk/ena/portal/api/filereport?accession=DRS057275&result=read_run&fields=run_accession,fastq_ftp,fastq_md5,fastq_bytes]]></ID>\n
-        \              </XREF_LINK>\n          </SAMPLE_LINK>\n          <SAMPLE_LINK>\n
-        \              <XREF_LINK>\n                    <DB>ENA-SUBMITTED-FILES</DB>\n
-        \                   <ID><![CDATA[https://www.ebi.ac.uk/ena/portal/api/filereport?accession=DRS057275&result=read_run&fields=run_accession,submitted_ftp,submitted_md5,submitted_bytes,submitted_format]]></ID>\n
-        \              </XREF_LINK>\n          </SAMPLE_LINK>\n     </SAMPLE_LINKS>\n
-        \    <SAMPLE_ATTRIBUTES>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>description</TAG>\n
-        \              <VALUE>Collected from 40 adult fish by using FACS</VALUE>\n
-        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>bioproject_id</TAG>\n
-        \              <VALUE>PRJDB4470</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
-        \              <TAG>sample_name</TAG>\n               <VALUE>h62A_GFP_plus_Tel</VALUE>\n
-        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>sample_title</TAG>\n
-        \              <VALUE>GFP+ cells from telencephalon of hspGFF62A;UAS:GFP transgenic
-        zebrafish</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
-        \              <TAG>genotype</TAG>\n               <VALUE>hspGFF62A;UAS:GFP</VALUE>\n
-        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>tissue_type</TAG>\n
-        \              <VALUE>brain</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
-        \              <TAG>ENA-SPOT-COUNT</TAG>\n               <VALUE>87106280</VALUE>\n
-        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-BASE-COUNT</TAG>\n
-        \              <VALUE>17421256000</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
-        \         <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-FIRST-PUBLIC</TAG>\n
-        \              <VALUE>2018-01-07</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
-        \         <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-LAST-UPDATE</TAG>\n
-        \              <VALUE>2018-01-07</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
+        alias=\"SAMD00044995\" center_name=\"National Institute of Genetics (Japan)\"
+        broker_name=\"DDBJ\">\n     <IDENTIFIERS>\n          <PRIMARY_ID>DRS057275</PRIMARY_ID>\n
+        \         <EXTERNAL_ID namespace=\"BioSample\">SAMD00044995</EXTERNAL_ID>\n
+        \    </IDENTIFIERS>\n     <TITLE>GFP+ cells from telencephalon of hspGFF62A;UAS:GFP
+        transgenic zebrafish</TITLE>\n     <SAMPLE_NAME>\n          <TAXON_ID>7955</TAXON_ID>\n
+        \         <SCIENTIFIC_NAME>Danio rerio</SCIENTIFIC_NAME>\n          <COMMON_NAME>zebrafish</COMMON_NAME>\n
+        \    </SAMPLE_NAME>\n     <DESCRIPTION>Collected from 40 adult fish by using
+        FACS</DESCRIPTION>\n     <SAMPLE_LINKS>\n    <SAMPLE_LINK>\n        <XREF_LINK>\n
+        \           <DB>ENA-FASTQ-FILES</DB>\n            <ID><![CDATA[https://www.ebi.ac.uk/ena/portal/api/filereport?accession=DRS057275&result=read_run&fields=run_accession,fastq_ftp,fastq_md5,fastq_bytes]]></ID>\n
+        \       </XREF_LINK>\n    </SAMPLE_LINK>\n    <SAMPLE_LINK>\n        <XREF_LINK>\n
+        \           <DB>ENA-SUBMITTED-FILES</DB>\n            <ID><![CDATA[https://www.ebi.ac.uk/ena/portal/api/filereport?accession=DRS057275&result=read_run&fields=run_accession,submitted_ftp,submitted_md5,submitted_bytes,submitted_format]]></ID>\n
+        \       </XREF_LINK>\n    </SAMPLE_LINK>\n</SAMPLE_LINKS>\n<SAMPLE_ATTRIBUTES>\n
+        \         <SAMPLE_ATTRIBUTE>\n               <TAG>INSDC secondary accession</TAG>\n
+        \              <VALUE>DRS057275</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
+        \              <TAG>NCBI submission package</TAG>\n               <VALUE>Generic.1.0</VALUE>\n
+        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>organism</TAG>\n
+        \              <VALUE>Danio rerio</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
+        \         <SAMPLE_ATTRIBUTE>\n               <TAG>tissue type</TAG>\n               <VALUE>brain</VALUE>\n
+        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>sample
+        name</TAG>\n               <VALUE>h62A_GFP_plus_Tel</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
+        \         <SAMPLE_ATTRIBUTE>\n               <TAG>genotype</TAG>\n               <VALUE>hspGFF62A;UAS:GFP</VALUE>\n
+        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>BioSampleModel</TAG>\n
+        \              <VALUE>Generic</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
+        \              <TAG>ENA-FIRST-PUBLIC</TAG>\n               <VALUE>2018-01-06</VALUE>\n
+        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-LAST-UPDATE</TAG>\n
+        \              <VALUE>2018-01-06</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
         \    </SAMPLE_ATTRIBUTES>\n</SAMPLE>\n</SAMPLE_SET>\n"
     headers:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:45:24 GMT
+      - Wed, 17 May 2023 18:37:56 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -11866,7 +9803,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/DRP003977
   response:
@@ -11874,14 +9811,16 @@ interactions:
       string: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<STUDY_SET>\n<STUDY accession=\"DRP003977\"
         alias=\"DRP003977\" center_name=\"NIG\" broker_name=\"DDBJ\">\n     <IDENTIFIERS>\n
         \         <PRIMARY_ID>DRP003977</PRIMARY_ID>\n          <SECONDARY_ID>PRJDB4470</SECONDARY_ID>\n
-        \         <EXTERNAL_ID label=\"primary\" namespace=\"BioProject\">PRJDB4470</EXTERNAL_ID>\n
+        \         <EXTERNAL_ID label=\"BioProject ID\" namespace=\"BioProject\">PRJDB4470</EXTERNAL_ID>\n
         \         <SUBMITTER_ID namespace=\"NIG\">DRP003977</SUBMITTER_ID>\n     </IDENTIFIERS>\n
         \    <DESCRIPTOR>\n          <STUDY_TITLE>Gene expression analysis of the
-        zebrafish brain</STUDY_TITLE>\n          <STUDY_TYPE existing_study_type=\"Transcriptome
-        Analysis\"/>\n          <STUDY_ABSTRACT>Gene expression profiling by RNA-seq
-        of specific regions and subpopulations of neurons in the zebrafish brain that
-        control behaviors.</STUDY_ABSTRACT>\n     </DESCRIPTOR>\n     <STUDY_LINKS>\n
-        \         <STUDY_LINK>\n               <XREF_LINK>\n                    <DB>ENA-SAMPLE</DB>\n
+        zebrafish brain</STUDY_TITLE>\n          <STUDY_TYPE existing_study_type=\"Other\"/>\n
+        \         <STUDY_ABSTRACT>Gene expression profiling by RNA-seq of specific
+        regions and subpopulations of neurons in the zebrafish brain that control
+        behaviors.</STUDY_ABSTRACT>\n          <STUDY_DESCRIPTION>Gene expression
+        profiling by RNA-seq of specific regions and subpopulations of neurons in
+        the zebrafish brain that control behaviors.</STUDY_DESCRIPTION>\n     </DESCRIPTOR>\n
+        \    <STUDY_LINKS>\n          <STUDY_LINK>\n               <XREF_LINK>\n                    <DB>ENA-SAMPLE</DB>\n
         \                   <ID>DRS057265-DRS057267,DRS057269-DRS057272,DRS057274-DRS057275</ID>\n
         \              </XREF_LINK>\n          </STUDY_LINK>\n          <STUDY_LINK>\n
         \              <XREF_LINK>\n                    <DB>ENA-EXPERIMENT</DB>\n
@@ -11890,7 +9829,7 @@ interactions:
         \                   <DB>ENA-RUN</DB>\n                    <ID>DRR051059-DRR051067</ID>\n
         \              </XREF_LINK>\n          </STUDY_LINK>\n          <STUDY_LINK>\n
         \              <XREF_LINK>\n                    <DB>ENA-SUBMISSION</DB>\n
-        \                   <ID>DRA004276</ID>\n               </XREF_LINK>\n          </STUDY_LINK>\n
+        \                   <ID>DRA008860</ID>\n               </XREF_LINK>\n          </STUDY_LINK>\n
         \         <STUDY_LINK>\n               <XREF_LINK>\n                    <DB>ENA-FASTQ-FILES</DB>\n
         \                   <ID><![CDATA[https://www.ebi.ac.uk/ena/portal/api/filereport?accession=DRP003977&result=read_run&fields=run_accession,fastq_ftp,fastq_md5,fastq_bytes]]></ID>\n
         \              </XREF_LINK>\n          </STUDY_LINK>\n          <STUDY_LINK>\n
@@ -11902,13 +9841,13 @@ interactions:
         \              <TAG>ENA-BASE-COUNT</TAG>\n               <VALUE>182690550386</VALUE>\n
         \         </STUDY_ATTRIBUTE>\n          <STUDY_ATTRIBUTE>\n               <TAG>ENA-FIRST-PUBLIC</TAG>\n
         \              <VALUE>2018-01-08</VALUE>\n          </STUDY_ATTRIBUTE>\n          <STUDY_ATTRIBUTE>\n
-        \              <TAG>ENA-LAST-UPDATE</TAG>\n               <VALUE>2018-01-08</VALUE>\n
+        \              <TAG>ENA-LAST-UPDATE</TAG>\n               <VALUE>2021-08-11</VALUE>\n
         \         </STUDY_ATTRIBUTE>\n     </STUDY_ATTRIBUTES>\n</STUDY>\n</STUDY_SET>\n"
     headers:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:45:24 GMT
+      - Wed, 17 May 2023 18:37:58 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -11926,7 +9865,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/DRA004276
   response:
@@ -11958,7 +9897,7 @@ interactions:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:45:25 GMT
+      - Wed, 17 May 2023 18:37:58 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -11967,68 +9906,6 @@ interactions:
       code: 200
       message: ''
 - request:
-    body: acc=DRR051066&accept-proto=fasp&version=2.0
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '43'
-      User-Agent:
-      - python-requests/2.25.1
-    method: POST
-    uri: https://www.ncbi.nlm.nih.gov/Traces/names/names.cgi
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAAwzIsQrCMBAA0L1fEXDoVLlLz7Tp7C4UJ7c0SakSeqGJiHAfr298J32Gphwuvxe5
-        zjNcEIwRRKIexoFAiwYcO8AOzF3jRDjh+BCiEOJKVvslGBs19R4t2rj2GGwYnIgQgNz29FXtVmsu
-        rcoHV/ac1LMolxJ/YlArH6pu/+DlFX1tfgAAAP//AwDkc5tCjwAAAA==
-    headers:
-      Cache-Control:
-      - private
-      Connection:
-      - Keep-Alive
-      Content-Encoding:
-      - gzip
-      Content-Security-Policy:
-      - upgrade-insecure-requests
-      Content-Type:
-      - text/plain
-      Date:
-      - Wed, 28 Jul 2021 19:45:25 GMT
-      Keep-Alive:
-      - timeout=1, max=10
-      NCBI-PHID:
-      - CC95FD3E101B3D510000000000000001.m_1
-      NCBI-SID:
-      - CC95FD3E101B3D51_0000SID
-      Referrer-Policy:
-      - origin-when-cross-origin
-      Server:
-      - Apache
-      Set-Cookie:
-      - ncbi_sid=CC95FD3E101B3D51_0000SID; domain=.nih.gov; path=/; expires=Thu, 28
-        Jul 2022 19:45:25 GMT
-      SraNameServerOutputVersion:
-      - '2.0'
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains; preload
-      Transfer-Encoding:
-      - chunked
-      Vary:
-      - Accept-Encoding
-      X-UA-Compatible:
-      - IE=Edge
-      X-XSS-Protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
-- request:
     body: null
     headers:
       Accept:
@@ -12038,29 +9915,27 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/portal/api/filereport?accession=DRR051066&result=read_run
   response:
     body:
-      string: "run_accession\tfastq_ftp\tfastq_bytes\tfastq_md5\tsubmitted_ftp\tsubmitted_bytes\tsubmitted_md5\tsra_ftp\tsra_bytes\tsra_md5\nDRR051066\tftp.sra.ebi.ac.uk/vol1/fastq/DRR051/DRR051066/DRR051066_1.fastq.gz;ftp.sra.ebi.ac.uk/vol1/fastq/DRR051/DRR051066/DRR051066_2.fastq.gz\t7169805313;7221515111\t2e696bf345b14809a945600e21d58496;9d1ad7f4856a258ebb7c5878a96d336a\t\t\t\t\t\t\n"
+      string: "run_accession\tfastq_ftp\tfastq_bytes\tfastq_md5\tbam_ftp\tbam_bytes\tbam_md5\tsubmitted_ftp\tsubmitted_bytes\tsubmitted_md5\tsra_ftp\tsra_bytes\tsra_md5\nDRR051066\tftp.sra.ebi.ac.uk/vol1/fastq/DRR051/DRR051066/DRR051066_1.fastq.gz;ftp.sra.ebi.ac.uk/vol1/fastq/DRR051/DRR051066/DRR051066_2.fastq.gz\t7169805313;7221515111\t2e696bf345b14809a945600e21d58496;9d1ad7f4856a258ebb7c5878a96d336a\t\t\t\t\t\t\tftp.sra.ebi.ac.uk/vol1/drr/DRR051/DRR051066\t11443087402\t44ddef492cbd69e243c1919ef31d9d7a\n"
     headers:
       Cache-Control:
       - no-cache, no-store, max-age=0, must-revalidate
+      Content-Length:
+      - '469'
       Content-Type:
       - text/plain
       Date:
-      - Wed, 28 Jul 2021 19:45:26 GMT
+      - Wed, 17 May 2023 18:37:59 GMT
       Expires:
       - '0'
       Pragma:
       - no-cache
-      Server:
-      - Apache-Coyote/1.1
       Strict-Transport-Security:
       - max-age=0
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Frame-Options:
@@ -12069,7 +9944,7 @@ interactions:
       - 1; mode=block
     status:
       code: 200
-      message: OK
+      message: ''
 - request:
     body: null
     headers:
@@ -12080,7 +9955,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/DRR051067
   response:
@@ -12114,7 +9989,7 @@ interactions:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:45:27 GMT
+      - Wed, 17 May 2023 18:37:59 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -12132,7 +10007,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/DRX045959
   response:
@@ -12189,7 +10064,7 @@ interactions:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:45:28 GMT
+      - Wed, 17 May 2023 18:37:59 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -12207,57 +10082,44 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/DRS057267
   response:
     body:
       string: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<SAMPLE_SET>\n<SAMPLE accession=\"DRS057267\"
-        alias=\"DRS057267\" center_name=\"NIG\" broker_name=\"DDBJ\">\n     <IDENTIFIERS>\n
-        \         <PRIMARY_ID>DRS057267</PRIMARY_ID>\n          <EXTERNAL_ID label=\"BioSample
-        ID\" namespace=\"BioSample\">SAMD00044994</EXTERNAL_ID>\n          <SUBMITTER_ID
-        namespace=\"NIG\">DRS057267</SUBMITTER_ID>\n     </IDENTIFIERS>\n     <TITLE>Danio
-        rerio</TITLE>\n     <SAMPLE_NAME>\n          <TAXON_ID>7955</TAXON_ID>\n          <SCIENTIFIC_NAME>Danio
-        rerio</SCIENTIFIC_NAME>\n          <COMMON_NAME>zebrafish</COMMON_NAME>\n
-        \    </SAMPLE_NAME>\n     <SAMPLE_LINKS>\n          <SAMPLE_LINK>\n               <XREF_LINK>\n
-        \                   <DB>ENA-STUDY</DB>\n                    <ID>DRP003977</ID>\n
-        \              </XREF_LINK>\n          </SAMPLE_LINK>\n          <SAMPLE_LINK>\n
-        \              <XREF_LINK>\n                    <DB>ENA-EXPERIMENT</DB>\n
-        \                   <ID>DRX045959</ID>\n               </XREF_LINK>\n          </SAMPLE_LINK>\n
-        \         <SAMPLE_LINK>\n               <XREF_LINK>\n                    <DB>ENA-RUN</DB>\n
-        \                   <ID>DRR051067</ID>\n               </XREF_LINK>\n          </SAMPLE_LINK>\n
-        \         <SAMPLE_LINK>\n               <XREF_LINK>\n                    <DB>ENA-SUBMISSION</DB>\n
-        \                   <ID>DRA004277</ID>\n               </XREF_LINK>\n          </SAMPLE_LINK>\n
-        \         <SAMPLE_LINK>\n               <XREF_LINK>\n                    <DB>ENA-FASTQ-FILES</DB>\n
-        \                   <ID><![CDATA[https://www.ebi.ac.uk/ena/portal/api/filereport?accession=DRS057267&result=read_run&fields=run_accession,fastq_ftp,fastq_md5,fastq_bytes]]></ID>\n
-        \              </XREF_LINK>\n          </SAMPLE_LINK>\n          <SAMPLE_LINK>\n
-        \              <XREF_LINK>\n                    <DB>ENA-SUBMITTED-FILES</DB>\n
-        \                   <ID><![CDATA[https://www.ebi.ac.uk/ena/portal/api/filereport?accession=DRS057267&result=read_run&fields=run_accession,submitted_ftp,submitted_md5,submitted_bytes,submitted_format]]></ID>\n
-        \              </XREF_LINK>\n          </SAMPLE_LINK>\n     </SAMPLE_LINKS>\n
-        \    <SAMPLE_ATTRIBUTES>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>description</TAG>\n
-        \              <VALUE>These cells are from the same fish as h62A_GFP_plus_Tel</VALUE>\n
-        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>bioproject_id</TAG>\n
-        \              <VALUE>PRJDB4470</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
-        \              <TAG>sample_name</TAG>\n               <VALUE>h62A_GFP_minus_Tel</VALUE>\n
-        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>sample_title</TAG>\n
-        \              <VALUE>GFP- cells from telencephalon of hspGFF62A;UAS:GFP transgenic
-        zebrafish</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
-        \              <TAG>genotype</TAG>\n               <VALUE>hspGFF62A;UAS:GFP</VALUE>\n
-        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>tissue_type</TAG>\n
-        \              <VALUE>brain</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
-        \              <TAG>ENA-SPOT-COUNT</TAG>\n               <VALUE>89569368</VALUE>\n
-        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-BASE-COUNT</TAG>\n
-        \              <VALUE>17913873600</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
-        \         <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-FIRST-PUBLIC</TAG>\n
-        \              <VALUE>2018-01-07</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
-        \         <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-LAST-UPDATE</TAG>\n
-        \              <VALUE>2018-01-07</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
+        alias=\"SAMD00044994\" center_name=\"National Institute of Genetics (Japan)\"
+        broker_name=\"DDBJ\">\n     <IDENTIFIERS>\n          <PRIMARY_ID>DRS057267</PRIMARY_ID>\n
+        \         <EXTERNAL_ID namespace=\"BioSample\">SAMD00044994</EXTERNAL_ID>\n
+        \    </IDENTIFIERS>\n     <TITLE>GFP- cells from telencephalon of hspGFF62A;UAS:GFP
+        transgenic zebrafish</TITLE>\n     <SAMPLE_NAME>\n          <TAXON_ID>7955</TAXON_ID>\n
+        \         <SCIENTIFIC_NAME>Danio rerio</SCIENTIFIC_NAME>\n          <COMMON_NAME>zebrafish</COMMON_NAME>\n
+        \    </SAMPLE_NAME>\n     <DESCRIPTION>These cells are from the same fish
+        as h62A_GFP_plus_Tel</DESCRIPTION>\n     <SAMPLE_LINKS>\n    <SAMPLE_LINK>\n
+        \       <XREF_LINK>\n            <DB>ENA-FASTQ-FILES</DB>\n            <ID><![CDATA[https://www.ebi.ac.uk/ena/portal/api/filereport?accession=DRS057267&result=read_run&fields=run_accession,fastq_ftp,fastq_md5,fastq_bytes]]></ID>\n
+        \       </XREF_LINK>\n    </SAMPLE_LINK>\n    <SAMPLE_LINK>\n        <XREF_LINK>\n
+        \           <DB>ENA-SUBMITTED-FILES</DB>\n            <ID><![CDATA[https://www.ebi.ac.uk/ena/portal/api/filereport?accession=DRS057267&result=read_run&fields=run_accession,submitted_ftp,submitted_md5,submitted_bytes,submitted_format]]></ID>\n
+        \       </XREF_LINK>\n    </SAMPLE_LINK>\n</SAMPLE_LINKS>\n<SAMPLE_ATTRIBUTES>\n
+        \         <SAMPLE_ATTRIBUTE>\n               <TAG>INSDC secondary accession</TAG>\n
+        \              <VALUE>DRS057267</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
+        \              <TAG>NCBI submission package</TAG>\n               <VALUE>Generic.1.0</VALUE>\n
+        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>organism</TAG>\n
+        \              <VALUE>Danio rerio</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
+        \         <SAMPLE_ATTRIBUTE>\n               <TAG>tissue type</TAG>\n               <VALUE>brain</VALUE>\n
+        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>sample
+        name</TAG>\n               <VALUE>h62A_GFP_minus_Tel</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
+        \         <SAMPLE_ATTRIBUTE>\n               <TAG>genotype</TAG>\n               <VALUE>hspGFF62A;UAS:GFP</VALUE>\n
+        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>BioSampleModel</TAG>\n
+        \              <VALUE>Generic</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
+        \              <TAG>ENA-FIRST-PUBLIC</TAG>\n               <VALUE>2018-01-06</VALUE>\n
+        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-LAST-UPDATE</TAG>\n
+        \              <VALUE>2018-01-06</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
         \    </SAMPLE_ATTRIBUTES>\n</SAMPLE>\n</SAMPLE_SET>\n"
     headers:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:45:28 GMT
+      - Wed, 17 May 2023 18:38:00 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -12275,7 +10137,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/DRP003977
   response:
@@ -12283,14 +10145,16 @@ interactions:
       string: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<STUDY_SET>\n<STUDY accession=\"DRP003977\"
         alias=\"DRP003977\" center_name=\"NIG\" broker_name=\"DDBJ\">\n     <IDENTIFIERS>\n
         \         <PRIMARY_ID>DRP003977</PRIMARY_ID>\n          <SECONDARY_ID>PRJDB4470</SECONDARY_ID>\n
-        \         <EXTERNAL_ID label=\"primary\" namespace=\"BioProject\">PRJDB4470</EXTERNAL_ID>\n
+        \         <EXTERNAL_ID label=\"BioProject ID\" namespace=\"BioProject\">PRJDB4470</EXTERNAL_ID>\n
         \         <SUBMITTER_ID namespace=\"NIG\">DRP003977</SUBMITTER_ID>\n     </IDENTIFIERS>\n
         \    <DESCRIPTOR>\n          <STUDY_TITLE>Gene expression analysis of the
-        zebrafish brain</STUDY_TITLE>\n          <STUDY_TYPE existing_study_type=\"Transcriptome
-        Analysis\"/>\n          <STUDY_ABSTRACT>Gene expression profiling by RNA-seq
-        of specific regions and subpopulations of neurons in the zebrafish brain that
-        control behaviors.</STUDY_ABSTRACT>\n     </DESCRIPTOR>\n     <STUDY_LINKS>\n
-        \         <STUDY_LINK>\n               <XREF_LINK>\n                    <DB>ENA-SAMPLE</DB>\n
+        zebrafish brain</STUDY_TITLE>\n          <STUDY_TYPE existing_study_type=\"Other\"/>\n
+        \         <STUDY_ABSTRACT>Gene expression profiling by RNA-seq of specific
+        regions and subpopulations of neurons in the zebrafish brain that control
+        behaviors.</STUDY_ABSTRACT>\n          <STUDY_DESCRIPTION>Gene expression
+        profiling by RNA-seq of specific regions and subpopulations of neurons in
+        the zebrafish brain that control behaviors.</STUDY_DESCRIPTION>\n     </DESCRIPTOR>\n
+        \    <STUDY_LINKS>\n          <STUDY_LINK>\n               <XREF_LINK>\n                    <DB>ENA-SAMPLE</DB>\n
         \                   <ID>DRS057265-DRS057267,DRS057269-DRS057272,DRS057274-DRS057275</ID>\n
         \              </XREF_LINK>\n          </STUDY_LINK>\n          <STUDY_LINK>\n
         \              <XREF_LINK>\n                    <DB>ENA-EXPERIMENT</DB>\n
@@ -12299,7 +10163,7 @@ interactions:
         \                   <DB>ENA-RUN</DB>\n                    <ID>DRR051059-DRR051067</ID>\n
         \              </XREF_LINK>\n          </STUDY_LINK>\n          <STUDY_LINK>\n
         \              <XREF_LINK>\n                    <DB>ENA-SUBMISSION</DB>\n
-        \                   <ID>DRA004276</ID>\n               </XREF_LINK>\n          </STUDY_LINK>\n
+        \                   <ID>DRA008860</ID>\n               </XREF_LINK>\n          </STUDY_LINK>\n
         \         <STUDY_LINK>\n               <XREF_LINK>\n                    <DB>ENA-FASTQ-FILES</DB>\n
         \                   <ID><![CDATA[https://www.ebi.ac.uk/ena/portal/api/filereport?accession=DRP003977&result=read_run&fields=run_accession,fastq_ftp,fastq_md5,fastq_bytes]]></ID>\n
         \              </XREF_LINK>\n          </STUDY_LINK>\n          <STUDY_LINK>\n
@@ -12311,13 +10175,13 @@ interactions:
         \              <TAG>ENA-BASE-COUNT</TAG>\n               <VALUE>182690550386</VALUE>\n
         \         </STUDY_ATTRIBUTE>\n          <STUDY_ATTRIBUTE>\n               <TAG>ENA-FIRST-PUBLIC</TAG>\n
         \              <VALUE>2018-01-08</VALUE>\n          </STUDY_ATTRIBUTE>\n          <STUDY_ATTRIBUTE>\n
-        \              <TAG>ENA-LAST-UPDATE</TAG>\n               <VALUE>2018-01-08</VALUE>\n
+        \              <TAG>ENA-LAST-UPDATE</TAG>\n               <VALUE>2021-08-11</VALUE>\n
         \         </STUDY_ATTRIBUTE>\n     </STUDY_ATTRIBUTES>\n</STUDY>\n</STUDY_SET>\n"
     headers:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:45:28 GMT
+      - Wed, 17 May 2023 18:37:59 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -12335,7 +10199,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/DRA004277
   response:
@@ -12369,7 +10233,7 @@ interactions:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:45:29 GMT
+      - Wed, 17 May 2023 18:38:00 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -12377,68 +10241,6 @@ interactions:
     status:
       code: 200
       message: ''
-- request:
-    body: acc=DRR051067&accept-proto=fasp&version=2.0
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '43'
-      User-Agent:
-      - python-requests/2.25.1
-    method: POST
-    uri: https://www.ncbi.nlm.nih.gov/Traces/names/names.cgi
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAAxTKsQrCMBQF0L1fEXDoVLkvTeJLZ3ehOLk1bUqVYEobEeF9vLoezkEfUe3bsL6C
-        nPseluBOQmTJcWvBJBrEDaiBuxJ3LXeabhIm43TU3pLBv3KY2fuRCD5iMhARA8jlmT6qXkpZ91qt
-        Wy55zEnddzWklN9xUnPeVFl+kMMjjqX6AgAA//8DAAVtKA+PAAAA
-    headers:
-      Cache-Control:
-      - private
-      Connection:
-      - Keep-Alive
-      Content-Encoding:
-      - gzip
-      Content-Security-Policy:
-      - upgrade-insecure-requests
-      Content-Type:
-      - text/plain
-      Date:
-      - Wed, 28 Jul 2021 19:45:30 GMT
-      Keep-Alive:
-      - timeout=1, max=10
-      NCBI-PHID:
-      - CC95FD87101B3DA10000000000000001.m_1
-      NCBI-SID:
-      - CC95FD87101B3DA1_0000SID
-      Referrer-Policy:
-      - origin-when-cross-origin
-      Server:
-      - Apache
-      Set-Cookie:
-      - ncbi_sid=CC95FD87101B3DA1_0000SID; domain=.nih.gov; path=/; expires=Thu, 28
-        Jul 2022 19:45:30 GMT
-      SraNameServerOutputVersion:
-      - '2.0'
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains; preload
-      Transfer-Encoding:
-      - chunked
-      Vary:
-      - Accept-Encoding
-      X-UA-Compatible:
-      - IE=Edge
-      X-XSS-Protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
 - request:
     body: null
     headers:
@@ -12449,29 +10251,27 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/portal/api/filereport?accession=DRR051067&result=read_run
   response:
     body:
-      string: "run_accession\tfastq_ftp\tfastq_bytes\tfastq_md5\tsubmitted_ftp\tsubmitted_bytes\tsubmitted_md5\tsra_ftp\tsra_bytes\tsra_md5\nDRR051067\tftp.sra.ebi.ac.uk/vol1/fastq/DRR051/DRR051067/DRR051067_1.fastq.gz;ftp.sra.ebi.ac.uk/vol1/fastq/DRR051/DRR051067/DRR051067_2.fastq.gz\t7040712780;7471523344\t83884a210f90531fc75f3e5751f93159;aba57b33a49964ab4b811b71e5827cde\t\t\t\t\t\t\n"
+      string: "run_accession\tfastq_ftp\tfastq_bytes\tfastq_md5\tbam_ftp\tbam_bytes\tbam_md5\tsubmitted_ftp\tsubmitted_bytes\tsubmitted_md5\tsra_ftp\tsra_bytes\tsra_md5\nDRR051067\tftp.sra.ebi.ac.uk/vol1/fastq/DRR051/DRR051067/DRR051067_1.fastq.gz;ftp.sra.ebi.ac.uk/vol1/fastq/DRR051/DRR051067/DRR051067_2.fastq.gz\t7040712780;7471523344\t83884a210f90531fc75f3e5751f93159;aba57b33a49964ab4b811b71e5827cde\t\t\t\t\t\t\tftp.sra.ebi.ac.uk/vol1/drr/DRR051/DRR051067\t11516835081\tbd462e29514051688bf899c1109e0d40\n"
     headers:
       Cache-Control:
       - no-cache, no-store, max-age=0, must-revalidate
+      Content-Length:
+      - '469'
       Content-Type:
       - text/plain
       Date:
-      - Wed, 28 Jul 2021 19:45:31 GMT
+      - Wed, 17 May 2023 18:38:01 GMT
       Expires:
       - '0'
       Pragma:
       - no-cache
-      Server:
-      - Apache-Coyote/1.1
       Strict-Transport-Security:
       - max-age=0
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Frame-Options:
@@ -12480,5 +10280,5 @@ interactions:
       - 1; mode=block
     status:
       code: 200
-      message: OK
+      message: ''
 version: 1

--- a/test_volume/cassettes/surveyor.sra.survey_nonexistant.yaml
+++ b/test_volume/cassettes/surveyor.sra.survey_nonexistant.yaml
@@ -9,19 +9,19 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/ERP006216
   response:
     body:
-      string: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<ErrorDetails>\n  <timestamp>1627501393717</timestamp>\n
+      string: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<ErrorDetails>\n  <timestamp>1684348606015</timestamp>\n
         \ <status>404</status>\n  <error>Not Found</error>\n  <message>ERP006216 not
         found.</message>\n  <path>/ena/browser/api/xml/ERP006216</path>\n</ErrorDetails>\n"
     headers:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:43:13 GMT
+      - Wed, 17 May 2023 18:36:45 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:

--- a/test_volume/cassettes/surveyor.sra.survey_unmated_reads.yaml
+++ b/test_volume/cassettes/surveyor.sra.survey_unmated_reads.yaml
@@ -9,7 +9,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/SRP048683
   response:
@@ -56,7 +56,7 @@ interactions:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:45:36 GMT
+      - Wed, 17 May 2023 18:38:04 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -74,7 +74,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/SRR1603661
   response:
@@ -121,7 +121,7 @@ interactions:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:45:36 GMT
+      - Wed, 17 May 2023 18:38:04 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -139,7 +139,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/SRX725593
   response:
@@ -198,7 +198,7 @@ interactions:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:45:36 GMT
+      - Wed, 17 May 2023 18:38:04 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -216,52 +216,45 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/SRS716925
   response:
     body:
       string: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<SAMPLE_SET>\n<SAMPLE accession=\"SRS716925\"
-        alias=\"GSM1519616\" center_name=\"GEO\" broker_name=\"NCBI\">\n     <IDENTIFIERS>\n
-        \         <PRIMARY_ID>SRS716925</PRIMARY_ID>\n          <EXTERNAL_ID namespace=\"BioSample\">SAMN03097499</EXTERNAL_ID>\n
-        \         <EXTERNAL_ID namespace=\"GEO\">GSM1519616</EXTERNAL_ID>\n     </IDENTIFIERS>\n
+        alias=\"GSM1519616\" center_name=\"Stanford University\" broker_name=\"NCBI\">\n
+        \    <IDENTIFIERS>\n          <PRIMARY_ID>SRS716925</PRIMARY_ID>\n          <EXTERNAL_ID
+        namespace=\"BioSample\">SAMN03097499</EXTERNAL_ID>\n          <SUBMITTER_ID
+        namespace=\"Stanford University\">GSM1519616</SUBMITTER_ID>\n     </IDENTIFIERS>\n
         \    <TITLE>RNA-seq of the corpus callosum #5308</TITLE>\n     <SAMPLE_NAME>\n
         \         <TAXON_ID>9606</TAXON_ID>\n          <SCIENTIFIC_NAME>Homo sapiens</SCIENTIFIC_NAME>\n
-        \    </SAMPLE_NAME>\n     <SAMPLE_LINKS>\n          <SAMPLE_LINK>\n               <XREF_LINK>\n
-        \                   <DB>ENA-STUDY</DB>\n                    <ID>SRP048683</ID>\n
-        \              </XREF_LINK>\n          </SAMPLE_LINK>\n          <SAMPLE_LINK>\n
-        \              <XREF_LINK>\n                    <DB>ENA-EXPERIMENT</DB>\n
-        \                   <ID>SRX725593</ID>\n               </XREF_LINK>\n          </SAMPLE_LINK>\n
-        \         <SAMPLE_LINK>\n               <XREF_LINK>\n                    <DB>ENA-RUN</DB>\n
-        \                   <ID>SRR1603661</ID>\n               </XREF_LINK>\n          </SAMPLE_LINK>\n
-        \         <SAMPLE_LINK>\n               <XREF_LINK>\n                    <DB>ENA-SUBMISSION</DB>\n
-        \                   <ID>SRA188845</ID>\n               </XREF_LINK>\n          </SAMPLE_LINK>\n
-        \         <SAMPLE_LINK>\n               <XREF_LINK>\n                    <DB>ARRAYEXPRESS</DB>\n
-        \                   <ID>E-GEOD-62098</ID>\n               </XREF_LINK>\n          </SAMPLE_LINK>\n
-        \         <SAMPLE_LINK>\n               <XREF_LINK>\n                    <DB>ENA-FASTQ-FILES</DB>\n
-        \                   <ID><![CDATA[https://www.ebi.ac.uk/ena/portal/api/filereport?accession=SRS716925&result=read_run&fields=run_accession,fastq_ftp,fastq_md5,fastq_bytes]]></ID>\n
-        \              </XREF_LINK>\n          </SAMPLE_LINK>\n          <SAMPLE_LINK>\n
-        \              <XREF_LINK>\n                    <DB>ENA-SUBMITTED-FILES</DB>\n
-        \                   <ID><![CDATA[https://www.ebi.ac.uk/ena/portal/api/filereport?accession=SRS716925&result=read_run&fields=run_accession,submitted_ftp,submitted_md5,submitted_bytes,submitted_format]]></ID>\n
-        \              </XREF_LINK>\n          </SAMPLE_LINK>\n     </SAMPLE_LINKS>\n
-        \    <SAMPLE_ATTRIBUTES>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>source_name</TAG>\n
-        \              <VALUE>human brain</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
-        \         <SAMPLE_ATTRIBUTE>\n               <TAG>tissue</TAG>\n               <VALUE>frozen
-        postmortem brain from NICHD</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
-        \              <TAG>disease</TAG>\n               <VALUE>autism spectrum disorder</VALUE>\n
-        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-SPOT-COUNT</TAG>\n
-        \              <VALUE>162048745</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
-        \              <TAG>ENA-BASE-COUNT</TAG>\n               <VALUE>28185753687</VALUE>\n
-        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-FIRST-PUBLIC</TAG>\n
-        \              <VALUE>2015-03-23</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
-        \         <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-LAST-UPDATE</TAG>\n
-        \              <VALUE>2015-06-23</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
+        \         <COMMON_NAME>human</COMMON_NAME>\n     </SAMPLE_NAME>\n     <SAMPLE_LINKS>\n
+        \   <SAMPLE_LINK>\n        <XREF_LINK>\n            <DB>ENA-FASTQ-FILES</DB>\n
+        \           <ID><![CDATA[https://www.ebi.ac.uk/ena/portal/api/filereport?accession=SRS716925&result=read_run&fields=run_accession,fastq_ftp,fastq_md5,fastq_bytes]]></ID>\n
+        \       </XREF_LINK>\n    </SAMPLE_LINK>\n    <SAMPLE_LINK>\n        <XREF_LINK>\n
+        \           <DB>ENA-SUBMITTED-FILES</DB>\n            <ID><![CDATA[https://www.ebi.ac.uk/ena/portal/api/filereport?accession=SRS716925&result=read_run&fields=run_accession,submitted_ftp,submitted_md5,submitted_bytes,submitted_format]]></ID>\n
+        \       </XREF_LINK>\n    </SAMPLE_LINK>\n</SAMPLE_LINKS>\n<SAMPLE_ATTRIBUTES>\n
+        \         <SAMPLE_ATTRIBUTE>\n               <TAG>INSDC secondary accession</TAG>\n
+        \              <VALUE>SRS716925</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
+        \              <TAG>NCBI submission package</TAG>\n               <VALUE>Generic.1.0</VALUE>\n
+        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>disease</TAG>\n
+        \              <VALUE>autism spectrum disorder</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
+        \         <SAMPLE_ATTRIBUTE>\n               <TAG>organism</TAG>\n               <VALUE>Homo
+        sapiens</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
+        \              <TAG>tissue</TAG>\n               <VALUE>frozen postmortem
+        brain from NICHD</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
+        \              <TAG>source_name</TAG>\n               <VALUE>human brain</VALUE>\n
+        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>BioSampleModel</TAG>\n
+        \              <VALUE>Generic</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
+        \              <TAG>ENA-FIRST-PUBLIC</TAG>\n               <VALUE>2015-01-01</VALUE>\n
+        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-LAST-UPDATE</TAG>\n
+        \              <VALUE>2015-01-01</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
         \    </SAMPLE_ATTRIBUTES>\n</SAMPLE>\n</SAMPLE_SET>\n"
     headers:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:45:37 GMT
+      - Wed, 17 May 2023 18:38:06 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -279,7 +272,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/SRP048683
   response:
@@ -326,7 +319,7 @@ interactions:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:45:38 GMT
+      - Wed, 17 May 2023 18:38:05 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -344,7 +337,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/SRA188845
   response:
@@ -381,7 +374,7 @@ interactions:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:45:38 GMT
+      - Wed, 17 May 2023 18:38:06 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -389,69 +382,6 @@ interactions:
     status:
       code: 200
       message: ''
-- request:
-    body: acc=SRR1603661&accept-proto=fasp&version=2.0
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '44'
-      User-Agent:
-      - python-requests/2.25.1
-    method: POST
-    uri: https://www.ncbi.nlm.nih.gov/Traces/names/names.cgi
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAA5zOPW4CMRBA4T6nsJSCCjQztseevUQkoKLzX7SJVni164CQfHiWtOnSvuZ973SA
-        t3UJ80/sp+MRGTQzdiRgzYJaXCdAs0fYA59JD2AGlEv3kiGzIbEB2LroEbyQ9sgxOGdT790A9I/r
-        9FC7sbV53al5qa2mOqmvVYVpqveS1WddVBu3UON3Se0v5XDLMYU0ls2ktx8Q/pLci0T6DDIYGIy5
-        dJJkMZBx2z+yzt4iFh9LBm+oFPkv6QkAAP//AwBM6dz2IwEAAA==
-    headers:
-      Cache-Control:
-      - private
-      Connection:
-      - Keep-Alive
-      Content-Encoding:
-      - gzip
-      Content-Security-Policy:
-      - upgrade-insecure-requests
-      Content-Type:
-      - text/plain
-      Date:
-      - Wed, 28 Jul 2021 19:45:39 GMT
-      Keep-Alive:
-      - timeout=1, max=10
-      NCBI-PHID:
-      - C7A42D50101B3E310000000000000001.m_1
-      NCBI-SID:
-      - C7A42D50101B3E31_0000SID
-      Referrer-Policy:
-      - origin-when-cross-origin
-      Server:
-      - Apache
-      Set-Cookie:
-      - ncbi_sid=C7A42D50101B3E31_0000SID; domain=.nih.gov; path=/; expires=Thu, 28
-        Jul 2022 19:45:39 GMT
-      SraNameServerOutputVersion:
-      - '2.0'
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains; preload
-      Transfer-Encoding:
-      - chunked
-      Vary:
-      - Accept-Encoding
-      X-UA-Compatible:
-      - IE=Edge
-      X-XSS-Protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
 - request:
     body: null
     headers:
@@ -462,7 +392,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://eutils.ncbi.nlm.nih.gov/entrez/eutils/esummary.fcgi?db=pubmed&id=25549968&retmode=json&tool=refinebio&email=hello@refine.bio
   response:
@@ -472,18 +402,18 @@ interactions:
         vR9vZmZUTAMLNjOG6cTYIPs4jiQTVvjJ4rWzSawXK/yqUJJpQg5HPXhs3nC52ay329s7fK9+5x8/
         YVelwlM8DhRywbK+WcMD97Cqk87/Gd5F6bPcOgPd5APca2eSQTEoJ7l9RktjjrxoeL44lyt251DS
         ehN9YDmvk064Ip3S0BYyLcGhEDkoctAVQo/Rf2jpFVvYl/bphNrib7zKkSzsCqknMmakieVv3zcA
-        AAD//7RVS2/TQBC+8ytWuTexHbtp0lNVeiiiqHfEwV5v0qX7KPsoFNT/zje7dpxADuWAZCnxeJ7f
-        fDPzFvTNC1j3xgaAWqr1Iff92DjIoMjy1gSxc6BRzzyoIrRnrWnVi5eeOfEsWgUB01YJHlXrmBHh
-        u3WPLBp4Ui/S7BjcS6+ZfxI8uKhZL711+OrniYwujLHkf4xFQ2dVTBiVNAXS+0gvNEHtToD1s9Wq
-        nhEiZkcDKPADgIzS0chvUSTMyqKsls3yYp09mOxA5H/lqq7P6mpd5anM2H+efcC8oQx25YLkKPQL
-        jTtHWkA+RAp8H7s7FH3GJCr5gX9biy7cvP94++km+9qrLqmx2VFeFL9msh+6DD0tesosSZBSiapb
-        lercbwwiy2Si+aH+xaR/f3ddL4uiXjfHFr2VhxbLyaIs5mVTNdVC+25OK6epL1bHxkS80+FOpyf+
-        UR/lHFs0kwW+ncl+w6bCLtMEPEgfLLYyQXmItDDBiZ9wNi3RZlGUeFhxvimKFPnQYA//Ww2graQR
-        RxbniwJPNVokrmyFE4aL3G28nl7gc0aYX5bFZrWiuwDFAZVrqzWqAbuITJqIPMC3Br9tCp1CtSE4
-        2cWQQmEJeXaFbF3LA5EWAMInt9HgUDVo/DYq9TWTe9zj+9kcB7hDZnZHN08oy9uAq5cGCTTasNOM
-        ARyWD6lzGZINbQrHuTWUoELHkCBS6qx9HLcHVACojHqYyV6GfGLzBMHoAVtiyOEP8ZB+jjI0I0H4
-        hPVkou7okJOkfW6lajslts7q6FSWjl7xRQwilPBXtpBNvin1KSx/aJ/CGIR24vHxXpTVYlmwoiBS
-        ZIWtdAebe7jTz1RKasAeldfX13e/AQAA//8DANw4jtyNCAAA
+        AAD//7RVyW7bMBC99ysI32NLthTHzilIc0jRFLkXPVA07bDhknJJmxb5974hJcuuc8ilgAFLo3mz
+        vVneU337gq57JwFoLc1DLLwfg6OKmpC3NsqdRxttWECrSBMYt1y/BBWYl8+SawiYcVqKpLlnVsaf
+        zj+yZGFJvyi7YzCvgmHhSYrok2EbFZzH1zDNzejj4Ev9R180dE6nXKOapkCFkPLLnGaI7yT6frJc
+        NhOqid3RCEr8oURWm2TVjyRz1eqqni/axcWq2KAZrpdNc9bMV2RJnoowh4WGr5NPGD1kxK58VAI5
+        f6PJF4gQJMREEdyn7g75nzGFpH7haetAyM3Hz7dfboqtveqCOC6Gys74M1GbnnDoGbmhELMEIdUo
+        ANc55f3yoL4ZIUYc6l+M+vd3182iqppVe4JQRz7aEYNvZ2qzZiP28hi8ceoQuhihdTWt23k7n5nQ
+        TWl1tc3FMjfrgwrRYYFSqoeVkDZ6+Rvmxn3XzqoaP1adr6sqez4E7MvzXgC0tbLyCHE+q/CbD4jM
+        5VZ6aYUsbOD17V07ZZTWZV2tl0ta4VDsq3LtjEE2YJ/INtRxPVsrNKLLrrMrHqNXXYrZFfZFYFeI
+        1nMRqalQfdgULlnclBZUbpPW30vzDSt3P0bDrHWIzO3oPEntBI84ULnjwdSavU0KyuFEH7pQMWNo
+        qL0QzlKAGowhQITUOfc4DDpUUFCVTHnGYyzXsHQ4QA8Y6D6Gf8R9+MVLT0Yu4RM2iU2mo5tLEv7M
+        leadllvvTPK6SAer+CJ7EVI4iRay0TaFProVD/wpDk5ofR3f2Vk9ny0qVlXUFEVhq/zBku1P6jOl
+        kgnYV+X19fXDXwAAAP//AwBNTBeGOAgAAA==
     headers:
       Access-Control-Allow-Origin:
       - '*'
@@ -498,18 +428,20 @@ interactions:
       Content-Type:
       - application/json; charset=UTF-8
       Date:
-      - Wed, 28 Jul 2021 19:45:38 GMT
+      - Wed, 17 May 2023 18:38:07 GMT
       Keep-Alive:
       - timeout=4, max=40
       NCBI-PHID:
-      - 322C6078A1DD3885000034FA20798E62.1.1.m_1
+      - 322C36E9C9D0D90500005E0AE30E5C73.1.1.m_1
       NCBI-SID:
-      - 9F4B36537CC83871_AAECSID
+      - 9A764307C0400C6F_B567SID
+      Referrer-Policy:
+      - origin-when-cross-origin
       Server:
       - Finatra
       Set-Cookie:
-      - ncbi_sid=9F4B36537CC83871_AAECSID; domain=.nih.gov; path=/; expires=Thu, 28
-        Jul 2022 19:45:39 GMT
+      - ncbi_sid=9A764307C0400C6F_B567SID; domain=.nih.gov; path=/; expires=Fri, 17
+        May 2024 18:38:07 GMT
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains; preload
       Transfer-Encoding:
@@ -537,29 +469,27 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/portal/api/filereport?accession=SRR1603661&result=read_run
   response:
     body:
-      string: "run_accession\tfastq_ftp\tfastq_bytes\tfastq_md5\tsubmitted_ftp\tsubmitted_bytes\tsubmitted_md5\tsra_ftp\tsra_bytes\tsra_md5\nSRR1603661\tftp.sra.ebi.ac.uk/vol1/fastq/SRR160/001/SRR1603661/SRR1603661.fastq.gz;ftp.sra.ebi.ac.uk/vol1/fastq/SRR160/001/SRR1603661/SRR1603661_1.fastq.gz;ftp.sra.ebi.ac.uk/vol1/fastq/SRR160/001/SRR1603661/SRR1603661_2.fastq.gz\t852745978;6751980628;6949912932\tbbd8e04db475a6b28fed8c74eeb9d701;502a9a482bfa5aa75865ccc0105ad13c;fffd24457418d255991f54ec82a39d57\t\t\t\t\t\t\n"
+      string: "run_accession\tfastq_ftp\tfastq_bytes\tfastq_md5\tbam_ftp\tbam_bytes\tbam_md5\tsubmitted_ftp\tsubmitted_bytes\tsubmitted_md5\tsra_ftp\tsra_bytes\tsra_md5\nSRR1603661\tftp.sra.ebi.ac.uk/vol1/fastq/SRR160/001/SRR1603661/SRR1603661.fastq.gz;ftp.sra.ebi.ac.uk/vol1/fastq/SRR160/001/SRR1603661/SRR1603661_1.fastq.gz;ftp.sra.ebi.ac.uk/vol1/fastq/SRR160/001/SRR1603661/SRR1603661_2.fastq.gz\t852745978;6751980628;6949912932\tbbd8e04db475a6b28fed8c74eeb9d701;502a9a482bfa5aa75865ccc0105ad13c;fffd24457418d255991f54ec82a39d57\t\t\t\t\t\t\tftp.sra.ebi.ac.uk/vol1/srr/SRR160/001/SRR1603661\t12063691397\t89d0d64295a0657b8108923816ba775c\n"
     headers:
       Cache-Control:
       - no-cache, no-store, max-age=0, must-revalidate
+      Content-Length:
+      - '601'
       Content-Type:
       - text/plain
       Date:
-      - Wed, 28 Jul 2021 19:45:39 GMT
+      - Wed, 17 May 2023 18:38:07 GMT
       Expires:
       - '0'
       Pragma:
       - no-cache
-      Server:
-      - Apache-Coyote/1.1
       Strict-Transport-Security:
       - max-age=0
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Frame-Options:
@@ -568,7 +498,7 @@ interactions:
       - 1; mode=block
     status:
       code: 200
-      message: OK
+      message: ''
 - request:
     body: null
     headers:
@@ -579,7 +509,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/SRR1603662
   response:
@@ -626,7 +556,7 @@ interactions:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:45:40 GMT
+      - Wed, 17 May 2023 18:38:07 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -644,7 +574,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/SRX725594
   response:
@@ -703,7 +633,7 @@ interactions:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:45:41 GMT
+      - Wed, 17 May 2023 18:38:08 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -721,52 +651,45 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/SRS716926
   response:
     body:
       string: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<SAMPLE_SET>\n<SAMPLE accession=\"SRS716926\"
-        alias=\"GSM1519617\" center_name=\"GEO\" broker_name=\"NCBI\">\n     <IDENTIFIERS>\n
-        \         <PRIMARY_ID>SRS716926</PRIMARY_ID>\n          <EXTERNAL_ID namespace=\"BioSample\">SAMN03097500</EXTERNAL_ID>\n
-        \         <EXTERNAL_ID namespace=\"GEO\">GSM1519617</EXTERNAL_ID>\n     </IDENTIFIERS>\n
+        alias=\"GSM1519617\" center_name=\"Stanford University\" broker_name=\"NCBI\">\n
+        \    <IDENTIFIERS>\n          <PRIMARY_ID>SRS716926</PRIMARY_ID>\n          <EXTERNAL_ID
+        namespace=\"BioSample\">SAMN03097500</EXTERNAL_ID>\n          <SUBMITTER_ID
+        namespace=\"Stanford University\">GSM1519617</SUBMITTER_ID>\n     </IDENTIFIERS>\n
         \    <TITLE>RNA-seq of the corpus callosum #5144</TITLE>\n     <SAMPLE_NAME>\n
         \         <TAXON_ID>9606</TAXON_ID>\n          <SCIENTIFIC_NAME>Homo sapiens</SCIENTIFIC_NAME>\n
-        \    </SAMPLE_NAME>\n     <SAMPLE_LINKS>\n          <SAMPLE_LINK>\n               <XREF_LINK>\n
-        \                   <DB>ENA-STUDY</DB>\n                    <ID>SRP048683</ID>\n
-        \              </XREF_LINK>\n          </SAMPLE_LINK>\n          <SAMPLE_LINK>\n
-        \              <XREF_LINK>\n                    <DB>ENA-EXPERIMENT</DB>\n
-        \                   <ID>SRX725594</ID>\n               </XREF_LINK>\n          </SAMPLE_LINK>\n
-        \         <SAMPLE_LINK>\n               <XREF_LINK>\n                    <DB>ENA-RUN</DB>\n
-        \                   <ID>SRR1603662</ID>\n               </XREF_LINK>\n          </SAMPLE_LINK>\n
-        \         <SAMPLE_LINK>\n               <XREF_LINK>\n                    <DB>ENA-SUBMISSION</DB>\n
-        \                   <ID>SRA188845</ID>\n               </XREF_LINK>\n          </SAMPLE_LINK>\n
-        \         <SAMPLE_LINK>\n               <XREF_LINK>\n                    <DB>ARRAYEXPRESS</DB>\n
-        \                   <ID>E-GEOD-62098</ID>\n               </XREF_LINK>\n          </SAMPLE_LINK>\n
-        \         <SAMPLE_LINK>\n               <XREF_LINK>\n                    <DB>ENA-FASTQ-FILES</DB>\n
-        \                   <ID><![CDATA[https://www.ebi.ac.uk/ena/portal/api/filereport?accession=SRS716926&result=read_run&fields=run_accession,fastq_ftp,fastq_md5,fastq_bytes]]></ID>\n
-        \              </XREF_LINK>\n          </SAMPLE_LINK>\n          <SAMPLE_LINK>\n
-        \              <XREF_LINK>\n                    <DB>ENA-SUBMITTED-FILES</DB>\n
-        \                   <ID><![CDATA[https://www.ebi.ac.uk/ena/portal/api/filereport?accession=SRS716926&result=read_run&fields=run_accession,submitted_ftp,submitted_md5,submitted_bytes,submitted_format]]></ID>\n
-        \              </XREF_LINK>\n          </SAMPLE_LINK>\n     </SAMPLE_LINKS>\n
-        \    <SAMPLE_ATTRIBUTES>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>source_name</TAG>\n
-        \              <VALUE>human brain</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
-        \         <SAMPLE_ATTRIBUTE>\n               <TAG>tissue</TAG>\n               <VALUE>frozen
-        postmortem brain from NICHD</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
-        \              <TAG>disease</TAG>\n               <VALUE>autism spectrum disorder</VALUE>\n
-        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-SPOT-COUNT</TAG>\n
-        \              <VALUE>172822773</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
-        \              <TAG>ENA-BASE-COUNT</TAG>\n               <VALUE>29944432518</VALUE>\n
-        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-FIRST-PUBLIC</TAG>\n
-        \              <VALUE>2015-03-23</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
-        \         <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-LAST-UPDATE</TAG>\n
-        \              <VALUE>2015-06-23</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
+        \         <COMMON_NAME>human</COMMON_NAME>\n     </SAMPLE_NAME>\n     <SAMPLE_LINKS>\n
+        \   <SAMPLE_LINK>\n        <XREF_LINK>\n            <DB>ENA-FASTQ-FILES</DB>\n
+        \           <ID><![CDATA[https://www.ebi.ac.uk/ena/portal/api/filereport?accession=SRS716926&result=read_run&fields=run_accession,fastq_ftp,fastq_md5,fastq_bytes]]></ID>\n
+        \       </XREF_LINK>\n    </SAMPLE_LINK>\n    <SAMPLE_LINK>\n        <XREF_LINK>\n
+        \           <DB>ENA-SUBMITTED-FILES</DB>\n            <ID><![CDATA[https://www.ebi.ac.uk/ena/portal/api/filereport?accession=SRS716926&result=read_run&fields=run_accession,submitted_ftp,submitted_md5,submitted_bytes,submitted_format]]></ID>\n
+        \       </XREF_LINK>\n    </SAMPLE_LINK>\n</SAMPLE_LINKS>\n<SAMPLE_ATTRIBUTES>\n
+        \         <SAMPLE_ATTRIBUTE>\n               <TAG>INSDC secondary accession</TAG>\n
+        \              <VALUE>SRS716926</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
+        \              <TAG>NCBI submission package</TAG>\n               <VALUE>Generic.1.0</VALUE>\n
+        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>disease</TAG>\n
+        \              <VALUE>autism spectrum disorder</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
+        \         <SAMPLE_ATTRIBUTE>\n               <TAG>organism</TAG>\n               <VALUE>Homo
+        sapiens</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
+        \              <TAG>tissue</TAG>\n               <VALUE>frozen postmortem
+        brain from NICHD</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
+        \              <TAG>source_name</TAG>\n               <VALUE>human brain</VALUE>\n
+        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>BioSampleModel</TAG>\n
+        \              <VALUE>Generic</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
+        \              <TAG>ENA-FIRST-PUBLIC</TAG>\n               <VALUE>2015-01-01</VALUE>\n
+        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-LAST-UPDATE</TAG>\n
+        \              <VALUE>2015-01-01</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
         \    </SAMPLE_ATTRIBUTES>\n</SAMPLE>\n</SAMPLE_SET>\n"
     headers:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:45:41 GMT
+      - Wed, 17 May 2023 18:38:08 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -784,7 +707,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/SRP048683
   response:
@@ -831,7 +754,7 @@ interactions:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:45:42 GMT
+      - Wed, 17 May 2023 18:38:09 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -849,7 +772,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/SRA188845
   response:
@@ -886,7 +809,7 @@ interactions:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:45:42 GMT
+      - Wed, 17 May 2023 18:38:08 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -895,69 +818,6 @@ interactions:
       code: 200
       message: ''
 - request:
-    body: acc=SRR1603662&accept-proto=fasp&version=2.0
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '44'
-      User-Agent:
-      - python-requests/2.25.1
-    method: POST
-    uri: https://www.ncbi.nlm.nih.gov/Traces/names/names.cgi
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAA5zOPU7EMBBA4Z5TWKLYalfjmfFfLoG0bLWdPbYVUISjxICQfHgCLR163au+R7zA
-        w77F9T2N5+tVWyBrcWhCDMAcwA4EzWcNZ7A3xIntRP4+hClY7SSXVD06yF6KMzFUD56ygTEGA4yn
-        t+VLnebe1/2k1q31Jm1RL7uKy9I+S1a1barPx2jptUj/S7l85CRR5nKYmDRa0r8k90NCukGYWE9k
-        7sMUdyiYMpakOVZ7ZIpIZUBhQ/8lfQMAAP//AwAfm9DBIwEAAA==
-    headers:
-      Cache-Control:
-      - private
-      Connection:
-      - Keep-Alive
-      Content-Encoding:
-      - gzip
-      Content-Security-Policy:
-      - upgrade-insecure-requests
-      Content-Type:
-      - text/plain
-      Date:
-      - Wed, 28 Jul 2021 19:45:43 GMT
-      Keep-Alive:
-      - timeout=1, max=10
-      NCBI-PHID:
-      - C7A42DCF101B3E710000000000000001.m_1
-      NCBI-SID:
-      - C7A42DCF101B3E71_0000SID
-      Referrer-Policy:
-      - origin-when-cross-origin
-      Server:
-      - Apache
-      Set-Cookie:
-      - ncbi_sid=C7A42DCF101B3E71_0000SID; domain=.nih.gov; path=/; expires=Thu, 28
-        Jul 2022 19:45:43 GMT
-      SraNameServerOutputVersion:
-      - '2.0'
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains; preload
-      Transfer-Encoding:
-      - chunked
-      Vary:
-      - Accept-Encoding
-      X-UA-Compatible:
-      - IE=Edge
-      X-XSS-Protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
-- request:
     body: null
     headers:
       Accept:
@@ -967,29 +827,27 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/portal/api/filereport?accession=SRR1603662&result=read_run
   response:
     body:
-      string: "run_accession\tfastq_ftp\tfastq_bytes\tfastq_md5\tsubmitted_ftp\tsubmitted_bytes\tsubmitted_md5\tsra_ftp\tsra_bytes\tsra_md5\nSRR1603662\tftp.sra.ebi.ac.uk/vol1/fastq/SRR160/002/SRR1603662/SRR1603662.fastq.gz;ftp.sra.ebi.ac.uk/vol1/fastq/SRR160/002/SRR1603662/SRR1603662_1.fastq.gz;ftp.sra.ebi.ac.uk/vol1/fastq/SRR160/002/SRR1603662/SRR1603662_2.fastq.gz\t998808350;7340614837;7522532959\t66f002c1cee8243129e9e73aa66a4e49;d9c461cdf14c6077f56b722fca8b6920;95eb1c28105297e66a9d70996ae69634\t\t\t\t\t\t\n"
+      string: "run_accession\tfastq_ftp\tfastq_bytes\tfastq_md5\tbam_ftp\tbam_bytes\tbam_md5\tsubmitted_ftp\tsubmitted_bytes\tsubmitted_md5\tsra_ftp\tsra_bytes\tsra_md5\nSRR1603662\tftp.sra.ebi.ac.uk/vol1/fastq/SRR160/002/SRR1603662/SRR1603662.fastq.gz;ftp.sra.ebi.ac.uk/vol1/fastq/SRR160/002/SRR1603662/SRR1603662_1.fastq.gz;ftp.sra.ebi.ac.uk/vol1/fastq/SRR160/002/SRR1603662/SRR1603662_2.fastq.gz\t998808350;7340614837;7522532959\t66f002c1cee8243129e9e73aa66a4e49;d9c461cdf14c6077f56b722fca8b6920;95eb1c28105297e66a9d70996ae69634\t\t\t\t\t\t\tftp.sra.ebi.ac.uk/vol1/srr/SRR160/002/SRR1603662\t13229044906\tc439617cdebf8270d8ce75a9f8083d50\n"
     headers:
       Cache-Control:
       - no-cache, no-store, max-age=0, must-revalidate
+      Content-Length:
+      - '601'
       Content-Type:
       - text/plain
       Date:
-      - Wed, 28 Jul 2021 19:45:43 GMT
+      - Wed, 17 May 2023 18:38:10 GMT
       Expires:
       - '0'
       Pragma:
       - no-cache
-      Server:
-      - Apache-Coyote/1.1
       Strict-Transport-Security:
       - max-age=0
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Frame-Options:
@@ -998,7 +856,7 @@ interactions:
       - 1; mode=block
     status:
       code: 200
-      message: OK
+      message: ''
 - request:
     body: null
     headers:
@@ -1009,7 +867,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/SRR1603663
   response:
@@ -1056,7 +914,7 @@ interactions:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:45:44 GMT
+      - Wed, 17 May 2023 18:38:10 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -1074,7 +932,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/SRX725595
   response:
@@ -1133,7 +991,7 @@ interactions:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:45:44 GMT
+      - Wed, 17 May 2023 18:38:10 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -1151,52 +1009,45 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/SRS716927
   response:
     body:
       string: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<SAMPLE_SET>\n<SAMPLE accession=\"SRS716927\"
-        alias=\"GSM1519618\" center_name=\"GEO\" broker_name=\"NCBI\">\n     <IDENTIFIERS>\n
-        \         <PRIMARY_ID>SRS716927</PRIMARY_ID>\n          <EXTERNAL_ID namespace=\"BioSample\">SAMN03097501</EXTERNAL_ID>\n
-        \         <EXTERNAL_ID namespace=\"GEO\">GSM1519618</EXTERNAL_ID>\n     </IDENTIFIERS>\n
+        alias=\"GSM1519618\" center_name=\"Stanford University\" broker_name=\"NCBI\">\n
+        \    <IDENTIFIERS>\n          <PRIMARY_ID>SRS716927</PRIMARY_ID>\n          <EXTERNAL_ID
+        namespace=\"BioSample\">SAMN03097501</EXTERNAL_ID>\n          <SUBMITTER_ID
+        namespace=\"Stanford University\">GSM1519618</SUBMITTER_ID>\n     </IDENTIFIERS>\n
         \    <TITLE>RNA-seq of the corpus callosum #4727</TITLE>\n     <SAMPLE_NAME>\n
         \         <TAXON_ID>9606</TAXON_ID>\n          <SCIENTIFIC_NAME>Homo sapiens</SCIENTIFIC_NAME>\n
-        \    </SAMPLE_NAME>\n     <SAMPLE_LINKS>\n          <SAMPLE_LINK>\n               <XREF_LINK>\n
-        \                   <DB>ENA-STUDY</DB>\n                    <ID>SRP048683</ID>\n
-        \              </XREF_LINK>\n          </SAMPLE_LINK>\n          <SAMPLE_LINK>\n
-        \              <XREF_LINK>\n                    <DB>ENA-EXPERIMENT</DB>\n
-        \                   <ID>SRX725595</ID>\n               </XREF_LINK>\n          </SAMPLE_LINK>\n
-        \         <SAMPLE_LINK>\n               <XREF_LINK>\n                    <DB>ENA-RUN</DB>\n
-        \                   <ID>SRR1603663</ID>\n               </XREF_LINK>\n          </SAMPLE_LINK>\n
-        \         <SAMPLE_LINK>\n               <XREF_LINK>\n                    <DB>ENA-SUBMISSION</DB>\n
-        \                   <ID>SRA188845</ID>\n               </XREF_LINK>\n          </SAMPLE_LINK>\n
-        \         <SAMPLE_LINK>\n               <XREF_LINK>\n                    <DB>ARRAYEXPRESS</DB>\n
-        \                   <ID>E-GEOD-62098</ID>\n               </XREF_LINK>\n          </SAMPLE_LINK>\n
-        \         <SAMPLE_LINK>\n               <XREF_LINK>\n                    <DB>ENA-FASTQ-FILES</DB>\n
-        \                   <ID><![CDATA[https://www.ebi.ac.uk/ena/portal/api/filereport?accession=SRS716927&result=read_run&fields=run_accession,fastq_ftp,fastq_md5,fastq_bytes]]></ID>\n
-        \              </XREF_LINK>\n          </SAMPLE_LINK>\n          <SAMPLE_LINK>\n
-        \              <XREF_LINK>\n                    <DB>ENA-SUBMITTED-FILES</DB>\n
-        \                   <ID><![CDATA[https://www.ebi.ac.uk/ena/portal/api/filereport?accession=SRS716927&result=read_run&fields=run_accession,submitted_ftp,submitted_md5,submitted_bytes,submitted_format]]></ID>\n
-        \              </XREF_LINK>\n          </SAMPLE_LINK>\n     </SAMPLE_LINKS>\n
-        \    <SAMPLE_ATTRIBUTES>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>source_name</TAG>\n
-        \              <VALUE>human brain</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
-        \         <SAMPLE_ATTRIBUTE>\n               <TAG>tissue</TAG>\n               <VALUE>frozen
-        postmortem brain from NICHD</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
-        \              <TAG>disease</TAG>\n               <VALUE>not available</VALUE>\n
-        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-SPOT-COUNT</TAG>\n
-        \              <VALUE>143636433</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
-        \              <TAG>ENA-BASE-COUNT</TAG>\n               <VALUE>25287600247</VALUE>\n
-        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-FIRST-PUBLIC</TAG>\n
-        \              <VALUE>2015-03-23</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
-        \         <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-LAST-UPDATE</TAG>\n
-        \              <VALUE>2015-06-23</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
+        \         <COMMON_NAME>human</COMMON_NAME>\n     </SAMPLE_NAME>\n     <SAMPLE_LINKS>\n
+        \   <SAMPLE_LINK>\n        <XREF_LINK>\n            <DB>ENA-FASTQ-FILES</DB>\n
+        \           <ID><![CDATA[https://www.ebi.ac.uk/ena/portal/api/filereport?accession=SRS716927&result=read_run&fields=run_accession,fastq_ftp,fastq_md5,fastq_bytes]]></ID>\n
+        \       </XREF_LINK>\n    </SAMPLE_LINK>\n    <SAMPLE_LINK>\n        <XREF_LINK>\n
+        \           <DB>ENA-SUBMITTED-FILES</DB>\n            <ID><![CDATA[https://www.ebi.ac.uk/ena/portal/api/filereport?accession=SRS716927&result=read_run&fields=run_accession,submitted_ftp,submitted_md5,submitted_bytes,submitted_format]]></ID>\n
+        \       </XREF_LINK>\n    </SAMPLE_LINK>\n</SAMPLE_LINKS>\n<SAMPLE_ATTRIBUTES>\n
+        \         <SAMPLE_ATTRIBUTE>\n               <TAG>INSDC secondary accession</TAG>\n
+        \              <VALUE>SRS716927</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
+        \              <TAG>NCBI submission package</TAG>\n               <VALUE>Generic.1.0</VALUE>\n
+        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>disease</TAG>\n
+        \              <VALUE>not available</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
+        \         <SAMPLE_ATTRIBUTE>\n               <TAG>organism</TAG>\n               <VALUE>Homo
+        sapiens</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
+        \              <TAG>tissue</TAG>\n               <VALUE>frozen postmortem
+        brain from NICHD</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
+        \              <TAG>source_name</TAG>\n               <VALUE>human brain</VALUE>\n
+        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>BioSampleModel</TAG>\n
+        \              <VALUE>Generic</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
+        \              <TAG>ENA-FIRST-PUBLIC</TAG>\n               <VALUE>2015-01-01</VALUE>\n
+        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-LAST-UPDATE</TAG>\n
+        \              <VALUE>2015-01-01</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
         \    </SAMPLE_ATTRIBUTES>\n</SAMPLE>\n</SAMPLE_SET>\n"
     headers:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:45:45 GMT
+      - Wed, 17 May 2023 18:38:11 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -1214,7 +1065,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/SRP048683
   response:
@@ -1261,7 +1112,7 @@ interactions:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:45:45 GMT
+      - Wed, 17 May 2023 18:38:11 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -1279,7 +1130,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/SRA188845
   response:
@@ -1316,7 +1167,7 @@ interactions:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:45:45 GMT
+      - Wed, 17 May 2023 18:38:11 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -1325,69 +1176,6 @@ interactions:
       code: 200
       message: ''
 - request:
-    body: acc=SRR1603663&accept-proto=fasp&version=2.0
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '44'
-      User-Agent:
-      - python-requests/2.25.1
-    method: POST
-    uri: https://www.ncbi.nlm.nih.gov/Traces/names/names.cgi
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAA5zOPU7EMBBA4Z5TWKLYKqv5sx3nEkgL1XaxJ1ZA0TpKAghpDs8iSjrap1d8j3SG
-        h30b1/dsz5cLBuAQ2JKPfe8xsRgBSofQQXghGigNAleTWEuWHJglBcIU5L6SV+w1VNZiZgJgT7fl
-        y53m41j3k1u3drTSFve6u3FZ2uekrrbNHfM9tPw2leOv5PyhuYxlngwxEETxyD+k2EHq8JckA/ZX
-        q1STRi3I1TN7GTXARMqZUWtM/r+kbwAAAP//AwCIsZKKIgEAAA==
-    headers:
-      Cache-Control:
-      - private
-      Connection:
-      - Keep-Alive
-      Content-Encoding:
-      - gzip
-      Content-Security-Policy:
-      - upgrade-insecure-requests
-      Content-Type:
-      - text/plain
-      Date:
-      - Wed, 28 Jul 2021 19:45:46 GMT
-      Keep-Alive:
-      - timeout=1, max=10
-      NCBI-PHID:
-      - CC95FED7101B3EA10000000000000001.m_1
-      NCBI-SID:
-      - CC95FED7101B3EA1_0000SID
-      Referrer-Policy:
-      - origin-when-cross-origin
-      Server:
-      - Apache
-      Set-Cookie:
-      - ncbi_sid=CC95FED7101B3EA1_0000SID; domain=.nih.gov; path=/; expires=Thu, 28
-        Jul 2022 19:45:46 GMT
-      SraNameServerOutputVersion:
-      - '2.0'
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains; preload
-      Transfer-Encoding:
-      - chunked
-      Vary:
-      - Accept-Encoding
-      X-UA-Compatible:
-      - IE=Edge
-      X-XSS-Protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
-- request:
     body: null
     headers:
       Accept:
@@ -1397,29 +1185,27 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/portal/api/filereport?accession=SRR1603663&result=read_run
   response:
     body:
-      string: "run_accession\tfastq_ftp\tfastq_bytes\tfastq_md5\tsubmitted_ftp\tsubmitted_bytes\tsubmitted_md5\tsra_ftp\tsra_bytes\tsra_md5\nSRR1603663\tftp.sra.ebi.ac.uk/vol1/fastq/SRR160/003/SRR1603663/SRR1603663.fastq.gz;ftp.sra.ebi.ac.uk/vol1/fastq/SRR160/003/SRR1603663/SRR1603663_1.fastq.gz;ftp.sra.ebi.ac.uk/vol1/fastq/SRR160/003/SRR1603663/SRR1603663_2.fastq.gz\t490810289;5442785670;5470533592\t27f4fe0eb14986a1727f080bc6db4d2b;83becc171cdf03d7c25aaf1d798b66e2;af9417bfd987797f395d201176adf9b3\t\t\t\t\t\t\n"
+      string: "run_accession\tfastq_ftp\tfastq_bytes\tfastq_md5\tbam_ftp\tbam_bytes\tbam_md5\tsubmitted_ftp\tsubmitted_bytes\tsubmitted_md5\tsra_ftp\tsra_bytes\tsra_md5\nSRR1603663\tftp.sra.ebi.ac.uk/vol1/fastq/SRR160/003/SRR1603663/SRR1603663.fastq.gz;ftp.sra.ebi.ac.uk/vol1/fastq/SRR160/003/SRR1603663/SRR1603663_1.fastq.gz;ftp.sra.ebi.ac.uk/vol1/fastq/SRR160/003/SRR1603663/SRR1603663_2.fastq.gz\t490810289;5442785670;5470533592\t27f4fe0eb14986a1727f080bc6db4d2b;83becc171cdf03d7c25aaf1d798b66e2;af9417bfd987797f395d201176adf9b3\t\t\t\t\t\t\tftp.sra.ebi.ac.uk/vol1/srr/SRR160/003/SRR1603663\t9578851934\t47fcb4b6334962196493425d18d6f3dc\n"
     headers:
       Cache-Control:
       - no-cache, no-store, max-age=0, must-revalidate
+      Content-Length:
+      - '600'
       Content-Type:
       - text/plain
       Date:
-      - Wed, 28 Jul 2021 19:45:47 GMT
+      - Wed, 17 May 2023 18:38:12 GMT
       Expires:
       - '0'
       Pragma:
       - no-cache
-      Server:
-      - Apache-Coyote/1.1
       Strict-Transport-Security:
       - max-age=0
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Frame-Options:
@@ -1428,7 +1214,7 @@ interactions:
       - 1; mode=block
     status:
       code: 200
-      message: OK
+      message: ''
 - request:
     body: null
     headers:
@@ -1439,7 +1225,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/SRR1603664
   response:
@@ -1486,7 +1272,7 @@ interactions:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:45:48 GMT
+      - Wed, 17 May 2023 18:38:12 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -1504,7 +1290,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/SRX725596
   response:
@@ -1563,7 +1349,7 @@ interactions:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:45:49 GMT
+      - Wed, 17 May 2023 18:38:13 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -1581,52 +1367,45 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/SRS716928
   response:
     body:
       string: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<SAMPLE_SET>\n<SAMPLE accession=\"SRS716928\"
-        alias=\"GSM1519619\" center_name=\"GEO\" broker_name=\"NCBI\">\n     <IDENTIFIERS>\n
-        \         <PRIMARY_ID>SRS716928</PRIMARY_ID>\n          <EXTERNAL_ID namespace=\"BioSample\">SAMN03097502</EXTERNAL_ID>\n
-        \         <EXTERNAL_ID namespace=\"GEO\">GSM1519619</EXTERNAL_ID>\n     </IDENTIFIERS>\n
+        alias=\"GSM1519619\" center_name=\"Stanford University\" broker_name=\"NCBI\">\n
+        \    <IDENTIFIERS>\n          <PRIMARY_ID>SRS716928</PRIMARY_ID>\n          <EXTERNAL_ID
+        namespace=\"BioSample\">SAMN03097502</EXTERNAL_ID>\n          <SUBMITTER_ID
+        namespace=\"Stanford University\">GSM1519619</SUBMITTER_ID>\n     </IDENTIFIERS>\n
         \    <TITLE>RNA-seq of the corpus callosum #5163</TITLE>\n     <SAMPLE_NAME>\n
         \         <TAXON_ID>9606</TAXON_ID>\n          <SCIENTIFIC_NAME>Homo sapiens</SCIENTIFIC_NAME>\n
-        \    </SAMPLE_NAME>\n     <SAMPLE_LINKS>\n          <SAMPLE_LINK>\n               <XREF_LINK>\n
-        \                   <DB>ENA-STUDY</DB>\n                    <ID>SRP048683</ID>\n
-        \              </XREF_LINK>\n          </SAMPLE_LINK>\n          <SAMPLE_LINK>\n
-        \              <XREF_LINK>\n                    <DB>ENA-EXPERIMENT</DB>\n
-        \                   <ID>SRX725596</ID>\n               </XREF_LINK>\n          </SAMPLE_LINK>\n
-        \         <SAMPLE_LINK>\n               <XREF_LINK>\n                    <DB>ENA-RUN</DB>\n
-        \                   <ID>SRR1603664</ID>\n               </XREF_LINK>\n          </SAMPLE_LINK>\n
-        \         <SAMPLE_LINK>\n               <XREF_LINK>\n                    <DB>ENA-SUBMISSION</DB>\n
-        \                   <ID>SRA188845</ID>\n               </XREF_LINK>\n          </SAMPLE_LINK>\n
-        \         <SAMPLE_LINK>\n               <XREF_LINK>\n                    <DB>ARRAYEXPRESS</DB>\n
-        \                   <ID>E-GEOD-62098</ID>\n               </XREF_LINK>\n          </SAMPLE_LINK>\n
-        \         <SAMPLE_LINK>\n               <XREF_LINK>\n                    <DB>ENA-FASTQ-FILES</DB>\n
-        \                   <ID><![CDATA[https://www.ebi.ac.uk/ena/portal/api/filereport?accession=SRS716928&result=read_run&fields=run_accession,fastq_ftp,fastq_md5,fastq_bytes]]></ID>\n
-        \              </XREF_LINK>\n          </SAMPLE_LINK>\n          <SAMPLE_LINK>\n
-        \              <XREF_LINK>\n                    <DB>ENA-SUBMITTED-FILES</DB>\n
-        \                   <ID><![CDATA[https://www.ebi.ac.uk/ena/portal/api/filereport?accession=SRS716928&result=read_run&fields=run_accession,submitted_ftp,submitted_md5,submitted_bytes,submitted_format]]></ID>\n
-        \              </XREF_LINK>\n          </SAMPLE_LINK>\n     </SAMPLE_LINKS>\n
-        \    <SAMPLE_ATTRIBUTES>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>source_name</TAG>\n
-        \              <VALUE>human brain</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
-        \         <SAMPLE_ATTRIBUTE>\n               <TAG>tissue</TAG>\n               <VALUE>frozen
-        postmortem brain from NICHD</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
-        \              <TAG>disease</TAG>\n               <VALUE>not available</VALUE>\n
-        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-SPOT-COUNT</TAG>\n
-        \              <VALUE>163384856</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
-        \              <TAG>ENA-BASE-COUNT</TAG>\n               <VALUE>28647959886</VALUE>\n
-        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-FIRST-PUBLIC</TAG>\n
-        \              <VALUE>2015-03-23</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
-        \         <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-LAST-UPDATE</TAG>\n
-        \              <VALUE>2015-06-23</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
+        \         <COMMON_NAME>human</COMMON_NAME>\n     </SAMPLE_NAME>\n     <SAMPLE_LINKS>\n
+        \   <SAMPLE_LINK>\n        <XREF_LINK>\n            <DB>ENA-FASTQ-FILES</DB>\n
+        \           <ID><![CDATA[https://www.ebi.ac.uk/ena/portal/api/filereport?accession=SRS716928&result=read_run&fields=run_accession,fastq_ftp,fastq_md5,fastq_bytes]]></ID>\n
+        \       </XREF_LINK>\n    </SAMPLE_LINK>\n    <SAMPLE_LINK>\n        <XREF_LINK>\n
+        \           <DB>ENA-SUBMITTED-FILES</DB>\n            <ID><![CDATA[https://www.ebi.ac.uk/ena/portal/api/filereport?accession=SRS716928&result=read_run&fields=run_accession,submitted_ftp,submitted_md5,submitted_bytes,submitted_format]]></ID>\n
+        \       </XREF_LINK>\n    </SAMPLE_LINK>\n</SAMPLE_LINKS>\n<SAMPLE_ATTRIBUTES>\n
+        \         <SAMPLE_ATTRIBUTE>\n               <TAG>INSDC secondary accession</TAG>\n
+        \              <VALUE>SRS716928</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
+        \              <TAG>NCBI submission package</TAG>\n               <VALUE>Generic.1.0</VALUE>\n
+        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>disease</TAG>\n
+        \              <VALUE>not available</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
+        \         <SAMPLE_ATTRIBUTE>\n               <TAG>organism</TAG>\n               <VALUE>Homo
+        sapiens</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
+        \              <TAG>tissue</TAG>\n               <VALUE>frozen postmortem
+        brain from NICHD</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
+        \              <TAG>source_name</TAG>\n               <VALUE>human brain</VALUE>\n
+        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>BioSampleModel</TAG>\n
+        \              <VALUE>Generic</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
+        \              <TAG>ENA-FIRST-PUBLIC</TAG>\n               <VALUE>2015-01-01</VALUE>\n
+        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-LAST-UPDATE</TAG>\n
+        \              <VALUE>2015-01-01</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
         \    </SAMPLE_ATTRIBUTES>\n</SAMPLE>\n</SAMPLE_SET>\n"
     headers:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:45:49 GMT
+      - Wed, 17 May 2023 18:38:13 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -1644,7 +1423,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/SRP048683
   response:
@@ -1691,7 +1470,7 @@ interactions:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:45:50 GMT
+      - Wed, 17 May 2023 18:38:13 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -1709,7 +1488,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/SRA188845
   response:
@@ -1746,7 +1525,7 @@ interactions:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:45:50 GMT
+      - Wed, 17 May 2023 18:38:13 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -1755,69 +1534,6 @@ interactions:
       code: 200
       message: ''
 - request:
-    body: acc=SRR1603664&accept-proto=fasp&version=2.0
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '44'
-      User-Agent:
-      - python-requests/2.25.1
-    method: POST
-    uri: https://www.ncbi.nlm.nih.gov/Traces/names/names.cgi
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAA5zOvU7DMBSG4Z2rsMTQqdV3fPybm0Aqnbo5tqOAIhwlBoR0Lp50ZkN6p3d6nvUF
-        T/uW1s9RXq9XcmDnjBCxjWRitF40yJwJZ7ib5oGOcJdpQo3sCudcUTBB52QQTNIUIrETEQPIy8fy
-        o05z7+t+UuvWesttUW+7SsvSvmtRU9tUn4/Rxvea+1/K5auMOeW5CkFHC8+MB8k/SJpviIMNA9xd
-        kFCt86FaMkUHNhxGU/zhjNmzKf8l/QIAAP//AwD/hMbsIwEAAA==
-    headers:
-      Cache-Control:
-      - private
-      Connection:
-      - Keep-Alive
-      Content-Encoding:
-      - gzip
-      Content-Security-Policy:
-      - upgrade-insecure-requests
-      Content-Type:
-      - text/plain
-      Date:
-      - Wed, 28 Jul 2021 19:45:51 GMT
-      Keep-Alive:
-      - timeout=1, max=10
-      NCBI-PHID:
-      - CC95FF33101B3EF10000000000000001.m_1
-      NCBI-SID:
-      - CC95FF33101B3EF1_0000SID
-      Referrer-Policy:
-      - origin-when-cross-origin
-      Server:
-      - Apache
-      Set-Cookie:
-      - ncbi_sid=CC95FF33101B3EF1_0000SID; domain=.nih.gov; path=/; expires=Thu, 28
-        Jul 2022 19:45:51 GMT
-      SraNameServerOutputVersion:
-      - '2.0'
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains; preload
-      Transfer-Encoding:
-      - chunked
-      Vary:
-      - Accept-Encoding
-      X-UA-Compatible:
-      - IE=Edge
-      X-XSS-Protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
-- request:
     body: null
     headers:
       Accept:
@@ -1827,29 +1543,27 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/portal/api/filereport?accession=SRR1603664&result=read_run
   response:
     body:
-      string: "run_accession\tfastq_ftp\tfastq_bytes\tfastq_md5\tsubmitted_ftp\tsubmitted_bytes\tsubmitted_md5\tsra_ftp\tsra_bytes\tsra_md5\nSRR1603664\tftp.sra.ebi.ac.uk/vol1/fastq/SRR160/004/SRR1603664/SRR1603664.fastq.gz;ftp.sra.ebi.ac.uk/vol1/fastq/SRR160/004/SRR1603664/SRR1603664_1.fastq.gz;ftp.sra.ebi.ac.uk/vol1/fastq/SRR160/004/SRR1603664/SRR1603664_2.fastq.gz\t663856366;6479922904;6586111087\td79a415b33c6fbd2159ea21122539fd8;a7337c4c402bff8aaa6dd474d7743a16;51d4b7a03a427f94df589dfb4060f4cb\t\t\t\t\t\t\n"
+      string: "run_accession\tfastq_ftp\tfastq_bytes\tfastq_md5\tbam_ftp\tbam_bytes\tbam_md5\tsubmitted_ftp\tsubmitted_bytes\tsubmitted_md5\tsra_ftp\tsra_bytes\tsra_md5\nSRR1603664\tftp.sra.ebi.ac.uk/vol1/fastq/SRR160/004/SRR1603664/SRR1603664.fastq.gz;ftp.sra.ebi.ac.uk/vol1/fastq/SRR160/004/SRR1603664/SRR1603664_1.fastq.gz;ftp.sra.ebi.ac.uk/vol1/fastq/SRR160/004/SRR1603664/SRR1603664_2.fastq.gz\t663856366;6479922904;6586111087\td79a415b33c6fbd2159ea21122539fd8;a7337c4c402bff8aaa6dd474d7743a16;51d4b7a03a427f94df589dfb4060f4cb\t\t\t\t\t\t\tftp.sra.ebi.ac.uk/vol1/srr/SRR160/004/SRR1603664\t11359149957\tff0e936d3cce0d0f02ca4084a2189136\n"
     headers:
       Cache-Control:
       - no-cache, no-store, max-age=0, must-revalidate
+      Content-Length:
+      - '601'
       Content-Type:
       - text/plain
       Date:
-      - Wed, 28 Jul 2021 19:45:52 GMT
+      - Wed, 17 May 2023 18:38:14 GMT
       Expires:
       - '0'
       Pragma:
       - no-cache
-      Server:
-      - Apache-Coyote/1.1
       Strict-Transport-Security:
       - max-age=0
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Frame-Options:
@@ -1858,7 +1572,7 @@ interactions:
       - 1; mode=block
     status:
       code: 200
-      message: OK
+      message: ''
 - request:
     body: null
     headers:
@@ -1869,7 +1583,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/SRR1603665
   response:
@@ -1916,7 +1630,7 @@ interactions:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:45:52 GMT
+      - Wed, 17 May 2023 18:38:15 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -1934,7 +1648,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/SRX725597
   response:
@@ -1993,7 +1707,7 @@ interactions:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:45:53 GMT
+      - Wed, 17 May 2023 18:38:15 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -2011,52 +1725,45 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/SRS716929
   response:
     body:
       string: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<SAMPLE_SET>\n<SAMPLE accession=\"SRS716929\"
-        alias=\"GSM1519620\" center_name=\"GEO\" broker_name=\"NCBI\">\n     <IDENTIFIERS>\n
-        \         <PRIMARY_ID>SRS716929</PRIMARY_ID>\n          <EXTERNAL_ID namespace=\"BioSample\">SAMN03097503</EXTERNAL_ID>\n
-        \         <EXTERNAL_ID namespace=\"GEO\">GSM1519620</EXTERNAL_ID>\n     </IDENTIFIERS>\n
+        alias=\"GSM1519620\" center_name=\"Stanford University\" broker_name=\"NCBI\">\n
+        \    <IDENTIFIERS>\n          <PRIMARY_ID>SRS716929</PRIMARY_ID>\n          <EXTERNAL_ID
+        namespace=\"BioSample\">SAMN03097503</EXTERNAL_ID>\n          <SUBMITTER_ID
+        namespace=\"Stanford University\">GSM1519620</SUBMITTER_ID>\n     </IDENTIFIERS>\n
         \    <TITLE>RNA-seq of the corpus callosum #5391</TITLE>\n     <SAMPLE_NAME>\n
         \         <TAXON_ID>9606</TAXON_ID>\n          <SCIENTIFIC_NAME>Homo sapiens</SCIENTIFIC_NAME>\n
-        \    </SAMPLE_NAME>\n     <SAMPLE_LINKS>\n          <SAMPLE_LINK>\n               <XREF_LINK>\n
-        \                   <DB>ENA-STUDY</DB>\n                    <ID>SRP048683</ID>\n
-        \              </XREF_LINK>\n          </SAMPLE_LINK>\n          <SAMPLE_LINK>\n
-        \              <XREF_LINK>\n                    <DB>ENA-EXPERIMENT</DB>\n
-        \                   <ID>SRX725597</ID>\n               </XREF_LINK>\n          </SAMPLE_LINK>\n
-        \         <SAMPLE_LINK>\n               <XREF_LINK>\n                    <DB>ENA-RUN</DB>\n
-        \                   <ID>SRR1603665</ID>\n               </XREF_LINK>\n          </SAMPLE_LINK>\n
-        \         <SAMPLE_LINK>\n               <XREF_LINK>\n                    <DB>ENA-SUBMISSION</DB>\n
-        \                   <ID>SRA188845</ID>\n               </XREF_LINK>\n          </SAMPLE_LINK>\n
-        \         <SAMPLE_LINK>\n               <XREF_LINK>\n                    <DB>ARRAYEXPRESS</DB>\n
-        \                   <ID>E-GEOD-62098</ID>\n               </XREF_LINK>\n          </SAMPLE_LINK>\n
-        \         <SAMPLE_LINK>\n               <XREF_LINK>\n                    <DB>ENA-FASTQ-FILES</DB>\n
-        \                   <ID><![CDATA[https://www.ebi.ac.uk/ena/portal/api/filereport?accession=SRS716929&result=read_run&fields=run_accession,fastq_ftp,fastq_md5,fastq_bytes]]></ID>\n
-        \              </XREF_LINK>\n          </SAMPLE_LINK>\n          <SAMPLE_LINK>\n
-        \              <XREF_LINK>\n                    <DB>ENA-SUBMITTED-FILES</DB>\n
-        \                   <ID><![CDATA[https://www.ebi.ac.uk/ena/portal/api/filereport?accession=SRS716929&result=read_run&fields=run_accession,submitted_ftp,submitted_md5,submitted_bytes,submitted_format]]></ID>\n
-        \              </XREF_LINK>\n          </SAMPLE_LINK>\n     </SAMPLE_LINKS>\n
-        \    <SAMPLE_ATTRIBUTES>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>source_name</TAG>\n
-        \              <VALUE>human brain</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
-        \         <SAMPLE_ATTRIBUTE>\n               <TAG>tissue</TAG>\n               <VALUE>frozen
-        postmortem brain from NICHD</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
-        \              <TAG>disease</TAG>\n               <VALUE>not available</VALUE>\n
-        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-SPOT-COUNT</TAG>\n
-        \              <VALUE>155224100</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
-        \              <TAG>ENA-BASE-COUNT</TAG>\n               <VALUE>27186376672</VALUE>\n
-        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-FIRST-PUBLIC</TAG>\n
-        \              <VALUE>2015-03-23</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
-        \         <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-LAST-UPDATE</TAG>\n
-        \              <VALUE>2015-06-23</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
+        \         <COMMON_NAME>human</COMMON_NAME>\n     </SAMPLE_NAME>\n     <SAMPLE_LINKS>\n
+        \   <SAMPLE_LINK>\n        <XREF_LINK>\n            <DB>ENA-FASTQ-FILES</DB>\n
+        \           <ID><![CDATA[https://www.ebi.ac.uk/ena/portal/api/filereport?accession=SRS716929&result=read_run&fields=run_accession,fastq_ftp,fastq_md5,fastq_bytes]]></ID>\n
+        \       </XREF_LINK>\n    </SAMPLE_LINK>\n    <SAMPLE_LINK>\n        <XREF_LINK>\n
+        \           <DB>ENA-SUBMITTED-FILES</DB>\n            <ID><![CDATA[https://www.ebi.ac.uk/ena/portal/api/filereport?accession=SRS716929&result=read_run&fields=run_accession,submitted_ftp,submitted_md5,submitted_bytes,submitted_format]]></ID>\n
+        \       </XREF_LINK>\n    </SAMPLE_LINK>\n</SAMPLE_LINKS>\n<SAMPLE_ATTRIBUTES>\n
+        \         <SAMPLE_ATTRIBUTE>\n               <TAG>INSDC secondary accession</TAG>\n
+        \              <VALUE>SRS716929</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
+        \              <TAG>NCBI submission package</TAG>\n               <VALUE>Generic.1.0</VALUE>\n
+        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>disease</TAG>\n
+        \              <VALUE>not available</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
+        \         <SAMPLE_ATTRIBUTE>\n               <TAG>organism</TAG>\n               <VALUE>Homo
+        sapiens</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
+        \              <TAG>tissue</TAG>\n               <VALUE>frozen postmortem
+        brain from NICHD</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
+        \              <TAG>source_name</TAG>\n               <VALUE>human brain</VALUE>\n
+        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>BioSampleModel</TAG>\n
+        \              <VALUE>Generic</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
+        \              <TAG>ENA-FIRST-PUBLIC</TAG>\n               <VALUE>2015-01-01</VALUE>\n
+        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-LAST-UPDATE</TAG>\n
+        \              <VALUE>2015-01-01</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
         \    </SAMPLE_ATTRIBUTES>\n</SAMPLE>\n</SAMPLE_SET>\n"
     headers:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:45:53 GMT
+      - Wed, 17 May 2023 18:38:16 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -2074,7 +1781,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/SRP048683
   response:
@@ -2121,7 +1828,7 @@ interactions:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:45:53 GMT
+      - Wed, 17 May 2023 18:38:16 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -2139,7 +1846,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/SRA188845
   response:
@@ -2176,7 +1883,7 @@ interactions:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:45:54 GMT
+      - Wed, 17 May 2023 18:38:16 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -2185,69 +1892,6 @@ interactions:
       code: 200
       message: ''
 - request:
-    body: acc=SRR1603665&accept-proto=fasp&version=2.0
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '44'
-      User-Agent:
-      - python-requests/2.25.1
-    method: POST
-    uri: https://www.ncbi.nlm.nih.gov/Traces/names/names.cgi
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAA5zOO27DMAwA0L2nENAhUwJS1I++RIE0UzZRluAWRmTYboICPHw/a7eub3rP9gRP
-        25qXD9HX8xkDUAheEXxCZo7eqQV0R4QjhIulAWAAf9UWEQUSs8NQGUMZsWUQjJQAhUhVHYC+3OZP
-        c5j2fdkOZln73kufzdtm8jz3Rx1N66vZp2/o8l7L/rdyuo9ScpmqJk6IyabfUfwZWboAD+QHxKuC
-        K7kJ+SaMLZbKWaoD8X6slBqV/46+AAAA//8DAPEhuy4iAQAA
-    headers:
-      Cache-Control:
-      - private
-      Connection:
-      - Keep-Alive
-      Content-Encoding:
-      - gzip
-      Content-Security-Policy:
-      - upgrade-insecure-requests
-      Content-Type:
-      - text/plain
-      Date:
-      - Wed, 28 Jul 2021 19:45:55 GMT
-      Keep-Alive:
-      - timeout=1, max=10
-      NCBI-PHID:
-      - CC95FF99101B3F310000000000000001.m_1
-      NCBI-SID:
-      - CC95FF99101B3F31_0000SID
-      Referrer-Policy:
-      - origin-when-cross-origin
-      Server:
-      - Apache
-      Set-Cookie:
-      - ncbi_sid=CC95FF99101B3F31_0000SID; domain=.nih.gov; path=/; expires=Thu, 28
-        Jul 2022 19:45:55 GMT
-      SraNameServerOutputVersion:
-      - '2.0'
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains; preload
-      Transfer-Encoding:
-      - chunked
-      Vary:
-      - Accept-Encoding
-      X-UA-Compatible:
-      - IE=Edge
-      X-XSS-Protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
-- request:
     body: null
     headers:
       Accept:
@@ -2257,29 +1901,27 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/portal/api/filereport?accession=SRR1603665&result=read_run
   response:
     body:
-      string: "run_accession\tfastq_ftp\tfastq_bytes\tfastq_md5\tsubmitted_ftp\tsubmitted_bytes\tsubmitted_md5\tsra_ftp\tsra_bytes\tsra_md5\nSRR1603665\tftp.sra.ebi.ac.uk/vol1/fastq/SRR160/005/SRR1603665/SRR1603665.fastq.gz;ftp.sra.ebi.ac.uk/vol1/fastq/SRR160/005/SRR1603665/SRR1603665_1.fastq.gz;ftp.sra.ebi.ac.uk/vol1/fastq/SRR160/005/SRR1603665/SRR1603665_2.fastq.gz\t637411585;6019011707;6096423865\tabe09a733a7f7164685e6a55c1c48e2a;0673ce2bd91a7bb8b7058af295715391;553f4ff4018716dc9fdffa9ff8cfdaa6\t\t\t\t\t\t\n"
+      string: "run_accession\tfastq_ftp\tfastq_bytes\tfastq_md5\tbam_ftp\tbam_bytes\tbam_md5\tsubmitted_ftp\tsubmitted_bytes\tsubmitted_md5\tsra_ftp\tsra_bytes\tsra_md5\nSRR1603665\tftp.sra.ebi.ac.uk/vol1/fastq/SRR160/005/SRR1603665/SRR1603665.fastq.gz;ftp.sra.ebi.ac.uk/vol1/fastq/SRR160/005/SRR1603665/SRR1603665_1.fastq.gz;ftp.sra.ebi.ac.uk/vol1/fastq/SRR160/005/SRR1603665/SRR1603665_2.fastq.gz\t637411585;6019011707;6096423865\tabe09a733a7f7164685e6a55c1c48e2a;0673ce2bd91a7bb8b7058af295715391;553f4ff4018716dc9fdffa9ff8cfdaa6\t\t\t\t\t\t\tftp.sra.ebi.ac.uk/vol1/srr/SRR160/005/SRR1603665\t10581999754\tf711b0899416e916cd1fa0b173801b33\n"
     headers:
       Cache-Control:
       - no-cache, no-store, max-age=0, must-revalidate
+      Content-Length:
+      - '601'
       Content-Type:
       - text/plain
       Date:
-      - Wed, 28 Jul 2021 19:45:56 GMT
+      - Wed, 17 May 2023 18:38:17 GMT
       Expires:
       - '0'
       Pragma:
       - no-cache
-      Server:
-      - Apache-Coyote/1.1
       Strict-Transport-Security:
       - max-age=0
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Frame-Options:
@@ -2288,7 +1930,7 @@ interactions:
       - 1; mode=block
     status:
       code: 200
-      message: OK
+      message: ''
 - request:
     body: null
     headers:
@@ -2299,7 +1941,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/SRR1603666
   response:
@@ -2346,7 +1988,7 @@ interactions:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:45:56 GMT
+      - Wed, 17 May 2023 18:38:17 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -2364,7 +2006,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/SRX725598
   response:
@@ -2423,7 +2065,7 @@ interactions:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:45:57 GMT
+      - Wed, 17 May 2023 18:38:17 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -2441,52 +2083,45 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/SRS716930
   response:
     body:
       string: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<SAMPLE_SET>\n<SAMPLE accession=\"SRS716930\"
-        alias=\"GSM1519621\" center_name=\"GEO\" broker_name=\"NCBI\">\n     <IDENTIFIERS>\n
-        \         <PRIMARY_ID>SRS716930</PRIMARY_ID>\n          <EXTERNAL_ID namespace=\"BioSample\">SAMN03097504</EXTERNAL_ID>\n
-        \         <EXTERNAL_ID namespace=\"GEO\">GSM1519621</EXTERNAL_ID>\n     </IDENTIFIERS>\n
+        alias=\"GSM1519621\" center_name=\"Stanford University\" broker_name=\"NCBI\">\n
+        \    <IDENTIFIERS>\n          <PRIMARY_ID>SRS716930</PRIMARY_ID>\n          <EXTERNAL_ID
+        namespace=\"BioSample\">SAMN03097504</EXTERNAL_ID>\n          <SUBMITTER_ID
+        namespace=\"Stanford University\">GSM1519621</SUBMITTER_ID>\n     </IDENTIFIERS>\n
         \    <TITLE>RNA-seq of the corpus callosum #5242</TITLE>\n     <SAMPLE_NAME>\n
         \         <TAXON_ID>9606</TAXON_ID>\n          <SCIENTIFIC_NAME>Homo sapiens</SCIENTIFIC_NAME>\n
-        \    </SAMPLE_NAME>\n     <SAMPLE_LINKS>\n          <SAMPLE_LINK>\n               <XREF_LINK>\n
-        \                   <DB>ENA-STUDY</DB>\n                    <ID>SRP048683</ID>\n
-        \              </XREF_LINK>\n          </SAMPLE_LINK>\n          <SAMPLE_LINK>\n
-        \              <XREF_LINK>\n                    <DB>ENA-EXPERIMENT</DB>\n
-        \                   <ID>SRX725598</ID>\n               </XREF_LINK>\n          </SAMPLE_LINK>\n
-        \         <SAMPLE_LINK>\n               <XREF_LINK>\n                    <DB>ENA-RUN</DB>\n
-        \                   <ID>SRR1603666</ID>\n               </XREF_LINK>\n          </SAMPLE_LINK>\n
-        \         <SAMPLE_LINK>\n               <XREF_LINK>\n                    <DB>ENA-SUBMISSION</DB>\n
-        \                   <ID>SRA188845</ID>\n               </XREF_LINK>\n          </SAMPLE_LINK>\n
-        \         <SAMPLE_LINK>\n               <XREF_LINK>\n                    <DB>ARRAYEXPRESS</DB>\n
-        \                   <ID>E-GEOD-62098</ID>\n               </XREF_LINK>\n          </SAMPLE_LINK>\n
-        \         <SAMPLE_LINK>\n               <XREF_LINK>\n                    <DB>ENA-FASTQ-FILES</DB>\n
-        \                   <ID><![CDATA[https://www.ebi.ac.uk/ena/portal/api/filereport?accession=SRS716930&result=read_run&fields=run_accession,fastq_ftp,fastq_md5,fastq_bytes]]></ID>\n
-        \              </XREF_LINK>\n          </SAMPLE_LINK>\n          <SAMPLE_LINK>\n
-        \              <XREF_LINK>\n                    <DB>ENA-SUBMITTED-FILES</DB>\n
-        \                   <ID><![CDATA[https://www.ebi.ac.uk/ena/portal/api/filereport?accession=SRS716930&result=read_run&fields=run_accession,submitted_ftp,submitted_md5,submitted_bytes,submitted_format]]></ID>\n
-        \              </XREF_LINK>\n          </SAMPLE_LINK>\n     </SAMPLE_LINKS>\n
-        \    <SAMPLE_ATTRIBUTES>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>source_name</TAG>\n
-        \              <VALUE>human brain</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
-        \         <SAMPLE_ATTRIBUTE>\n               <TAG>tissue</TAG>\n               <VALUE>frozen
-        postmortem brain from NICHD</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
-        \              <TAG>disease</TAG>\n               <VALUE>not available</VALUE>\n
-        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-SPOT-COUNT</TAG>\n
-        \              <VALUE>163481475</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
-        \              <TAG>ENA-BASE-COUNT</TAG>\n               <VALUE>28665079898</VALUE>\n
-        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-FIRST-PUBLIC</TAG>\n
-        \              <VALUE>2015-03-23</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
-        \         <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-LAST-UPDATE</TAG>\n
-        \              <VALUE>2015-06-23</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
+        \         <COMMON_NAME>human</COMMON_NAME>\n     </SAMPLE_NAME>\n     <SAMPLE_LINKS>\n
+        \   <SAMPLE_LINK>\n        <XREF_LINK>\n            <DB>ENA-FASTQ-FILES</DB>\n
+        \           <ID><![CDATA[https://www.ebi.ac.uk/ena/portal/api/filereport?accession=SRS716930&result=read_run&fields=run_accession,fastq_ftp,fastq_md5,fastq_bytes]]></ID>\n
+        \       </XREF_LINK>\n    </SAMPLE_LINK>\n    <SAMPLE_LINK>\n        <XREF_LINK>\n
+        \           <DB>ENA-SUBMITTED-FILES</DB>\n            <ID><![CDATA[https://www.ebi.ac.uk/ena/portal/api/filereport?accession=SRS716930&result=read_run&fields=run_accession,submitted_ftp,submitted_md5,submitted_bytes,submitted_format]]></ID>\n
+        \       </XREF_LINK>\n    </SAMPLE_LINK>\n</SAMPLE_LINKS>\n<SAMPLE_ATTRIBUTES>\n
+        \         <SAMPLE_ATTRIBUTE>\n               <TAG>INSDC secondary accession</TAG>\n
+        \              <VALUE>SRS716930</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
+        \              <TAG>NCBI submission package</TAG>\n               <VALUE>Generic.1.0</VALUE>\n
+        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>disease</TAG>\n
+        \              <VALUE>not available</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
+        \         <SAMPLE_ATTRIBUTE>\n               <TAG>organism</TAG>\n               <VALUE>Homo
+        sapiens</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
+        \              <TAG>tissue</TAG>\n               <VALUE>frozen postmortem
+        brain from NICHD</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
+        \              <TAG>source_name</TAG>\n               <VALUE>human brain</VALUE>\n
+        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>BioSampleModel</TAG>\n
+        \              <VALUE>Generic</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
+        \              <TAG>ENA-FIRST-PUBLIC</TAG>\n               <VALUE>2015-01-01</VALUE>\n
+        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-LAST-UPDATE</TAG>\n
+        \              <VALUE>2015-01-01</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
         \    </SAMPLE_ATTRIBUTES>\n</SAMPLE>\n</SAMPLE_SET>\n"
     headers:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:45:57 GMT
+      - Wed, 17 May 2023 18:38:18 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -2504,7 +2139,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/SRP048683
   response:
@@ -2551,7 +2186,7 @@ interactions:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:45:58 GMT
+      - Wed, 17 May 2023 18:38:18 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -2569,7 +2204,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/SRA188845
   response:
@@ -2606,7 +2241,7 @@ interactions:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:45:58 GMT
+      - Wed, 17 May 2023 18:38:19 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -2615,69 +2250,6 @@ interactions:
       code: 200
       message: ''
 - request:
-    body: acc=SRR1603666&accept-proto=fasp&version=2.0
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '44'
-      User-Agent:
-      - python-requests/2.25.1
-    method: POST
-    uri: https://www.ncbi.nlm.nih.gov/Traces/names/names.cgi
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAA5zOu07DMBQA0J2vsMTQqdV92L52fgKpdOpmOzcKKKqjxLRC8sdDZzbWM51XOsHL
-        vqX1K/f38xk9sPe+IzorjJEIOwHaI8IR5AI4WDcgX3tgTJTGoFbEKaBkP3GIGlEZiLT3bgH62235
-        Noe5tXU/mHWrrZa6mI/dpGWpDx3NVDfT5l+o+VNL+1s53cdcUpm1o3MYMQjEZ0meJeILwkB2cOHa
-        J7JlkiLFUWSIScakQEEhk+XI/r+lHwAAAP//AwDIQTI1IwEAAA==
-    headers:
-      Cache-Control:
-      - private
-      Connection:
-      - Keep-Alive
-      Content-Encoding:
-      - gzip
-      Content-Security-Policy:
-      - upgrade-insecure-requests
-      Content-Type:
-      - text/plain
-      Date:
-      - Wed, 28 Jul 2021 19:45:59 GMT
-      Keep-Alive:
-      - timeout=1, max=10
-      NCBI-PHID:
-      - C7A42EE4101B3F710000000000000001.m_1
-      NCBI-SID:
-      - C7A42EE4101B3F71_0000SID
-      Referrer-Policy:
-      - origin-when-cross-origin
-      Server:
-      - Apache
-      Set-Cookie:
-      - ncbi_sid=C7A42EE4101B3F71_0000SID; domain=.nih.gov; path=/; expires=Thu, 28
-        Jul 2022 19:45:59 GMT
-      SraNameServerOutputVersion:
-      - '2.0'
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains; preload
-      Transfer-Encoding:
-      - chunked
-      Vary:
-      - Accept-Encoding
-      X-UA-Compatible:
-      - IE=Edge
-      X-XSS-Protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
-- request:
     body: null
     headers:
       Accept:
@@ -2687,29 +2259,27 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/portal/api/filereport?accession=SRR1603666&result=read_run
   response:
     body:
-      string: "run_accession\tfastq_ftp\tfastq_bytes\tfastq_md5\tsubmitted_ftp\tsubmitted_bytes\tsubmitted_md5\tsra_ftp\tsra_bytes\tsra_md5\nSRR1603666\tftp.sra.ebi.ac.uk/vol1/fastq/SRR160/006/SRR1603666/SRR1603666.fastq.gz;ftp.sra.ebi.ac.uk/vol1/fastq/SRR160/006/SRR1603666/SRR1603666_1.fastq.gz;ftp.sra.ebi.ac.uk/vol1/fastq/SRR160/006/SRR1603666/SRR1603666_2.fastq.gz\t653021683;6452705895;6593977478\td9eb9f296bb1ed25506469e9ba292272;8730290dbb90c069cac0662d3b06a69f;5a32c8ae794dd25e5d1e85c89a751020\t\t\t\t\t\t\n"
+      string: "run_accession\tfastq_ftp\tfastq_bytes\tfastq_md5\tbam_ftp\tbam_bytes\tbam_md5\tsubmitted_ftp\tsubmitted_bytes\tsubmitted_md5\tsra_ftp\tsra_bytes\tsra_md5\nSRR1603666\tftp.sra.ebi.ac.uk/vol1/fastq/SRR160/006/SRR1603666/SRR1603666.fastq.gz;ftp.sra.ebi.ac.uk/vol1/fastq/SRR160/006/SRR1603666/SRR1603666_1.fastq.gz;ftp.sra.ebi.ac.uk/vol1/fastq/SRR160/006/SRR1603666/SRR1603666_2.fastq.gz\t653021683;6452705895;6593977478\td9eb9f296bb1ed25506469e9ba292272;8730290dbb90c069cac0662d3b06a69f;5a32c8ae794dd25e5d1e85c89a751020\t\t\t\t\t\t\tftp.sra.ebi.ac.uk/vol1/srr/SRR160/006/SRR1603666\t11547319221\t831a2ad8e4775e017b6f389e91e3022e\n"
     headers:
       Cache-Control:
       - no-cache, no-store, max-age=0, must-revalidate
+      Content-Length:
+      - '601'
       Content-Type:
       - text/plain
       Date:
-      - Wed, 28 Jul 2021 19:46:00 GMT
+      - Wed, 17 May 2023 18:38:19 GMT
       Expires:
       - '0'
       Pragma:
       - no-cache
-      Server:
-      - Apache-Coyote/1.1
       Strict-Transport-Security:
       - max-age=0
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Frame-Options:
@@ -2718,7 +2288,7 @@ interactions:
       - 1; mode=block
     status:
       code: 200
-      message: OK
+      message: ''
 - request:
     body: null
     headers:
@@ -2729,7 +2299,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/SRR1603667
   response:
@@ -2776,7 +2346,7 @@ interactions:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:46:00 GMT
+      - Wed, 17 May 2023 18:38:20 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -2794,7 +2364,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/SRX725599
   response:
@@ -2853,7 +2423,7 @@ interactions:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:46:01 GMT
+      - Wed, 17 May 2023 18:38:20 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -2871,52 +2441,45 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/SRS716931
   response:
     body:
       string: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<SAMPLE_SET>\n<SAMPLE accession=\"SRS716931\"
-        alias=\"GSM1519622\" center_name=\"GEO\" broker_name=\"NCBI\">\n     <IDENTIFIERS>\n
-        \         <PRIMARY_ID>SRS716931</PRIMARY_ID>\n          <EXTERNAL_ID namespace=\"BioSample\">SAMN03097505</EXTERNAL_ID>\n
-        \         <EXTERNAL_ID namespace=\"GEO\">GSM1519622</EXTERNAL_ID>\n     </IDENTIFIERS>\n
+        alias=\"GSM1519622\" center_name=\"Stanford University\" broker_name=\"NCBI\">\n
+        \    <IDENTIFIERS>\n          <PRIMARY_ID>SRS716931</PRIMARY_ID>\n          <EXTERNAL_ID
+        namespace=\"BioSample\">SAMN03097505</EXTERNAL_ID>\n          <SUBMITTER_ID
+        namespace=\"Stanford University\">GSM1519622</SUBMITTER_ID>\n     </IDENTIFIERS>\n
         \    <TITLE>RNA-seq of the corpus callosum #4899</TITLE>\n     <SAMPLE_NAME>\n
         \         <TAXON_ID>9606</TAXON_ID>\n          <SCIENTIFIC_NAME>Homo sapiens</SCIENTIFIC_NAME>\n
-        \    </SAMPLE_NAME>\n     <SAMPLE_LINKS>\n          <SAMPLE_LINK>\n               <XREF_LINK>\n
-        \                   <DB>ENA-STUDY</DB>\n                    <ID>SRP048683</ID>\n
-        \              </XREF_LINK>\n          </SAMPLE_LINK>\n          <SAMPLE_LINK>\n
-        \              <XREF_LINK>\n                    <DB>ENA-EXPERIMENT</DB>\n
-        \                   <ID>SRX725599</ID>\n               </XREF_LINK>\n          </SAMPLE_LINK>\n
-        \         <SAMPLE_LINK>\n               <XREF_LINK>\n                    <DB>ENA-RUN</DB>\n
-        \                   <ID>SRR1603667</ID>\n               </XREF_LINK>\n          </SAMPLE_LINK>\n
-        \         <SAMPLE_LINK>\n               <XREF_LINK>\n                    <DB>ENA-SUBMISSION</DB>\n
-        \                   <ID>SRA188845</ID>\n               </XREF_LINK>\n          </SAMPLE_LINK>\n
-        \         <SAMPLE_LINK>\n               <XREF_LINK>\n                    <DB>ARRAYEXPRESS</DB>\n
-        \                   <ID>E-GEOD-62098</ID>\n               </XREF_LINK>\n          </SAMPLE_LINK>\n
-        \         <SAMPLE_LINK>\n               <XREF_LINK>\n                    <DB>ENA-FASTQ-FILES</DB>\n
-        \                   <ID><![CDATA[https://www.ebi.ac.uk/ena/portal/api/filereport?accession=SRS716931&result=read_run&fields=run_accession,fastq_ftp,fastq_md5,fastq_bytes]]></ID>\n
-        \              </XREF_LINK>\n          </SAMPLE_LINK>\n          <SAMPLE_LINK>\n
-        \              <XREF_LINK>\n                    <DB>ENA-SUBMITTED-FILES</DB>\n
-        \                   <ID><![CDATA[https://www.ebi.ac.uk/ena/portal/api/filereport?accession=SRS716931&result=read_run&fields=run_accession,submitted_ftp,submitted_md5,submitted_bytes,submitted_format]]></ID>\n
-        \              </XREF_LINK>\n          </SAMPLE_LINK>\n     </SAMPLE_LINKS>\n
-        \    <SAMPLE_ATTRIBUTES>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>source_name</TAG>\n
-        \              <VALUE>human brain</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
-        \         <SAMPLE_ATTRIBUTE>\n               <TAG>tissue</TAG>\n               <VALUE>frozen
-        postmortem brain from NICHD</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
-        \              <TAG>disease</TAG>\n               <VALUE>autism spectrum disorder</VALUE>\n
-        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-SPOT-COUNT</TAG>\n
-        \              <VALUE>167246977</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
-        \              <TAG>ENA-BASE-COUNT</TAG>\n               <VALUE>29215101734</VALUE>\n
-        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-FIRST-PUBLIC</TAG>\n
-        \              <VALUE>2015-03-23</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
-        \         <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-LAST-UPDATE</TAG>\n
-        \              <VALUE>2015-06-23</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
+        \         <COMMON_NAME>human</COMMON_NAME>\n     </SAMPLE_NAME>\n     <SAMPLE_LINKS>\n
+        \   <SAMPLE_LINK>\n        <XREF_LINK>\n            <DB>ENA-FASTQ-FILES</DB>\n
+        \           <ID><![CDATA[https://www.ebi.ac.uk/ena/portal/api/filereport?accession=SRS716931&result=read_run&fields=run_accession,fastq_ftp,fastq_md5,fastq_bytes]]></ID>\n
+        \       </XREF_LINK>\n    </SAMPLE_LINK>\n    <SAMPLE_LINK>\n        <XREF_LINK>\n
+        \           <DB>ENA-SUBMITTED-FILES</DB>\n            <ID><![CDATA[https://www.ebi.ac.uk/ena/portal/api/filereport?accession=SRS716931&result=read_run&fields=run_accession,submitted_ftp,submitted_md5,submitted_bytes,submitted_format]]></ID>\n
+        \       </XREF_LINK>\n    </SAMPLE_LINK>\n</SAMPLE_LINKS>\n<SAMPLE_ATTRIBUTES>\n
+        \         <SAMPLE_ATTRIBUTE>\n               <TAG>INSDC secondary accession</TAG>\n
+        \              <VALUE>SRS716931</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
+        \              <TAG>NCBI submission package</TAG>\n               <VALUE>Generic.1.0</VALUE>\n
+        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>disease</TAG>\n
+        \              <VALUE>autism spectrum disorder</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
+        \         <SAMPLE_ATTRIBUTE>\n               <TAG>organism</TAG>\n               <VALUE>Homo
+        sapiens</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
+        \              <TAG>tissue</TAG>\n               <VALUE>frozen postmortem
+        brain from NICHD</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
+        \              <TAG>source_name</TAG>\n               <VALUE>human brain</VALUE>\n
+        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>BioSampleModel</TAG>\n
+        \              <VALUE>Generic</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
+        \              <TAG>ENA-FIRST-PUBLIC</TAG>\n               <VALUE>2015-01-01</VALUE>\n
+        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-LAST-UPDATE</TAG>\n
+        \              <VALUE>2015-01-01</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
         \    </SAMPLE_ATTRIBUTES>\n</SAMPLE>\n</SAMPLE_SET>\n"
     headers:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:46:01 GMT
+      - Wed, 17 May 2023 18:38:20 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -2934,7 +2497,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/SRP048683
   response:
@@ -2981,7 +2544,7 @@ interactions:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:46:02 GMT
+      - Wed, 17 May 2023 18:38:21 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -2999,7 +2562,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/SRA188845
   response:
@@ -3036,7 +2599,7 @@ interactions:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:46:02 GMT
+      - Wed, 17 May 2023 18:38:21 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -3045,69 +2608,6 @@ interactions:
       code: 200
       message: ''
 - request:
-    body: acc=SRR1603667&accept-proto=fasp&version=2.0
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '44'
-      User-Agent:
-      - python-requests/2.25.1
-    method: POST
-    uri: https://www.ncbi.nlm.nih.gov/Traces/names/names.cgi
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAA5zOsWoDMRAE0D5fIUjhyma1klbS/UTAceVOWum4hCM67pQEw368z7U7VwMDw7x3
-        PMHbtqblN8vn+awJDJEXrWPAgEjBCoK2Rw1H8BeAwcAA7irAMXNxbD2jo2qcTdHFTHsUcsmJiAWQ
-        j5/5pg5T78t2UMvaeuM2q69NpXlu/7Wosa2qT3vR8nfl/kw5/ZXMiacq2lq7f4A2D5J/kNBcNAzO
-        D4hXGSmSqfuIS8aRjC+1FOMhUQ0pcHqVdAcAAP//AwC3OmTcIwEAAA==
-    headers:
-      Cache-Control:
-      - private
-      Connection:
-      - Keep-Alive
-      Content-Encoding:
-      - gzip
-      Content-Security-Policy:
-      - upgrade-insecure-requests
-      Content-Type:
-      - text/plain
-      Date:
-      - Wed, 28 Jul 2021 19:46:03 GMT
-      Keep-Alive:
-      - timeout=1, max=10
-      NCBI-PHID:
-      - C7A42F75101B3FB10000000000000001.m_1
-      NCBI-SID:
-      - C7A42F75101B3FB1_0000SID
-      Referrer-Policy:
-      - origin-when-cross-origin
-      Server:
-      - Apache
-      Set-Cookie:
-      - ncbi_sid=C7A42F75101B3FB1_0000SID; domain=.nih.gov; path=/; expires=Thu, 28
-        Jul 2022 19:46:03 GMT
-      SraNameServerOutputVersion:
-      - '2.0'
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains; preload
-      Transfer-Encoding:
-      - chunked
-      Vary:
-      - Accept-Encoding
-      X-UA-Compatible:
-      - IE=Edge
-      X-XSS-Protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
-- request:
     body: null
     headers:
       Accept:
@@ -3117,29 +2617,27 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/portal/api/filereport?accession=SRR1603667&result=read_run
   response:
     body:
-      string: "run_accession\tfastq_ftp\tfastq_bytes\tfastq_md5\tsubmitted_ftp\tsubmitted_bytes\tsubmitted_md5\tsra_ftp\tsra_bytes\tsra_md5\nSRR1603667\tftp.sra.ebi.ac.uk/vol1/fastq/SRR160/007/SRR1603667/SRR1603667.fastq.gz;ftp.sra.ebi.ac.uk/vol1/fastq/SRR160/007/SRR1603667/SRR1603667_1.fastq.gz;ftp.sra.ebi.ac.uk/vol1/fastq/SRR160/007/SRR1603667/SRR1603667_2.fastq.gz\t760314180;6805213530;6809395591\t658f2f20dcd16b96c7ff7e9d7da63635;333a0f373e628864dc005ab47e5c241c;b4e6c453e6d964c33ec48adfdce22900\t\t\t\t\t\t\n"
+      string: "run_accession\tfastq_ftp\tfastq_bytes\tfastq_md5\tbam_ftp\tbam_bytes\tbam_md5\tsubmitted_ftp\tsubmitted_bytes\tsubmitted_md5\tsra_ftp\tsra_bytes\tsra_md5\nSRR1603667\tftp.sra.ebi.ac.uk/vol1/fastq/SRR160/007/SRR1603667/SRR1603667.fastq.gz;ftp.sra.ebi.ac.uk/vol1/fastq/SRR160/007/SRR1603667/SRR1603667_1.fastq.gz;ftp.sra.ebi.ac.uk/vol1/fastq/SRR160/007/SRR1603667/SRR1603667_2.fastq.gz\t760314180;6805213530;6809395591\t658f2f20dcd16b96c7ff7e9d7da63635;333a0f373e628864dc005ab47e5c241c;b4e6c453e6d964c33ec48adfdce22900\t\t\t\t\t\t\tftp.sra.ebi.ac.uk/vol1/srr/SRR160/007/SRR1603667\t11982822684\t0c9bcd5c47c256e354a959b64a9d65a5\n"
     headers:
       Cache-Control:
       - no-cache, no-store, max-age=0, must-revalidate
+      Content-Length:
+      - '601'
       Content-Type:
       - text/plain
       Date:
-      - Wed, 28 Jul 2021 19:46:04 GMT
+      - Wed, 17 May 2023 18:38:21 GMT
       Expires:
       - '0'
       Pragma:
       - no-cache
-      Server:
-      - Apache-Coyote/1.1
       Strict-Transport-Security:
       - max-age=0
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Frame-Options:
@@ -3148,7 +2646,7 @@ interactions:
       - 1; mode=block
     status:
       code: 200
-      message: OK
+      message: ''
 - request:
     body: null
     headers:
@@ -3159,7 +2657,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/SRR1603668
   response:
@@ -3206,7 +2704,7 @@ interactions:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:46:04 GMT
+      - Wed, 17 May 2023 18:38:22 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -3224,7 +2722,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/SRX725600
   response:
@@ -3283,7 +2781,7 @@ interactions:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:46:05 GMT
+      - Wed, 17 May 2023 18:38:22 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -3301,52 +2799,45 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/SRS716934
   response:
     body:
       string: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<SAMPLE_SET>\n<SAMPLE accession=\"SRS716934\"
-        alias=\"GSM1519623\" center_name=\"GEO\" broker_name=\"NCBI\">\n     <IDENTIFIERS>\n
-        \         <PRIMARY_ID>SRS716934</PRIMARY_ID>\n          <EXTERNAL_ID namespace=\"BioSample\">SAMN03097506</EXTERNAL_ID>\n
-        \         <EXTERNAL_ID namespace=\"GEO\">GSM1519623</EXTERNAL_ID>\n     </IDENTIFIERS>\n
+        alias=\"GSM1519623\" center_name=\"Stanford University\" broker_name=\"NCBI\">\n
+        \    <IDENTIFIERS>\n          <PRIMARY_ID>SRS716934</PRIMARY_ID>\n          <EXTERNAL_ID
+        namespace=\"BioSample\">SAMN03097506</EXTERNAL_ID>\n          <SUBMITTER_ID
+        namespace=\"Stanford University\">GSM1519623</SUBMITTER_ID>\n     </IDENTIFIERS>\n
         \    <TITLE>RNA-seq of the corpus callosum #4670</TITLE>\n     <SAMPLE_NAME>\n
         \         <TAXON_ID>9606</TAXON_ID>\n          <SCIENTIFIC_NAME>Homo sapiens</SCIENTIFIC_NAME>\n
-        \    </SAMPLE_NAME>\n     <SAMPLE_LINKS>\n          <SAMPLE_LINK>\n               <XREF_LINK>\n
-        \                   <DB>ENA-STUDY</DB>\n                    <ID>SRP048683</ID>\n
-        \              </XREF_LINK>\n          </SAMPLE_LINK>\n          <SAMPLE_LINK>\n
-        \              <XREF_LINK>\n                    <DB>ENA-EXPERIMENT</DB>\n
-        \                   <ID>SRX725600</ID>\n               </XREF_LINK>\n          </SAMPLE_LINK>\n
-        \         <SAMPLE_LINK>\n               <XREF_LINK>\n                    <DB>ENA-RUN</DB>\n
-        \                   <ID>SRR1603668</ID>\n               </XREF_LINK>\n          </SAMPLE_LINK>\n
-        \         <SAMPLE_LINK>\n               <XREF_LINK>\n                    <DB>ENA-SUBMISSION</DB>\n
-        \                   <ID>SRA188845</ID>\n               </XREF_LINK>\n          </SAMPLE_LINK>\n
-        \         <SAMPLE_LINK>\n               <XREF_LINK>\n                    <DB>ARRAYEXPRESS</DB>\n
-        \                   <ID>E-GEOD-62098</ID>\n               </XREF_LINK>\n          </SAMPLE_LINK>\n
-        \         <SAMPLE_LINK>\n               <XREF_LINK>\n                    <DB>ENA-FASTQ-FILES</DB>\n
-        \                   <ID><![CDATA[https://www.ebi.ac.uk/ena/portal/api/filereport?accession=SRS716934&result=read_run&fields=run_accession,fastq_ftp,fastq_md5,fastq_bytes]]></ID>\n
-        \              </XREF_LINK>\n          </SAMPLE_LINK>\n          <SAMPLE_LINK>\n
-        \              <XREF_LINK>\n                    <DB>ENA-SUBMITTED-FILES</DB>\n
-        \                   <ID><![CDATA[https://www.ebi.ac.uk/ena/portal/api/filereport?accession=SRS716934&result=read_run&fields=run_accession,submitted_ftp,submitted_md5,submitted_bytes,submitted_format]]></ID>\n
-        \              </XREF_LINK>\n          </SAMPLE_LINK>\n     </SAMPLE_LINKS>\n
-        \    <SAMPLE_ATTRIBUTES>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>source_name</TAG>\n
-        \              <VALUE>human brain</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
-        \         <SAMPLE_ATTRIBUTE>\n               <TAG>tissue</TAG>\n               <VALUE>frozen
-        postmortem brain from NICHD</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
-        \              <TAG>disease</TAG>\n               <VALUE>not available</VALUE>\n
-        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-SPOT-COUNT</TAG>\n
-        \              <VALUE>166075695</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
-        \              <TAG>ENA-BASE-COUNT</TAG>\n               <VALUE>29040785228</VALUE>\n
-        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-FIRST-PUBLIC</TAG>\n
-        \              <VALUE>2015-03-23</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
-        \         <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-LAST-UPDATE</TAG>\n
-        \              <VALUE>2015-06-23</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
+        \         <COMMON_NAME>human</COMMON_NAME>\n     </SAMPLE_NAME>\n     <SAMPLE_LINKS>\n
+        \   <SAMPLE_LINK>\n        <XREF_LINK>\n            <DB>ENA-FASTQ-FILES</DB>\n
+        \           <ID><![CDATA[https://www.ebi.ac.uk/ena/portal/api/filereport?accession=SRS716934&result=read_run&fields=run_accession,fastq_ftp,fastq_md5,fastq_bytes]]></ID>\n
+        \       </XREF_LINK>\n    </SAMPLE_LINK>\n    <SAMPLE_LINK>\n        <XREF_LINK>\n
+        \           <DB>ENA-SUBMITTED-FILES</DB>\n            <ID><![CDATA[https://www.ebi.ac.uk/ena/portal/api/filereport?accession=SRS716934&result=read_run&fields=run_accession,submitted_ftp,submitted_md5,submitted_bytes,submitted_format]]></ID>\n
+        \       </XREF_LINK>\n    </SAMPLE_LINK>\n</SAMPLE_LINKS>\n<SAMPLE_ATTRIBUTES>\n
+        \         <SAMPLE_ATTRIBUTE>\n               <TAG>INSDC secondary accession</TAG>\n
+        \              <VALUE>SRS716934</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
+        \              <TAG>NCBI submission package</TAG>\n               <VALUE>Generic.1.0</VALUE>\n
+        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>disease</TAG>\n
+        \              <VALUE>not available</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
+        \         <SAMPLE_ATTRIBUTE>\n               <TAG>organism</TAG>\n               <VALUE>Homo
+        sapiens</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
+        \              <TAG>tissue</TAG>\n               <VALUE>frozen postmortem
+        brain from NICHD</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
+        \              <TAG>source_name</TAG>\n               <VALUE>human brain</VALUE>\n
+        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>BioSampleModel</TAG>\n
+        \              <VALUE>Generic</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
+        \              <TAG>ENA-FIRST-PUBLIC</TAG>\n               <VALUE>2015-01-01</VALUE>\n
+        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-LAST-UPDATE</TAG>\n
+        \              <VALUE>2015-01-01</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
         \    </SAMPLE_ATTRIBUTES>\n</SAMPLE>\n</SAMPLE_SET>\n"
     headers:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:46:06 GMT
+      - Wed, 17 May 2023 18:38:23 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -3364,7 +2855,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/SRP048683
   response:
@@ -3411,7 +2902,7 @@ interactions:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:46:07 GMT
+      - Wed, 17 May 2023 18:38:23 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -3429,7 +2920,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/SRA188845
   response:
@@ -3466,7 +2957,7 @@ interactions:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:46:07 GMT
+      - Wed, 17 May 2023 18:38:23 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -3475,69 +2966,6 @@ interactions:
       code: 200
       message: ''
 - request:
-    body: acc=SRR1603668&accept-proto=fasp&version=2.0
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '44'
-      User-Agent:
-      - python-requests/2.25.1
-    method: POST
-    uri: https://www.ncbi.nlm.nih.gov/Traces/names/names.cgi
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAA5zOPWrEMBBA4T6nEKTYapeZ0e/4EoHNVulGIxsnmJWxlYSADh9vnS7tgwffM13g
-        ad9k/cz99XrFADaE1BGZMLH1CToBujPCGcKN7ABhcPzWUbX4PNExFBHK4qx3XEiz2JAT9t4dQH+5
-        Lz/mNLe27iezbrVVrYt5340sS/0ei5nqZtp8hJo/Rm1/KZevklV0HjtaCMw+xvggxQeJ7A148GHA
-        g1S8jEFsUY0eo5uIrePEGVUmSUj/Jf0CAAD//wMAMjlgZiMBAAA=
-    headers:
-      Cache-Control:
-      - private
-      Connection:
-      - Keep-Alive
-      Content-Encoding:
-      - gzip
-      Content-Security-Policy:
-      - upgrade-insecure-requests
-      Content-Type:
-      - text/plain
-      Date:
-      - Wed, 28 Jul 2021 19:46:08 GMT
-      Keep-Alive:
-      - timeout=1, max=10
-      NCBI-PHID:
-      - C7A42FD2101B40010000000000000001.m_1
-      NCBI-SID:
-      - C7A42FD2101B4001_0000SID
-      Referrer-Policy:
-      - origin-when-cross-origin
-      Server:
-      - Apache
-      Set-Cookie:
-      - ncbi_sid=C7A42FD2101B4001_0000SID; domain=.nih.gov; path=/; expires=Thu, 28
-        Jul 2022 19:46:08 GMT
-      SraNameServerOutputVersion:
-      - '2.0'
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains; preload
-      Transfer-Encoding:
-      - chunked
-      Vary:
-      - Accept-Encoding
-      X-UA-Compatible:
-      - IE=Edge
-      X-XSS-Protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
-- request:
     body: null
     headers:
       Accept:
@@ -3547,29 +2975,27 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/portal/api/filereport?accession=SRR1603668&result=read_run
   response:
     body:
-      string: "run_accession\tfastq_ftp\tfastq_bytes\tfastq_md5\tsubmitted_ftp\tsubmitted_bytes\tsubmitted_md5\tsra_ftp\tsra_bytes\tsra_md5\nSRR1603668\tftp.sra.ebi.ac.uk/vol1/fastq/SRR160/008/SRR1603668/SRR1603668.fastq.gz;ftp.sra.ebi.ac.uk/vol1/fastq/SRR160/008/SRR1603668/SRR1603668_1.fastq.gz;ftp.sra.ebi.ac.uk/vol1/fastq/SRR160/008/SRR1603668/SRR1603668_2.fastq.gz\t746191256;6748922507;6789323499\t1929c6ddedde0bccd594d572548529fd;7859ec8ac9d10a54e6f9ae1249ac050a;38c8883b06c88930a116c314ea738bb1\t\t\t\t\t\t\n"
+      string: "run_accession\tfastq_ftp\tfastq_bytes\tfastq_md5\tbam_ftp\tbam_bytes\tbam_md5\tsubmitted_ftp\tsubmitted_bytes\tsubmitted_md5\tsra_ftp\tsra_bytes\tsra_md5\nSRR1603668\tftp.sra.ebi.ac.uk/vol1/fastq/SRR160/008/SRR1603668/SRR1603668.fastq.gz;ftp.sra.ebi.ac.uk/vol1/fastq/SRR160/008/SRR1603668/SRR1603668_1.fastq.gz;ftp.sra.ebi.ac.uk/vol1/fastq/SRR160/008/SRR1603668/SRR1603668_2.fastq.gz\t746191256;6748922507;6789323499\t1929c6ddedde0bccd594d572548529fd;7859ec8ac9d10a54e6f9ae1249ac050a;38c8883b06c88930a116c314ea738bb1\t\t\t\t\t\t\tftp.sra.ebi.ac.uk/vol1/srr/SRR160/008/SRR1603668\t11921893580\t1ccd5bf2160daa2ba43549d2cba36b81\n"
     headers:
       Cache-Control:
       - no-cache, no-store, max-age=0, must-revalidate
+      Content-Length:
+      - '601'
       Content-Type:
       - text/plain
       Date:
-      - Wed, 28 Jul 2021 19:46:08 GMT
+      - Wed, 17 May 2023 18:38:24 GMT
       Expires:
       - '0'
       Pragma:
       - no-cache
-      Server:
-      - Apache-Coyote/1.1
       Strict-Transport-Security:
       - max-age=0
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Frame-Options:
@@ -3578,7 +3004,7 @@ interactions:
       - 1; mode=block
     status:
       code: 200
-      message: OK
+      message: ''
 - request:
     body: null
     headers:
@@ -3589,7 +3015,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/SRR1603669
   response:
@@ -3636,7 +3062,7 @@ interactions:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:46:09 GMT
+      - Wed, 17 May 2023 18:38:25 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -3654,7 +3080,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/SRX725601
   response:
@@ -3713,7 +3139,7 @@ interactions:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:46:09 GMT
+      - Wed, 17 May 2023 18:38:25 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -3731,52 +3157,45 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/SRS716932
   response:
     body:
       string: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<SAMPLE_SET>\n<SAMPLE accession=\"SRS716932\"
-        alias=\"GSM1519624\" center_name=\"GEO\" broker_name=\"NCBI\">\n     <IDENTIFIERS>\n
-        \         <PRIMARY_ID>SRS716932</PRIMARY_ID>\n          <EXTERNAL_ID namespace=\"BioSample\">SAMN03097507</EXTERNAL_ID>\n
-        \         <EXTERNAL_ID namespace=\"GEO\">GSM1519624</EXTERNAL_ID>\n     </IDENTIFIERS>\n
+        alias=\"GSM1519624\" center_name=\"Stanford University\" broker_name=\"NCBI\">\n
+        \    <IDENTIFIERS>\n          <PRIMARY_ID>SRS716932</PRIMARY_ID>\n          <EXTERNAL_ID
+        namespace=\"BioSample\">SAMN03097507</EXTERNAL_ID>\n          <SUBMITTER_ID
+        namespace=\"Stanford University\">GSM1519624</SUBMITTER_ID>\n     </IDENTIFIERS>\n
         \    <TITLE>RNA-seq of the corpus callosum #5407</TITLE>\n     <SAMPLE_NAME>\n
         \         <TAXON_ID>9606</TAXON_ID>\n          <SCIENTIFIC_NAME>Homo sapiens</SCIENTIFIC_NAME>\n
-        \    </SAMPLE_NAME>\n     <SAMPLE_LINKS>\n          <SAMPLE_LINK>\n               <XREF_LINK>\n
-        \                   <DB>ENA-STUDY</DB>\n                    <ID>SRP048683</ID>\n
-        \              </XREF_LINK>\n          </SAMPLE_LINK>\n          <SAMPLE_LINK>\n
-        \              <XREF_LINK>\n                    <DB>ENA-EXPERIMENT</DB>\n
-        \                   <ID>SRX725601</ID>\n               </XREF_LINK>\n          </SAMPLE_LINK>\n
-        \         <SAMPLE_LINK>\n               <XREF_LINK>\n                    <DB>ENA-RUN</DB>\n
-        \                   <ID>SRR1603669</ID>\n               </XREF_LINK>\n          </SAMPLE_LINK>\n
-        \         <SAMPLE_LINK>\n               <XREF_LINK>\n                    <DB>ENA-SUBMISSION</DB>\n
-        \                   <ID>SRA188845</ID>\n               </XREF_LINK>\n          </SAMPLE_LINK>\n
-        \         <SAMPLE_LINK>\n               <XREF_LINK>\n                    <DB>ARRAYEXPRESS</DB>\n
-        \                   <ID>E-GEOD-62098</ID>\n               </XREF_LINK>\n          </SAMPLE_LINK>\n
-        \         <SAMPLE_LINK>\n               <XREF_LINK>\n                    <DB>ENA-FASTQ-FILES</DB>\n
-        \                   <ID><![CDATA[https://www.ebi.ac.uk/ena/portal/api/filereport?accession=SRS716932&result=read_run&fields=run_accession,fastq_ftp,fastq_md5,fastq_bytes]]></ID>\n
-        \              </XREF_LINK>\n          </SAMPLE_LINK>\n          <SAMPLE_LINK>\n
-        \              <XREF_LINK>\n                    <DB>ENA-SUBMITTED-FILES</DB>\n
-        \                   <ID><![CDATA[https://www.ebi.ac.uk/ena/portal/api/filereport?accession=SRS716932&result=read_run&fields=run_accession,submitted_ftp,submitted_md5,submitted_bytes,submitted_format]]></ID>\n
-        \              </XREF_LINK>\n          </SAMPLE_LINK>\n     </SAMPLE_LINKS>\n
-        \    <SAMPLE_ATTRIBUTES>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>source_name</TAG>\n
-        \              <VALUE>human brain</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
-        \         <SAMPLE_ATTRIBUTE>\n               <TAG>tissue</TAG>\n               <VALUE>frozen
-        postmortem brain from NICHD</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
-        \              <TAG>disease</TAG>\n               <VALUE>not available</VALUE>\n
-        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-SPOT-COUNT</TAG>\n
-        \              <VALUE>165948423</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
-        \              <TAG>ENA-BASE-COUNT</TAG>\n               <VALUE>28994442750</VALUE>\n
-        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-FIRST-PUBLIC</TAG>\n
-        \              <VALUE>2015-03-23</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
-        \         <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-LAST-UPDATE</TAG>\n
-        \              <VALUE>2015-06-23</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
+        \         <COMMON_NAME>human</COMMON_NAME>\n     </SAMPLE_NAME>\n     <SAMPLE_LINKS>\n
+        \   <SAMPLE_LINK>\n        <XREF_LINK>\n            <DB>ENA-FASTQ-FILES</DB>\n
+        \           <ID><![CDATA[https://www.ebi.ac.uk/ena/portal/api/filereport?accession=SRS716932&result=read_run&fields=run_accession,fastq_ftp,fastq_md5,fastq_bytes]]></ID>\n
+        \       </XREF_LINK>\n    </SAMPLE_LINK>\n    <SAMPLE_LINK>\n        <XREF_LINK>\n
+        \           <DB>ENA-SUBMITTED-FILES</DB>\n            <ID><![CDATA[https://www.ebi.ac.uk/ena/portal/api/filereport?accession=SRS716932&result=read_run&fields=run_accession,submitted_ftp,submitted_md5,submitted_bytes,submitted_format]]></ID>\n
+        \       </XREF_LINK>\n    </SAMPLE_LINK>\n</SAMPLE_LINKS>\n<SAMPLE_ATTRIBUTES>\n
+        \         <SAMPLE_ATTRIBUTE>\n               <TAG>INSDC secondary accession</TAG>\n
+        \              <VALUE>SRS716932</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
+        \              <TAG>NCBI submission package</TAG>\n               <VALUE>Generic.1.0</VALUE>\n
+        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>disease</TAG>\n
+        \              <VALUE>not available</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
+        \         <SAMPLE_ATTRIBUTE>\n               <TAG>organism</TAG>\n               <VALUE>Homo
+        sapiens</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
+        \              <TAG>tissue</TAG>\n               <VALUE>frozen postmortem
+        brain from NICHD</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
+        \              <TAG>source_name</TAG>\n               <VALUE>human brain</VALUE>\n
+        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>BioSampleModel</TAG>\n
+        \              <VALUE>Generic</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
+        \              <TAG>ENA-FIRST-PUBLIC</TAG>\n               <VALUE>2015-01-01</VALUE>\n
+        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-LAST-UPDATE</TAG>\n
+        \              <VALUE>2015-01-01</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
         \    </SAMPLE_ATTRIBUTES>\n</SAMPLE>\n</SAMPLE_SET>\n"
     headers:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:46:10 GMT
+      - Wed, 17 May 2023 18:38:25 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -3794,7 +3213,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/SRP048683
   response:
@@ -3841,7 +3260,7 @@ interactions:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:46:10 GMT
+      - Wed, 17 May 2023 18:38:25 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -3859,7 +3278,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/SRA188845
   response:
@@ -3896,7 +3315,7 @@ interactions:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:46:11 GMT
+      - Wed, 17 May 2023 18:38:26 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -3905,69 +3324,6 @@ interactions:
       code: 200
       message: ''
 - request:
-    body: acc=SRR1603669&accept-proto=fasp&version=2.0
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '44'
-      User-Agent:
-      - python-requests/2.25.1
-    method: POST
-    uri: https://www.ncbi.nlm.nih.gov/Traces/names/names.cgi
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAA5zOu07DQBCF4Z6nWIkiVaKZ2fFe/BJIIVW62YtlkMVa9gJCmofHqelojn6d6num
-        Czztm6yfSV+vV3RgnYuKGI4EP/ioBMhnhDO4G9FoccThrrUMkSZiF10KkaWwl1wkO8w14kSqygD6
-        8rH8mNPc+7qfzLq13nJbzNtuZFnady1mapvp83G09F5z/0u5fJWUJc9V0QZmT8HCg+QfJLI3CCPT
-        iHRXyM6zSArABTyRq8JWxOKxrmb5L+kXAAD//wMABzwKSCMBAAA=
-    headers:
-      Cache-Control:
-      - private
-      Connection:
-      - Keep-Alive
-      Content-Encoding:
-      - gzip
-      Content-Security-Policy:
-      - upgrade-insecure-requests
-      Content-Type:
-      - text/plain
-      Date:
-      - Wed, 28 Jul 2021 19:46:12 GMT
-      Keep-Alive:
-      - timeout=1, max=10
-      NCBI-PHID:
-      - CC9501E2101B40410000000000000001.m_1
-      NCBI-SID:
-      - CC9501E2101B4041_0000SID
-      Referrer-Policy:
-      - origin-when-cross-origin
-      Server:
-      - Apache
-      Set-Cookie:
-      - ncbi_sid=CC9501E2101B4041_0000SID; domain=.nih.gov; path=/; expires=Thu, 28
-        Jul 2022 19:46:12 GMT
-      SraNameServerOutputVersion:
-      - '2.0'
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains; preload
-      Transfer-Encoding:
-      - chunked
-      Vary:
-      - Accept-Encoding
-      X-UA-Compatible:
-      - IE=Edge
-      X-XSS-Protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
-- request:
     body: null
     headers:
       Accept:
@@ -3977,29 +3333,27 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/portal/api/filereport?accession=SRR1603669&result=read_run
   response:
     body:
-      string: "run_accession\tfastq_ftp\tfastq_bytes\tfastq_md5\tsubmitted_ftp\tsubmitted_bytes\tsubmitted_md5\tsra_ftp\tsra_bytes\tsra_md5\nSRR1603669\tftp.sra.ebi.ac.uk/vol1/fastq/SRR160/009/SRR1603669/SRR1603669.fastq.gz;ftp.sra.ebi.ac.uk/vol1/fastq/SRR160/009/SRR1603669/SRR1603669_1.fastq.gz;ftp.sra.ebi.ac.uk/vol1/fastq/SRR160/009/SRR1603669/SRR1603669_2.fastq.gz\t740881940;6633314923;6798374768\te796f40ceb70b3cd1dc0a9a542859b48;aa894e681310d52d109c9cd827e2bbc8;963d262188a629d68131281893e0f569\t\t\t\t\t\t\n"
+      string: "run_accession\tfastq_ftp\tfastq_bytes\tfastq_md5\tbam_ftp\tbam_bytes\tbam_md5\tsubmitted_ftp\tsubmitted_bytes\tsubmitted_md5\tsra_ftp\tsra_bytes\tsra_md5\nSRR1603669\tftp.sra.ebi.ac.uk/vol1/fastq/SRR160/009/SRR1603669/SRR1603669.fastq.gz;ftp.sra.ebi.ac.uk/vol1/fastq/SRR160/009/SRR1603669/SRR1603669_1.fastq.gz;ftp.sra.ebi.ac.uk/vol1/fastq/SRR160/009/SRR1603669/SRR1603669_2.fastq.gz\t740881940;6633314923;6798374768\te796f40ceb70b3cd1dc0a9a542859b48;aa894e681310d52d109c9cd827e2bbc8;963d262188a629d68131281893e0f569\t\t\t\t\t\t\tftp.sra.ebi.ac.uk/vol1/srr/SRR160/009/SRR1603669\t11816007579\ted592f24696b894ad47acdac61ce91f2\n"
     headers:
       Cache-Control:
       - no-cache, no-store, max-age=0, must-revalidate
+      Content-Length:
+      - '601'
       Content-Type:
       - text/plain
       Date:
-      - Wed, 28 Jul 2021 19:46:12 GMT
+      - Wed, 17 May 2023 18:38:27 GMT
       Expires:
       - '0'
       Pragma:
       - no-cache
-      Server:
-      - Apache-Coyote/1.1
       Strict-Transport-Security:
       - max-age=0
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Frame-Options:
@@ -4008,7 +3362,7 @@ interactions:
       - 1; mode=block
     status:
       code: 200
-      message: OK
+      message: ''
 - request:
     body: null
     headers:
@@ -4019,7 +3373,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/SRR1603670
   response:
@@ -4066,7 +3420,7 @@ interactions:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:46:13 GMT
+      - Wed, 17 May 2023 18:38:27 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -4084,7 +3438,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/SRX725602
   response:
@@ -4143,7 +3497,7 @@ interactions:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:46:14 GMT
+      - Wed, 17 May 2023 18:38:27 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -4161,52 +3515,45 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/SRS716933
   response:
     body:
       string: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<SAMPLE_SET>\n<SAMPLE accession=\"SRS716933\"
-        alias=\"GSM1519625\" center_name=\"GEO\" broker_name=\"NCBI\">\n     <IDENTIFIERS>\n
-        \         <PRIMARY_ID>SRS716933</PRIMARY_ID>\n          <EXTERNAL_ID namespace=\"BioSample\">SAMN03097508</EXTERNAL_ID>\n
-        \         <EXTERNAL_ID namespace=\"GEO\">GSM1519625</EXTERNAL_ID>\n     </IDENTIFIERS>\n
+        alias=\"GSM1519625\" center_name=\"Stanford University\" broker_name=\"NCBI\">\n
+        \    <IDENTIFIERS>\n          <PRIMARY_ID>SRS716933</PRIMARY_ID>\n          <EXTERNAL_ID
+        namespace=\"BioSample\">SAMN03097508</EXTERNAL_ID>\n          <SUBMITTER_ID
+        namespace=\"Stanford University\">GSM1519625</SUBMITTER_ID>\n     </IDENTIFIERS>\n
         \    <TITLE>RNA-seq of the corpus callosum #4999</TITLE>\n     <SAMPLE_NAME>\n
         \         <TAXON_ID>9606</TAXON_ID>\n          <SCIENTIFIC_NAME>Homo sapiens</SCIENTIFIC_NAME>\n
-        \    </SAMPLE_NAME>\n     <SAMPLE_LINKS>\n          <SAMPLE_LINK>\n               <XREF_LINK>\n
-        \                   <DB>ENA-STUDY</DB>\n                    <ID>SRP048683</ID>\n
-        \              </XREF_LINK>\n          </SAMPLE_LINK>\n          <SAMPLE_LINK>\n
-        \              <XREF_LINK>\n                    <DB>ENA-EXPERIMENT</DB>\n
-        \                   <ID>SRX725602</ID>\n               </XREF_LINK>\n          </SAMPLE_LINK>\n
-        \         <SAMPLE_LINK>\n               <XREF_LINK>\n                    <DB>ENA-RUN</DB>\n
-        \                   <ID>SRR1603670</ID>\n               </XREF_LINK>\n          </SAMPLE_LINK>\n
-        \         <SAMPLE_LINK>\n               <XREF_LINK>\n                    <DB>ENA-SUBMISSION</DB>\n
-        \                   <ID>SRA188845</ID>\n               </XREF_LINK>\n          </SAMPLE_LINK>\n
-        \         <SAMPLE_LINK>\n               <XREF_LINK>\n                    <DB>ARRAYEXPRESS</DB>\n
-        \                   <ID>E-GEOD-62098</ID>\n               </XREF_LINK>\n          </SAMPLE_LINK>\n
-        \         <SAMPLE_LINK>\n               <XREF_LINK>\n                    <DB>ENA-FASTQ-FILES</DB>\n
-        \                   <ID><![CDATA[https://www.ebi.ac.uk/ena/portal/api/filereport?accession=SRS716933&result=read_run&fields=run_accession,fastq_ftp,fastq_md5,fastq_bytes]]></ID>\n
-        \              </XREF_LINK>\n          </SAMPLE_LINK>\n          <SAMPLE_LINK>\n
-        \              <XREF_LINK>\n                    <DB>ENA-SUBMITTED-FILES</DB>\n
-        \                   <ID><![CDATA[https://www.ebi.ac.uk/ena/portal/api/filereport?accession=SRS716933&result=read_run&fields=run_accession,submitted_ftp,submitted_md5,submitted_bytes,submitted_format]]></ID>\n
-        \              </XREF_LINK>\n          </SAMPLE_LINK>\n     </SAMPLE_LINKS>\n
-        \    <SAMPLE_ATTRIBUTES>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>source_name</TAG>\n
-        \              <VALUE>human brain</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
-        \         <SAMPLE_ATTRIBUTE>\n               <TAG>tissue</TAG>\n               <VALUE>frozen
-        postmortem brain from NICHD</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
-        \              <TAG>disease</TAG>\n               <VALUE>autism spectrum disorder</VALUE>\n
-        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-SPOT-COUNT</TAG>\n
-        \              <VALUE>176741134</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
-        \              <TAG>ENA-BASE-COUNT</TAG>\n               <VALUE>30790991868</VALUE>\n
-        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-FIRST-PUBLIC</TAG>\n
-        \              <VALUE>2015-03-23</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
-        \         <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-LAST-UPDATE</TAG>\n
-        \              <VALUE>2015-06-23</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
+        \         <COMMON_NAME>human</COMMON_NAME>\n     </SAMPLE_NAME>\n     <SAMPLE_LINKS>\n
+        \   <SAMPLE_LINK>\n        <XREF_LINK>\n            <DB>ENA-FASTQ-FILES</DB>\n
+        \           <ID><![CDATA[https://www.ebi.ac.uk/ena/portal/api/filereport?accession=SRS716933&result=read_run&fields=run_accession,fastq_ftp,fastq_md5,fastq_bytes]]></ID>\n
+        \       </XREF_LINK>\n    </SAMPLE_LINK>\n    <SAMPLE_LINK>\n        <XREF_LINK>\n
+        \           <DB>ENA-SUBMITTED-FILES</DB>\n            <ID><![CDATA[https://www.ebi.ac.uk/ena/portal/api/filereport?accession=SRS716933&result=read_run&fields=run_accession,submitted_ftp,submitted_md5,submitted_bytes,submitted_format]]></ID>\n
+        \       </XREF_LINK>\n    </SAMPLE_LINK>\n</SAMPLE_LINKS>\n<SAMPLE_ATTRIBUTES>\n
+        \         <SAMPLE_ATTRIBUTE>\n               <TAG>INSDC secondary accession</TAG>\n
+        \              <VALUE>SRS716933</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
+        \              <TAG>NCBI submission package</TAG>\n               <VALUE>Generic.1.0</VALUE>\n
+        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>disease</TAG>\n
+        \              <VALUE>autism spectrum disorder</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
+        \         <SAMPLE_ATTRIBUTE>\n               <TAG>organism</TAG>\n               <VALUE>Homo
+        sapiens</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
+        \              <TAG>tissue</TAG>\n               <VALUE>frozen postmortem
+        brain from NICHD</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
+        \              <TAG>source_name</TAG>\n               <VALUE>human brain</VALUE>\n
+        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>BioSampleModel</TAG>\n
+        \              <VALUE>Generic</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
+        \              <TAG>ENA-FIRST-PUBLIC</TAG>\n               <VALUE>2015-01-01</VALUE>\n
+        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-LAST-UPDATE</TAG>\n
+        \              <VALUE>2015-01-01</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
         \    </SAMPLE_ATTRIBUTES>\n</SAMPLE>\n</SAMPLE_SET>\n"
     headers:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:46:13 GMT
+      - Wed, 17 May 2023 18:38:27 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -4224,7 +3571,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/SRP048683
   response:
@@ -4271,7 +3618,7 @@ interactions:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:46:14 GMT
+      - Wed, 17 May 2023 18:38:28 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -4289,7 +3636,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/SRA188845
   response:
@@ -4326,7 +3673,7 @@ interactions:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:46:14 GMT
+      - Wed, 17 May 2023 18:38:28 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -4335,69 +3682,6 @@ interactions:
       code: 200
       message: ''
 - request:
-    body: acc=SRR1603670&accept-proto=fasp&version=2.0
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '44'
-      User-Agent:
-      - python-requests/2.25.1
-    method: POST
-    uri: https://www.ncbi.nlm.nih.gov/Traces/names/names.cgi
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAA5zOvW7CMBRA4b1PYakDE+j+2L5OXqISZWKzHUcBRXWUGCqk+/DA3K3b0Zm+TzrA
-        x7bG5Zb0+3hED+wFFBmI0TO/mgDtHmEP/kTUM/coZ3URaHAudJGAkhCDjN6KZZd8GaJTVQugXz/z
-        w+ym1pZtZ5a1tprrbC6bifNcf8tgxrqaNr1GTdeS21/K4T6kHPNUFB1KoK4TfpPkTSI+Qehd6AnP
-        WgJ6zGUsriSUhBTGAC5TROtTkn+TngAAAP//AwC/Hb8rIwEAAA==
-    headers:
-      Cache-Control:
-      - private
-      Connection:
-      - Keep-Alive
-      Content-Encoding:
-      - gzip
-      Content-Security-Policy:
-      - upgrade-insecure-requests
-      Content-Type:
-      - text/plain
-      Date:
-      - Wed, 28 Jul 2021 19:46:15 GMT
-      Keep-Alive:
-      - timeout=1, max=10
-      NCBI-PHID:
-      - CC95022E101B40810000000000000001.m_1
-      NCBI-SID:
-      - CC95022E101B4081_0000SID
-      Referrer-Policy:
-      - origin-when-cross-origin
-      Server:
-      - Apache
-      Set-Cookie:
-      - ncbi_sid=CC95022E101B4081_0000SID; domain=.nih.gov; path=/; expires=Thu, 28
-        Jul 2022 19:46:16 GMT
-      SraNameServerOutputVersion:
-      - '2.0'
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains; preload
-      Transfer-Encoding:
-      - chunked
-      Vary:
-      - Accept-Encoding
-      X-UA-Compatible:
-      - IE=Edge
-      X-XSS-Protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
-- request:
     body: null
     headers:
       Accept:
@@ -4407,29 +3691,27 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/portal/api/filereport?accession=SRR1603670&result=read_run
   response:
     body:
-      string: "run_accession\tfastq_ftp\tfastq_bytes\tfastq_md5\tsubmitted_ftp\tsubmitted_bytes\tsubmitted_md5\tsra_ftp\tsra_bytes\tsra_md5\nSRR1603670\tftp.sra.ebi.ac.uk/vol1/fastq/SRR160/000/SRR1603670/SRR1603670.fastq.gz;ftp.sra.ebi.ac.uk/vol1/fastq/SRR160/000/SRR1603670/SRR1603670_1.fastq.gz;ftp.sra.ebi.ac.uk/vol1/fastq/SRR160/000/SRR1603670/SRR1603670_2.fastq.gz\t867311136;7337073265;7405687750\t2b6346b111fd7b6767b5703771c05312;0cf4bd30cd674d940b5ecb1b816c2e6f;4f1f26d76abae3ef698f4c552456a54d\t\t\t\t\t\t\n"
+      string: "run_accession\tfastq_ftp\tfastq_bytes\tfastq_md5\tbam_ftp\tbam_bytes\tbam_md5\tsubmitted_ftp\tsubmitted_bytes\tsubmitted_md5\tsra_ftp\tsra_bytes\tsra_md5\nSRR1603670\tftp.sra.ebi.ac.uk/vol1/fastq/SRR160/000/SRR1603670/SRR1603670.fastq.gz;ftp.sra.ebi.ac.uk/vol1/fastq/SRR160/000/SRR1603670/SRR1603670_1.fastq.gz;ftp.sra.ebi.ac.uk/vol1/fastq/SRR160/000/SRR1603670/SRR1603670_2.fastq.gz\t867311136;7337073265;7405687750\t2b6346b111fd7b6767b5703771c05312;0cf4bd30cd674d940b5ecb1b816c2e6f;4f1f26d76abae3ef698f4c552456a54d\t\t\t\t\t\t\tftp.sra.ebi.ac.uk/vol1/srr/SRR160/000/SRR1603670\t13023163370\t5a02d5589a202b72307f647435b6eda5\n"
     headers:
       Cache-Control:
       - no-cache, no-store, max-age=0, must-revalidate
+      Content-Length:
+      - '601'
       Content-Type:
       - text/plain
       Date:
-      - Wed, 28 Jul 2021 19:46:21 GMT
+      - Wed, 17 May 2023 18:38:29 GMT
       Expires:
       - '0'
       Pragma:
       - no-cache
-      Server:
-      - Apache-Coyote/1.1
       Strict-Transport-Security:
       - max-age=0
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Frame-Options:
@@ -4438,7 +3720,7 @@ interactions:
       - 1; mode=block
     status:
       code: 200
-      message: OK
+      message: ''
 - request:
     body: null
     headers:
@@ -4449,7 +3731,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/SRR1603671
   response:
@@ -4496,7 +3778,7 @@ interactions:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:46:21 GMT
+      - Wed, 17 May 2023 18:38:29 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -4514,7 +3796,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/SRX725603
   response:
@@ -4573,7 +3855,7 @@ interactions:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:46:22 GMT
+      - Wed, 17 May 2023 18:38:29 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -4591,52 +3873,45 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/SRS716935
   response:
     body:
       string: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<SAMPLE_SET>\n<SAMPLE accession=\"SRS716935\"
-        alias=\"GSM1519626\" center_name=\"GEO\" broker_name=\"NCBI\">\n     <IDENTIFIERS>\n
-        \         <PRIMARY_ID>SRS716935</PRIMARY_ID>\n          <EXTERNAL_ID namespace=\"BioSample\">SAMN03097509</EXTERNAL_ID>\n
-        \         <EXTERNAL_ID namespace=\"GEO\">GSM1519626</EXTERNAL_ID>\n     </IDENTIFIERS>\n
+        alias=\"GSM1519626\" center_name=\"Stanford University\" broker_name=\"NCBI\">\n
+        \    <IDENTIFIERS>\n          <PRIMARY_ID>SRS716935</PRIMARY_ID>\n          <EXTERNAL_ID
+        namespace=\"BioSample\">SAMN03097509</EXTERNAL_ID>\n          <SUBMITTER_ID
+        namespace=\"Stanford University\">GSM1519626</SUBMITTER_ID>\n     </IDENTIFIERS>\n
         \    <TITLE>RNA-seq of the corpus callosum #5302</TITLE>\n     <SAMPLE_NAME>\n
         \         <TAXON_ID>9606</TAXON_ID>\n          <SCIENTIFIC_NAME>Homo sapiens</SCIENTIFIC_NAME>\n
-        \    </SAMPLE_NAME>\n     <SAMPLE_LINKS>\n          <SAMPLE_LINK>\n               <XREF_LINK>\n
-        \                   <DB>ENA-STUDY</DB>\n                    <ID>SRP048683</ID>\n
-        \              </XREF_LINK>\n          </SAMPLE_LINK>\n          <SAMPLE_LINK>\n
-        \              <XREF_LINK>\n                    <DB>ENA-EXPERIMENT</DB>\n
-        \                   <ID>SRX725603</ID>\n               </XREF_LINK>\n          </SAMPLE_LINK>\n
-        \         <SAMPLE_LINK>\n               <XREF_LINK>\n                    <DB>ENA-RUN</DB>\n
-        \                   <ID>SRR1603671</ID>\n               </XREF_LINK>\n          </SAMPLE_LINK>\n
-        \         <SAMPLE_LINK>\n               <XREF_LINK>\n                    <DB>ENA-SUBMISSION</DB>\n
-        \                   <ID>SRA188845</ID>\n               </XREF_LINK>\n          </SAMPLE_LINK>\n
-        \         <SAMPLE_LINK>\n               <XREF_LINK>\n                    <DB>ARRAYEXPRESS</DB>\n
-        \                   <ID>E-GEOD-62098</ID>\n               </XREF_LINK>\n          </SAMPLE_LINK>\n
-        \         <SAMPLE_LINK>\n               <XREF_LINK>\n                    <DB>ENA-FASTQ-FILES</DB>\n
-        \                   <ID><![CDATA[https://www.ebi.ac.uk/ena/portal/api/filereport?accession=SRS716935&result=read_run&fields=run_accession,fastq_ftp,fastq_md5,fastq_bytes]]></ID>\n
-        \              </XREF_LINK>\n          </SAMPLE_LINK>\n          <SAMPLE_LINK>\n
-        \              <XREF_LINK>\n                    <DB>ENA-SUBMITTED-FILES</DB>\n
-        \                   <ID><![CDATA[https://www.ebi.ac.uk/ena/portal/api/filereport?accession=SRS716935&result=read_run&fields=run_accession,submitted_ftp,submitted_md5,submitted_bytes,submitted_format]]></ID>\n
-        \              </XREF_LINK>\n          </SAMPLE_LINK>\n     </SAMPLE_LINKS>\n
-        \    <SAMPLE_ATTRIBUTES>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>source_name</TAG>\n
-        \              <VALUE>human brain</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
-        \         <SAMPLE_ATTRIBUTE>\n               <TAG>tissue</TAG>\n               <VALUE>frozen
-        postmortem brain from NICHD</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
-        \              <TAG>disease</TAG>\n               <VALUE>autism spectrum disorder</VALUE>\n
-        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-SPOT-COUNT</TAG>\n
-        \              <VALUE>160334858</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
-        \              <TAG>ENA-BASE-COUNT</TAG>\n               <VALUE>27850705155</VALUE>\n
-        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-FIRST-PUBLIC</TAG>\n
-        \              <VALUE>2015-03-23</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
-        \         <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-LAST-UPDATE</TAG>\n
-        \              <VALUE>2015-06-23</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
+        \         <COMMON_NAME>human</COMMON_NAME>\n     </SAMPLE_NAME>\n     <SAMPLE_LINKS>\n
+        \   <SAMPLE_LINK>\n        <XREF_LINK>\n            <DB>ENA-FASTQ-FILES</DB>\n
+        \           <ID><![CDATA[https://www.ebi.ac.uk/ena/portal/api/filereport?accession=SRS716935&result=read_run&fields=run_accession,fastq_ftp,fastq_md5,fastq_bytes]]></ID>\n
+        \       </XREF_LINK>\n    </SAMPLE_LINK>\n    <SAMPLE_LINK>\n        <XREF_LINK>\n
+        \           <DB>ENA-SUBMITTED-FILES</DB>\n            <ID><![CDATA[https://www.ebi.ac.uk/ena/portal/api/filereport?accession=SRS716935&result=read_run&fields=run_accession,submitted_ftp,submitted_md5,submitted_bytes,submitted_format]]></ID>\n
+        \       </XREF_LINK>\n    </SAMPLE_LINK>\n</SAMPLE_LINKS>\n<SAMPLE_ATTRIBUTES>\n
+        \         <SAMPLE_ATTRIBUTE>\n               <TAG>INSDC secondary accession</TAG>\n
+        \              <VALUE>SRS716935</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
+        \              <TAG>NCBI submission package</TAG>\n               <VALUE>Generic.1.0</VALUE>\n
+        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>disease</TAG>\n
+        \              <VALUE>autism spectrum disorder</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
+        \         <SAMPLE_ATTRIBUTE>\n               <TAG>organism</TAG>\n               <VALUE>Homo
+        sapiens</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
+        \              <TAG>tissue</TAG>\n               <VALUE>frozen postmortem
+        brain from NICHD</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
+        \              <TAG>source_name</TAG>\n               <VALUE>human brain</VALUE>\n
+        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>BioSampleModel</TAG>\n
+        \              <VALUE>Generic</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
+        \              <TAG>ENA-FIRST-PUBLIC</TAG>\n               <VALUE>2015-01-01</VALUE>\n
+        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-LAST-UPDATE</TAG>\n
+        \              <VALUE>2015-01-01</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
         \    </SAMPLE_ATTRIBUTES>\n</SAMPLE>\n</SAMPLE_SET>\n"
     headers:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:46:22 GMT
+      - Wed, 17 May 2023 18:38:30 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -4654,7 +3929,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/SRP048683
   response:
@@ -4701,7 +3976,7 @@ interactions:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:46:24 GMT
+      - Wed, 17 May 2023 18:38:30 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -4719,7 +3994,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/SRA188845
   response:
@@ -4756,7 +4031,7 @@ interactions:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:46:24 GMT
+      - Wed, 17 May 2023 18:38:30 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -4765,69 +4040,6 @@ interactions:
       code: 200
       message: ''
 - request:
-    body: acc=SRR1603671&accept-proto=fasp&version=2.0
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '44'
-      User-Agent:
-      - python-requests/2.25.1
-    method: POST
-    uri: https://www.ncbi.nlm.nih.gov/Traces/names/names.cgi
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAA5zOu27DMAyF4b1PIaBDpgQkRUuKX6JAmimbLhTcwqgMW0lRgA9fZ+7W7eAfDr5X
-        OsHLtsblnvT9ckEH1nlURKIhkGVnlQD5iHAEdyUaCUccbpqrELokMRQvHkKwIAgAnFNixqqqDKBv
-        X/OPOUy9L9vBLGvrLbfZfGwmznP7lmJqW02f9tDSp+T+l3J6lJRjnkSRPQfYX/2T5J8kslcI43Ae
-        yd40Cbnq/NkVSvu2nKnWGCKAgyJF/kv6BQAA//8DAKotCFkjAQAA
-    headers:
-      Cache-Control:
-      - private
-      Connection:
-      - Keep-Alive
-      Content-Encoding:
-      - gzip
-      Content-Security-Policy:
-      - upgrade-insecure-requests
-      Content-Type:
-      - text/plain
-      Date:
-      - Wed, 28 Jul 2021 19:46:24 GMT
-      Keep-Alive:
-      - timeout=1, max=10
-      NCBI-PHID:
-      - C7A4309F101B41010000000000000001.m_1
-      NCBI-SID:
-      - C7A4309F101B4101_0000SID
-      Referrer-Policy:
-      - origin-when-cross-origin
-      Server:
-      - Apache
-      Set-Cookie:
-      - ncbi_sid=C7A4309F101B4101_0000SID; domain=.nih.gov; path=/; expires=Thu, 28
-        Jul 2022 19:46:24 GMT
-      SraNameServerOutputVersion:
-      - '2.0'
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains; preload
-      Transfer-Encoding:
-      - chunked
-      Vary:
-      - Accept-Encoding
-      X-UA-Compatible:
-      - IE=Edge
-      X-XSS-Protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
-- request:
     body: null
     headers:
       Accept:
@@ -4837,29 +4049,27 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/portal/api/filereport?accession=SRR1603671&result=read_run
   response:
     body:
-      string: "run_accession\tfastq_ftp\tfastq_bytes\tfastq_md5\tsubmitted_ftp\tsubmitted_bytes\tsubmitted_md5\tsra_ftp\tsra_bytes\tsra_md5\nSRR1603671\tftp.sra.ebi.ac.uk/vol1/fastq/SRR160/001/SRR1603671/SRR1603671.fastq.gz;ftp.sra.ebi.ac.uk/vol1/fastq/SRR160/001/SRR1603671/SRR1603671_1.fastq.gz;ftp.sra.ebi.ac.uk/vol1/fastq/SRR160/001/SRR1603671/SRR1603671_2.fastq.gz\t819349138;6452549543;6449393711\tba486058bffc91225b827a35e209657c;b1ebed75e329fcf4f428cd91b383a0e7;c83664b7dc22a679de808221216e63ea\t\t\t\t\t\t\n"
+      string: "run_accession\tfastq_ftp\tfastq_bytes\tfastq_md5\tbam_ftp\tbam_bytes\tbam_md5\tsubmitted_ftp\tsubmitted_bytes\tsubmitted_md5\tsra_ftp\tsra_bytes\tsra_md5\nSRR1603671\tftp.sra.ebi.ac.uk/vol1/fastq/SRR160/001/SRR1603671/SRR1603671.fastq.gz;ftp.sra.ebi.ac.uk/vol1/fastq/SRR160/001/SRR1603671/SRR1603671_1.fastq.gz;ftp.sra.ebi.ac.uk/vol1/fastq/SRR160/001/SRR1603671/SRR1603671_2.fastq.gz\t819349138;6452549543;6449393711\tba486058bffc91225b827a35e209657c;b1ebed75e329fcf4f428cd91b383a0e7;c83664b7dc22a679de808221216e63ea\t\t\t\t\t\t\tftp.sra.ebi.ac.uk/vol1/srr/SRR160/001/SRR1603671\t11225823463\tcfe216bea8d7e708830e10004cbb441f\n"
     headers:
       Cache-Control:
       - no-cache, no-store, max-age=0, must-revalidate
+      Content-Length:
+      - '601'
       Content-Type:
       - text/plain
       Date:
-      - Wed, 28 Jul 2021 19:46:24 GMT
+      - Wed, 17 May 2023 18:38:31 GMT
       Expires:
       - '0'
       Pragma:
       - no-cache
-      Server:
-      - Apache-Coyote/1.1
       Strict-Transport-Security:
       - max-age=0
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Frame-Options:
@@ -4868,7 +4078,7 @@ interactions:
       - 1; mode=block
     status:
       code: 200
-      message: OK
+      message: ''
 - request:
     body: null
     headers:
@@ -4879,7 +4089,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/SRR1603672
   response:
@@ -4926,7 +4136,7 @@ interactions:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:46:26 GMT
+      - Wed, 17 May 2023 18:38:31 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -4944,7 +4154,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/SRX725604
   response:
@@ -5003,7 +4213,7 @@ interactions:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:46:26 GMT
+      - Wed, 17 May 2023 18:38:32 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -5021,52 +4231,45 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/SRS716936
   response:
     body:
       string: "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<SAMPLE_SET>\n<SAMPLE accession=\"SRS716936\"
-        alias=\"GSM1519627\" center_name=\"GEO\" broker_name=\"NCBI\">\n     <IDENTIFIERS>\n
-        \         <PRIMARY_ID>SRS716936</PRIMARY_ID>\n          <EXTERNAL_ID namespace=\"BioSample\">SAMN03097510</EXTERNAL_ID>\n
-        \         <EXTERNAL_ID namespace=\"GEO\">GSM1519627</EXTERNAL_ID>\n     </IDENTIFIERS>\n
+        alias=\"GSM1519627\" center_name=\"Stanford University\" broker_name=\"NCBI\">\n
+        \    <IDENTIFIERS>\n          <PRIMARY_ID>SRS716936</PRIMARY_ID>\n          <EXTERNAL_ID
+        namespace=\"BioSample\">SAMN03097510</EXTERNAL_ID>\n          <SUBMITTER_ID
+        namespace=\"Stanford University\">GSM1519627</SUBMITTER_ID>\n     </IDENTIFIERS>\n
         \    <TITLE>RNA-seq of the corpus callosum #5403</TITLE>\n     <SAMPLE_NAME>\n
         \         <TAXON_ID>9606</TAXON_ID>\n          <SCIENTIFIC_NAME>Homo sapiens</SCIENTIFIC_NAME>\n
-        \    </SAMPLE_NAME>\n     <SAMPLE_LINKS>\n          <SAMPLE_LINK>\n               <XREF_LINK>\n
-        \                   <DB>ENA-STUDY</DB>\n                    <ID>SRP048683</ID>\n
-        \              </XREF_LINK>\n          </SAMPLE_LINK>\n          <SAMPLE_LINK>\n
-        \              <XREF_LINK>\n                    <DB>ENA-EXPERIMENT</DB>\n
-        \                   <ID>SRX725604</ID>\n               </XREF_LINK>\n          </SAMPLE_LINK>\n
-        \         <SAMPLE_LINK>\n               <XREF_LINK>\n                    <DB>ENA-RUN</DB>\n
-        \                   <ID>SRR1603672</ID>\n               </XREF_LINK>\n          </SAMPLE_LINK>\n
-        \         <SAMPLE_LINK>\n               <XREF_LINK>\n                    <DB>ENA-SUBMISSION</DB>\n
-        \                   <ID>SRA188845</ID>\n               </XREF_LINK>\n          </SAMPLE_LINK>\n
-        \         <SAMPLE_LINK>\n               <XREF_LINK>\n                    <DB>ARRAYEXPRESS</DB>\n
-        \                   <ID>E-GEOD-62098</ID>\n               </XREF_LINK>\n          </SAMPLE_LINK>\n
-        \         <SAMPLE_LINK>\n               <XREF_LINK>\n                    <DB>ENA-FASTQ-FILES</DB>\n
-        \                   <ID><![CDATA[https://www.ebi.ac.uk/ena/portal/api/filereport?accession=SRS716936&result=read_run&fields=run_accession,fastq_ftp,fastq_md5,fastq_bytes]]></ID>\n
-        \              </XREF_LINK>\n          </SAMPLE_LINK>\n          <SAMPLE_LINK>\n
-        \              <XREF_LINK>\n                    <DB>ENA-SUBMITTED-FILES</DB>\n
-        \                   <ID><![CDATA[https://www.ebi.ac.uk/ena/portal/api/filereport?accession=SRS716936&result=read_run&fields=run_accession,submitted_ftp,submitted_md5,submitted_bytes,submitted_format]]></ID>\n
-        \              </XREF_LINK>\n          </SAMPLE_LINK>\n     </SAMPLE_LINKS>\n
-        \    <SAMPLE_ATTRIBUTES>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>source_name</TAG>\n
-        \              <VALUE>human brain</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
-        \         <SAMPLE_ATTRIBUTE>\n               <TAG>tissue</TAG>\n               <VALUE>frozen
-        postmortem brain from NICHD</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
-        \              <TAG>disease</TAG>\n               <VALUE>autism spectrum disorder</VALUE>\n
-        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-SPOT-COUNT</TAG>\n
-        \              <VALUE>173441471</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
-        \              <TAG>ENA-BASE-COUNT</TAG>\n               <VALUE>30240407743</VALUE>\n
-        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-FIRST-PUBLIC</TAG>\n
-        \              <VALUE>2015-03-23</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
-        \         <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-LAST-UPDATE</TAG>\n
-        \              <VALUE>2015-06-23</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
+        \         <COMMON_NAME>human</COMMON_NAME>\n     </SAMPLE_NAME>\n     <SAMPLE_LINKS>\n
+        \   <SAMPLE_LINK>\n        <XREF_LINK>\n            <DB>ENA-FASTQ-FILES</DB>\n
+        \           <ID><![CDATA[https://www.ebi.ac.uk/ena/portal/api/filereport?accession=SRS716936&result=read_run&fields=run_accession,fastq_ftp,fastq_md5,fastq_bytes]]></ID>\n
+        \       </XREF_LINK>\n    </SAMPLE_LINK>\n    <SAMPLE_LINK>\n        <XREF_LINK>\n
+        \           <DB>ENA-SUBMITTED-FILES</DB>\n            <ID><![CDATA[https://www.ebi.ac.uk/ena/portal/api/filereport?accession=SRS716936&result=read_run&fields=run_accession,submitted_ftp,submitted_md5,submitted_bytes,submitted_format]]></ID>\n
+        \       </XREF_LINK>\n    </SAMPLE_LINK>\n</SAMPLE_LINKS>\n<SAMPLE_ATTRIBUTES>\n
+        \         <SAMPLE_ATTRIBUTE>\n               <TAG>INSDC secondary accession</TAG>\n
+        \              <VALUE>SRS716936</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
+        \              <TAG>NCBI submission package</TAG>\n               <VALUE>Generic.1.0</VALUE>\n
+        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>disease</TAG>\n
+        \              <VALUE>autism spectrum disorder</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
+        \         <SAMPLE_ATTRIBUTE>\n               <TAG>organism</TAG>\n               <VALUE>Homo
+        sapiens</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
+        \              <TAG>tissue</TAG>\n               <VALUE>frozen postmortem
+        brain from NICHD</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
+        \              <TAG>source_name</TAG>\n               <VALUE>human brain</VALUE>\n
+        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>BioSampleModel</TAG>\n
+        \              <VALUE>Generic</VALUE>\n          </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n
+        \              <TAG>ENA-FIRST-PUBLIC</TAG>\n               <VALUE>2015-01-01</VALUE>\n
+        \         </SAMPLE_ATTRIBUTE>\n          <SAMPLE_ATTRIBUTE>\n               <TAG>ENA-LAST-UPDATE</TAG>\n
+        \              <VALUE>2015-01-01</VALUE>\n          </SAMPLE_ATTRIBUTE>\n
         \    </SAMPLE_ATTRIBUTES>\n</SAMPLE>\n</SAMPLE_SET>\n"
     headers:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:46:27 GMT
+      - Wed, 17 May 2023 18:38:33 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -5084,7 +4287,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/SRP048683
   response:
@@ -5131,7 +4334,7 @@ interactions:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:46:28 GMT
+      - Wed, 17 May 2023 18:38:33 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -5149,7 +4352,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/browser/api/xml/SRA188845
   response:
@@ -5186,7 +4389,7 @@ interactions:
       Content-Type:
       - application/xml
       Date:
-      - Wed, 28 Jul 2021 19:46:28 GMT
+      - Wed, 17 May 2023 18:38:33 GMT
       Strict-Transport-Security:
       - max-age=0
       Transfer-Encoding:
@@ -5194,69 +4397,6 @@ interactions:
     status:
       code: 200
       message: ''
-- request:
-    body: acc=SRR1603672&accept-proto=fasp&version=2.0
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '44'
-      User-Agent:
-      - python-requests/2.25.1
-    method: POST
-    uri: https://www.ncbi.nlm.nih.gov/Traces/names/names.cgi
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAA5zOPWrEMBBA4T6nEKTYapeZ0Xgk+RKBzVbb6c84wUTGVhICc/h463SBV73qe6YL
-        PO1bXD+Tvl6vKGDFkSKJJXDgGZUA+YxwBrkRjQwj+7tONASPLgoy2RpqDER1KrYCQkhxUlUG0JeP
-        5cec5t7X/WTWrfWW22LedhOXpX3XYqa2mT4fo6X3mvtfyuWrpBzzXBUdHR4ZxD5I7kEie4MwAh/d
-        FUj8AJLBScks3llOuTAULsUKDv8l/QIAAP//AwDto5TxIwEAAA==
-    headers:
-      Cache-Control:
-      - private
-      Connection:
-      - Keep-Alive
-      Content-Encoding:
-      - gzip
-      Content-Security-Policy:
-      - upgrade-insecure-requests
-      Content-Type:
-      - text/plain
-      Date:
-      - Wed, 28 Jul 2021 19:46:28 GMT
-      Keep-Alive:
-      - timeout=1, max=10
-      NCBI-PHID:
-      - CC95032A101B41410000000000000001.m_1
-      NCBI-SID:
-      - CC95032A101B4141_0000SID
-      Referrer-Policy:
-      - origin-when-cross-origin
-      Server:
-      - Apache
-      Set-Cookie:
-      - ncbi_sid=CC95032A101B4141_0000SID; domain=.nih.gov; path=/; expires=Thu, 28
-        Jul 2022 19:46:28 GMT
-      SraNameServerOutputVersion:
-      - '2.0'
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains; preload
-      Transfer-Encoding:
-      - chunked
-      Vary:
-      - Accept-Encoding
-      X-UA-Compatible:
-      - IE=Edge
-      X-XSS-Protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
 - request:
     body: null
     headers:
@@ -5267,29 +4407,27 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.25.1
+      - python-requests/2.30.0
     method: GET
     uri: https://www.ebi.ac.uk/ena/portal/api/filereport?accession=SRR1603672&result=read_run
   response:
     body:
-      string: "run_accession\tfastq_ftp\tfastq_bytes\tfastq_md5\tsubmitted_ftp\tsubmitted_bytes\tsubmitted_md5\tsra_ftp\tsra_bytes\tsra_md5\nSRR1603672\tftp.sra.ebi.ac.uk/vol1/fastq/SRR160/002/SRR1603672/SRR1603672.fastq.gz;ftp.sra.ebi.ac.uk/vol1/fastq/SRR160/002/SRR1603672/SRR1603672_1.fastq.gz;ftp.sra.ebi.ac.uk/vol1/fastq/SRR160/002/SRR1603672/SRR1603672_2.fastq.gz\t829817369;7077631307;7106859277\t48400cd04f90d2d71139d6fa0efa1f6a;48c5e235e622c53dc0dc3e2f278cdc3d;7a09a8762df9b8982e956bf8e5b13663\t\t\t\t\t\t\n"
+      string: "run_accession\tfastq_ftp\tfastq_bytes\tfastq_md5\tbam_ftp\tbam_bytes\tbam_md5\tsubmitted_ftp\tsubmitted_bytes\tsubmitted_md5\tsra_ftp\tsra_bytes\tsra_md5\nSRR1603672\tftp.sra.ebi.ac.uk/vol1/fastq/SRR160/002/SRR1603672/SRR1603672.fastq.gz;ftp.sra.ebi.ac.uk/vol1/fastq/SRR160/002/SRR1603672/SRR1603672_1.fastq.gz;ftp.sra.ebi.ac.uk/vol1/fastq/SRR160/002/SRR1603672/SRR1603672_2.fastq.gz\t829817369;7077631307;7106859277\t48400cd04f90d2d71139d6fa0efa1f6a;48c5e235e622c53dc0dc3e2f278cdc3d;7a09a8762df9b8982e956bf8e5b13663\t\t\t\t\t\t\tftp.sra.ebi.ac.uk/vol1/srr/SRR160/002/SRR1603672\t12632070841\tf259817a61423e9ea922efd3e0109baf\n"
     headers:
       Cache-Control:
       - no-cache, no-store, max-age=0, must-revalidate
+      Content-Length:
+      - '601'
       Content-Type:
       - text/plain
       Date:
-      - Wed, 28 Jul 2021 19:46:29 GMT
+      - Wed, 17 May 2023 18:38:33 GMT
       Expires:
       - '0'
       Pragma:
       - no-cache
-      Server:
-      - Apache-Coyote/1.1
       Strict-Transport-Security:
       - max-age=0
-      Transfer-Encoding:
-      - chunked
       X-Content-Type-Options:
       - nosniff
       X-Frame-Options:
@@ -5298,5 +4436,5 @@ interactions:
       - 1; mode=block
     status:
       code: 200
-      message: OK
+      message: ''
 version: 1

--- a/workers/data_refinery_workers/downloaders/sra.py
+++ b/workers/data_refinery_workers/downloaders/sra.py
@@ -17,7 +17,7 @@ from data_refinery_common.models import (
     Sample,
 )
 from data_refinery_common.rna_seq import _build_ena_file_url
-from data_refinery_common.utils import download_file, get_env_variable, get_https_sra_download
+from data_refinery_common.utils import download_file, get_env_variable
 from data_refinery_workers.downloaders import utils
 
 logger = get_and_configure_logger(__name__)

--- a/workers/tests/downloaders/test_sra.py
+++ b/workers/tests/downloaders/test_sra.py
@@ -1,5 +1,4 @@
 import os
-from unittest.mock import patch
 
 from django.test import TestCase, tag
 


### PR DESCRIPTION
## Issue Number

#3283 

## Purpose/Implementation Notes

- Updates out of date vcr cassettes for sra surveyor metadata requests
- Removes url creation for ncbi via ftp and uses s3 location
- since the response changed from ENA I have updated the test values and removed keys that are no longer returned
  - this is honestly kind of weird, the dates for first published and last update are now further in the past...
  - some attributes (spot count, base count) are no longer on sample and only on run

ENA changes information here: https://docs.google.com/document/d/1RPHmK8Pvm9UxSa21Ej3MkGoGYO9baSxwxk_dOuWWyNE

## Methods

There aren't any methods, that I can tell, that should be called out here.
There isn't much we can do about the `sample_ena_base_count` and `sample_ena_spot_count` being removed. For newly surveyed samples we will only be able to capture what is presented to us. The test validates that the method in which we capture the data works, and this test still captures that truthiness.

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

- n/a
- sra surveyor tests are passing
- sra downloader tests are passing

## Checklist

_Put an `x` in the boxes that apply._

- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works

## Screenshots

n/a
