### PR TITLE
explicitly set RDS cert to latest default for posterity

### DIFF
--- a/infrastructure/database.tf
+++ b/infrastructure/database.tf
@@ -1,5 +1,11 @@
 # This file contains the configuration for the database and related resources.
 
+data "aws_rds_certificate" "cert" {
+  id = "rds-ca-rsa2048-g1"
+  # This returns multiple certs and the aws provider throws an error.
+  # latest_valid_till = true
+}
+
 resource "aws_db_parameter_group" "postgres_parameters" {
   name = "postgres-parameters-${var.user}-${var.stage}"
   description = "Postgres Parameters ${var.user} ${var.stage}"
@@ -162,6 +168,8 @@ resource "aws_db_instance" "postgres_db" {
   vpc_security_group_ids = [aws_security_group.data_refinery_db.id]
   multi_az = true
   publicly_accessible = true
+
+  ca_cert_identifier = data.aws_rds_certificate.cert.id
 
   backup_retention_period = var.stage == "prod" ? "7" : "0"
 


### PR DESCRIPTION
## Issue Number

#3505

## Purpose/Implementation Notes

- Explicitly sets RDS CA identifier to `rds-ca-rsa2048-g1`

The current cert has expired and this one will be good through 

I have manually updated this in the AWS console prior to deploying these changes. So that the next deploy will see that this change has already been applied and skip.

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

List out the functional tests you've completed to verify your changes work locally.

## Checklist

_Put an `x` in the boxes that apply._

- [X] Lint and unit tests pass locally with my changes

## Screenshots

N/A
