### PR TITLE
ci: bump pre-commit/pre-commit-hooks to v5.0.0 for Python 3.13 compat

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@ exclude: '^(.*\.pem|.*\.tfvars)$'
 
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v2.4.0
+    rev: v5.0.0
     hooks:
       - id: end-of-file-fixer
       - id: mixed-line-ending


### PR DESCRIPTION
## Issue Number

N/A

## Purpose/Implementation Notes

This pull request updates the pre-commit hooks configuration to use a newer version of the `pre-commit-hooks` repository.

Tooling update:

* Upgraded the `pre-commit-hooks` repository from version `v2.4.0` to `v5.0.0` in `.pre-commit-config.yaml`, ensuring access to the latest bug fixes and features for code quality checks.

## Methods

N/A

## Types of changes

- Bugfix (allows running pre-commit with recent python versions)
- New feature (adds 3.13 support)
- Breaking change (remove host python 3.8 support)

## Functional tests

N/A

## Checklist

- [x] Lint and unit tests pass locally with my changes

## Screenshots

N/A
