### PR TITLE
Fix test api

### DIFF
--- a/.github/workflows/config.yml
+++ b/.github/workflows/config.yml
@@ -159,10 +159,10 @@ jobs:
         run: scripts/install_db_docker.sh
 
       - name: Update Models
-        run: scripts/update_models.sh
+        run: bin/rbio common:update
 
       - name: Rebuild the Elasticsearch Index
-        run: scripts/rebuild_es_index.sh
+        run: bin/rbio es:rebuild
 
       - name: Run API Tests
         run: |

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,6 +26,7 @@ repos:
       - id: black
         args: [--line-length=100]
         files: \.pyi?$|^bin/rbio$
+        types_or: [file]
 
   - repo: https://github.com/detailyang/pre-commit-shell
     rev: 1.0.5

--- a/api/run_tests.sh
+++ b/api/run_tests.sh
@@ -40,9 +40,6 @@ chmod -R a+rwX "$volume_directory"
 
 . ./scripts/common.sh
 
-DB_HOST_IP=$(get_docker_db_ip_address)
-ES_HOST_IP=$(get_docker_es_ip_address)
-
 # Only run interactively if we are on a TTY.
 if [ -t 1 ]; then
     INTERACTIVE="--interactive"
@@ -50,8 +47,7 @@ fi
 
 # shellcheck disable=SC2086
 docker run \
-    --add-host=database:"$DB_HOST_IP" \
-    --add-host=elasticsearch:"$ES_HOST_IP" \
+    --network refinebio_default \
     --env-file api/environments/test \
     --platform linux/amd64 \
     --tty \

--- a/bin/rbio
+++ b/bin/rbio
@@ -296,10 +296,20 @@ def cmd_es_rebuild(argv):
         return rc
     if (rc := bake_target("api_local")) != 0:
         return rc
-    return run([
-        "docker", "compose", "run", "--rm", "api",
-        "python3", "manage.py", "search_index", "--rebuild", "-f",
-    ])
+    return run(
+        [
+            "docker",
+            "compose",
+            "run",
+            "--rm",
+            "api",
+            "python3",
+            "manage.py",
+            "search_index",
+            "--rebuild",
+            "-f",
+        ]
+    )
 
 
 DEV_UP_DEFAULT_SERVICES = ["api", "postgres", "elasticsearch"]

--- a/bin/rbio
+++ b/bin/rbio
@@ -38,23 +38,31 @@ def bake_target(target):
     return run(["docker", "buildx", "bake", "-f", "docker-bake.hcl", target, "--load"])
 
 
-def is_drdb_running():
-    """True if the drdb container is up. Used as a pre-flight by common:*."""
+def is_container_running(name):
+    """True if a container with this name is up."""
     result = subprocess.run(
-        ["docker", "container", "inspect", "drdb", "--format", "{{.State.Running}}"],
+        ["docker", "container", "inspect", name, "--format", "{{.State.Running}}"],
         capture_output=True,
         text=True,
     )
     return result.returncode == 0 and result.stdout.strip() == "true"
 
 
-def require_drdb(cmd_name):
-    """Pre-flight: error with a hint if drdb isn't running. Skipped under --dry-run."""
-    if Globals.dry_run or is_drdb_running():
+def require_container(cmd_name, container, friendly, compose_service):
+    """Pre-flight: error with a hint if the named container isn't running. Skipped under --dry-run."""
+    if Globals.dry_run or is_container_running(container):
         return 0
-    stderr(f"rbio {cmd_name}: postgres (drdb) is not running")
-    stderr("start it first:  rbio dev:up  (or docker compose up -d postgres)")
+    stderr(f"rbio {cmd_name}: {friendly} ({container}) is not running")
+    stderr(f"start it first:  rbio dev:up  (or docker compose up -d {compose_service})")
     return 1
+
+
+def require_drdb(cmd_name):
+    return require_container(cmd_name, "drdb", "postgres", "postgres")
+
+
+def require_dres(cmd_name):
+    return require_container(cmd_name, "dres", "elasticsearch", "elasticsearch")
 
 
 # ─── commands ───────────────────────────────────────────────────────────
