### PR TITLE
Update supported_microarray_platforms.csv to fix GPL24242 internal accession field

### DIFF
--- a/config/supported_microarray_platforms.csv
+++ b/config/supported_microarray_platforms.csv
@@ -35,7 +35,7 @@ clariomdhuman,A-GEOD-22844,y
 clariomshumanht,GPL24324,y
 clariomshuman,GPL23159,y
 clariomsmouse,GPL23038,y
-clariomsmouse,GPL24242,y
+clariomsmouseht,GPL24242,y
 clariomsrat,GPL23040,y
 drogene10st,GPL20842,y
 drogene10st,GPL18094,y


### PR DESCRIPTION
## Issue Number

N/A. The following error came up in processing on staging:

> Unhandled exception caught while running processor function _run_scan_upc in pipeline: 'clariomsmouseht'

Which drew my attention to the `supported_microarray_platforms.csv` file.

## Purpose/Implementation Notes

Here, I'm updating the internal accession column for [`GPL24242`](https://www.ncbi.nlm.nih.gov/geo/query/acc.cgi?acc=GPL24242) `clariomsmouse` -> `clariomsmouseht`, which is an error.

I'm not sure if this will fix the failure we saw in staging.

## Types of changes

What types of changes does your code introduce?

<!-- Remove any which your PR isn't -->
- Bugfix (non-breaking change which fixes an issue)


## Functional tests

List out the functional tests you've completed to verify your changes work locally.

N/A

## Checklist

_Put an `x` in the boxes that apply._

- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots

Please attach any screenshots that illustrate these changes.
