### PR TITLE
temporarily disable e2e tests

### DIFF
--- a/.github/scripts/remote_deploy.sh
+++ b/.github/scripts/remote_deploy.sh
@@ -105,10 +105,11 @@ run_on_deploy_box ". env_vars && echo -e '######\nDeploying $CI_TAG finished!\n#
 
 .github/scripts/slackpost_deploy.sh robots deploybot
 
-if [[ "$BRANCH" == "dev" ]]; then
-    run_on_deploy_box ". env_vars && ./foreman/run_end_to_end_tests.sh"
-    .github/scripts/slackpost_end_to_end.sh robots deploybot
-fi
+# Temporarily disabled due to surveyor pipeline, only API + smasher are currently operational.
+# if [[ "$BRANCH" == "dev" ]]; then
+#     run_on_deploy_box ". env_vars && ./foreman/run_end_to_end_tests.sh"
+#     .github/scripts/slackpost_end_to_end.sh robots deploybot
+# fi
 
 # Don't leave secrets lying around.
 run_on_deploy_box "git clean -f"


### PR DESCRIPTION
## Issue Number

N/A

## Purpose/Implementation Notes

This pull request temporarily disables the automatic running of end-to-end tests and related Slack notifications during deployments to the `dev` branch. This change is due to the current state of the surveyor pipeline, where only the API and smasher components are operational.

Deployment pipeline adjustments:

* Commented out the section in `.github/scripts/remote_deploy.sh` that runs end-to-end tests and posts Slack notifications when deploying to the `dev` branch, with an explanatory comment about the surveyor pipeline status.

## Methods

N/A

## Types of changes

- Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Functional tests

N/A

## Checklist

- [X] Lint and unit tests pass locally with my changes
- [x] I have added necessary documentation (if appropriate)

## Screenshots

N/A
