### PR TITLE
follow bioc archive redirect

### DIFF
--- a/common/R/renv_load.R
+++ b/common/R/renv_load.R
@@ -1,8 +1,13 @@
 options(warn = 2)
+# Bioconductor 3.6 (R 3.4.x era) is archived. The main bioconductor.org URLs
+# return 302 redirects that R 3.4.4's url() connections do not follow, causing
+# install.packages() to fail on the PACKAGES index check. Use the archive
+# mirror directly instead.
+BIOC_ARCHIVE <- "https://mghp.osn.xsede.org/bir190004-bucket01/archive.bioconductor.org/packages/3.6"
 options(repos = structure(c(
-    Bioconductor = "https://bioconductor.org/packages/3.6/bioc",
-    BioconductorAnnotation = "https://bioconductor.org/packages/3.6/data/annotation",
-    BioconductorExperiment = "https://bioconductor.org/packages/3.6/data/experiment",
+    Bioconductor = paste0(BIOC_ARCHIVE, "/bioc"),
+    BioconductorAnnotation = paste0(BIOC_ARCHIVE, "/data/annotation"),
+    BioconductorExperiment = paste0(BIOC_ARCHIVE, "/data/experiment"),
     CRAN = "https://cloud.r-project.org"
 )))
 options(Ncpus = parallel::detectCores())


### PR DESCRIPTION
## Issue Number

N/A

## Purpose/Implementation Notes

This pull request updates the Bioconductor repository URLs in `common/R/renv_load.R` to use an archived mirror, ensuring compatibility with R 3.4.x. This change addresses issues caused by the main Bioconductor URLs redirecting in a way that is not supported by older versions of R, which would otherwise cause package installation failures.

Repository URL update for compatibility:

* Switched Bioconductor, BioconductorAnnotation, and BioconductorExperiment repository URLs to use the Bioconductor 3.6 archive mirror (`https://mghp.osn.xsede.org/bir190004-bucket01/archive.bioconductor.org/packages/3.6`), avoiding problematic HTTP redirects that R 3.4.4 cannot handle.

## Methods

N/A

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

N/A

## Checklist

- [x] Lint and unit tests pass locally with my changes

## Screenshots

N/A
