### PR TITLE
fix: pin AWS provider to ~> 5.25.0 last good deploy

### DIFF
--- a/infrastructure/backend.tf
+++ b/infrastructure/backend.tf
@@ -1,4 +1,14 @@
 terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.25.0"
+    }
+    local = {
+      source  = "hashicorp/local"
+      version = "~> 2.4.0"
+    }
+  }
   backend "s3" {
     bucket = "refinebio-tfstate-deploy-${var.stage}"
     encrypt = true

--- a/infrastructure/batch/versions.tf
+++ b/infrastructure/batch/versions.tf
@@ -1,7 +1,8 @@
 terraform {
   required_providers {
     aws = {
-      source = "hashicorp/aws"
+      source  = "hashicorp/aws"
+      version = "~> 5.25.0"
     }
   }
   required_version = ">= 0.13"


### PR DESCRIPTION
## Issue Number

N/A

## Purpose/Implementation Notes

This pull request updates the Terraform provider versions in the infrastructure configuration to ensure compatibility and stability. The main changes are focused on specifying exact versions for the AWS and Local providers.

**Provider version updates:**

* Added explicit version constraints for the `aws` provider (`~> 5.25.0`) in both `infrastructure/backend.tf` and `infrastructure/batch/versions.tf` to ensure consistent behavior across environments. [[1]](diffhunk://#diff-222798d442ab8de37c2208c69ca04c41db157e00509ecacd5f20afb4bbc4bed5R2-R11) [[2]](diffhunk://#diff-f029db4eec623811f91500eac508584a417601605d22a6f287347f6d7411aed8R5)
* Added the `local` provider with a version constraint (`~> 2.4.0`) to `infrastructure/backend.tf`.

## Methods

N/A - Terraform only

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

N/A - Checked logs against last known good deploy for aws provider version

## Checklist

- [x] Lint and unit tests pass locally with my changes

## Screenshots

N/A
