### PR TITLE
Add initial rbio command

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,6 +25,7 @@ repos:
     hooks:
       - id: black
         args: [--line-length=100]
+        files: \.pyi?$|^bin/rbio$
 
   - repo: https://github.com/detailyang/pre-commit-shell
     rev: 1.0.5

--- a/README.md
+++ b/README.md
@@ -19,53 +19,99 @@ Refine.bio currently has four sub-projects contained within this repo:
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 ## Table of Contents
 
-- [Refine.bio  ](#refinebio--)
-  - [Table of Contents](#table-of-contents)
-  - [Development](#development)
-    - [Git Workflow](#git-workflow)
-    - [Installation](#installation)
-      - [Automatic](#automatic)
-      - [Linux (Manual)](#linux-manual)
-      - [Mac (Manual)](#mac-manual)
-      - [Virtual Environment](#virtual-environment)
-      - [Services](#services)
-        - [Postgres](#postgres)
-      - [Common Dependecies](#common-dependecies)
-      - [ElasticSearch](#elasticsearch)
-    - [Testing](#testing)
-      - [API](#api)
-      - [Common](#common)
-      - [Foreman](#foreman)
-      - [Workers](#workers)
-    - [Style](#style)
-    - [Gotchas](#gotchas)
-      - [R](#r)
-  - [Running Locally](#running-locally)
-    - [API](#api-1)
-    - [Surveyor Jobs](#surveyor-jobs)
-      - [Sequence Read Archive](#sequence-read-archive)
-      - [Ensembl Transcriptome Indices](#ensembl-transcriptome-indices)
-    - [Downloader Jobs](#downloader-jobs)
-    - [Processor Jobs](#processor-jobs)
-    - [Creating Quantile Normalization Reference Targets](#creating-quantile-normalization-reference-targets)
-    - [Creating Compendia](#creating-compendia)
-    - [Running Tximport Early](#running-tximport-early)
-    - [Development Helpers](#development-helpers)
-  - [Cloud Deployment](#cloud-deployment)
-    - [Docker Images](#docker-images)
-    - [Terraform](#terraform)
-    - [AWS Batch](#aws-batch)
-    - [Running Jobs](#running-jobs)
-    - [Log Consumption](#log-consumption)
-    - [Dumping and Restoring Database Backups](#dumping-and-restoring-database-backups)
-    - [Tearing Down](#tearing-down)
-  - [Support](#support)
-  - [Meta-README](#meta-readme)
-  - [License](#license)
+- [Development](#development)
+  - [Quick Start (local development)](#quick-start-local-development)
+  - [Git Workflow](#git-workflow)
+  - [Installation](#installation)
+    - [Automatic](#automatic)
+    - [Linux (Manual)](#linux-manual)
+    - [Mac (Manual)](#mac-manual)
+    - [Virtual Environment](#virtual-environment)
+    - [Services](#services)
+      - [Postgres](#postgres)
+    - [Common Dependecies](#common-dependecies)
+    - [ElasticSearch](#elasticsearch)
+  - [Testing](#testing)
+    - [API](#api)
+    - [Common](#common)
+    - [Foreman](#foreman)
+    - [Workers](#workers)
+  - [Style](#style)
+  - [Gotchas](#gotchas)
+    - [R](#r)
+- [Running Locally](#running-locally)
+  - [API](#api-1)
+  - [Surveyor Jobs](#surveyor-jobs)
+    - [Sequence Read Archive](#sequence-read-archive)
+    - [Ensembl Transcriptome Indices](#ensembl-transcriptome-indices)
+  - [Downloader Jobs](#downloader-jobs)
+  - [Processor Jobs](#processor-jobs)
+  - [Creating Quantile Normalization Reference Targets](#creating-quantile-normalization-reference-targets)
+  - [Creating Compendia](#creating-compendia)
+  - [Running Tximport Early](#running-tximport-early)
+  - [Development Helpers](#development-helpers)
+- [Cloud Deployment](#cloud-deployment)
+  - [Docker Images](#docker-images)
+  - [Terraform](#terraform)
+  - [AWS Batch](#aws-batch)
+  - [Running Jobs](#running-jobs)
+  - [Log Consumption](#log-consumption)
+  - [Dumping and Restoring Database Backups](#dumping-and-restoring-database-backups)
+  - [Tearing Down](#tearing-down)
+- [Support](#support)
+- [Meta-README](#meta-readme)
+- [License](#license)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
 ## Development
+
+### Quick Start (local development)
+
+`bin/rbio` is a small wrapper around `docker buildx bake` and
+`docker compose` that handles the order of operations for the common
+dev workflows. It needs only Docker — no other system dependencies.
+
+1. Add `bin/` to your `PATH` (recommend [direnv](https://direnv.net/)
+   to scope it per-project):
+
+   ```sh
+   export PATH="$PWD/bin:$PATH"
+   ```
+
+2. Build the images you'll need:
+
+   ```sh
+   rbio build              # default group: base + api_local + foreman + smasher
+   rbio build api_local    # one image
+   rbio build all          # everything
+   ```
+
+3. Start the dev stack:
+
+   ```sh
+   rbio dev:up                  # api + postgres + elasticsearch
+   rbio dev:up --with foreman   # add the foreman (optional)
+   ```
+
+   The API is reachable at `http://localhost:8000`.
+
+4. When you're done:
+
+   ```sh
+   rbio dev:down       # stop services, keep your db
+   rbio dev:down -v    # nuke everything including the db
+   ```
+
+For all available commands and per-command help:
+
+```sh
+rbio --help
+rbio <command> --help
+```
+
+The existing `scripts/*.sh` wrappers continue to work unchanged for
+anyone or anything (CI included) that already uses them.
 
 ### Git Workflow
 

--- a/bin/rbio
+++ b/bin/rbio
@@ -56,11 +56,22 @@ def cmd_build(argv):
         metavar="TARGET",
         help="image(s) or group(s) to build (see list below). default: 'default' group.",
     )
-    p.add_argument("--push", action="store_true", help="push to registry after build (requires creds)")
-    p.add_argument("--load", action="store_true", help="load into local docker (default for single-target builds)")
+    p.add_argument(
+        "--push", action="store_true", help="push to registry after build (requires creds)"
+    )
+    p.add_argument(
+        "--load",
+        action="store_true",
+        help="load into local docker (default for single-target builds)",
+    )
     p.add_argument("--no-cache", action="store_true", help="rebuild from scratch")
     p.add_argument("--pull", action="store_true", help="pull latest base images before building")
-    p.add_argument("--print", dest="print_only", action="store_true", help="resolve and print HCL; build nothing")
+    p.add_argument(
+        "--print",
+        dest="print_only",
+        action="store_true",
+        help="resolve and print HCL; build nothing",
+    )
     args = p.parse_args(argv)
 
     cmd = ["docker", "buildx", "bake", "-f", "docker-bake.hcl"]
@@ -91,8 +102,15 @@ def render_bake_targets_section():
     """Return formatted groups + targets sections as a string. Empty on failure."""
     try:
         result = subprocess.run(
-            ["docker", "buildx", "bake", "-f", "docker-bake.hcl",
-             "--list", "type=targets,format=json"],
+            [
+                "docker",
+                "buildx",
+                "bake",
+                "-f",
+                "docker-bake.hcl",
+                "--list",
+                "type=targets,format=json",
+            ],
             capture_output=True,
             text=True,
             cwd=str(REPO_ROOT),
@@ -163,7 +181,9 @@ def cmd_dev_up(argv):
         choices=sorted(DEV_UP_OPTIONAL_SERVICES),
         help="optional service to start (repeatable)",
     )
-    p.add_argument("--wait", action="store_true", help="block until services pass their healthchecks")
+    p.add_argument(
+        "--wait", action="store_true", help="block until services pass their healthchecks"
+    )
     args = p.parse_args(argv)
 
     services = list(DEV_UP_DEFAULT_SERVICES)
@@ -192,7 +212,9 @@ def check_missing_local_images(services):
     """Return refinebio-built images that compose needs but aren't in the local daemon."""
     cfg = subprocess.run(
         ["docker", "compose", "config", "--format", "json"],
-        capture_output=True, text=True, cwd=str(REPO_ROOT),
+        capture_output=True,
+        text=True,
+        cwd=str(REPO_ROOT),
     )
     if cfg.returncode != 0:
         return []
@@ -206,7 +228,8 @@ def check_missing_local_images(services):
         return []
     ls = subprocess.run(
         ["docker", "image", "ls", "--format", "{{.Repository}}:{{.Tag}}"],
-        capture_output=True, text=True,
+        capture_output=True,
+        text=True,
     )
     local = set(ls.stdout.splitlines()) if ls.returncode == 0 else set()
     return [i for i in needed if i not in local]
@@ -222,7 +245,12 @@ def cmd_dev_down(argv):
         epilog="wraps: docker compose down",
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
-    p.add_argument("-v", "--volumes", action="store_true", help="also remove volumes (DESTRUCTIVE — wipes the db)")
+    p.add_argument(
+        "-v",
+        "--volumes",
+        action="store_true",
+        help="also remove volumes (DESTRUCTIVE — wipes the db)",
+    )
     p.add_argument("--rmi", action="store_true", help="remove images built by compose")
     args = p.parse_args(argv)
 

--- a/bin/rbio
+++ b/bin/rbio
@@ -212,12 +212,35 @@ def check_missing_local_images(services):
     return [i for i in needed if i not in local]
 
 
+def cmd_dev_down(argv):
+    p = argparse.ArgumentParser(
+        prog="rbio dev:down",
+        description=(
+            "Stop the local dev stack. Volumes are preserved by default — "
+            "your postgres data is safe."
+        ),
+        epilog="wraps: docker compose down",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    p.add_argument("-v", "--volumes", action="store_true", help="also remove volumes (DESTRUCTIVE — wipes the db)")
+    p.add_argument("--rmi", action="store_true", help="remove images built by compose")
+    args = p.parse_args(argv)
+
+    cmd = ["docker", "compose", "down"]
+    if args.volumes:
+        cmd.append("--volumes")
+    if args.rmi:
+        cmd.extend(["--rmi", "local"])
+    return run(cmd)
+
+
 # ─── dispatch ───────────────────────────────────────────────────────────
 
 
 COMMANDS = {
     "build": cmd_build,
     "dev:up": cmd_dev_up,
+    "dev:down": cmd_dev_down,
 }
 
 
@@ -230,6 +253,7 @@ usage:  rbio <command> [args...]
 commands:
   build           build one or more docker images
   dev:up          start the dev stack
+  dev:down        stop the dev stack
 
 global flags:
   -h, --help      show help for the current command

--- a/bin/rbio
+++ b/bin/rbio
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+
+import shlex
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+class Globals:
+    verbose = False
+    quiet = False
+    dry_run = False
+    no_color = False
+
+
+def stderr(msg):
+    print(msg, file=sys.stderr)
+
+
+def run(cmd):
+    """Run a subprocess; honor --verbose / --dry-run."""
+    rendered = " ".join(shlex.quote(c) for c in cmd)
+    if Globals.dry_run:
+        print(f"DRY RUN: {rendered}", file=sys.stderr)
+        return 0
+    if Globals.verbose:
+        print(f"+ {rendered}", file=sys.stderr)
+    return subprocess.call(cmd, cwd=str(REPO_ROOT))
+
+
+# ─── dispatch ───────────────────────────────────────────────────────────
+
+
+COMMANDS = {}
+
+
+TOP_HELP = """\
+rbio — refinebio dev tool.
+
+usage:  rbio <command> [args...]
+        rbio <command> --help             # detailed help for any command
+
+global flags:
+  -h, --help      show help for the current command
+      --verbose   echo every underlying command before running it
+      --quiet     suppress non-error output
+      --dry-run   print what would run; don't execute
+      --no-color  disable color (auto-detected when stdout isn't a TTY)
+"""
+
+
+def extract_globals(argv):
+    """Strip global flags out of argv (at any position); set Globals.* accordingly."""
+    remaining = []
+    for arg in argv:
+        if arg == "--verbose":
+            Globals.verbose = True
+        elif arg == "--quiet":
+            Globals.quiet = True
+        elif arg == "--dry-run":
+            Globals.dry_run = True
+        elif arg == "--no-color":
+            Globals.no_color = True
+        else:
+            remaining.append(arg)
+    return remaining
+
+
+def main():
+    argv = extract_globals(sys.argv[1:])
+
+    if not argv or argv[0] in ("-h", "--help"):
+        print(TOP_HELP)
+        return 0
+
+    cmd_name, cmd_args = argv[0], argv[1:]
+
+    if cmd_name not in COMMANDS:
+        stderr(f"rbio: unknown command '{cmd_name}'")
+        stderr("run 'rbio --help' to see available commands")
+        return 2
+
+    return COMMANDS[cmd_name](cmd_args) or 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/bin/rbio
+++ b/bin/rbio
@@ -134,11 +134,90 @@ def render_bake_targets_section():
     return "\n".join(lines)
 
 
+DEV_UP_DEFAULT_SERVICES = ["api", "postgres", "elasticsearch"]
+DEV_UP_OPTIONAL_SERVICES = {"foreman"}
+
+
+def cmd_dev_up(argv):
+    p = argparse.ArgumentParser(
+        prog="rbio dev:up",
+        description="Start the local dev stack.",
+        epilog=(
+            "stack:\n"
+            f"  default:   {', '.join(DEV_UP_DEFAULT_SERVICES)}\n"
+            f"  optional:  {', '.join(sorted(DEV_UP_OPTIONAL_SERVICES))} (use --with NAME)\n"
+            "\n"
+            "  workers are not part of dev:up — they're ephemeral job\n"
+            "  containers, started on demand by other commands.\n"
+            "\n"
+            "wraps: docker compose up -d <services>"
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    p.add_argument(
+        "--with",
+        dest="extras",
+        action="append",
+        default=[],
+        metavar="SERVICE",
+        choices=sorted(DEV_UP_OPTIONAL_SERVICES),
+        help="optional service to start (repeatable)",
+    )
+    p.add_argument("--wait", action="store_true", help="block until services pass their healthchecks")
+    args = p.parse_args(argv)
+
+    services = list(DEV_UP_DEFAULT_SERVICES)
+    for s in args.extras:
+        if s not in services:
+            services.append(s)
+
+    if not Globals.dry_run:
+        missing = check_missing_local_images(services)
+        if missing:
+            stderr("rbio dev:up: missing local image(s):")
+            for img in sorted(missing):
+                stderr(f"  {img}")
+            stderr("")
+            stderr("build them first:  rbio build")
+            return 1
+
+    cmd = ["docker", "compose", "up", "-d"]
+    if args.wait:
+        cmd.append("--wait")
+    cmd.extend(services)
+    return run(cmd)
+
+
+def check_missing_local_images(services):
+    """Return refinebio-built images that compose needs but aren't in the local daemon."""
+    cfg = subprocess.run(
+        ["docker", "compose", "config", "--format", "json"],
+        capture_output=True, text=True, cwd=str(REPO_ROOT),
+    )
+    if cfg.returncode != 0:
+        return []
+    try:
+        config = json.loads(cfg.stdout)
+    except json.JSONDecodeError:
+        return []
+    needed = [config.get("services", {}).get(s, {}).get("image", "") for s in services]
+    needed = [i for i in needed if "/dr_" in i]
+    if not needed:
+        return []
+    ls = subprocess.run(
+        ["docker", "image", "ls", "--format", "{{.Repository}}:{{.Tag}}"],
+        capture_output=True, text=True,
+    )
+    local = set(ls.stdout.splitlines()) if ls.returncode == 0 else set()
+    return [i for i in needed if i not in local]
+
+
 # ─── dispatch ───────────────────────────────────────────────────────────
 
 
 COMMANDS = {
     "build": cmd_build,
+    "dev:up": cmd_dev_up,
 }
 
 
@@ -150,6 +229,7 @@ usage:  rbio <command> [args...]
 
 commands:
   build           build one or more docker images
+  dev:up          start the dev stack
 
 global flags:
   -h, --help      show help for the current command

--- a/bin/rbio
+++ b/bin/rbio
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
 
+import argparse
+import json
 import shlex
 import subprocess
 import sys
@@ -30,10 +32,114 @@ def run(cmd):
     return subprocess.call(cmd, cwd=str(REPO_ROOT))
 
 
+# ─── commands ───────────────────────────────────────────────────────────
+
+
+def cmd_build(argv):
+    needs_help = any(a in ("-h", "--help") for a in argv)
+    epilog = "wraps: docker buildx bake -f docker-bake.hcl <targets>"
+    if needs_help:
+        section = render_bake_targets_section()
+        if section:
+            epilog = section + "\n\n" + epilog
+
+    p = argparse.ArgumentParser(
+        prog="rbio build",
+        description="Build one or more docker images.",
+        epilog=epilog,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    p.add_argument(
+        "targets",
+        nargs="*",
+        default=["default"],
+        metavar="TARGET",
+        help="image(s) or group(s) to build (see list below). default: 'default' group.",
+    )
+    p.add_argument("--push", action="store_true", help="push to registry after build (requires creds)")
+    p.add_argument("--load", action="store_true", help="load into local docker (default for single-target builds)")
+    p.add_argument("--no-cache", action="store_true", help="rebuild from scratch")
+    p.add_argument("--pull", action="store_true", help="pull latest base images before building")
+    p.add_argument("--print", dest="print_only", action="store_true", help="resolve and print HCL; build nothing")
+    args = p.parse_args(argv)
+
+    cmd = ["docker", "buildx", "bake", "-f", "docker-bake.hcl"]
+    if args.push:
+        cmd.append("--push")
+    if args.load:
+        cmd.append("--load")
+    if args.no_cache:
+        cmd.append("--no-cache")
+    if args.pull:
+        cmd.append("--pull")
+    if args.print_only:
+        cmd.append("--print")
+    cmd.extend(args.targets)
+    return run(cmd)
+
+
+# Keep in sync with docker-bake.hcl group definitions.
+GROUP_DESCRIPTIONS = {
+    "all": "every image",
+    "default": "all images except affymetrix (long build time)",
+    "deploy": "production images only (skips the local-dev variants)",
+    "workers": "only the worker images",
+}
+
+
+def render_bake_targets_section():
+    """Return formatted groups + targets sections as a string. Empty on failure."""
+    try:
+        result = subprocess.run(
+            ["docker", "buildx", "bake", "-f", "docker-bake.hcl",
+             "--list", "type=targets,format=json"],
+            capture_output=True,
+            text=True,
+            cwd=str(REPO_ROOT),
+        )
+        if result.returncode != 0:
+            return ""
+        entries = json.loads(result.stdout)
+    except (FileNotFoundError, json.JSONDecodeError):
+        return ""
+
+    groups = sorted(e["name"] for e in entries if e.get("group"))
+    targets = sorted(e["name"] for e in entries if not e.get("group"))
+    if not (groups or targets):
+        return ""
+
+    lines = []
+
+    if groups:
+        lines.append("groups:")
+        col = max(len(g) for g in groups) + 2
+        for g in groups:
+            lines.append(f"  {g.ljust(col)}{GROUP_DESCRIPTIONS.get(g, '')}")
+
+    if targets:
+        if groups:
+            lines.append("")
+        lines.append("images:")
+        col_width = max(len(t) for t in targets) + 2
+        n_cols = max(1, 78 // col_width)
+        n_rows = (len(targets) + n_cols - 1) // n_cols
+        for r in range(n_rows):
+            row = []
+            for c in range(n_cols):
+                idx = c * n_rows + r
+                if idx < len(targets):
+                    row.append(targets[idx].ljust(col_width))
+            lines.append("  " + "".join(row).rstrip())
+
+    return "\n".join(lines)
+
+
 # ─── dispatch ───────────────────────────────────────────────────────────
 
 
-COMMANDS = {}
+COMMANDS = {
+    "build": cmd_build,
+}
 
 
 TOP_HELP = """\
@@ -41,6 +147,9 @@ rbio — refinebio dev tool.
 
 usage:  rbio <command> [args...]
         rbio <command> --help             # detailed help for any command
+
+commands:
+  build           build one or more docker images
 
 global flags:
   -h, --help      show help for the current command


### PR DESCRIPTION
## Issue Number

Part of #3538.

## Purpose

Introduce `bin/rbio` — a stdlib-only Python CLI that wraps the common docker workflows behind one tool. Three commands ship in this PR: `build`, `dev:up`, `dev:down`. The README gets a "Quick Start (local development)" section using them.

## Implementation Notes

- `bin/rbio` is a single executable Python script. Standard library only — no new system dependencies.
- Each command has its own `--help` with a `wraps:` line at the bottom documenting the underlying docker invocation it runs. `--verbose` echoes the resolved command at runtime.
- `build` wraps `docker buildx bake`. Its `--help` includes a dynamically-generated list of available groups (with a one-line description of what each selects) and the individual images, derived from the bake config so it can't drift.
- `dev:up` wraps `docker compose up`. Default services are `api + postgres + elasticsearch` (refine.bio is API-first — the default is enough to actually use the API). `foreman` is optional via `--with foreman`. Workers are deliberately excluded — they're ephemeral job containers, not long-running services.
- `dev:up` runs a pre-flight check for refinebio-built images that compose needs but aren't present locally; if any are missing it errors with an actionable hint pointing at `rbio build` rather than letting compose fail with a cryptic "image not found" from the daemon. The check is skipped under `--dry-run`.
- `dev:down` wraps `docker compose down`. Volumes are preserved by default — postgres data survives across runs. `-v` / `--volumes` opts into the destructive cleanup; `--rmi` also removes locally-built compose images.
- Global flags: `--verbose`, `--quiet`, `--dry-run`, `--no-color`, parsed at any position in argv.
- No existing scripts are touched. Every CI step and every README reference still works.

### Types of Changes

- [x] New feature (non-breaking change which adds functionality).
- [x] Documentation update.

### Functional Tests

- [x] `rbio --help` lists the three commands and the global flags.
- [x] `rbio <command> --help` renders the per-command help with a `wraps:` line.
- [x] `rbio build --help` lists groups + images derived from `docker-bake.hcl`.
- [x] `rbio --dry-run <command>` prints the resolved docker invocation without executing it.
- [x] `rbio dev:up` errors with an actionable hint when one of the refinebio-built images compose needs is missing locally.
- [x] `rbio dev:down` defaults to preserving volumes; `-v` removes them; `--rmi` also removes built images.

### Checklist

- [x] `bin/rbio` is committed with the executable bit set in the git index (`100755`).
- [x] Stdlib-only — no third-party Python dependencies.
- [x] README "Quick Start (local development)" section added under Development.
- [x] No existing scripts are modified or removed.
- [x] ran doctoc on README.md after editing 

### Screenshots
```bash
$ rbio --help
rbio — refinebio dev tool.

usage:  rbio  [args...]
        rbio  --help             # detailed help for any command

commands:
  build           build one or more docker images
  dev:up          start the dev stack
  dev:down        stop the dev stack

global flags:
  -h, --help      show help for the current command
      --verbose   echo every underlying command before running it
      --quiet     suppress non-error output
      --dry-run   print what would run; don't execute
      --no-color  disable color (auto-detected when stdout isn't a TTY)
```