### PR TITLE
3452 Ensure /var/www/volumes_static exists on container restart

### DIFF
--- a/infrastructure/deploy.sh
+++ b/infrastructure/deploy.sh
@@ -388,6 +388,19 @@ if [[ -n $container_running ]]; then
         -i data-refinery-key.pem \
         api-configuration/environment "ubuntu@$API_IP_ADDRESS:/home/ubuntu/environment"
 
+    # Ensure the API's static file dir exists and is accessible"
+    ssh -o StrictHostKeyChecking=no \
+        -o ServerAliveInterval=15 \
+        -o ConnectTimeout=5 \
+        -i data-refinery-key.pem \
+        "ubuntu@$API_IP_ADDRESS" "mkdir -p /var/www/volumes_static"
+
+    ssh -o StrictHostKeyChecking=no \
+        -o ServerAliveInterval=15 \
+        -o ConnectTimeout=5 \
+        -i data-refinery-key.pem \
+        "ubuntu@$API_IP_ADDRESS" "chmod a+rwx /var/www/volumes_static"
+
     # shellcheck disable=SC2029
     ssh -o StrictHostKeyChecking=no \
         -o ServerAliveInterval=15 \

--- a/infrastructure/deploy.sh
+++ b/infrastructure/deploy.sh
@@ -388,18 +388,12 @@ if [[ -n $container_running ]]; then
         -i data-refinery-key.pem \
         api-configuration/environment "ubuntu@$API_IP_ADDRESS:/home/ubuntu/environment"
 
-    # Ensure the API's static file dir exists and is accessible"
+    # Ensure the API's static file dir exists and is accessible.
     ssh -o StrictHostKeyChecking=no \
         -o ServerAliveInterval=15 \
         -o ConnectTimeout=5 \
         -i data-refinery-key.pem \
-        "ubuntu@$API_IP_ADDRESS" "mkdir -p /var/www/volumes_static"
-
-    ssh -o StrictHostKeyChecking=no \
-        -o ServerAliveInterval=15 \
-        -o ConnectTimeout=5 \
-        -i data-refinery-key.pem \
-        "ubuntu@$API_IP_ADDRESS" "chmod a+rwx /var/www/volumes_static"
+        "ubuntu@$API_IP_ADDRESS" "mkdir -m a+rwx -p /var/www/volumes_static"
 
     # shellcheck disable=SC2029
     ssh -o StrictHostKeyChecking=no \


### PR DESCRIPTION
## Issue Number

#3452 

## Purpose/Implementation Notes

This PR adds the same creation and permission settings to the static dir when the API container is restart. We have already moved the static dir out of `tmp`. This change could safely be removed in the future.

Thoughts for the future: We probably should consider pulling out the starting of the container to it's own script so that we can just call that remotely on the API instead of duplicating the setup in user data and deploy scripts. That change is more involved than what we need at this moment. If we encounter issues with the API standing up or docs not being available again I strongly recommend addressing that then.

## Methods

n/a

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

n/a

## Checklist

- [X] Lint and unit tests pass locally with my changes

## Screenshots

n/a
