### PR TITLE
use bioconductor mirror for package resolution

### DIFF
--- a/common/R/dependencies/common_tests/renv.lock
+++ b/common/R/dependencies/common_tests/renv.lock
@@ -4,15 +4,15 @@
     "Repositories": [
       {
         "Name": "Bioconductor",
-        "URL": "https://bioconductor.org/packages/3.6/bioc"
+        "URL": "https://mghp.osn.xsede.org/bir190004-bucket01/archive.bioconductor.org/packages/3.6/bioc"
       },
       {
         "Name": "BioconductorAnnotation",
-        "URL": "https://bioconductor.org/packages/3.6/data/annotation"
+        "URL": "https://mghp.osn.xsede.org/bir190004-bucket01/archive.bioconductor.org/packages/3.6/data/annotation"
       },
       {
         "Name": "BioconductorExperiment",
-        "URL": "https://bioconductor.org/packages/3.6/data/experiment"
+        "URL": "https://mghp.osn.xsede.org/bir190004-bucket01/archive.bioconductor.org/packages/3.6/data/experiment"
       },
       {
         "Name": "CRAN",

--- a/common/R/renv_save.R
+++ b/common/R/renv_save.R
@@ -1,8 +1,8 @@
 options(warn = 2)
 options(repos = structure(c(
-    Bioconductor = "https://bioconductor.org/packages/3.6/bioc",
-    BioconductorAnnotation = "https://bioconductor.org/packages/3.6/data/annotation",
-    BioconductorExperiment = "https://bioconductor.org/packages/3.6/data/experiment",
+    Bioconductor = "https://mghp.osn.xsede.org/bir190004-bucket01/archive.bioconductor.org/packages/3.6/bioc",
+    BioconductorAnnotation = "https://mghp.osn.xsede.org/bir190004-bucket01/archive.bioconductor.org/packages/3.6/data/annotation",
+    BioconductorExperiment = "https://mghp.osn.xsede.org/bir190004-bucket01/archive.bioconductor.org/packages/3.6/data/experiment",
     CRAN = "https://cloud.r-project.org"
 )))
 options(Ncpus = parallel::detectCores())

--- a/workers/R/dependencies/affymetrix/renv.lock
+++ b/workers/R/dependencies/affymetrix/renv.lock
@@ -4,15 +4,15 @@
     "Repositories": [
       {
         "Name": "Bioconductor",
-        "URL": "https://bioconductor.org/packages/3.6/bioc"
+        "URL": "https://mghp.osn.xsede.org/bir190004-bucket01/archive.bioconductor.org/packages/3.6/bioc"
       },
       {
         "Name": "BioconductorAnnotation",
-        "URL": "https://bioconductor.org/packages/3.6/data/annotation"
+        "URL": "https://mghp.osn.xsede.org/bir190004-bucket01/archive.bioconductor.org/packages/3.6/data/annotation"
       },
       {
         "Name": "BioconductorExperiment",
-        "URL": "https://bioconductor.org/packages/3.6/data/experiment"
+        "URL": "https://mghp.osn.xsede.org/bir190004-bucket01/archive.bioconductor.org/packages/3.6/data/experiment"
       },
       {
         "Name": "CRAN",

--- a/workers/R/dependencies/compendia/renv.lock
+++ b/workers/R/dependencies/compendia/renv.lock
@@ -4,15 +4,15 @@
     "Repositories": [
       {
         "Name": "Bioconductor",
-        "URL": "https://bioconductor.org/packages/3.6/bioc"
+        "URL": "https://mghp.osn.xsede.org/bir190004-bucket01/archive.bioconductor.org/packages/3.6/bioc"
       },
       {
         "Name": "BioconductorAnnotation",
-        "URL": "https://bioconductor.org/packages/3.6/data/annotation"
+        "URL": "https://mghp.osn.xsede.org/bir190004-bucket01/archive.bioconductor.org/packages/3.6/data/annotation"
       },
       {
         "Name": "BioconductorExperiment",
-        "URL": "https://bioconductor.org/packages/3.6/data/experiment"
+        "URL": "https://mghp.osn.xsede.org/bir190004-bucket01/archive.bioconductor.org/packages/3.6/data/experiment"
       },
       {
         "Name": "CRAN",

--- a/workers/R/dependencies/downloaders/renv.lock
+++ b/workers/R/dependencies/downloaders/renv.lock
@@ -4,15 +4,15 @@
     "Repositories": [
       {
         "Name": "Bioconductor",
-        "URL": "https://bioconductor.org/packages/3.6/bioc"
+        "URL": "https://mghp.osn.xsede.org/bir190004-bucket01/archive.bioconductor.org/packages/3.6/bioc"
       },
       {
         "Name": "BioconductorAnnotation",
-        "URL": "https://bioconductor.org/packages/3.6/data/annotation"
+        "URL": "https://mghp.osn.xsede.org/bir190004-bucket01/archive.bioconductor.org/packages/3.6/data/annotation"
       },
       {
         "Name": "BioconductorExperiment",
-        "URL": "https://bioconductor.org/packages/3.6/data/experiment"
+        "URL": "https://mghp.osn.xsede.org/bir190004-bucket01/archive.bioconductor.org/packages/3.6/data/experiment"
       },
       {
         "Name": "CRAN",

--- a/workers/R/dependencies/illumina/renv.lock
+++ b/workers/R/dependencies/illumina/renv.lock
@@ -4,15 +4,15 @@
     "Repositories": [
       {
         "Name": "Bioconductor",
-        "URL": "https://bioconductor.org/packages/3.6/bioc"
+        "URL": "https://mghp.osn.xsede.org/bir190004-bucket01/archive.bioconductor.org/packages/3.6/bioc"
       },
       {
         "Name": "BioconductorAnnotation",
-        "URL": "https://bioconductor.org/packages/3.6/data/annotation"
+        "URL": "https://mghp.osn.xsede.org/bir190004-bucket01/archive.bioconductor.org/packages/3.6/data/annotation"
       },
       {
         "Name": "BioconductorExperiment",
-        "URL": "https://bioconductor.org/packages/3.6/data/experiment"
+        "URL": "https://mghp.osn.xsede.org/bir190004-bucket01/archive.bioconductor.org/packages/3.6/data/experiment"
       },
       {
         "Name": "CRAN",

--- a/workers/R/dependencies/no_op/renv.lock
+++ b/workers/R/dependencies/no_op/renv.lock
@@ -4,15 +4,15 @@
     "Repositories": [
       {
         "Name": "Bioconductor",
-        "URL": "https://bioconductor.org/packages/3.6/bioc"
+        "URL": "https://mghp.osn.xsede.org/bir190004-bucket01/archive.bioconductor.org/packages/3.6/bioc"
       },
       {
         "Name": "BioconductorAnnotation",
-        "URL": "https://bioconductor.org/packages/3.6/data/annotation"
+        "URL": "https://mghp.osn.xsede.org/bir190004-bucket01/archive.bioconductor.org/packages/3.6/data/annotation"
       },
       {
         "Name": "BioconductorExperiment",
-        "URL": "https://bioconductor.org/packages/3.6/data/experiment"
+        "URL": "https://mghp.osn.xsede.org/bir190004-bucket01/archive.bioconductor.org/packages/3.6/data/experiment"
       },
       {
         "Name": "CRAN",

--- a/workers/R/dependencies/salmon/renv.lock
+++ b/workers/R/dependencies/salmon/renv.lock
@@ -4,15 +4,15 @@
     "Repositories": [
       {
         "Name": "Bioconductor",
-        "URL": "https://bioconductor.org/packages/3.6/bioc"
+        "URL": "https://mghp.osn.xsede.org/bir190004-bucket01/archive.bioconductor.org/packages/3.6/bioc"
       },
       {
         "Name": "BioconductorAnnotation",
-        "URL": "https://bioconductor.org/packages/3.6/data/annotation"
+        "URL": "https://mghp.osn.xsede.org/bir190004-bucket01/archive.bioconductor.org/packages/3.6/data/annotation"
       },
       {
         "Name": "BioconductorExperiment",
-        "URL": "https://bioconductor.org/packages/3.6/data/experiment"
+        "URL": "https://mghp.osn.xsede.org/bir190004-bucket01/archive.bioconductor.org/packages/3.6/data/experiment"
       },
       {
         "Name": "CRAN",

--- a/workers/R/dependencies/smasher/renv.lock
+++ b/workers/R/dependencies/smasher/renv.lock
@@ -4,15 +4,15 @@
     "Repositories": [
       {
         "Name": "Bioconductor",
-        "URL": "https://bioconductor.org/packages/3.6/bioc"
+        "URL": "https://mghp.osn.xsede.org/bir190004-bucket01/archive.bioconductor.org/packages/3.6/bioc"
       },
       {
         "Name": "BioconductorAnnotation",
-        "URL": "https://bioconductor.org/packages/3.6/data/annotation"
+        "URL": "https://mghp.osn.xsede.org/bir190004-bucket01/archive.bioconductor.org/packages/3.6/data/annotation"
       },
       {
         "Name": "BioconductorExperiment",
-        "URL": "https://bioconductor.org/packages/3.6/data/experiment"
+        "URL": "https://mghp.osn.xsede.org/bir190004-bucket01/archive.bioconductor.org/packages/3.6/data/experiment"
       },
       {
         "Name": "CRAN",


### PR DESCRIPTION
## Issue Number

N/A

## Purpose/Implementation Notes

Same issue as before but need to also update the renv.lock file, otherwise we would have to regenerate it again.

**Purpose**

Fix staging deploys broken by Bioconductor archiving their 3.6 package repos. The canonical bioconductor.org packages/3.6 URLs now return 302 redirects that R 3.4.4's HTTP client does not follow, causing renv::restore() to fail with a warning promoted to an error by options(warn = 2).

**Implementation Notes**

  - Updated the Repositories block in all renv.lock files to point at the OSN archive mirror
  (mghp.osn.xsede.org/bir190004-bucket01/archive.bioconductor.org/packages/3.6), which serves packages directly without redirects
  - Updated renv_load.R to use the same archive URLs for the install.packages("BiocInstaller") call that runs before renv::restore()
  - Updated renv_save.R so future renv::snapshot() runs don't regenerate lock files with the broken URLs
  - Also removed unsupported description fields from docker-bake.hcl variable blocks, which were breaking the build on the deploy box (Ubuntu 18.04, Buildx v0.10.5 — description requires v0.13+)

Note: the lock file edits are a direct fix rather than a proper renv::snapshot() regeneration. The changes are limited to the Repositories block URLs; package hashes are unchanged.


## Methods

N/A

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

Testing

- Verified all three archive mirror URLs (/bioc, /data/annotation, /data/experiment) return HTTP 200 with no redirects via curl -sI
- Confirmed no remaining references to the old bioconductor.org/packages/3.6 URLs in any R or lock file
- Walked through a staging hotfix deploy end-to-end: GPG tag verification passed, Docker login unblocked by refreshing credentials on the deploy box, docker-bake.hcl parse error resolved by removing unsupported description fields, and compendia build failure diagnosed to the lock file Repositories block

## Checklist

- [x] Lint and unit tests pass locally with my changes

## Screenshots

N/A
