### PR TITLE
rbio test: add test:all + common-freshness pre-flight on every test:*

### DIFF
--- a/bin/lib/common.py
+++ b/bin/lib/common.py
@@ -4,7 +4,35 @@ import argparse
 import os
 
 from lib._docker import bake_target, require_drdb
-from lib._runtime import REPO_ROOT, Globals, run
+from lib._runtime import REPO_ROOT, Globals, run, stderr
+
+
+def is_common_stale():
+    """True if any common/data_refinery_common/*.py is newer than the most recent common/dist sdist."""
+    sdist_dir = REPO_ROOT / "common" / "dist"
+    sdists = list(sdist_dir.glob("*.tar.gz"))
+    if not sdists:
+        return True
+    newest_sdist = max(s.stat().st_mtime for s in sdists)
+    src = REPO_ROOT / "common" / "data_refinery_common"
+    if not src.is_dir():
+        return False
+    newest_src = max((p.stat().st_mtime for p in src.rglob("*.py")), default=0)
+    return newest_src > newest_sdist
+
+
+def require_common_fresh(cmd_name):
+    """Pre-flight: fail with a hint if common/ source is newer than the last sdist build.
+
+    Caller is responsible for honoring a --allow-stale-common flag; this helper
+    is unconditional.
+    """
+    if not is_common_stale():
+        return 0
+    stderr(f"rbio {cmd_name}: common/ source has changed since the last sdist build")
+    stderr("  fix:    rbio common:update")
+    stderr(f"  bypass: rbio {cmd_name} --allow-stale-common")
+    return 1
 
 
 def _compose_run_migrations(*manage_args):

--- a/bin/lib/test/__init__.py
+++ b/bin/lib/test/__init__.py
@@ -1,6 +1,7 @@
-"""test:* — per-subproject test runners (api / common / foreman / workers)."""
+"""test:* — per-subproject test runners (api / common / foreman / workers) + test:all."""
 
+from lib.test.all import COMMANDS as _ALL_COMMANDS
 from lib.test.subprojects import COMMANDS as _SUBPROJECT_COMMANDS
 from lib.test.workers import COMMANDS as _WORKER_COMMANDS
 
-COMMANDS = [*_SUBPROJECT_COMMANDS, *_WORKER_COMMANDS]
+COMMANDS = [*_SUBPROJECT_COMMANDS, *_WORKER_COMMANDS, *_ALL_COMMANDS]

--- a/bin/lib/test/all.py
+++ b/bin/lib/test/all.py
@@ -1,0 +1,38 @@
+"""test:all — clean-state entry point: common:update + every test:<subproject> suite."""
+
+import argparse
+
+from lib import common
+from lib._docker import require_drdb
+from lib.test.subprojects import cmd_test_api, cmd_test_common, cmd_test_foreman
+from lib.test.workers import cmd_test_workers
+
+
+def cmd_test_all(argv):
+    p = argparse.ArgumentParser(
+        prog="rbio test:all",
+        description=(
+            "Run the full test suite from a clean state: common:update "
+            "(rebuild migrations + sdist), then test:api, test:common, "
+            "test:foreman, test:workers. Aborts on the first failure. Each "
+            "suite is invoked with --allow-stale-common because we just "
+            "refreshed."
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    p.parse_args(argv)
+
+    if (rc := require_drdb("test:all")) != 0:
+        return rc
+    if (rc := common.cmd_common_update([])) != 0:
+        return rc
+
+    for cmd_fn in (cmd_test_api, cmd_test_common, cmd_test_foreman, cmd_test_workers):
+        if (rc := cmd_fn(["--allow-stale-common"])) != 0:
+            return rc
+    return 0
+
+
+COMMANDS = [
+    ("test:all", cmd_test_all, "full chain: common:update + every test:* suite"),
+]

--- a/bin/lib/test/subprojects.py
+++ b/bin/lib/test/subprojects.py
@@ -4,6 +4,7 @@ import argparse
 
 from lib._docker import bake_target, require_services
 from lib._runtime import REPO_ROOT, run
+from lib.common import require_common_fresh
 from lib.test._shared import coverage_command
 
 # Per-subproject knobs for `rbio test:<name>`: which bake target supplies
@@ -43,12 +44,19 @@ def _test_subproject(name, argv):
         ),
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
-    _, forwarded = p.parse_known_args(argv)
+    p.add_argument(
+        "--allow-stale-common",
+        action="store_true",
+        help="skip the pre-flight check that common/dist is up to date with common/ source",
+    )
+    args, forwarded = p.parse_known_args(argv)
 
     services = {"postgres": "drdb"}
     if cfg["needs_es"]:
         services["elasticsearch"] = "dres"
     if (rc := require_services(f"test:{name}", services)) != 0:
+        return rc
+    if not args.allow_stale_common and (rc := require_common_fresh(f"test:{name}")) != 0:
         return rc
     if (rc := bake_target(cfg["image"])) != 0:
         return rc

--- a/bin/lib/test/workers.py
+++ b/bin/lib/test/workers.py
@@ -10,6 +10,7 @@ import urllib.request
 
 from lib._docker import bake_target, require_drdb
 from lib._runtime import REPO_ROOT, Globals, run, stderr
+from lib.common import require_common_fresh
 from lib.test._shared import coverage_command
 
 # S3 bucket holding worker test fixtures (tarballs, fastq/sra/cel/PCL files).
@@ -324,9 +325,16 @@ def cmd_test_workers(argv):
         choices=WORKER_TAGS,
         help="run tests for a single worker tag (default: every tag in order).",
     )
