### PR TITLE
fix: wait for pgbouncer backend connection before running migrations

### DIFF
--- a/infrastructure/deploy.sh
+++ b/infrastructure/deploy.sh
@@ -272,17 +272,37 @@ echo "Job registrations have been fired off."
 # Get an image to run the migrations with.
 docker pull --platform linux/amd64 "$DOCKERHUB_REPO/$FOREMAN_DOCKER_IMAGE"
 
-# Test that the pg_bouncer instance is up. 15 minutes should be more than enough.
+# Verify that pg_bouncer can reach the RDS backend by running a real query.
+# pg_isready only tests TCP connectivity to pg_bouncer itself and will pass
+# even when pg_bouncer cannot connect to postgres (e.g. during an RDS reboot
+# or parameter group modification).
+db_warn_after=900    # seconds before warning that something may be wrong
+db_timeout=2700      # seconds before giving up entirely
 start_time=$(date +%s)
 diff=0
-until pg_isready -d "$DATABASE_NAME" -h "$DATABASE_PUBLIC_HOST" -p "$DATABASE_PORT" -U "$DATABASE_USER" &>/dev/null || [ "$diff" -gt "900" ]; do
-    echo "Waiting for the pg_bouncer instance to come online..."
+warned=false
+db_ready() {
+    PGPASSWORD="$DATABASE_PASSWORD" psql \
+        -h "$DATABASE_PUBLIC_HOST" \
+        -p "$DATABASE_PORT" \
+        -U "$DATABASE_USER" \
+        -d "$DATABASE_NAME" \
+        -c "SELECT 1" &>/dev/null
+}
+until db_ready || [ "$diff" -gt "$db_timeout" ]; do
+    echo "Waiting for pg_bouncer to connect to the database..."
+    if [ "$diff" -gt "$db_warn_after" ] && [ "$warned" = false ]; then
+        echo "WARNING: Database has been unreachable for 15 minutes. Unless a" \
+             "major version upgrade is in progress, there may be an issue." \
+             "Will wait up to another 30 minutes."
+        warned=true
+    fi
     sleep 10
     ((diff = $(date +%s) - start_time))
 done
 
-if ! pg_isready -d "$DATABASE_NAME" -h "$DATABASE_PUBLIC_HOST" -p "$DATABASE_PORT" -U "$DATABASE_USER" &>/dev/null; then
-    echo "pg_bouncer instance failed to come up after 15 minutes."
+if ! db_ready; then
+    echo "pg_bouncer failed to connect to the database after 45 minutes."
     exit 1
 fi
 


### PR DESCRIPTION
## Issue Number

N/A

## Purpose/Implementation Notes

The deploy script used `pg_isready` to check that the database was ready before running migrations. `pg_isready` only tests TCP connectivity to the PgBouncer instance itself — it returns success even when PgBouncer cannot connect to the RDS backend (e.g. during an RDS reboot triggered by a parameter group modification). This caused manage.py migrate to fail immediately after the check passed, because PgBouncer had no live backend connection.

Replaces the `pg_isready` check with a real `psql query (SELECT 1)` that exercises the full connection path from the deploy box through PgBouncer to RDS. Also extends the timeout from 15 minutes to 45 minutes to accommodate RDS modifications on production-sized instances, and adds a warning log at 15 minutes to flag unexpectedly long waits without silently waiting the full duration.


## Methods

N/A

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

- Observed the failure on the staging hotfix deploy where pg_isready passed but manage.py migrate immediately failed with pgbouncer cannot connect to server
- Fix is consistent with the root cause: a real query would have waited until PgBouncer could reach the RDS backend


## Checklist

- [x] Lint and unit tests pass locally with my changes

## Screenshots

N/A
