### PR TITLE
Add compose services

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,6 @@ test_volume/*
 !test_volume/cassettes
 !test_volume/externally_supplied_metadata
 workers/test_volume/processed/TEST/TRANSCRIPTOME_INDEX/Homo_sapiens_short.tar.gz
-volumes_postgres/
 aspera*
 !workers/keys/asperaweb_id_dsa.openssh
 common/version

--- a/compose.yml
+++ b/compose.yml
@@ -1,0 +1,26 @@
+# Local-development services for refinebio.
+
+name: refinebio
+
+services:
+  postgres:
+    image: postgres:9.6.6
+    container_name: drdb
+    environment:
+      POSTGRES_PASSWORD: mysecretpassword
+      PGDATA: /var/lib/postgresql/data/pgdata
+    ports:
+      - "5432:5432"
+    volumes:
+      - ./volumes_postgres:/var/lib/postgresql/data
+
+  elasticsearch:
+    image: docker.elastic.co/elasticsearch/elasticsearch:6.5.4
+    container_name: dres
+    platform: linux/amd64
+    environment:
+      discovery.type: single-node
+      indices.query.bool.max_clause_count: 16384
+    ports:
+      - "9200:9200"
+      - "9300:9300"

--- a/scripts/run_es.sh
+++ b/scripts/run_es.sh
@@ -1,21 +1,16 @@
-#! /bin/sh
+#!/bin/sh
 
-docker rm -f dres 2>/dev/null
+# Thin shim around `docker compose up -d elasticsearch`.
 
-# Check if a docker database named "dres" exists, and if so just start it.
-if [ "$(docker ps -a --filter name=dres -q)" ]; then
-    docker start dres >/dev/null
-# Otherwise, run it with `docker run`.
-else
-    docker run \
-        --detach \
-        --env "discovery.type=single-node" \
-        --env "indices.query.bool.max_clause_count=16384" \
-        --name dres \
-        --platform linux/amd64 \
-        --publish 9200:9200 \
-        --publish 9300:9300 \
-        docker.elastic.co/elasticsearch/elasticsearch:6.5.4
-fi
+set -e
 
-echo "Started ElasticSearch."
+script_directory="$(
+    cd "$(dirname "$0")" || exit
+    pwd
+)"
+cd "$script_directory" || exit
+
+# Run from the repo root so compose.yml resolves.
+cd ..
+
+exec docker compose up -d elasticsearch

--- a/scripts/run_postgres.sh
+++ b/scripts/run_postgres.sh
@@ -1,40 +1,16 @@
-#! /bin/sh
+#!/bin/sh
 
-# This script should always run as if it were being called from
-# the directory it lives in.
+# Thin shim around `docker compose up -d postgres`.
+
+set -e
+
 script_directory="$(
     cd "$(dirname "$0")" || exit
     pwd
 )"
 cd "$script_directory" || exit
 
-# Get access to all of refinebio
+# Run from the repo root so compose.yml resolves.
 cd ..
 
-# CircleCI Docker won't make this by default for some reason.
-# This doubly nested directory is a hacky workaround to prevent permissions issues.
-# Suggested here:
-# https://github.com/docker/for-linux/issues/380#issuecomment-436419102
-VOLUMES="$script_directory/../volumes_postgres/volumes_postgres"
-if [ ! -d "$VOLUMES" ]; then
-    mkdir -p "$VOLUMES"
-fi
-
-# Check if a docker database named "drdb" exists, and if so just run it
-if [ "$(docker ps -a --filter name=drdb -q)" ]; then
-    docker start drdb >/dev/null
-    echo "Started database."
-# Otherwise, install it from Docker Hub.
-else
-    # via https://hub.docker.com/_/postgres/
-    # 9.6.6 is the current (as of Jan 23 2018) RDS most recent version.
-    # Password can be exposed to git/CI because this is only for dev/testing purposes, not real data.
-    echo "Installing database..."
-    docker run \
-        --detach \
-        --env POSTGRES_PASSWORD=mysecretpassword \
-        --name drdb \
-        --publish 5432:5432 \
-        --volume "$VOLUMES":/var/lib/postgresql/data \
-        postgres:9.6.6
-fi
+exec docker compose up -d postgres

--- a/volumes_postgres/.gitignore
+++ b/volumes_postgres/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore


### PR DESCRIPTION
## Issue Number

#3538

## Purpose/Implementation Notes

Introduces `docker compose` for the local-development services (`postgres` and `elasticsearch`), and shrinks the bespoke `run_postgres.sh` / `run_es.sh` wrapper scripts to thin shims that call compose under the hood. Container names match what the rest of the codebase looks up (`drdb` for postgres, `dres` for elasticsearch), so existing helpers (`get_docker_db_ip_address`, `get_docker_es_ip_address`, `--add-host=...` invocations in wrapper scripts) keep working without changes.

### Postgres data layout

The original `run_postgres.sh` used a doubly-nested host path (`volumes_postgres/volumes_postgres/`) as a workaround for a docker permissions issue: when docker creates a bind-mount target as root, the host user can't write into it. The script papered over this by `mkdir -p`-ing both directories before `docker run`.

This PR replaces the workaround with a tracked outer directory:

- `volumes_postgres/.gitignore` is committed and contains `*\n!.gitignore` (ignores everything in the directory except itself). The outer dir now exists on a fresh clone, owned by the cloning user.
- The bind mount in `compose.yml` is `./volumes_postgres:/var/lib/postgresql/data`.
- Postgres is configured with `PGDATA=/var/lib/postgresql/data/pgdata` so its init logic creates and uses a subdirectory of the bind mount, sidestepping its "data directory must be empty" check (which would otherwise trip on the `.gitignore` sitting at the root of the mount).

Net effect: no setup `mkdir` needed, no permissions dance, and the on-disk data lives at `volumes_postgres/pgdata/`.

### Path migration

The actual postgres data directory on the host moves from `volumes_postgres/volumes_postgres/` to
`volumes_postgres/pgdata/`. Anyone with existing data needs to migrate before the next `docker compose up`:

```sh
mv volumes_postgres/volumes_postgres volumes_postgres/pgdata
```

Or just nuke and recreate if the dev DB is disposable.

### Wrappers

Both `scripts/run_postgres.sh` and `scripts/run_es.sh` now collapse to one-liners around `docker compose up -d <service>`. They're kept in place because the CI workflow, README, and per-subproject test runners all reference them; cleanup of those call sites and deletion of the shims is a separate task.

### Other

- Removed `volumes_postgres/` from the root `.gitignore` (it was blocking git from descending into the directory at all). The new nested `.gitignore` handles content exclusion.

## Methods

N/A — no data or metadata processing implications. Local-dev service orchestration only.

## Types of changes

- New feature (non-breaking change which adds functionality)
- Breaking change (postgres data path moves; one-line `mv` to migrate)

## Functional tests

Verified locally:

- `docker compose config --services` lists `postgres` and `elasticsearch`.
- `docker compose config` resolves both service definitions without errors.
- `./scripts/run_es.sh` brings up `dres`; `curl -s localhost:9200/_cluster/health` returns `green`;
`get_docker_es_ip_address` finds the container.