+    p.add_argument(
+        "--allow-stale-common",
+        action="store_true",
+        help="skip the pre-flight check that common/dist is up to date with common/ source",
+    )
     args, forwarded = p.parse_known_args(argv)
 
     if (rc := require_drdb("test:workers")) != 0:
+        return rc
+    if not args.allow_stale_common and (rc := require_common_fresh("test:workers")) != 0:
         return rc
 
     # Workers have their own test_volume next to the worker code (matches the


### PR DESCRIPTION
## Issue Number

#3572 

## Purpose/Implementation Notes

Adds a one-shot test entry point (rbio test:all) and a pre-flight guard that warns when the common Python distribution is stale relative to its source, so per-subproject test runs fail fast with actionable guidance instead of producing confusing failures from out-of-date code.

Note: While the mtime check is a little overly sensitive, one common gotcha while working in this repo is not updating the common package when you make changes. This should help catch those issues. If it has issues, it is simple to gut from the preflight or switch to a loud warning at the top and at the bottom of test runs.

  Changes

  New command - rbio test:all (bin/lib/test/all.py, bin/lib/test/__init__.py)
  - Chains the full clean-state sequence in one invocation: common:update, then test:api, test:common, test:foreman, test:workers
  - Aborts on first failure
  - Pre-flights require_drdb before running anything

  New helpers in bin/lib/common.py
  - is_common_stale() - mtime check: any common/data_refinery_common/**/*.py newer than the most recent common/dist/*.tar.gz. Returns True if no sdist exists yet.
  - require_common_fresh(cmd_name) - wraps is_common_stale() into an rbio-style pre-flight: returns non-zero with stderr guidance pointing at rbio common:update (or the bypass flag) when stale.

  Pre-flight wiring in every test:* command (bin/lib/test/subprojects.py, bin/lib/test/workers.py)
  - Adds a --allow-stale-common flag to test:api, test:common, test:foreman, test:workers
  - Each command runs require_common_fresh() after the service pre-flight unless the flag is set
  - test:all passes the flag to each child suite because it just refreshed common itself, so the re-check would be noise

  Design notes

  - Fail-by-default, opt-out bypass rather than warn-and-continue: stale-common failures in tests are confusing enough that a hard stop with a one-line fix instruction is more useful than a warning buried in verbose test output.
  - Cheap pre-flight: filesystem mtime comparison only - no DB connection, no container invocation. Microseconds.
  - Helpers live in common.py rather than test/ so other namespaces can adopt the same guard later (e.g., rbio dev:manage running against stale code).

  Risk

  - mtime check is heuristic; touching a source file with no semantic change will trigger a false positive. The bypass flag exists exactly for this case.
  - No new package dependencies. No changes to existing test execution paths (only adds a pre-flight in front of them).
  - test:all adds a new namespace command but doesn't modify any existing one.


## Methods

N/A

## Types of changes

- New feature (non-breaking change which adds functionality)

## Functional tests

N/A

## Checklist

- [x] Lint and unit tests pass locally with my changes

## Screenshots

N/A
