### PR TITLE
ubuntu outage cache purge

### DIFF
--- a/api/dockerfiles/Dockerfile.api_base
+++ b/api/dockerfiles/Dockerfile.api_base
@@ -3,6 +3,14 @@ FROM python:3.8.5-buster
 # Fail in case of an error at any stage in the pipe.
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
+# Debian Buster packages moved to archive.debian.org after EOL (June 2024).
+# buster-updates does not exist in the archive so remove it entirely.
+RUN sed -i \
+    -e 's|http://deb.debian.org/debian|http://archive.debian.org/debian|g' \
+    -e 's|http://security.debian.org/debian-security|http://archive.debian.org/debian-security|g' \
+    -e '/buster-updates/d' \
+    /etc/apt/sources.list
+
 # Install gcc and libpq-dev for psycopg2.
 RUN <<EOF
 apt-get update -qq

--- a/common/dockerfiles/Dockerfile.base
+++ b/common/dockerfiles/Dockerfile.base
@@ -3,6 +3,12 @@ FROM ubuntu:18.04
 # Fail in case of an error at any stage in the pipe.
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
+# Add MIT as a fallback mirror alongside archive.ubuntu.com.
+RUN grep '^deb ' /etc/apt/sources.list \
+    | sed -e 's|http://archive.ubuntu.com/ubuntu|http://mirrors.mit.edu/ubuntu|g' \
+          -e 's|http://security.ubuntu.com/ubuntu|http://mirrors.mit.edu/ubuntu|g' \
+    >> /etc/apt/sources.list
+
 WORKDIR /home/user
 
 # Prevent tzdata from prompting us for a timezone and hanging the build.

--- a/workers/dockerfiles/Dockerfile.compendia
+++ b/workers/dockerfiles/Dockerfile.compendia
@@ -6,6 +6,12 @@ FROM nvidia/cuda:11.8.0-runtime-ubuntu18.04
 # Fail in case of an error at any stage in the pipe.
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
+# Add MIT as a fallback mirror alongside archive.ubuntu.com.
+RUN grep '^deb ' /etc/apt/sources.list \
+    | sed -e 's|http://archive.ubuntu.com/ubuntu|http://mirrors.mit.edu/ubuntu|g' \
+          -e 's|http://security.ubuntu.com/ubuntu|http://mirrors.mit.edu/ubuntu|g' \
+    >> /etc/apt/sources.list
+
 # Prevent tzdata from prompting us for a timezone and hanging the build.
 ENV DEBIAN_FRONTEND=noninteractive
 


### PR DESCRIPTION
## Issue Number

N/A

## Purpose/Implementation Notes

When the deploy box failed, I freed up some space by purging all of the caches which were hiding an error around some packages no longer being available (debian buster was EOL in 2024). Additionally, some ubuntu packages are still failing to be fetched because of the cononical DDOS. This PR addresses both of these.

This pull request updates several Dockerfiles to improve package source reliability for legacy Debian and Ubuntu images. The changes address issues caused by end-of-life (EOL) distributions and potential mirror outages, ensuring that package installations remain functional.

**Package source updates for EOL distributions:**

* [`api/dockerfiles/Dockerfile.api_base`](diffhunk://#diff-2db1aab457170fedf41f45af8045b81df468aa887b7460ca01381d43f1d7069bR6-R13): Replaces all Debian Buster sources with `archive.debian.org` and removes the non-existent `buster-updates` entry to support continued package installation after Buster's EOL (June 2024).

**Addition of fallback mirrors for Ubuntu 18.04:**

* [`common/dockerfiles/Dockerfile.base`](diffhunk://#diff-18d8b27ce5b06a0571bbcd6984c593ab9b71ba9dd53490a183fd5a7201bafb13R6-R11): Adds the MIT mirror as a fallback for both main and security Ubuntu repositories by appending alternate sources to `sources.list`, improving reliability if the primary mirror is unavailable.
* [`workers/dockerfiles/Dockerfile.compendia`](diffhunk://#diff-29d25019d22c78c05a9fc64a5e2aaa55283391b6a80c71e585a0889556d1bd02R9-R14): Applies the same MIT mirror fallback strategy for Ubuntu repositories as above, ensuring consistent package installation reliability in CUDA-based worker images. 

## Methods

N/A

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

Pulled the images locally and tested the package installation.

## Checklist

- [x] Lint and unit tests pass locally with my changes

## Screenshots

Please attach any screenshots that illustrate these changes.
