### PR TITLE
Fix for SRA file report API url construction

### DIFF
--- a/foreman/data_refinery_foreman/surveyor/sra.py
+++ b/foreman/data_refinery_foreman/surveyor/sra.py
@@ -57,7 +57,10 @@ class SraSurveyor(ExternalSourceSurveyor):
     @staticmethod
     def get_ena_json_api(endpoint: str, accession: str, params: dict = {}):
 
-        params.update({"format": "json", "includeAccessions": accession})
+        params.update({"format": "json"})
+
+        if "accession" not in params:
+            params.update({"includeAccessions": accession})
 
         return f"{ENA_API}{endpoint}/?{urlencode(params, )}"
 
@@ -114,6 +117,8 @@ class SraSurveyor(ExternalSourceSurveyor):
             "filereport",
             run_accession,
             {
+                "accession": run_accession,
+                "result": "read_run",
                 "fields": "all",
             },
         )


### PR DESCRIPTION
## Issue Number

#3320

## Purpose/Implementation Notes

In the latest e2e tests, a SRA surveyor job failed because it could not get the file report. I went to the url that was attempted and the API responded with an error saying that `accession` and `result` were missing. This PR adds a fix for the url construction.

## Methods

n/a

## Types of changes

What types of changes does your code introduce?

- Bugfix (non-breaking change which fixes an issue)


## Functional tests

n/a

## Checklist

- [X] Lint and unit tests pass locally with my changes

## Screenshots

n/a
