### PR TITLE
Run agilent tests after affymetrix image is ready

### DIFF
--- a/.github/workflows/config.yml
+++ b/.github/workflows/config.yml
@@ -83,7 +83,7 @@ jobs:
     env:
       IMAGES: migrations affymetrix
     needs:
-      - test_base
+      - test_affymetrix
     runs-on: ubuntu-latest-m
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
## Purpose/Implementation Notes

The idea is not to run agilent/affymetrix tests simultaneously. This should decrease the time we utilize larger runners in build from scratch cases.

## Types of changes

<!-- Remove any which your PR isn't -->
- Bugfix (non-breaking change which fixes an issue)


## Checklist

- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules
