### PR TITLE
Add restart flag to API docker container

### DIFF
--- a/infrastructure/api-configuration/api-server-instance-user-data.tpl.sh
+++ b/infrastructure/api-configuration/api-server-instance-user-data.tpl.sh
@@ -154,6 +154,7 @@ docker run \
     --name dr_api \
     --platform linux/amd64 \
     --publish 8081:8081 \
+    --restart always \
     --tty \
     --volume "$STATIC_VOLUMES":/tmp/www/static \
     "${dockerhub_repo}/${api_docker_image}" \

--- a/infrastructure/deploy.sh
+++ b/infrastructure/deploy.sh
@@ -408,9 +408,11 @@ if [[ -n $container_running ]]; then
             --log-opt awslogs-region=$AWS_REGION \
             --log-opt awslogs-stream=log-stream-api-$USER-$STAGE \
             --name=dr_api \
+            --platform linux/amd64 \
+            --publish 8081:8081 \
+            --restart always \
             --tty \
             --volume /tmp/volumes_static:/tmp/www/static \
-            --publish 8081:8081 \
             $DOCKERHUB_REPO/$API_DOCKER_IMAGE \
             /bin/sh -c /home/user/collect_and_run_uwsgi.sh"
 


### PR DESCRIPTION
## Purpose/Implementation Notes

Add restart flag to API docker container to ensure it's running after failures/reboots.

## Types of changes

<!-- Remove any which your PR isn't -->
- Bugfix (non-breaking change which fixes an issue)

## Checklist

- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules