### PR TITLE
clean up common helpers

### DIFF
--- a/.github/workflows/config.yml
+++ b/.github/workflows/config.yml
@@ -217,7 +217,7 @@ jobs:
         run: scripts/update_models.sh
 
       - name: Build the Docker Image
-        run: scripts/prepare_image.sh -i api_base -s api
+        run: scripts/prepare_image.sh -u -i api_base -s api
 
   test_base:
     name: Test Base
@@ -244,7 +244,7 @@ jobs:
           password: ${{ env.DOCKER_PASSWORD }}
 
       - name: Build the Docker Image
-        run: scripts/prepare_image.sh -i base -s common
+        run: scripts/prepare_image.sh -u -i base -s common
 
   test_common:
     name: Test Common

--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -71,64 +71,6 @@ run_tests_with_coverage() {
     echo "$COVERAGE $PRINT_REPORT $SAVE_REPORT $RETURN"
 }
 
-# Create docker-container/desktop-linux Docker builder if none provided.
-# Set the builder as currently used.
-set_up_docker_builder() {
-    if [ -z "$DOCKER_BUILDER" ]; then
-        DOCKER_BUILDER="refinebio_local_builder"
-        echo "Creating Docker builder $DOCKER_BUILDER."
-        docker buildx create \
-            --driver=docker-container \
-            --name="$DOCKER_BUILDER" \
-            --platform=linux/amd64 2>/dev/null ||
-            true
-    fi
-
-    docker buildx use "$DOCKER_BUILDER"
-    echo "Using Docker builder $DOCKER_BUILDER:"
-    docker buildx inspect
-}
-
-update_docker_image() {
-    DOCKERHUB_REPO="$1"
-    IMAGE_NAME="$2"
-    SYSTEM_VERSION="$3"
-    DOCKER_FILE_PATH="$4"
-    DOCKER_ACTION="$5"
-
-    if [ -z "$DOCKER_ACTION" ]; then
-        DOCKER_ACTION="--load"
-    fi
-
-    CCDL_STAGING_IMAGE="ccdlstaging/dr_$IMAGE_NAME"
-    DOCKERHUB_IMAGE="$DOCKERHUB_REPO/dr_$IMAGE_NAME"
-    CACHE_FROM_CCDL_STAGING_LATEST="type=registry,ref=${CCDL_STAGING_IMAGE}_cache:latest"
-    CACHE_FROM_CCDL_STAGING_VERSION="type=registry,ref=${CCDL_STAGING_IMAGE}_cache:$SYSTEM_VERSION"
-    CACHE_FROM_LATEST="type=registry,ref=${DOCKERHUB_IMAGE}_cache:latest"
-    CACHE_FROM_VERSION="type=registry,ref=${DOCKERHUB_IMAGE}_cache:$SYSTEM_VERSION"
-    CACHE_TO_LATEST="type=registry,ref=${DOCKERHUB_IMAGE}_cache:latest,mode=max"
-    CACHE_TO_VERSION="type=registry,ref=${DOCKERHUB_IMAGE}_cache:$SYSTEM_VERSION,mode=max"
-
-
-    set_up_docker_builder
-
-    docker buildx build \
-        --build-arg DOCKERHUB_REPO="$DOCKERHUB_REPO" \
-        --build-arg SYSTEM_VERSION="$SYSTEM_VERSION" \
-        --cache-from "$CACHE_FROM_CCDL_STAGING_LATEST" \
-        --cache-from "$CACHE_FROM_CCDL_STAGING_VERSION" \
-        --cache-from "$CACHE_FROM_LATEST" \
-        --cache-from "$CACHE_FROM_VERSION" \
-        --cache-to "$CACHE_TO_LATEST" \
-        --cache-to "$CACHE_TO_VERSION" \
-        --file "$DOCKER_FILE_PATH" \
-        --platform linux/amd64 \
-        --tag "$DOCKERHUB_IMAGE:latest" \
-        --tag "$DOCKERHUB_IMAGE:$SYSTEM_VERSION" \
-        "$DOCKER_ACTION" \
-        .
-}
-
 # Default Docker registry.
 if [ -z "$DOCKERHUB_REPO" ]; then
     DOCKERHUB_REPO="ccdlstaging"

--- a/scripts/prepare_image.sh
+++ b/scripts/prepare_image.sh
@@ -1,7 +1,12 @@
 #!/bin/sh
 
-# This script should always run as if it were being called from
-# the directory it lives in.
+# Thin wrapper around `docker buildx bake` for building a single image.
+# Build configuration (tags, cache, platform, FROM resolution) lives in
+# docker-bake.hcl; this script provides the equivalent CLI for callers that
+# expect a per-image entry point.
+
+set -e
+
 script_directory="$(
     cd "$(dirname "$0")" || exit
     pwd
@@ -11,107 +16,66 @@ cd "$script_directory" || exit
 # shellcheck disable=SC1091
 . ./common.sh
 
-# We need access to all of the projects
+# Run from the repo root so bake's relative context (".") resolves correctly.
 cd ..
 
-print_description() {
-    echo "Prepares an image specified by -i."
-    echo "Must be called from the repo root."
+print_help() {
+    cat <<EOF
+Build a single docker image via 'docker buildx bake'.
+
+Usage: $(basename "$0") -i IMAGE [-s SERVICE] [-r REPO] [-v VERSION] [-u] [-h]
+
+Options:
+  -i IMAGE     Image (bake target) to build, e.g. base, api, salmon. Required.
+  -s SERVICE   Accepted for back-compat with existing callers; ignored.
+               docker-bake.hcl already declares the dockerfile path per target.
+  -r REPO      Override DOCKERHUB_REPO (default: ccdlstaging).
+  -v VERSION   Override SYSTEM_VERSION (default: a hash of the current branch).
+  -u           Push to DOCKERHUB_REPO instead of loading to the local daemon.
+  -h           Print this help.
+EOF
 }
 
-print_options() {
-    echo "Options:"
-    echo "    -h           Prints the help message."
-    echo "    -i IMAGE     The image to be prepared. This must be specified."
-    echo "    -s SERVICE   The service to seach for a dockerfile."
-    echo "                 The default option is 'workers'."
-    echo "    -u           Push the built image to the Dockerhub."
-    echo "    -r REPO      The docker registry to use for pull/push actions."
-    echo "                 The default option is 'ccdlstaging'."
-    echo
-    echo "Examples:"
-    echo "    Build the image ccdl/dr_downloaders:"
-    echo "    ./scripts/prepare_image.sh -i downloaders -r ccdlstaging"
-}
+ACTION="--load"
 
-while getopts "uhi:r:s:" opt; do
+while getopts "uhi:r:s:v:" opt; do
     case $opt in
-    i)
-        IMAGE_NAME="$OPTARG"
-        ;;
-    r)
-        DOCKERHUB_REPO="$OPTARG"
-        ;;
-
-    s)
-        SERVICE="$OPTARG"
-        ;;
-    u)
-        DOCKER_ACTION="--push"
-        ;;
+    i) IMAGE_NAME="$OPTARG" ;;
+    s) : ;; # accepted but no longer needed; see help
+    r) export DOCKERHUB_REPO="$OPTARG" ;;
+    v) export SYSTEM_VERSION="$OPTARG" ;;
+    u) ACTION="--push" ;;
     h)
-        print_description
-        echo
-        print_options
+        print_help
         exit 0
         ;;
     \?)
         echo "Invalid option: -$OPTARG" >&2
-        print_options >&2
+        print_help >&2
         exit 1
         ;;
     :)
         echo "Option -$OPTARG requires an argument." >&2
-        print_options >&2
         exit 1
         ;;
     esac
 done
 
 if [ -z "$IMAGE_NAME" ]; then
-    echo "Error: you must specify an image with -i" >&2
+    echo "Error: must specify image with -i" >&2
     exit 1
 fi
 
-if [ -z "$SERVICE" ]; then
-    SERVICE="workers"
+# When pushing to a registry, also push cache layers (mode=max).
+if [ "$ACTION" = "--push" ]; then
+    export PUSH_CACHE=true
 fi
 
-if [ -z "$DOCKERHUB_REPO" ]; then
-    DOCKERHUB_REPO="ccdlstaging"
+docker buildx bake "$IMAGE_NAME" "$ACTION"
+
+# When pushed, pull back so the image is also in the local daemon.
+# Mirrors the original script's trailing `docker pull`.
+if [ "$ACTION" = "--push" ]; then
+    docker pull --platform linux/amd64 \
+        "$DOCKERHUB_REPO/dr_$IMAGE_NAME:$SYSTEM_VERSION"
 fi
-
-# Defaults to commit hash value for if we're not running in the cloud.
-if [ -z "$SYSTEM_VERSION" ]; then
-    SYSTEM_VERSION="$(get_branch_hash)"
-fi
-
-if [ -z "$DOCKER_ACTION" ]; then
-    DOCKER_ACTION="--push"
-fi
-
-DOCKER_FILE_PATH="$SERVICE/dockerfiles/Dockerfile.$IMAGE_NAME"
-
-attempt=0
-max_attempts=3
-finished=1
-while [ $finished != 0 ] && [ $attempt -lt $max_attempts ]; do
-    if [ $attempt -gt 0 ]; then
-        echo "Failed to build $IMAGE_NAME:$SYSTEM_VERSION image, trying again."
-    fi
-
-    echo "Building the $IMAGE_NAME:$SYSTEM_VERSION image from $DOCKER_FILE_PATH."
-    update_docker_image "$DOCKERHUB_REPO" "$IMAGE_NAME" "$SYSTEM_VERSION" "$DOCKER_FILE_PATH" "$DOCKER_ACTION"
-
-    finished=$?
-    attempt=$((attempt + 1))
-done
-
-if [ $finished -ne 0 ] && [ $attempt -ge $max_attempts ]; then
-    echo "Could not build $DOCKERHUB_IMAGE after $attempt attempts."
-    exit 1
-fi
-
-docker pull \
-    --platform linux/amd64 \
-    "$DOCKERHUB_IMAGE:$SYSTEM_VERSION"

--- a/scripts/update_docker_images.sh
+++ b/scripts/update_docker_images.sh
@@ -1,9 +1,11 @@
 #!/bin/sh
 
+# Thin wrapper around `docker buildx bake` for building all images at once.
+# Build configuration lives in docker-bake.hcl. Also (re)builds the common
+# sdist that worker/foreman dockerfiles COPY in.
+
 set -e
 
-# This script should always run as if it were being called from
-# the directory it lives in.
 script_directory="$(
     cd "$(dirname "$0")" || exit
     pwd
@@ -13,102 +15,57 @@ cd "$script_directory" || exit
 # shellcheck disable=SC1091
 . ./common.sh
 
-# Get access to all of refinebio.
+# Run from the repo root so bake's relative context and sdist paths resolve.
 cd ..
 
-print_description() {
-    echo 'This script will re-build all refine.bio docker images and push '
-    echo 'them to the specified Dockerhub repository.'
-}
-
-print_options() {
+print_help() {
     cat <<EOF
-There are two required arguments for this script:
--r specifies the Dockerhub repository you would like to deploy to.
--v specifies the version you would like to build. This version will passed into
-    the Docker image as the environment variable SYSTEM_VERSION.
-    It also will be used as the tag for the Docker images built.
+Build all docker images via 'docker buildx bake'.
 
-There are also optional arguments:
--a also build the affymetrix image
-    (we normally don't because it is so intense to build)
+Usage: $(basename "$0") [-r REPO] [-v VERSION] [-a] [-u] [-h]
+
+Options:
+  -r REPO      Override DOCKERHUB_REPO (default: ccdlstaging).
+  -v VERSION   Override SYSTEM_VERSION (default: a hash of the current branch).
+  -a           Also build affymetrix (uses bake's "all" group; default omits it).
+  -u           Push to DOCKERHUB_REPO instead of loading to the local daemon.
+  -h           Print this help.
 EOF
 }
 
-while getopts ":r:v:ah" opt; do
+ACTION="--load"
+GROUP="default"
+
+while getopts ":r:v:auh" opt; do
     case $opt in
-    r)
-        export DOCKERHUB_REPO="$OPTARG"
-        ;;
-    v)
-        export SYSTEM_VERSION="$OPTARG"
-        ;;
-    a)
-        BUILD_AFFYMETRIX=true
-        ;;
+    r) export DOCKERHUB_REPO="$OPTARG" ;;
+    v) export SYSTEM_VERSION="$OPTARG" ;;
+    a) GROUP="all" ;;
+    u) ACTION="--push" ;;
     h)
-        print_description
-        echo
-        print_options
+        print_help
         exit 0
         ;;
     \?)
         echo "Invalid option: -$OPTARG" >&2
-        print_options >&2
+        print_help >&2
         exit 1
         ;;
     :)
         echo "Option -$OPTARG requires an argument." >&2
-        print_options >&2
         exit 1
         ;;
     esac
 done
 
-if [ -z "$DOCKERHUB_REPO" ]; then
-    echo 'Error: must specify the Dockerhub repository with -r'
-    exit 1
+if [ "$ACTION" = "--push" ]; then
+    export PUSH_CACHE=true
 fi
 
-if [ -z "$SYSTEM_VERSION" ]; then
-    SYSTEM_VERSION="$(get_branch_hash)"
-fi
-
-DOCKER_ACTION="--push"
-
-# Intentionally omit affymetrix unless specifically requested since it is so
-# intense to build.
-IMAGE_NAMES="base migrations common_tests foreman api_base api api_local \
-    transcriptome smasher salmon no_op illumina downloaders compendia"
-if [ "$BUILD_AFFYMETRIX" ]; then
-    IMAGE_NAMES="$IMAGE_NAMES affymetrix"
-fi
-
-# Set the version for the common project.
+# Set the version for the common project, then build the sdist that
+# worker/foreman dockerfiles COPY in. Both are preconditions for those builds.
 echo "$SYSTEM_VERSION" >common/version
