### PR TITLE
postgres: upgrade to 17.9

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -15,7 +15,7 @@ x-worker: &worker
 
 services:
   postgres:
-    image: postgres:9.6.6
+    image: postgres:17.9
     container_name: drdb
     environment:
       POSTGRES_PASSWORD: mysecretpassword

--- a/infrastructure/database.tf
+++ b/infrastructure/database.tf
@@ -138,12 +138,114 @@ resource "aws_db_parameter_group" "postgres_parameters" {
   tags = var.default_tags
 }
 
+# pg17 parameter group, mirror of the postgres11 group above.
+# Defined as a new resource (rather than changing family on the existing
+# group) so terraform creates it cleanly and AWS can attach it during
+# the major version upgrade without trying to mutate a parameter group
+# already in use. The legacy postgres_parameters (pg11) resource above
+# is kept in place for now so its detach happens cleanly during the
+# upgrade; remove it in a follow-up PR once the upgrade is verified.
+resource "aws_db_parameter_group" "postgres_parameters_pg17" {
+  name = "postgres-parameters-${var.user}-${var.stage}-pg17"
+  description = "Postgres Parameters ${var.user} ${var.stage} (pg17)"
+  family = "postgres17"
+
+  parameter {
+    name = "deadlock_timeout"
+    value = "60000" # 60000ms = 60s
+  }
+
+  parameter {
+    name = "statement_timeout"
+    value = "60000" # 60000ms = 60s
+  }
+
+  parameter {
+    name = "log_checkpoints"
+    value = false
+  }
+
+  parameter {
+    name = "work_mem"
+    value = 128000
+    apply_method = "pending-reboot"
+  }
+
+  parameter {
+    name = "shared_buffers"
+    value = "{DBInstanceClassMemory/20480}"
+    apply_method = "pending-reboot"
+  }
+
+  parameter {
+    name = "max_wal_size"
+    value = 4096
+    apply_method = "pending-reboot"
+  }
+
+  parameter {
+    name = "min_wal_size"
+    value = 1024
+    apply_method = "pending-reboot"
+  }
+
+  parameter {
+    name = "wal_buffers"
+    value = 16384
+    apply_method = "pending-reboot"
+  }
+
+  parameter {
+    name = "effective_cache_size"
+    value = "{DBInstanceClassMemory/10922}"
+    apply_method = "pending-reboot"
+  }
+
+  parameter {
+    name = "maintenance_work_mem"
+    value = 1048576
+    apply_method = "pending-reboot"
+  }
+
+  parameter {
+    name = "random_page_cost"
+    value = 1.1
+    apply_method = "pending-reboot"
+  }
+
+  parameter {
+    name = "effective_io_concurrency"
+    value = 200
+    apply_method = "pending-reboot"
+  }
+
+  parameter {
+    name = "max_worker_processes"
+    value = "{DBInstanceVCPU}"
+    apply_method = "pending-reboot"
+  }
+
+  parameter {
+    name = "max_parallel_workers"
+    value = "{DBInstanceVCPU}"
+    apply_method = "pending-reboot"
+  }
+
+  parameter {
+    name = "autovacuum_vacuum_scale_factor"
+    value = "0.01"
+    apply_method = "pending-reboot"
+  }
+
+  tags = var.default_tags
+}
+
 resource "aws_db_instance" "postgres_db" {
   identifier = "data-refinery-${var.user}-${var.stage}"
   allocated_storage = 100
   storage_type = "gp2"
   engine = "postgres"
-  engine_version = "11.16"
+  engine_version = "17.9"
   allow_major_version_upgrade = true
   auto_minor_version_upgrade = false
   instance_class = "db.${var.database_instance_type}"
@@ -155,7 +257,7 @@ resource "aws_db_instance" "postgres_db" {
   apply_immediately = true
 
   db_subnet_group_name = aws_db_subnet_group.data_refinery.name
-  parameter_group_name = aws_db_parameter_group.postgres_parameters.name
+  parameter_group_name = aws_db_parameter_group.postgres_parameters_pg17.name
 
   # TF is broken, but we do want this protection in prod.
   # Related: https://github.com/hashicorp/terraform/issues/5417


### PR DESCRIPTION
## Issue Number

#3554 

## Purpose/Implementation Notes

This pull request upgrades the PostgreSQL version used in both local development and AWS infrastructure from 11.16/9.6.6 to 17.9. It introduces a new parameter group for PostgreSQL 17 to ensure a smooth upgrade and avoid mutating in-use resources. Existing resources are updated to reference the new version and parameter group.

**PostgreSQL Version Upgrade:**
* Updates the Docker Compose `postgres` service to use the `postgres:17.9` image for local development (`compose.yml`).
* Upgrades the AWS RDS instance engine version from `11.16` to `17.9` (`infrastructure/database.tf`).

**Infrastructure Parameter Group Changes:**
* Adds a new `aws_db_parameter_group` resource (`postgres_parameters_pg17`) specifically for PostgreSQL 17, mirroring the previous configuration and ensuring AWS can attach it cleanly during the upgrade (`infrastructure/database.tf`).
* Updates the RDS instance to use the new PostgreSQL 17 parameter group instead of the old one (`infrastructure/database.tf`).

## Methods

N/A

## Types of changes

What types of changes does your code introduce?

- New feature (non-breaking change which adds functionality)


## Functional tests

N/A - Ran tests locally

## Checklist

- [x] Lint and unit tests pass locally with my changes

## Screenshots

N/A