### PR TITLE
fix test common

### DIFF
--- a/common/run_tests.sh
+++ b/common/run_tests.sh
@@ -33,9 +33,6 @@ chmod -R a+rwX "$volume_directory"
 
 . ./scripts/common.sh
 
-DB_HOST_IP=$(get_docker_db_ip_address)
-ES_HOST_IP=$(get_docker_es_ip_address)
-
 # Only run interactively if we are on a TTY.
 if [ -t 1 ]; then
     INTERACTIVE="--interactive"
@@ -43,8 +40,7 @@ fi
 
 # shellcheck disable=SC2086
 docker run \
-    --add-host=database:"$DB_HOST_IP" \
-    --add-host=elasticsearch:"$ES_HOST_IP" \
+    --network refinebio_default \
     --env-file common/environments/test \
     --platform linux/amd64 \
     --tty \


### PR DESCRIPTION
## Issue Number

Part of #3538.

## Purpose/Implementation Notes

Unblock `test_common` CI. Same network-isolation bug as `api/run_tests.sh` had in PR 9 (#3547): `docker run` for the common_tests container used `--add-host=database:IP --add-host=elasticsearch:IP` without `--network`, so the test container couldn't reach drdb/dres on compose's network from a Linux runner.

Drop the `--add-host` lines (and the IP discovery they require), add `--network refinebio_default`. Postgres has the `database` alias on that network and elasticsearch resolves by its compose service name, so DNS works without the explicit hosts.

Wave 3 absorption (`rbio test:*`) is deferred — the plan is to land test_common + test_foreman in-place fixes first (this PR + a sibling), then do the rbio absorption against a fully-green baseline so any regression introduced by the refactor is unambiguous.

## Methods

N/A — no data or metadata processing implications.

## Types of changes

- Bugfix — same network regression as PR 9, in another script.

## Functional tests

- [ ] CI run on this PR will exercise the test_common container with proper compose networking.

## Checklist

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works _(CI run is
 the test)_
- [ ] I have added necessary documentation (if appropriate) _(N/A)_
- [x] Any dependent changes have been merged and published in downstream modules _(test_api
sibling fix in #3547)_

## Screenshots

(CI run screenshot once available)
