### PR TITLE
rbio: add @requires decorator + mtime-gated common sdist rebuild

### DIFF
--- a/bin/lib/_requirements.py
+++ b/bin/lib/_requirements.py
@@ -1,0 +1,45 @@
+"""@requires decorator and epilog helper for rbio commands.
+
+Commands declare env vars + external tools they need via @requires. Future
+debug:env and debug:deps commands will aggregate this registry to render
+per-command and cross-command views. Per-command help text pulls the same
+metadata via epilog_from().
+"""
+
+
+def requires(*, env=None, env_optional=None, tools=None):
+    """Declare a command's env var + external tool requirements.
+
+    env             — required env vars (debug:env flags them red when unset)
+    env_optional    — {name: default} env vars (default shown in help)
+    tools           — external commands the implementation calls (docker, aws, ...)
+    """
+
+    def decorator(fn):
+        fn._requirements = {
+            "env": list(env or []),
+            "env_optional": dict(env_optional or {}),
+            "tools": list(tools or []),
+        }
+        return fn
+
+    return decorator
+
+
+def epilog_from(fn, extra=""):
+    """Build a help-text epilog block from a command's @requires metadata."""
+    req = getattr(fn, "_requirements", {})
+    lines = []
+    if req.get("env"):
+        lines.append("required env:")
+        lines.extend(f"  {v}" for v in req["env"])
+    if req.get("env_optional"):
+        lines.append("optional env (defaults shown):")
+        lines.extend(f"  {v}={d}" for v, d in req["env_optional"].items())
+    if req.get("tools"):
+        lines.append(f"requires: {', '.join(req['tools'])}")
+    if extra:
+        if lines:
+            lines.append("")
+        lines.append(extra)
+    return "\n".join(lines)

--- a/bin/lib/build.py
+++ b/bin/lib/build.py
@@ -5,14 +5,21 @@ import json
 import subprocess
 import time
 
+from lib._requirements import requires
 from lib._runtime import REPO_ROOT, run, stderr
+from lib.common import rebuild_common_sdist
 
 RETRY_BACKOFF_SECONDS = 5
 
 
+@requires(tools=["docker"])
 def cmd_build(argv):
     needs_help = any(a in ("-h", "--help") for a in argv)
-    epilog = "wraps: docker buildx bake -f docker-bake.hcl <targets>"
+    epilog = (
+        "wraps:\n"
+        "  rbio common:build-sdist  (mtime-gated; skipped when common source unchanged)\n"
+        "  docker buildx bake -f docker-bake.hcl <targets>"
+    )
     if needs_help:
         section = render_bake_targets_section()
         if section:
@@ -58,6 +65,14 @@ def cmd_build(argv):
         ),
     )
     args = p.parse_args(argv)
+
+    # Bake's worker/foreman/api targets COPY common/dist/data-refinery-common-*
+    # at image-build time. Make sure that tarball reflects current source
+    # before bake reads it. The helper short-circuits when nothing changed,
+    # preserving docker's COPY layer cache for downstream images.
+    if not args.print_only:
+        if (rc := rebuild_common_sdist()) != 0:
+            return rc
 
     cmd = ["docker", "buildx", "bake", "-f", "docker-bake.hcl"]
     if args.push:

--- a/bin/lib/common.py
+++ b/bin/lib/common.py
@@ -2,8 +2,10 @@
 
 import argparse
 import os
+from pathlib import Path
 
 from lib._docker import bake_target, require_drdb
+from lib._requirements import epilog_from, requires
 from lib._runtime import REPO_ROOT, Globals, run
 
 
@@ -23,6 +25,54 @@ def _compose_run_migrations(*manage_args):
     )
 
 
+def _sdist_python():
+    # `setup.py sdist` needs setuptools. System python3 on PEP-668 distros
+    # (Ubuntu 23.04+, Debian 12+) won't accept casual pip-installs into the
+    # system site, so we prefer the venv created by `rbio install:venv`.
+    # Falls back to `python3` when the venv isn't present.
+    venv_python = REPO_ROOT / "dr_env" / "bin" / "python3"
+    if venv_python.exists():
+        return str(venv_python)
+    return "python3"
+
+
+def _sdist_needs_rebuild(common_dir, sdist_file):
+    sdist_mtime = sdist_file.stat().st_mtime
+    sources = list((common_dir / "data_refinery_common").rglob("*.py"))
+    sources += [common_dir / "MANIFEST.in", common_dir / "setup.py"]
+    return any(f.stat().st_mtime > sdist_mtime for f in sources if f.exists())
+
+
+def rebuild_common_sdist():
+    """Rebuild the common sdist tarball if any source file is newer than the existing one.
+
+    Used by `rbio common:build-sdist` (standalone), `rbio common:update`
+    (as the final step), and `rbio build` (as a pre-bake step so downstream
+    images pick up an updated package).
+
+    The mtime gate is the cache-correctness primitive: when source is
+    unchanged, we skip `setup.py sdist` entirely and reuse the existing
+    tarball. Docker's COPY layer hash holds → downstream `pip install
+    common` layers stay cached. When source changes, a fresh sdist is
+    produced and the cache busts correctly.
+    """
+    common_dir = REPO_ROOT / "common"
+    dist_dir = common_dir / "dist"
+    existing = list(dist_dir.glob("data*refinery*common-*.tar.gz"))
+
+    if existing and not _sdist_needs_rebuild(common_dir, existing[0]):
+        return 0
+
+    if not Globals.dry_run:
+        # setup.py reads the version from this file
+        (common_dir / "version").write_text(os.environ.get("SYSTEM_VERSION", "local") + "\n")
+        for old in existing:
+            old.unlink()
+
+    return run([_sdist_python(), "setup.py", "sdist"], cwd=common_dir)
+
+
+@requires(tools=["docker"])
 def cmd_common_make_migrations(argv):
     p = argparse.ArgumentParser(
         prog="rbio common:make-migrations",
@@ -42,6 +92,7 @@ def cmd_common_make_migrations(argv):
     return _compose_run_migrations("makemigrations", "data_refinery_common")
 
 
+@requires(tools=["docker"])
 def cmd_common_apply(argv):
     p = argparse.ArgumentParser(
         prog="rbio common:apply",
@@ -64,6 +115,7 @@ def cmd_common_apply(argv):
     return _compose_run_migrations("createcachetable")
 
 
+@requires(tools=["docker"])
 def cmd_common_update(argv):
     p = argparse.ArgumentParser(
         prog="rbio common:update",
@@ -76,7 +128,7 @@ def cmd_common_update(argv):
             "wraps:\n"
             "  rbio common:make-migrations\n"
             "  rbio common:apply\n"
-            "  cd common && python3 setup.py sdist  (host)"
+            "  rbio common:build-sdist"
         ),
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
@@ -91,19 +143,37 @@ def cmd_common_update(argv):
         return rc
     if (rc := _compose_run_migrations("createcachetable")) != 0:
         return rc
-    # Rebuild common sdist on the host so other images (built by bake) pick it
-    # up via Dockerfile COPY common/dist/...
-    common_dir = REPO_ROOT / "common"
-    if not Globals.dry_run:
-        # setup.py reads the version from this file
-        (common_dir / "version").write_text(os.environ.get("SYSTEM_VERSION", "local") + "\n")
-        for old in (common_dir / "dist").glob("*"):
-            old.unlink()
-    return run(["python3", "setup.py", "sdist"], cwd=common_dir)
+    return rebuild_common_sdist()
+
+
+@requires(tools=["python3"])
+def cmd_common_build_sdist(argv):
+    p = argparse.ArgumentParser(
+        prog="rbio common:build-sdist",
+        description="Rebuild the data_refinery_common sdist if any source file is newer than the existing tarball.",
+        epilog=epilog_from(
+            cmd_common_build_sdist,
+            "wraps:\n"
+            "  cd common && python3 setup.py sdist\n"
+            "\n"
+            "Skips the rebuild entirely when no source file is newer than the\n"
+            "current sdist — keeps docker layer cache valid for downstream images.\n"
+            "Uses dr_env/bin/python3 when the venv exists (system python3 lacks\n"
+            "setuptools on PEP-668 distros).",
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    p.parse_args(argv)
+    return rebuild_common_sdist()
 
 
 COMMANDS = [
     ("common:make-migrations", cmd_common_make_migrations, "generate Django migration files"),
     ("common:apply", cmd_common_apply, "apply migrations to the database"),
     ("common:update", cmd_common_update, "full chain: make + apply + rebuild common sdist"),
+    (
+        "common:build-sdist",
+        cmd_common_build_sdist,
+        "rebuild data_refinery_common sdist (mtime-gated)",
+    ),
 ]


### PR DESCRIPTION
## Issue Number

#3572 

## Purpose/Implementation Notes

- bin/lib/_requirements.py (new) — @requires(env=, env_optional=, tools=)
    decorator + epilog_from() helper. Commands declare their env vars and
    external tool deps; future debug:env / debug:deps will read this
    registry to render per-command and aggregate views.
- bin/lib/common.py — factor the inline sdist rebuild out of cmd_common_update
  into rebuild_common_sdist(), which now:
    * uses an mtime gate to skip the rebuild when no common source file
      is newer than the existing sdist (preserves docker COPY layer cache
      for downstream worker/foreman/api images)
    * prefers dr_env/bin/python3 when the venv is present (system python3
      lacks setuptools on PEP-668 distros)
  Surfaces the helper as a standalone command, rbio common:build-sdist.
- bin/lib/build.py — invoke rebuild_common_sdist() before bake so
  downstream targets pick up the latest common package. No-op when source
  is unchanged (gate above).


## Methods

N/A

## Types of changes

- New feature (non-breaking change which adds functionality)

## Functional tests

rbio functional tests only

## Checklist

- [x] Lint and unit tests pass locally with my changes

## Screenshots

N/A
