### PR TITLE
Move smasher test jobs to larger runners

### DIFF
--- a/.github/workflows/config.yml
+++ b/.github/workflows/config.yml
@@ -502,7 +502,7 @@ jobs:
       IMAGES: migrations smasher
     needs:
       - test_base
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-m
     steps:
       - uses: actions/checkout@v3
 


### PR DESCRIPTION
## Purpose/Implementation Notes

Move smasher test jobs to larger runners. The culprit is pretty much the same -- insufficient disk space.

## Types of changes

<!-- Remove any which your PR isn't -->
- Bugfix (non-breaking change which fixes an issue)

## Checklist

- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules