### PR TITLE
add s3 to sra urls to check

### DIFF
--- a/workers/data_refinery_workers/processors/salmon.py
+++ b/workers/data_refinery_workers/processors/salmon.py
@@ -120,8 +120,11 @@ def _prepare_files(job_context: Dict) -> Dict:
         return job_context
 
     # Detect that this is an SRA file from the source URL
-    if ("ncbi.nlm.nih.gov" in job_context["original_files"][0].source_url) or (
-        job_context["input_file_path"][-4:].upper() == ".SRA"
+    source_url = job_context["original_files"][0].source_url
+    if (
+        ("ncbi.nlm.nih.gov" in source_url)
+        or ("sra-pub-run-odp.s3.amazonaws.com" in source_url)
+        or (job_context["input_file_path"][-4:].upper() == ".SRA")
     ):
         new_input_file_path = os.path.join(job_context["work_dir"], original_files[0].filename)
         shutil.copyfile(job_context["input_file_path"], new_input_file_path)
@@ -461,7 +464,6 @@ def _find_or_download_index(job_context: Dict) -> Dict:
 def _run_tximport_for_experiment(
     job_context: Dict, experiment: Experiment, quant_files: List[ComputedFile]
 ) -> Dict:
-
     # Download all the quant.sf fles for this experiment. Write all
     # their paths to a file so we can pass a path to that to
     # tximport.R rather than having to pass in one argument per
@@ -688,10 +690,8 @@ def _run_salmon(job_context: Dict) -> Dict:
     # SRA files also get processed differently as we don't want to use fasterq-dump to extract
     # them to disk.
     if job_context.get("sra_input_file_path", None):
-
         # Single reads
         if job_context["sra_num_reads"] == 1:
-
             fifo = "/tmp/barney"
             os.mkfifo(fifo)
 
@@ -715,7 +715,6 @@ def _run_salmon(job_context: Dict) -> Dict:
             )
         # Paired are trickier
         else:
-
             # Okay, for some reason I can't explain, this only works
             # in the temp directory, otherwise the `tee` part will
             # only output to one or the other of the streams

--- a/workers/data_refinery_workers/processors/salmon.py
+++ b/workers/data_refinery_workers/processors/salmon.py
@@ -122,9 +122,9 @@ def _prepare_files(job_context: Dict) -> Dict:
     # Detect that this is an SRA file from the source URL
     source_url = job_context["original_files"][0].source_url
     if (
-        ("ncbi.nlm.nih.gov" in source_url)
-        or ("sra-pub-run-odp.s3.amazonaws.com" in source_url)
-        or (job_context["input_file_path"][-4:].upper() == ".SRA")
+        "ncbi.nlm.nih.gov" in source_url
+        or "sra-pub-run-odp.s3.amazonaws.com" in source_url
+        or job_context["input_file_path"][-4:].upper() == ".SRA"
     ):
         new_input_file_path = os.path.join(job_context["work_dir"], original_files[0].filename)
         shutil.copyfile(job_context["input_file_path"], new_input_file_path)


### PR DESCRIPTION
## Issue Number

N/A

## Purpose/Implementation Notes

We are now pulling NCBI SRA data from s3. When we go to determine the transcriptome index length to process these files we need to use `sra-stat` to read the file. In order for that code path to execute we need to ensure that we define `sra_file_input_path`.

Note: I think it would be better instead of looking at the download source, to instead inspect the file to determine its type before determining index length.

## Methods

n/a

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

n/a tested locally

## Checklist

- [X] Lint and unit tests pass locally with my changes

## Screenshots

N/A