-
-# Create common/dist/data-refinery-common-*.tar.gz, which is
-# required by the workers and data_refinery_foreman images.
-# Remove old common distributions if they exist.
 rm -f common/dist/*
-(cd common && python3 setup.py sdist 1>/dev/null) # Run quietly in a subshell.
+(cd common && python3 setup.py sdist 1>/dev/null)
 
-for IMAGE_NAME in $IMAGE_NAMES; do
-    case $IMAGE_NAME in
-    api_base | api | api_local)
-        DOCKER_FILE_PATH="api/dockerfiles/Dockerfile.$IMAGE_NAME"
-        ;;
-    base | common_tests | migrations)
-        DOCKER_FILE_PATH="common/dockerfiles/Dockerfile.$IMAGE_NAME"
-        ;;
-    foreman)
-        DOCKER_FILE_PATH="foreman/dockerfiles/Dockerfile.$IMAGE_NAME"
-        ;;
-    *)
-        DOCKER_FILE_PATH="workers/dockerfiles/Dockerfile.$IMAGE_NAME"
-        ;;
-    esac
-
-    echo "Building the $IMAGE_NAME:$SYSTEM_VERSION image from $DOCKER_FILE_PATH."
-    update_docker_image "$DOCKERHUB_REPO" "$IMAGE_NAME" "$SYSTEM_VERSION" "$DOCKER_FILE_PATH" "$DOCKER_ACTION"
-done
+docker buildx bake "$GROUP" "$ACTION"


### PR DESCRIPTION
## Issue Number

#3538

## Purpose/Implementation Notes

Cuts `scripts/prepare_image.sh` and `scripts/update_docker_images.sh` over to use `docker buildx bake` (added in #3539). Drops the `update_docker_image()` and `set_up_docker_builder()` helpers from `scripts/common.sh` since nothing in `scripts/` calls them after the rewrite.

Both wrappers now default to `--load` (image into local docker daemon) instead of `--push` (to
a registry). Pushing requires the explicit `-u` flag. This means non-CCDL contributors can run the wrappers locally
without dockerhub credentials.

To preserve CI's push behavior under the new default, `-u` is added to the two `prepare_image.sh` invocations in
`.github/workflows/config.yml` (`test_base` and `test_api_base` jobs).

The `-s SERVICE` flag is kept on `prepare_image.sh` as a no-op for back-compat — every per-subproject wrapper passes it;
they get reworked in a later PR in this stack and `-s` can be retired then.

Behavioral summary by mode:

| Invocation | Old behavior | New behavior |
|---|---|---|
| `prepare_image.sh -i base -s common` | Builds + pushes to ccdlstaging (fails without auth) | Builds + loads to local daemon |
| `prepare_image.sh -u -i base -s common` | Same as above (default was already push) | Builds + pushes to DOCKERHUB_REPO |
| `update_docker_images.sh -r ccdlstaging -v $TAG` | Builds all + pushes | Builds all + loads to local daemon |
| `update_docker_images.sh -u -r ccdlstaging -v $TAG` | Same as above | Builds all + pushes (CI use case) |

Note: `update_docker_image()` is still referenced from `.github/scripts/update_docker_images.sh`, which is removed in
the next PR in this stack. Until that lands, the deploy path on this branch would not run cleanly — non-issue since
deploys don't run from here.

## Methods

N/A — no data or metadata processing implications. Build orchestration changes only.

## Types of changes

- New feature (non-breaking change which adds functionality)

## Functional tests

Verified locally:

- `./scripts/prepare_image.sh -h` and `./scripts/update_docker_images.sh -h` both print usable help with the new `-u`
flag and the deprecated-no-op `-s` flag documented.
- `./scripts/prepare_image.sh -i base -s common` translates internally to `docker buildx bake base --load` (verified via
`sh -x`) and produces an image tagged `ccdlstaging/dr_base:<branch_hash>` in the local docker daemon.
- `./scripts/prepare_image.sh -u -i base -s common` (push mode) sets `PUSH_CACHE=true`, runs `docker buildx bake base
--push`, and pulls the image back to the local daemon (preserving the original script's trailing `docker pull` behavior).
- `grep -E '^(set_up_docker_builder|update_docker_image)\(\)' scripts/common.sh` returns nothing — both helpers removed.
- `git grep -n 'set_up_docker_builder'` returns no callers anywhere in the repo.

## Checklist

- [x] I have added necessary documentation (if appropriate)

## Screenshots

N/A
