### PR TITLE
3452 move nginx logs and static files to /var

### DIFF
--- a/infrastructure/api-configuration/api-server-instance-user-data.tpl.sh
+++ b/infrastructure/api-configuration/api-server-instance-user-data.tpl.sh
@@ -83,13 +83,13 @@ cat <<EOF >awslogs.conf
 [general]
 state_file = /var/lib/awslogs/agent-state
 
-[/tmp/error.log]
-file = /tmp/error.log
+[/var/log/nginx/error.log]
+file = /var/log/nginx/error.log
 log_group_name = ${log_group}
 log_stream_name = log-stream-api-nginx-error-${user}-${stage}
 
-[/tmp/access.log]
-file = /tmp/access.log
+[/var/log/nginx/access.log]
+file = /var/log/nginx/access.log
 log_group_name = ${log_group}
 log_stream_name = log-stream-api-nginx-access-${user}-${stage}
 
@@ -100,7 +100,7 @@ wget https://s3.amazonaws.com/aws-cloudwatch/downloads/latest/awslogs-agent-setu
 python3.5 ./awslogs-agent-setup.py --region "${region}" --non-interactive --configfile awslogs.conf
 # Rotate the logs, delete after 3 days.
 echo "
-/tmp/error.log {
+/var/log/nginx/error.log {
     missingok
     notifempty
     compress
@@ -109,7 +109,7 @@ echo "
     maxage 3
 }" >>/etc/logrotate.conf
 echo "
-/tmp/access.log {
+/var/log/nginx/access.log {
     missingok
     notifempty
     compress

--- a/infrastructure/api-configuration/api-server-instance-user-data.tpl.sh
+++ b/infrastructure/api-configuration/api-server-instance-user-data.tpl.sh
@@ -125,9 +125,9 @@ EOF
 
 chown -R ubuntu /home/ubuntu
 
-STATIC_VOLUMES=/tmp/volumes_static
-mkdir -p /tmp/volumes_static
-chmod a+rwx /tmp/volumes_static
+STATIC_VOLUMES=/var/www/volumes_static
+mkdir -p /var/www/volumes_static
+chmod a+rwx /var/www/volumes_static
 
 # Pull the API image.
 docker pull "${dockerhub_repo}/${api_docker_image}"

--- a/infrastructure/api-configuration/nginx_config.conf
+++ b/infrastructure/api-configuration/nginx_config.conf
@@ -50,7 +50,7 @@ http {
 
         location /static {
             autoindex on;
-            alias /tmp/volumes_static/;
+            alias /var/www/volumes_static/;
         }
 
         location / {

--- a/infrastructure/api-configuration/nginx_config.conf
+++ b/infrastructure/api-configuration/nginx_config.conf
@@ -3,7 +3,7 @@
 # Optionally, we can have Nginx sort itself out:
 worker_processes  auto;
 
-error_log  /tmp/error.log  error;
+error_log  /var/log/nginx/error.log  error;
 
 events {
     # Set this to ulimit -n
@@ -25,7 +25,7 @@ http {
                       '$status $body_bytes_sent "$http_referer" '
                       '"$http_user_agent" "$http_x_forwarded_for"';
 
-    access_log  /tmp/access.log  main;
+    access_log  /var/log/nginx/access.log  main;
 
     sendfile        on;
     client_body_timeout 12;


### PR DESCRIPTION
## Issue Number

#3452 

## Purpose/Implementation Notes

Pretty straight forward change that does 2 things.
- Moves nginx logs from `/tmp/[access / error].log` to  `/var/log/nginx/[access / error].log`
- Moves where we serve static files from `tmp/volumes_static` to `/var/www/volumes_static` 

## Methods

n/a 

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

n/a

## Checklist

- [X] Lint and unit tests pass locally with my changes

## Screenshots

n/a
