### PR TITLE
Slow down batch job deregistering process

### DIFF
--- a/infrastructure/deregister_batch_job_definitions.py
+++ b/infrastructure/deregister_batch_job_definitions.py
@@ -1,4 +1,5 @@
 import os
+import time
 
 import boto3
 
@@ -35,3 +36,5 @@ for job_name in sorted(job_names):
         # There can be multiple revisions per job definition. We want them all gone.
         for job_definition in job_definitions:
             batch.deregister_job_definition(jobDefinition=job_definition["jobDefinitionArn"])
+
+        time.sleep(1)


### PR DESCRIPTION
It looks like the production deploy process failed because of AWS API rate limit. 

```
Traceback (most recent call last):
  File "deregister_batch_job_definitions.py", line 28, in <module>
    response = batch.describe_job_definitions(**data)
  File "/home/ubuntu/.local/lib/python3.6/site-packages/botocore/client.py", line 386, in _api_call
    return self._make_api_call(operation_name, kwargs)
  File "/home/ubuntu/.local/lib/python3.6/site-packages/botocore/client.py", line 705, in _make_api_call
    raise error_class(parsed_response, operation_name)
botocore.exceptions.ClientError: An error occurred (TooManyRequestsException) when calling the DescribeJobDefinitions operation (reached max retries: 4): Too Many Requests
```
In order to slow down our request rate we are going to add some sleeps to the terraform script to prevent being throttled.