### PR TITLE
queryset ordering: don't rely on Postgres default row order

### DIFF
--- a/common/data_refinery_common/job_lookup.py
+++ b/common/data_refinery_common/job_lookup.py
@@ -131,9 +131,12 @@ def determine_processor_pipeline(sample_object: Sample, original_file=None) -> P
             # We currently aren't prepared to process Agilent because we don't have
             # whitelist of supported platforms for it. However this code works so
             # let's keep it around until we're ready for Agilent.
-            annotations = sample_object.sampleannotation_set.all()[0]
-            channel1_protocol = annotations.data.get("label_protocol_ch1", "").upper()
-            channel2_protocol = annotations.data.get("label_protocol_ch2", "").upper()
+            annotation = sample_object.sampleannotation_set.filter(
+                data__has_keys=["label_protocol_ch1", "label_protocol_ch2"]
+            ).first()
+            data = annotation.data if annotation else {}
+            channel1_protocol = data.get("label_protocol_ch1", "").upper()
+            channel2_protocol = data.get("label_protocol_ch2", "").upper()
             if ("AGILENT" in channel1_protocol) and ("AGILENT" in channel2_protocol):
                 return ProcessorPipeline.AGILENT_TWOCOLOR_TO_PCL
             else:

--- a/foreman/tests/foreman/management/commands/test_run_tximport.py
+++ b/foreman/tests/foreman/management/commands/test_run_tximport.py
@@ -241,7 +241,9 @@ class RunTximportTestCase(TestCase):
 
         run_tximport.run_tximport_for_all_eligible_experiments()
 
-        pj = ProcessorJob.objects.all()[0]
+        pj = ProcessorJob.objects.filter(pipeline_applied=ProcessorPipeline.TXIMPORT.value).latest(
+            "created_at"
+        )
         self.assertEqual(pj.pipeline_applied, ProcessorPipeline.TXIMPORT.value)
 
         # Verify that we attempted to send the jobs off to Batch
@@ -255,7 +257,9 @@ class RunTximportTestCase(TestCase):
         # to verify that run_tximport_for_list also works.
         run_tximport.run_tximport_for_list("SRP095529,TO_BE_SKIPPED")
 
-        pj = ProcessorJob.objects.all()[1]
+        pj = ProcessorJob.objects.filter(pipeline_applied=ProcessorPipeline.TXIMPORT.value).latest(
+            "created_at"
+        )
         self.assertEqual(pj.pipeline_applied, ProcessorPipeline.TXIMPORT.value)
 
         # Verify that we attempted to send the jobs off to Batch

--- a/workers/tests/processors/test_illumina.py
+++ b/workers/tests/processors/test_illumina.py
@@ -214,7 +214,8 @@ class IlluminaToPCLTestCase(TestCase, test_utils.ProcessorJobTestCaseMixin):
         self.assertSucceeded(pj)
         self.assertEqual(final_context["platform"], "illuminaHumanv3")
 
-        for key in final_context["samples"][0].sampleannotation_set.all()[0].data.keys():
+        ccdl_annotation = final_context["samples"][0].sampleannotation_set.get(is_ccdl=True)
+        for key in ccdl_annotation.data.keys():
             self.assertTrue(
                 key in ["detected_platform", "detection_percentage", "mapped_percentage"]
             )


### PR DESCRIPTION
## Issue Number

N/A

## Purpose/Implementation Notes

The PG17 planner works differently than before so now we need to be more explicit with the order of what we receive from the database.

This pull request improves the robustness and accuracy of how sample annotations and processor jobs are selected in both the main codebase and tests. The changes ensure that queries are more precise and less error-prone, especially in cases where multiple annotations or jobs may exist.

**Sample annotation handling improvements:**

* In `job_lookup.py`, updated the logic to select the sample annotation containing both `label_protocol_ch1` and `label_protocol_ch2` keys, rather than always taking the first annotation. This prevents errors when multiple annotations are present and ensures the correct protocols are checked.
* In `test_illumina.py`, changed the test to specifically select the annotation with `is_ccdl=True` instead of relying on the first annotation, making the test more robust to multiple annotations.

**Processor job selection improvements in tests:**

* In `test_run_tximport.py`, updated the tests to select the latest `ProcessorJob` with the correct pipeline applied, instead of assuming order in the queryset. This avoids errors when multiple jobs exist and ensures the test checks the correct job. [[1]](diffhunk://#diff-42f8254870f877281789440abb99d88edd3e3fd4c9e71a33cb7c1386ca867298L244-R246) [[2]](diffhunk://#diff-42f8254870f877281789440abb99d88edd3e3fd4c9e71a33cb7c1386ca867298L258-R262)

## Methods

N/A

## Types of changes

What types of changes does your code introduce?

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

N/A

## Checklist

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works

## Screenshots

N/A
