### PR TITLE
Add deploy box cleanup instructions

### DIFF
--- a/infrastructure/deploy.sh
+++ b/infrastructure/deploy.sh
@@ -423,3 +423,8 @@ if [[ -n $container_running ]]; then
 fi
 
 echo "Deploy completed successfully."
+
+# Remove Docker images created more than 30 days ago.
+echo "Cleaning up Docker images."
+docker image prune -a --force --filter "until=720h"
+echo "Cleanup completed."


### PR DESCRIPTION
## Purpose/Implementation Notes

Removing 30d+ old Docker images on every deploy would make sure we have enough disk space for the next one while keeping relatively fresh images in place. 

This will address

`#18 ERROR: write /var/lib/buildkit/runc-overlayfs/snapshots/snapshots/4383/fs/usr/local/lib/R/site-library/pd.genomewidesnp.5/extdata/pd.genomewidesnp.5.sqlite: no space left on device` 

type of issues.

## Types of changes

What types of changes does your code introduce?

<!-- Remove any which your PR isn't -->
- Bugfix (non-breaking change which fixes an issue)

## Functional tests

List out the functional tests you've completed to verify your changes work locally.

## Checklist

_Put an `x` in the boxes that apply._

- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules
