### PR TITLE
Extend using of staging images cache

### DIFF
--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -100,17 +100,23 @@ update_docker_image() {
         DOCKER_ACTION="--load"
     fi
 
+    CCDL_STAGING_IMAGE="ccdlstaging/dr_$IMAGE_NAME"
     DOCKERHUB_IMAGE="$DOCKERHUB_REPO/dr_$IMAGE_NAME"
+    CACHE_FROM_CCDL_STAGING_LATEST="type=registry,ref=${CCDL_STAGING_IMAGE}_cache:latest"
+    CACHE_FROM_CCDL_STAGING_VERSION="type=registry,ref=${CCDL_STAGING_IMAGE}_cache:$SYSTEM_VERSION"
     CACHE_FROM_LATEST="type=registry,ref=${DOCKERHUB_IMAGE}_cache:latest"
     CACHE_FROM_VERSION="type=registry,ref=${DOCKERHUB_IMAGE}_cache:$SYSTEM_VERSION"
     CACHE_TO_LATEST="type=registry,ref=${DOCKERHUB_IMAGE}_cache:latest,mode=max"
     CACHE_TO_VERSION="type=registry,ref=${DOCKERHUB_IMAGE}_cache:$SYSTEM_VERSION,mode=max"
+
 
     set_up_docker_builder
 
     docker buildx build \
         --build-arg DOCKERHUB_REPO="$DOCKERHUB_REPO" \
         --build-arg SYSTEM_VERSION="$SYSTEM_VERSION" \
+        --cache-from "$CACHE_FROM_CCDL_STAGING_LATEST" \
+        --cache-from "$CACHE_FROM_CCDL_STAGING_VERSION" \
         --cache-from "$CACHE_FROM_LATEST" \
         --cache-from "$CACHE_FROM_VERSION" \
         --cache-to "$CACHE_TO_LATEST" \


### PR DESCRIPTION
## Issue Number

#3380 

## Purpose/Implementation Notes

Extend using of staging images cache.
It's mostly done to speed up the prod (different docker registry) build process.

## Types of changes

<!-- Remove any which your PR isn't -->
- Bugfix (non-breaking change which fixes an issue)

## Checklist

- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots

Please attach any screenshots that illustrate these changes.
