### PR TITLE
Add compose service definitions

### DIFF
--- a/api/serve.sh
+++ b/api/serve.sh
@@ -1,33 +1,19 @@
 #!/bin/sh
 
-# Script for executing Django PyUnit tests within a Docker container.
+# Serve the API on localhost:8000.
 
-# This script should always run as if it were being called from
-# the directory it lives in.
+set -e
+
 script_directory="$(
     cd "$(dirname "$0")" || exit
     pwd
 )"
 cd "$script_directory" || exit
 
-# However, in order to give Docker access to all the code we have to
-# move up a level.
+# Run from the repo root so prepare_image.sh and compose.yml resolve.
 cd ..
 
 ./scripts/prepare_image.sh -i api_local -s api
 
-. ./scripts/common.sh
-
-DB_HOST_IP=$(get_docker_db_ip_address)
-ES_HOST_IP=$(get_docker_es_ip_address)
-
-docker run \
-    --add-host=database:"$DB_HOST_IP" \
-    --add-host=elasticsearch:"$ES_HOST_IP" \
-    --env-file api/environments/local \
-    --interactive \
-    --platform linux/amd64 \
-    --publish 8000:8000 \
-    --tty \
-    "$DOCKERHUB_REPO/dr_api_local:$SYSTEM_VERSION" \
+exec docker compose run --rm --service-ports api \
     python3 manage.py runserver 0.0.0.0:8000 "$@"

--- a/compose.yml
+++ b/compose.yml
@@ -2,6 +2,17 @@
 
 name: refinebio
 
+# Shared config for the worker app services. Each worker image gets its own
+# service so callers can `docker compose run --rm <worker> ...`.
+x-worker: &worker
+  platform: linux/amd64
+  env_file: workers/environments/local
+  environment:
+    AWS_ACCESS_KEY_ID:
+    AWS_SECRET_ACCESS_KEY:
+  volumes:
+    - ./workers/volume:/home/user/data_store
+
 services:
   postgres:
     image: postgres:9.6.6
@@ -9,6 +20,12 @@ services:
     environment:
       POSTGRES_PASSWORD: mysecretpassword
       PGDATA: /var/lib/postgresql/data/pgdata
+    networks:
+      # Reachable as `database` from app services (matches the env files'
+      # DATABASE_HOST=database) so env files don't need updating.
+      default:
+        aliases:
+          - database
     ports:
       - "5432:5432"
     volumes:
@@ -24,3 +41,53 @@ services:
     ports:
       - "9200:9200"
       - "9300:9300"
+
+  api:
+    image: ${DOCKERHUB_REPO:-ccdlstaging}/dr_api_local:${SYSTEM_VERSION:-local}
+    platform: linux/amd64
+    env_file: api/environments/local
+    ports:
+      - "8000:8000"
+
+  foreman:
+    image: ${DOCKERHUB_REPO:-ccdlstaging}/dr_foreman:${SYSTEM_VERSION:-local}
+    platform: linux/amd64
+    env_file: foreman/environments/local
+    environment:
+      AWS_ACCESS_KEY_ID:
+      AWS_SECRET_ACCESS_KEY:
+    volumes:
+      - ./foreman/volume:/home/user/data_store
+      - /tmp:/tmp
+
+  smasher:
+    <<: *worker
+    image: ${DOCKERHUB_REPO:-ccdlstaging}/dr_smasher:${SYSTEM_VERSION:-local}
+
+  salmon:
+    <<: *worker
+    image: ${DOCKERHUB_REPO:-ccdlstaging}/dr_salmon:${SYSTEM_VERSION:-local}
+
+  no_op:
+    <<: *worker
+    image: ${DOCKERHUB_REPO:-ccdlstaging}/dr_no_op:${SYSTEM_VERSION:-local}
+
+  illumina:
+    <<: *worker
+    image: ${DOCKERHUB_REPO:-ccdlstaging}/dr_illumina:${SYSTEM_VERSION:-local}
+
+  downloaders:
+    <<: *worker
+    image: ${DOCKERHUB_REPO:-ccdlstaging}/dr_downloaders:${SYSTEM_VERSION:-local}
+
+  transcriptome:
+    <<: *worker
+    image: ${DOCKERHUB_REPO:-ccdlstaging}/dr_transcriptome:${SYSTEM_VERSION:-local}
+
+  compendia:
+    <<: *worker
+    image: ${DOCKERHUB_REPO:-ccdlstaging}/dr_compendia:${SYSTEM_VERSION:-local}
+
+  affymetrix:
+    <<: *worker
+    image: ${DOCKERHUB_REPO:-ccdlstaging}/dr_affymetrix:${SYSTEM_VERSION:-local}

--- a/foreman/run_management_command.sh
+++ b/foreman/run_management_command.sh
@@ -1,43 +1,25 @@
 #!/bin/sh
 
-# Script for running the Data Refinery Surveyor container.
+# Run a Django management command in the foreman container.
 
-# This script should always run as if it were being called from
-# the directory it lives in.
+set -e
+
 script_directory="$(
     cd "$(dirname "$0")" || exit
     pwd
 )"
 cd "$script_directory" || exit
 
-# However, in order to give Docker access to all the code we have to
-# move up a level
-cd ..
-
-# Set up the data volume directory if it does not already exist
+# Set up the data volume directory if it does not already exist.
 volume_directory="$script_directory/volume"
 if [ ! -d "$volume_directory" ]; then
     mkdir "$volume_directory"
 fi
 chmod -R a+rwX "$volume_directory"
 
-. ./scripts/common.sh
+# Run from the repo root so prepare_image.sh and compose.yml resolve.
+cd ..
 
-./scripts/prepare_image.sh -i base -s common
 ./scripts/prepare_image.sh -i foreman -s foreman
 
-. ./scripts/common.sh
-
-DB_HOST_IP=$(get_docker_db_ip_address)
-
-docker run \
-    --add-host=database:"$DB_HOST_IP" \
-    --env AWS_ACCESS_KEY_ID="$AWS_ACCESS_KEY_ID" \
-    --env AWS_SECRET_ACCESS_KEY="$AWS_SECRET_ACCESS_KEY" \
-    --env-file foreman/environments/local \
-    --interactive \
-    --platform linux/amd64 \
-    --tty \
-    --volume "$volume_directory":/home/user/data_store \
-    "$DOCKERHUB_REPO/dr_foreman:$SYSTEM_VERSION" \
-    python3 manage.py "$@"
+exec docker compose run --rm foreman python3 manage.py "$@"

--- a/scripts/run_shell.sh
+++ b/scripts/run_shell.sh
@@ -1,54 +1,25 @@
 #!/bin/sh
 
-# Exit on error:
+# Open an interactive Python shell in the foreman container.
+
 set -e
 
-# Running this script will start an interactive python shell running
-# within the context of a Docker container.
-# By default the Docker container will be for the foreman project.
-# This can be changed by modifying the --env-file command line arg,
-# changing foreman/Dockerfile to the appropriate Dockerfile,
-# and changing the volume_directory path.
-
-# This script should always run as if it were being called from
-# the directory it lives in.
 script_directory="$(
     cd "$(dirname "$0")" || exit
     pwd
 )"
 cd "$script_directory" || exit
 
-# Import functions in common.sh
-. ./common.sh
-
-# Get access to all of refinebio
-cd ..
-
-# Set up the data volume directory if it does not already exist
+# Set up the foreman data volume directory if it does not already exist.
 volume_directory="$script_directory/../foreman/volume"
 if [ ! -d "$volume_directory" ]; then
     mkdir "$volume_directory"
 fi
 chmod -R a+rwX "$volume_directory"
 
-docker build \
-    --build-arg DOCKERHUB_REPO="$DOCKERHUB_REPO" \
-    --build-arg SYSTEM_VERSION="$SYSTEM_VERSION" \
-    --file foreman/dockerfiles/Dockerfile.foreman \
-    --tag dr_shell \
-    .
+# Run from the repo root so prepare_image.sh and compose.yml resolve.
+cd ..
 
-DB_HOST_IP=$(get_docker_db_ip_address)
+./scripts/prepare_image.sh -i foreman -s foreman
 
-docker run \
-    --add-host="database:$DB_HOST_IP" \
-    --env AWS_ACCESS_KEY_ID="$AWS_ACCESS_KEY_ID" \
-    --env AWS_SECRET_ACCESS_KEY="$AWS_SECRET_ACCESS_KEY" \
-    --env-file foreman/environments/local \
-    --interactive \
-    --platform linux/amd64 \
-    --tty \
-    --volume "$volume_directory":/home/user/data_store \
-    --volume /tmp:/tmp \
-    dr_shell \
-    python3 manage.py shell
+exec docker compose run --rm foreman python3 manage.py shell

--- a/workers/run_command.sh
+++ b/workers/run_command.sh
@@ -1,8 +1,7 @@
 #!/bin/sh
 
-# Script for executing Django management commands within a Docker container.
+# Run a command inside a worker container.
 
-# Exit on failure
 set -e
 
 while getopts "i:" opt; do
@@ -24,19 +23,13 @@ else
     shift
 fi
 
-# This script should always run as if it were being called from
-# the directory it lives in.
 script_directory="$(
     cd "$(dirname "$0")" || exit
     pwd
 )"
 cd "$script_directory" || exit
 
-# However in order to give Docker access to all the code we have to
-# move up a level
-cd ..
-
-# Ensure that postgres is running
+# Ensure that postgres is running.
 if ! [ "$(docker ps --filter name=drdb -q)" ]; then
     echo "You must start Postgres first with:" >&2
     echo "./scripts/run_postgres.sh" >&2
@@ -49,21 +42,9 @@ if [ ! -d "$volume_directory" ]; then
 fi
 chmod -R a+rwX "$volume_directory"
 
-. ./scripts/common.sh
-
-DB_HOST_IP=$(get_docker_db_ip_address)
+# Run from the repo root so prepare_image.sh and compose.yml resolve.
+cd ..
 
 ./scripts/prepare_image.sh -i "$IMAGE" -s workers
 
-docker run \
-    --add-host=database:"$DB_HOST_IP" \
-    --env AWS_ACCESS_KEY_ID \
-    --env AWS_SECRET_ACCESS_KEY \
-    --env-file workers/environments/local \
-    --interactive \
-    --link drdb:postgres \
-    --platform linux/amd64 \
-    --tty \
-    --volume "$volume_directory":/home/user/data_store \
-    "$DOCKERHUB_REPO/dr_$IMAGE" \
-    bash -c "$@"
+exec docker compose run --rm "$IMAGE" bash -c "$@"


### PR DESCRIPTION
## Issue Number

#3538

## Purpose/Implementation Notes

Adds compose service definitions for the application containers (`api`, `foreman`, and one service per worker image — `smasher`, `salmon`, `no_op`, `illumina`, `downloaders`, `transcriptome`, `compendia`, `affymetrix`), and replaces the four bespoke `docker run` wrapper scripts (`api/serve.sh`, `foreman/run_management_command.sh`, `workers/run_command.sh`, `scripts/run_shell.sh`) with thin shims that invoke `docker buildx bake` to build, then `docker compose run` to execute.

User-facing behavior is unchanged. Each wrapper still does "build the image then run the command" in one invocation, accepts the same arguments, mounts the same volumes, exposes the same ports, and reads the same env files. Net effect: about 80 lines of bespoke `docker run` invocations removed in favor of declarative compose service definitions.

### Network DNS replaces `--add-host`

The original wrappers each ran `--add-host=database:<ip>` (and `--add-host=elasticsearch:<ip>` for the API) using the IPs returned by `get_docker_db_ip_address` / `get_docker_es_ip_address`. With compose's default network, services can resolve each other by name, so:

- `elasticsearch` is reachable as `elasticsearch` (matches `ELASTICSEARCH_HOST` in the env files).
- The `postgres` service has a network alias `database` so the existing env files (`DATABASE_HOST=database`) keep working without edits.

### Worker services share config via a YAML anchor

Each worker image gets its own service definition so callers can do `docker compose run --rm <worker> ...`. Common config (platform, env file, AWS env passthrough, volume) lives in a top-level `x-worker:` anchor, so each worker service is one line of inheritance plus its own image ref.

### Build path unchanged

Compose services use `image: …` (no `build:` block), so compose doesn't build anything itself. Each shim runs `./scripts/prepare_image.sh -i <name> -s <subdir>` first — same as before — which routes through bake under the hood. This keeps a single source of truth for builds (`docker-bake.hcl`) and preserves the cache/contexts behavior from earlier in the stack.

### Notable removal: `dr_shell`

`scripts/run_shell.sh` previously did its own `docker build … --tag dr_shell` and ran the resulting image. The shim now uses the `foreman` service directly — same env file, same volumes, same Python shell behavior, no custom image tag.

## Methods

N/A — no data or metadata processing implications. Local-dev orchestration only.

## Types of changes

- New feature (non-breaking change which adds functionality)

## Functional tests

Verified locally:

- `docker compose config --services` lists all 12 services (postgres, elasticsearch, api, foreman, plus 8 workers).
- `docker compose config <worker>` shows the YAML anchor inheritance applied (env_file loaded, AWS env passthrough, volume mount).
- `docker compose config postgres` shows the `database` network alias in the resolved network block.
- Each shim's argv parsing matches the original (workers `-i IMAGE`, foreman/api args passed through to manage.py).
- `bash -n` syntax-clean on all four shims.
- Each shim runs `prepare_image.sh -i <image> -s <subdir>` before `docker compose run`, so the build-then-run UX is preserved.

## Checklist

- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots

N/A
