### PR TITLE
Refactor sample_protocols update

### DIFF
--- a/workers/data_refinery_workers/downloaders/sra.py
+++ b/workers/data_refinery_workers/downloaders/sra.py
@@ -147,7 +147,12 @@ def _download_file_aspera(
             else:
                 time.sleep(5)
                 return _download_file_aspera(
-                    download_url, downloader_job, target_file_path, attempt + 1, source
+                    download_url,
+                    downloader_job,
+                    target_file_path,
+                    attempt + 1,
+                    original_file,
+                    source,
                 )
     except Exception:
         logger.exception(
@@ -176,7 +181,7 @@ def _download_file_aspera(
         )
         time.sleep(10)
         return _download_file_aspera(
-            download_url, downloader_job, target_file_path, attempt + 1, source
+            download_url, downloader_job, target_file_path, attempt + 1, original_file, source
         )
     return True
 

--- a/workers/data_refinery_workers/downloaders/sra.py
+++ b/workers/data_refinery_workers/downloaders/sra.py
@@ -100,11 +100,13 @@ def _download_file_aspera(
             # and we are not using any kind of rate limiting.
             command_str = "ascp -QT -l 300m -P 33001 -i keys/asperaweb_id_dsa.openssh {src} {dest}"
             formatted_command = command_str.format(src=download_url, dest=target_file_path)
+            logger.info("Starting ENA ascp", time=str(timezone.now()))
             completed_command = subprocess.run(
                 formatted_command.split(),
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
             )
+            logger.info("Ending ENA ascp", time=str(timezone.now()))
         else:
             # NCBI requires encryption and recommends -k1 resume, as
             # well as the 450m limit and -Q (play fair).

--- a/workers/tests/downloaders/test_sra.py
+++ b/workers/tests/downloaders/test_sra.py
@@ -26,17 +26,17 @@ class DownloadSraTestCase(TestCase):
     @tag("downloaders_sra")
     def test_download_file(self):
         dlj = DownloaderJob()
-        dlj.accession_code = "ERR036"
+        dlj.accession_code = "SRR24086949"
         dlj.save()
 
         og = OriginalFile()
-        og.source_filename = "ERR036000.fastq.gz"
-        og.source_url = "ftp.sra.ebi.ac.uk/vol1/fastq/ERR036/ERR036000/ERR036000_1.fastq.gz"
+        og.source_filename = "SRR24086949.fastq.gz"
+        og.source_url = "ftp.sra.ebi.ac.uk/vol1/fastq/SRR240/049/SRR24086949/SRR24086949_1.fastq.gz"
         og.is_archive = True
         og.save()
 
         sample = Sample()
-        sample.accession_code = "ERR036000"
+        sample.accession_code = "SRR24086949"
         sample.save()
 
         assoc = OriginalFileSampleAssociation()
@@ -52,7 +52,8 @@ class DownloadSraTestCase(TestCase):
         result, downloaded_files = sra.download_sra(dlj.pk)
 
         self.assertTrue(result)
-        self.assertEqual(downloaded_files[0].sha1, "1dfe5460a4101fe87feeffec0cb2e053f6695961")
+        self.assertEqual(downloaded_files[0].sha1, "ef52900be820e4001988e64b7d664f7af595e581")
+        print(downloaded_files[0].sha1)
         self.assertTrue(os.path.exists(downloaded_files[0].absolute_file_path))
 
     @tag("downloaders")


### PR DESCRIPTION
## Issue Number

#3326 

## Purpose/Implementation Notes

This PR fixes a bug where variable type was not being checked correctly.
From the e2e tests logs:
> AttributeError: 'dict' object has no attribute 'append'

Additionally, it refactors the `update_sample_protocol_info` method that takes an experiments protocol and adds to the sample to now take a sample and an experiment.

Update:

This PR also contains a fix for the downloaders test. It seems that the particular sample we were testing (also SRA) was not able to be downloaded via ascp.

Also, I noticed that when ENA aspera downloader performed a retry, the original_file parameter was missing which caused it to try to use the NCBI instead of ENA configuration for downloading.

## Methods

To replace the sample tested in the downloader @jaclyn-taroni provided the following query:

```bash
 curl -X POST -H "Content-Type: application/x-www-form-urlencoded" -d 'result=read_run&query=tax_eq(6239)%20AND%20library_strategy%3D%22RNA-Seq%22%20AND%20library_layout%3D%22PAIRED%22&fields=run_accession%2Cexperiment_title%2Ctax_id%2Clibrary_strategy%2Cfastq_bytes%2Cfastq_ftp&format=tsv' "https://www.ebi.ac.uk/ena/portal/api/search"
```
And sorted by filesize and landed on `SRR24086949` as a suitable replacement.

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

n/a

## Checklist

- [X] Lint and unit tests pass locally with my changes

## Screenshots

n/a
