### PR TITLE
fix: require SSL for pgbouncer server connections to RDS

### DIFF
--- a/infrastructure/workers-configuration/pg-bouncer-instance-user-data.tpl.sh
+++ b/infrastructure/workers-configuration/pg-bouncer-instance-user-data.tpl.sh
@@ -47,6 +47,7 @@ server_reset_query = DISCARD ALL
 syslog = 1
 pidfile = /var/run/postgresql/pgbouncer.pid
 unix_socket_dir = /var/run/postgresql
+server_tls_sslmode = require
 FOE
 
 # Set up PG Bouncer


### PR DESCRIPTION
## Issue Number

#3554 

## Purpose/Implementation Notes

Previously we thought that pg bouncer just needed more time to boot up before we could try to connect and then run migrations and finish the deploy process. However in subsequent PRs once the migration took place pg bouncer fails to connect because RDS requires now requires connections to be over ssl. This PR sets that in the ini.

- Adds `server_tls_sslmode = require` to `pg-bouncer-instance-user-data.tpl.sh`

## Methods

N/A

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

SSHed onto the staging pgbouncer ec2 instance and manually edited the ini file before restarting the service. This resolved the connection issue on staging.

## Checklist

- [x] Lint and unit tests pass locally with my changes

## Screenshots

N/A
