### PR TITLE
Follow redirect when downloading gene_indexes

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,10 +15,11 @@ repos:
       # - id: check-docstring-first # We can enable this rule once models.py is simplified
       - id: check-yaml
 
-  - repo: https://github.com/PyCQA/isort
-    rev: 4.3.21
+  - repo: https://github.com/pycqa/isort
+    rev: 5.11.5
     hooks:
       - id: isort
+        name: isort (python)
 
   - repo: https://github.com/psf/black
     rev: 22.3.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,8 +15,8 @@ repos:
       # - id: check-docstring-first # We can enable this rule once models.py is simplified
       - id: check-yaml
 
-  - repo: https://github.com/pre-commit/mirrors-isort
-    rev: v4.3.21
+  - repo: https://github.com/PyCQA/isort
+    rev: 4.3.21
     hooks:
       - id: isort
 

--- a/workers/dockerfiles/Dockerfile.no_op
+++ b/workers/dockerfiles/Dockerfile.no_op
@@ -19,7 +19,7 @@ RUN mkdir -p gene_indexes
 WORKDIR /home/user/gene_indexes
 ENV ID_REFINERY_URL=https://zenodo.org/record/1410647/files/all_1536267482.zip
 RUN <<EOF
-curl -O $ID_REFINERY_URL
+curl -OL $ID_REFINERY_URL
 echo $ID_REFINERY_URL > /etc/identifier_refinery_url
 unzip *.zip
 rm *.zip


### PR DESCRIPTION
## Issue Number

#3436 

## Purpose/Implementation Notes

NOTE: This PR encountered an error with isort that I could not reproduce locally. I saw that the repo we were using has recently changed so I am now targeting the branch that contains that fix. https://github.com/AlexsLemonade/refinebio/tree/davidsmejia/isort-upgrade-5.11.5

Running `docker run -it ccdlstaging/dr_no_op ls -l /home/user/gene_indexes`. Would give the correct output but rebuilding the container failed.

While testing out the code locally I noticed that curling the `ID_REFINERY_URL` was not downloading the indexes and the subsequent unzip command exit code 9.

This change tells curl to follow the redirect. Which then allows the no_op to build correctly.

This change invalidates the cache layer and makes the files available that were missing during the no_op tests.

## Methods

n/a

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

List out the functional tests you've completed to verify your changes work locally.

## Checklist

- [x] Lint and unit tests pass locally with my changes

## Screenshots

n/a
