### PR TITLE
Update downloaders image

### DIFF
--- a/workers/dockerfiles/Dockerfile.downloaders
+++ b/workers/dockerfiles/Dockerfile.downloaders
@@ -24,9 +24,9 @@ EOF
 USER user
 
 RUN <<EOF
-mkdir -m 700 ~.gnupg/
+mkdir -m 700 /home/user/.gnupg
 # Disable IPv6 to avoid "Cannot assign requested address" error.
-echo "disable-ipv6" >> ~.gnupg/dirmngr.conf
+echo "disable-ipv6" >> /home/user/.gnupg/dirmngr.conf
 . /home/user/rvm/scripts/rvm
 ascli conf ascp install
 EOF


### PR DESCRIPTION
## Purpose/Implementation Notes

Set proper gnupg path.

// The downloaders tests pass, no-op job is failing with `We found an Illumina file to NO_OP that we're not set up to process yet` though.

## Types of changes

<!-- Remove any which your PR isn't -->
- Bugfix (non-breaking change which fixes an issue)

## Checklist

- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules