### PR TITLE
migrate test_base ci to rbio w/ buildx

### DIFF
--- a/.github/workflows/config.yml
+++ b/.github/workflows/config.yml
@@ -243,8 +243,13 @@ jobs:
           username: ${{ env.DOCKER_USERNAME }}
           password: ${{ env.DOCKER_PASSWORD }}
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Build the Docker Image
-        run: scripts/prepare_image.sh -u -i base -s common
+        env:
+          PUSH_CACHE: "true"
+        run: bin/rbio build base --push
 
   test_common:
     name: Test Common


### PR DESCRIPTION
=## Issue Number

Part of #3538.

## Purpose/Implementation Notes

Unblock the `test_base` CI job, which currently fails with "Cache export is not supported for the docker driver." The default docker driver on GitHub Actions runners doesn't support cache export, but bake tries to push cache when invoked with `--push` (because `PUSH_CACHE=true` gets set). The container driver does support cache export.

This PR makes two coordinated changes:

1. **Add `docker/setup-buildx-action@v3`** before the build step. This creates a buildx builder with the `docker-container` driver, which supports cache export. The old `update_docker_image()` helper used to set this up; the bake migration in #3540 didn't carry that forward, which is the regression.
2. **Switch the build step to `bin/rbio build base --push`** with `PUSH_CACHE=true` set explicitly in the step env. rbio (introduced in #3543) doesn't auto-set PUSH_CACHE on `--push` — CI sets it explicitly so the intent is visible. This is the first place CI exercises rbio.

Underlying `Dockerfile.base` rot (Ubuntu 18.04 EOL, Python 3.8 EOL, etc.) is a separate concern and may surface as the next failure once this lands. That work continues on this branch (or follows in a sibling PR) — the present PR is scoped to the cache-export fix and the rbio cut-over for this one CI step.

## Methods

N/A — no data or metadata processing implications.

## Types of changes

- Bugfix (non-breaking change which fixes an issue) — the CI cache-export regression.

## Functional tests

- `bin/rbio build base --print` resolves the same HCL as the previous invocation (verified locally).
- The CI run on this PR will exercise the actual workflow change; expected outcome is the cache-export error is gone and the build proceeds (likely failing later on the dockerfile rot until that's addressed).

## Checklist

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works _(CI run is the test)_
- [ ] I have added necessary documentation (if appropriate) _(N/A)_
- [x] Any dependent changes have been merged and published in downstream modules _(rbio shipped in #3543)_

## Screenshots
N/A