### PR TITLE
Map static dir on API to /var/www/volumes_static on deploy

### DIFF
--- a/infrastructure/deploy.sh
+++ b/infrastructure/deploy.sh
@@ -412,7 +412,7 @@ if [[ -n $container_running ]]; then
             --publish 8081:8081 \
             --restart always \
             --tty \
-            --volume /tmp/volumes_static:/tmp/www/static \
+            --volume /var/www/volumes_static:/tmp/www/static \
             $DOCKERHUB_REPO/$API_DOCKER_IMAGE \
             /bin/sh -c /home/user/collect_and_run_uwsgi.sh"
 


### PR DESCRIPTION
## Issue Number

#3452

## Purpose/Implementation Notes

This PR is related to #3453 and adds the same mapping from the API's user data script for static files. This should allow us to generate the static files / documentation on deploy when the API is not tainted.

## Methods

N/A

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

n/a

## Checklist

- [x] Lint and unit tests pass locally with my changes

## Screenshots

n/a