@@ -272,6 +280,28 @@ def cmd_common_update(argv):
     return run(["python3", "setup.py", "sdist"], cwd=common_dir)
 
 
+def cmd_es_rebuild(argv):
+    p = argparse.ArgumentParser(
+        prog="rbio es:rebuild",
+        description="Rebuild the elasticsearch index from scratch.",
+        epilog=(
+            "wraps:\n"
+            "  docker buildx bake api_local\n"
+            "  docker compose run --rm api python3 manage.py search_index --rebuild -f"
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    p.parse_args(argv)
+    if (rc := require_dres("es:rebuild")) != 0:
+        return rc
+    if (rc := bake_target("api_local")) != 0:
+        return rc
+    return run([
+        "docker", "compose", "run", "--rm", "api",
+        "python3", "manage.py", "search_index", "--rebuild", "-f",
+    ])
+
+
 DEV_UP_DEFAULT_SERVICES = ["api", "postgres", "elasticsearch"]
 DEV_UP_OPTIONAL_SERVICES = {"foreman"}
 
@@ -392,6 +422,7 @@ COMMANDS = {
     "common:update": cmd_common_update,
     "dev:up": cmd_dev_up,
     "dev:down": cmd_dev_down,
+    "es:rebuild": cmd_es_rebuild,
 }
 
 
@@ -408,6 +439,7 @@ commands:
   common:update            full chain: make + apply + rebuild common sdist
   dev:up                   start the dev stack
   dev:down                 stop the dev stack
+  es:rebuild               rebuild the elasticsearch index
 
 global flags:
   -h, --help      show help for the current command

--- a/scripts/rebuild_es_index.sh
+++ b/scripts/rebuild_es_index.sh
@@ -1,11 +1,2 @@
 #!/bin/sh
-
-# This script should always run as if it were being called from
-# the directory it lives in.
-script_directory="$(
-    cd "$(dirname "$0")" || exit
-    pwd
-)"
-cd "$script_directory" || exit
-
-./run_manage.sh -i api_local -s api search_index --rebuild -f
+exec "$(dirname "$0")/../bin/rbio" es:rebuild "$@"


### PR DESCRIPTION
## Issue Number

Part of #3538.

## Purpose/Implementation Notes

Unblock the `test_api` CI job. After PR 8 (#3546) made test_api_base green, test_api inherits the same shape but hits two more script-level network bugs caused by compose moving `drdb`/`dres` to its own network (introduced in PR 4).

Fixes both, using the now-established two-flavor approach:

1. **`rebuild_es_index.sh` → `rbio es:rebuild` (B-mini absorption).** New rbio command uses `docker compose run --rm api python3 manage.py search_index --rebuild -f` so compose handles networking. Adds reusable `is_container_running` / `require_container` helpers (replacing the drdb-specific ones from PR 8). Script becomes a thin shim. Other CI jobs that call the script directly continue to work.

2. **`api/run_tests.sh` in-place network fix.** Same network bug, but absorbing this into `rbio test:api` is meaningful Wave 3 work (coverage runner, test env, etc.) better suited to its own PR. For now: drop `--add-host=database:IP --add-host=elasticsearch:IP`, add `--network refinebio_default`. Postgres/ES are already reachable by their compose service names on that network.

3. **CI test_api workflow migration.** `Update Models` → `bin/rbio common:update` (matches test_api_base), `Rebuild Elasticsearch Index` → `bin/rbio es:rebuild`.

## Methods

N/A — no data or metadata processing implications.

## Types of changes

- Bugfix — same network regression as PR 8, surfacing in different scripts as test_api gets to run.

## Functional tests

- [x] `bin/rbio es:rebuild --help` renders correctly.
- [ ] CI run of test_api will exercise the full chain: rebuild ES via rbio + run_tests.sh against compose-networked deps.

## Checklist

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works _(CI run is the test)_
- [ ] I have added necessary documentation (if appropriate) _(N/A)_
- [x] Any dependent changes have been merged and published in downstream modules _(test_api_base sibling fix in #3546)_

## Screenshots

N/A