### PR TITLE
Increase launch templates /dev/xvda volume size

### DIFF
--- a/infrastructure/batch/launch_templates.tf
+++ b/infrastructure/batch/launch_templates.tf
@@ -6,7 +6,7 @@ resource "aws_launch_template" "data_refinery_worker" {
   block_device_mappings {
     device_name = "/dev/xvda"
     ebs {
-      volume_size = 64
+      volume_size = 128
       encrypted = true
       delete_on_termination = true
     }
@@ -43,7 +43,7 @@ resource "aws_launch_template" "data_refinery_compendia" {
   block_device_mappings {
     device_name = "/dev/xvda"
     ebs {
-      volume_size = 64
+      volume_size = 128
       encrypted = true
       delete_on_termination = true
     }


### PR DESCRIPTION
## Purpose/Implementation Notes

Increase launch templates /dev/xvda volume size. 
Avoid docker no space left on device error.

## Types of changes

<!-- Remove any which your PR isn't -->
- Bugfix (non-breaking change which fixes an issue)

## Checklist

- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules
