### PR TITLE
scale up worker volume

### DIFF
--- a/infrastructure/batch/launch_templates.tf
+++ b/infrastructure/batch/launch_templates.tf
@@ -16,7 +16,9 @@ resource "aws_launch_template" "data_refinery_worker" {
     device_name = "/dev/sdf"
     ebs {
       volume_type = "st1"
-      volume_size = 500
+      # Provide the workers with 1TB of storage
+      # for working with more experiments concurrently.
+      volume_size = 1000
       encrypted = true
       delete_on_termination = true
     }


### PR DESCRIPTION
## Issue Number

n/a

## Purpose/Implementation Notes

While processing a batch of requested experiments we encountered a high failure rate due to a lack of available storage attached to the batch instance. This PR doubles the available working space.

## Methods

n/a

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

n/a

## Checklist

- [X] Lint and unit tests pass locally with my changes

## Screenshots

n/a
