### PR TITLE
remove docker bake description for deploy box

### DIFF
--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -17,35 +17,38 @@
 
 // Default matches the project's existing tag convention so local builds are
 // findable by tag without a registry round-trip.
+// TODO: the deploy box runs Ubuntu 18.04 with Buildx v0.10.5, which does not support
+// the `description` field in variable blocks (requires Buildx v0.13+). Once the deploy
+// box is upgraded to Ubuntu 22.04+, uncomment the description lines below.
 variable "DOCKERHUB_REPO" {
-  description = "Registry namespace used for image tags (e.g. <repo>/dr_base:<version>)."
-  default     = "ccdlstaging"
+  // description = "Registry namespace used for image tags (e.g. <repo>/dr_base:<version>)."
+  default = "ccdlstaging"
 }
 
 variable "SYSTEM_VERSION" {
-  description = "Tag suffix applied to every built image and cache ref."
-  default     = "local"
+  // description = "Tag suffix applied to every built image and cache ref."
+  default = "local"
 }
 
 // Default is the public read-only cache that CI pushes to.
 // Note: when DOCKERHUB_REPO differs, cache is also read from DOCKERHUB_REPO
 // so writers benefit from their own previously-pushed cache.
 variable "CACHE_FROM_REPO" {
-  description = "Registry to read cache layers from."
-  default     = "ccdlstaging"
+  // description = "Registry to read cache layers from."
+  default = "ccdlstaging"
 }
 
 // Default false so unauthed local builds don't fail trying to push cache.
 variable "PUSH_CACHE" {
-  description = "If true, write cache layers to DOCKERHUB_REPO. Requires push access."
-  default     = false
+  // description = "If true, write cache layers to DOCKERHUB_REPO. Requires push access."
+  default = false
 }
 
 // Default amd64 because some upstream bases (nvidia/cuda for compendia) and
 // apt packages have no arm64 variant.
 variable "PLATFORMS" {
-  description = "Comma-separated platforms to build for."
-  default     = "linux/amd64"
+  // description = "Comma-separated platforms to build for."
+  default = "linux/amd64"
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Issue Number

N/A

## Purpose/Implementation Notes

This pull request updates the `docker-bake.hcl` file to improve compatibility with the current deployment environment. The main change is commenting out the `description` fields in variable blocks, with a note explaining this is due to the deploy box using an older version of Buildx that does not support these fields.

Build configuration compatibility:

* Commented out all `description` fields in variable blocks to ensure compatibility with Buildx v0.10.5 on Ubuntu 18.04, and added a TODO note to restore them after upgrading to Ubuntu 22.04+ and Buildx v0.13+.

## Methods

N/A

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

N/A

## Checklist

- [x] Lint and unit tests pass locally with my changes

## Screenshots

N/A
