### PR TITLE
dockerfiles: redeclare ARG SYSTEM_VERSION after FROM

### DIFF
--- a/api/dockerfiles/Dockerfile.api
+++ b/api/dockerfiles/Dockerfile.api
@@ -1,6 +1,7 @@
 ARG DOCKERHUB_REPO
 ARG SYSTEM_VERSION
 FROM $DOCKERHUB_REPO/dr_api_base:$SYSTEM_VERSION
+ARG SYSTEM_VERSION
 
 # Fail in case of an error at any stage in the pipe.
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]

--- a/api/dockerfiles/Dockerfile.api_local
+++ b/api/dockerfiles/Dockerfile.api_local
@@ -1,6 +1,7 @@
 ARG DOCKERHUB_REPO
 ARG SYSTEM_VERSION
 FROM $DOCKERHUB_REPO/dr_api_base:$SYSTEM_VERSION
+ARG SYSTEM_VERSION
 
 # Fail in case of an error at any stage in the pipe.
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]

--- a/common/dockerfiles/Dockerfile.common_tests
+++ b/common/dockerfiles/Dockerfile.common_tests
@@ -1,6 +1,7 @@
 ARG DOCKERHUB_REPO
 ARG SYSTEM_VERSION
 FROM $DOCKERHUB_REPO/dr_base:$SYSTEM_VERSION
+ARG SYSTEM_VERSION
 
 # Fail in case of an error at any stage in the pipe.
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]

--- a/common/dockerfiles/Dockerfile.migrations
+++ b/common/dockerfiles/Dockerfile.migrations
@@ -1,6 +1,7 @@
 ARG DOCKERHUB_REPO
 ARG SYSTEM_VERSION
 FROM $DOCKERHUB_REPO/dr_base:$SYSTEM_VERSION
+ARG SYSTEM_VERSION
 
 # Fail in case of an error at any stage in the pipe.
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]

--- a/foreman/dockerfiles/Dockerfile.foreman
+++ b/foreman/dockerfiles/Dockerfile.foreman
@@ -1,6 +1,7 @@
 ARG DOCKERHUB_REPO
 ARG SYSTEM_VERSION
 FROM $DOCKERHUB_REPO/dr_base:$SYSTEM_VERSION
+ARG SYSTEM_VERSION
 
 # Fail in case of an error at any stage in the pipe.
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]

--- a/workers/dockerfiles/Dockerfile.affymetrix
+++ b/workers/dockerfiles/Dockerfile.affymetrix
@@ -1,6 +1,7 @@
 ARG DOCKERHUB_REPO
 ARG SYSTEM_VERSION
 FROM $DOCKERHUB_REPO/dr_base:$SYSTEM_VERSION
+ARG SYSTEM_VERSION
 
 # Fail in case of an error at any stage in the pipe.
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]

--- a/workers/dockerfiles/Dockerfile.downloaders
+++ b/workers/dockerfiles/Dockerfile.downloaders
@@ -1,6 +1,7 @@
 ARG DOCKERHUB_REPO
 ARG SYSTEM_VERSION
 FROM $DOCKERHUB_REPO/dr_base:$SYSTEM_VERSION
+ARG SYSTEM_VERSION
 
 # Fail in case of an error at any stage in the pipe.
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]

--- a/workers/dockerfiles/Dockerfile.illumina
+++ b/workers/dockerfiles/Dockerfile.illumina
@@ -1,6 +1,7 @@
 ARG DOCKERHUB_REPO
 ARG SYSTEM_VERSION
 FROM $DOCKERHUB_REPO/dr_base:$SYSTEM_VERSION
+ARG SYSTEM_VERSION
 
 # Fail in case of an error at any stage in the pipe.
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]

--- a/workers/dockerfiles/Dockerfile.no_op
+++ b/workers/dockerfiles/Dockerfile.no_op
@@ -1,6 +1,7 @@
 ARG DOCKERHUB_REPO
 ARG SYSTEM_VERSION
 FROM $DOCKERHUB_REPO/dr_base:$SYSTEM_VERSION
+ARG SYSTEM_VERSION
 
 # Fail in case of an error at any stage in the pipe.
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]

--- a/workers/dockerfiles/Dockerfile.salmon
+++ b/workers/dockerfiles/Dockerfile.salmon
@@ -1,6 +1,7 @@
 ARG DOCKERHUB_REPO
 ARG SYSTEM_VERSION
 FROM $DOCKERHUB_REPO/dr_base:$SYSTEM_VERSION
+ARG SYSTEM_VERSION
 
 # Fail in case of an error at any stage in the pipe.
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]

--- a/workers/dockerfiles/Dockerfile.smasher
+++ b/workers/dockerfiles/Dockerfile.smasher
@@ -1,6 +1,7 @@
 ARG DOCKERHUB_REPO
 ARG SYSTEM_VERSION
 FROM $DOCKERHUB_REPO/dr_base:$SYSTEM_VERSION
+ARG SYSTEM_VERSION
 
 # Fail in case of an error at any stage in the pipe.
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]

--- a/workers/dockerfiles/Dockerfile.transcriptome
+++ b/workers/dockerfiles/Dockerfile.transcriptome
@@ -1,6 +1,7 @@
 ARG DOCKERHUB_REPO
 ARG SYSTEM_VERSION
 FROM $DOCKERHUB_REPO/dr_base:$SYSTEM_VERSION
+ARG SYSTEM_VERSION
 
 # Fail in case of an error at any stage in the pipe.
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]


### PR DESCRIPTION
## Issue Number

N/A

## Purpose/Implementation Notes

This pull request makes a minor but consistent update across all Dockerfiles in the project. It adds a redundant declaration of the `SYSTEM_VERSION` build argument after the `FROM` statement in each Dockerfile.

This prevents the SYSTEM_VERSION from being undefined inside the container.

Dockerfile updates:

* Added an extra `ARG SYSTEM_VERSION` declaration after the `FROM` statement in the following Dockerfiles to ensure the build argument is available in later stages:
  - `api/dockerfiles/Dockerfile.api`
  - `api/dockerfiles/Dockerfile.api_local`
  - `common/dockerfiles/Dockerfile.common_tests`
  - `common/dockerfiles/Dockerfile.migrations`
  - `foreman/dockerfiles/Dockerfile.foreman`
  - `workers/dockerfiles/Dockerfile.affymetrix`
  - `workers/dockerfiles/Dockerfile.downloaders`
  - `workers/dockerfiles/Dockerfile.illumina`
  - `workers/dockerfiles/Dockerfile.no_op`
  - `workers/dockerfiles/Dockerfile.salmon`
  - `workers/dockerfiles/Dockerfile.smasher`
  - `workers/dockerfiles/Dockerfile.transcriptome`

## Methods

N/A

## Types of changes

What types of changes does your code introduce?

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

List out the functional tests you've completed to verify your changes work locally.

## Checklist

- [x] Lint and unit tests pass locally with my changes


## Screenshots

N/A
