### PR TITLE
rbio: add compose:* + new dev:* + test:all (local dev surface)

### DIFF
--- a/.github/workflows/config.yml
+++ b/.github/workflows/config.yml
@@ -64,7 +64,7 @@ jobs:
           password: ${{ env.DOCKER_PASSWORD }}
 
       - name: Start Postgres
-        run: bin/rbio dev:up -s postgres
+        run: bin/rbio compose:up -s postgres
 
       - name: Pause for Initialization
         run: sleep 15
@@ -105,7 +105,7 @@ jobs:
           password: ${{ env.DOCKER_PASSWORD }}
 
       - name: Start Postgres
-        run: bin/rbio dev:up -s postgres
+        run: bin/rbio compose:up -s postgres
 
       - name: Pause for Initialization
         run: sleep 15
@@ -147,10 +147,10 @@ jobs:
           password: ${{ env.DOCKER_PASSWORD }}
 
       - name: Start Postgres
-        run: bin/rbio dev:up -s postgres
+        run: bin/rbio compose:up -s postgres
 
       - name: Start Elasticsearch
-        run: bin/rbio dev:up -s elasticsearch
+        run: bin/rbio compose:up -s elasticsearch
 
       - name: Pause for Initialization
         run: sleep 15
@@ -200,10 +200,10 @@ jobs:
           password: ${{ env.DOCKER_PASSWORD }}
 
       - name: Start Postgres
-        run: bin/rbio dev:up -s postgres
+        run: bin/rbio compose:up -s postgres
 
       - name: Start Elasticsearch
-        run: bin/rbio dev:up -s elasticsearch
+        run: bin/rbio compose:up -s elasticsearch
 
       - name: Pause for Initialization
         run: sleep 15
@@ -279,10 +279,10 @@ jobs:
           password: ${{ env.DOCKER_PASSWORD }}
 
       - name: Start Postgres
-        run: bin/rbio dev:up -s postgres
+        run: bin/rbio compose:up -s postgres
 
       - name: Start Elasticsearch
-        run: bin/rbio dev:up -s elasticsearch
+        run: bin/rbio compose:up -s elasticsearch
 
       - name: Pause for Initialization
         run: sleep 15
@@ -332,7 +332,7 @@ jobs:
           password: ${{ env.DOCKER_PASSWORD }}
 
       - name: Start Postgres
-        run: bin/rbio dev:up -s postgres
+        run: bin/rbio compose:up -s postgres
 
       - name: Pause for Initialization
         run: sleep 15
@@ -372,10 +372,10 @@ jobs:
           password: ${{ env.DOCKER_PASSWORD }}
 
       - name: Start Postgres
-        run: bin/rbio dev:up -s postgres
+        run: bin/rbio compose:up -s postgres
 
       - name: Start Elasticsearch
-        run: bin/rbio dev:up -s elasticsearch
+        run: bin/rbio compose:up -s elasticsearch
 
       - name: Pause for Initialization
         run: sleep 15
@@ -425,7 +425,7 @@ jobs:
           password: ${{ env.DOCKER_PASSWORD }}
 
       - name: Start Postgres
-        run: bin/rbio dev:up -s postgres
+        run: bin/rbio compose:up -s postgres
 
       - name: Pause for Initialization
         run: sleep 15
@@ -474,7 +474,7 @@ jobs:
           password: ${{ env.DOCKER_PASSWORD }}
 
       - name: Start Postgres
-        run: bin/rbio dev:up -s postgres
+        run: bin/rbio compose:up -s postgres
 
       - name: Pause for Initialization
         run: sleep 15
@@ -515,7 +515,7 @@ jobs:
           password: ${{ env.DOCKER_PASSWORD }}
 
       - name: Start Postgres
-        run: bin/rbio dev:up -s postgres
+        run: bin/rbio compose:up -s postgres
 
       - name: Pause for Initialization
         run: sleep 15
@@ -563,7 +563,7 @@ jobs:
           password: ${{ env.DOCKER_PASSWORD }}
 
       - name: Start Postgres
-        run: bin/rbio dev:up -s postgres
+        run: bin/rbio compose:up -s postgres
 
       - name: Pause for Initialization
         run: sleep 15
@@ -643,7 +643,7 @@ jobs:
           password: ${{ env.DOCKER_PASSWORD }}
 
       - name: Start Postgres
-        run: bin/rbio dev:up -s postgres
+        run: bin/rbio compose:up -s postgres
 
       - name: Pause for Initialization
         run: sleep 15

--- a/bin/lib/compose.py
+++ b/bin/lib/compose.py
@@ -1,0 +1,167 @@
+"""compose:* — wrappers around docker compose for the local dev stack."""
+
+import argparse
+import json
+import subprocess
+
+from lib._requirements import epilog_from, requires
+from lib._runtime import REPO_ROOT, Globals, run, stderr
+
+COMPOSE_UP_DEFAULT_SERVICES = ["api", "postgres", "elasticsearch"]
+COMPOSE_UP_OPTIONAL_SERVICES = ["foreman"]
+COMPOSE_UP_ALL_SERVICES = sorted(
+    set(COMPOSE_UP_DEFAULT_SERVICES) | set(COMPOSE_UP_OPTIONAL_SERVICES)
+)
+
+
+@requires(tools=["docker"])
+def cmd_compose_up(argv):
+    p = argparse.ArgumentParser(
+        prog="rbio compose:up",
+        description="Start the local dev stack.",
+        epilog=(
+            "services:\n"
+            f"  default:   {', '.join(COMPOSE_UP_DEFAULT_SERVICES)}\n"
+            f"  optional:  {', '.join(COMPOSE_UP_OPTIONAL_SERVICES)}\n"
+            "\n"
+            "  workers are not part of compose:up — they're ephemeral job\n"
+            "  containers, started on demand by other commands.\n"
+            "\n"
+            "wraps: docker compose up -d <services>"
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    p.add_argument(
+        "-s",
+        "--service",
+        dest="services",
+        action="append",
+        default=[],
+        metavar="SERVICE",
+        choices=COMPOSE_UP_ALL_SERVICES,
+        help="service to start (repeatable). default: the full default stack.",
+    )
+    p.add_argument(
+        "--wait", action="store_true", help="block until services pass their healthchecks"
+    )
+    args = p.parse_args(argv)
+
+    services = list(args.services) if args.services else list(COMPOSE_UP_DEFAULT_SERVICES)
+
+    if not Globals.dry_run:
+        missing = check_missing_local_images(services)
+        if missing:
+            stderr("rbio compose:up: missing local image(s):")
+            for img in sorted(missing):
+                stderr(f"  {img}")
+            stderr("")
+            stderr("build them first:  rbio build")
+            return 1
+
+    cmd = ["docker", "compose", "up", "-d"]
+    if args.wait:
+        cmd.append("--wait")
+    cmd.extend(services)
+    return run(cmd)
+
+
+def check_missing_local_images(services):
+    """Return refinebio-built images that compose needs but aren't in the local daemon."""
+    cfg = subprocess.run(
+        ["docker", "compose", "config", "--format", "json"],
+        capture_output=True,
+        text=True,
+        cwd=str(REPO_ROOT),
+    )
+    if cfg.returncode != 0:
+        return []
+    try:
+        config = json.loads(cfg.stdout)
+    except json.JSONDecodeError:
+        return []
+    needed = [config.get("services", {}).get(s, {}).get("image", "") for s in services]
+    needed = [i for i in needed if "/dr_" in i]
+    if not needed:
+        return []
+    ls = subprocess.run(
+        ["docker", "image", "ls", "--format", "{{.Repository}}:{{.Tag}}"],
+        capture_output=True,
+        text=True,
+    )
+    local = set(ls.stdout.splitlines()) if ls.returncode == 0 else set()
+    return [i for i in needed if i not in local]
+
+
+@requires(tools=["docker"])
+def cmd_compose_down(argv):
+    p = argparse.ArgumentParser(
+        prog="rbio compose:down",
+        description=(
+            "Stop the local dev stack. Volumes are preserved by default — "
+            "your postgres data is safe."
+        ),
+        epilog="wraps: docker compose down",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    p.add_argument(
+        "-v",
+        "--volumes",
+        action="store_true",
+        help="also remove volumes (DESTRUCTIVE — wipes the db)",
+    )
+    p.add_argument("--rmi", action="store_true", help="remove images built by compose")
+    args = p.parse_args(argv)
+
+    cmd = ["docker", "compose", "down"]
+    if args.volumes:
+        cmd.append("--volumes")
+    if args.rmi:
+        cmd.extend(["--rmi", "local"])
+    return run(cmd)
+
+
+@requires(tools=["docker"])
+def cmd_compose_manage(argv):
+    p = argparse.ArgumentParser(
+        prog="rbio compose:manage",
+        description="Run a Django management command in a service container.",
+        epilog=epilog_from(
+            cmd_compose_manage,
+            "examples:\n"
+            "  rbio compose:manage foreman shell\n"
+            "  rbio compose:manage foreman clear_database\n"
+            "  rbio compose:manage api search_index --rebuild -f\n"
+            "\n"
+            "shell is just another management command (python3 manage.py shell),\n"
+            "so it works through the same path as everything else.\n"
+            "\n"
+            "wraps: docker compose run --rm <service> python3 manage.py <args>",
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    p.add_argument("service", help="compose service (foreman, api, workers, ...)")
+    p.add_argument(
+        "args",
+        nargs=argparse.REMAINDER,
+        help="forwarded to python3 manage.py",
+    )
+    args = p.parse_args(argv)
+    return run(
+        [
+            "docker",
+            "compose",
+            "run",
+            "--rm",
+            args.service,
+            "python3",
+            "manage.py",
+            *args.args,
+        ]
+    )
+
+
+COMMANDS = [
+    ("compose:up", cmd_compose_up, "start the dev stack"),
+    ("compose:down", cmd_compose_down, "stop the dev stack"),
+    ("compose:manage", cmd_compose_manage, "run a management command in a service container"),
+]

--- a/bin/lib/dev.py
+++ b/bin/lib/dev.py
@@ -1,121 +1,223 @@
-"""dev:* — local dev stack lifecycle (compose up/down)."""
+"""dev:* — higher-level local dev workflows that orchestrate jobs."""
 
 import argparse
 import json
 import subprocess
 
-from lib._runtime import REPO_ROOT, Globals, run, stderr
+from lib._requirements import epilog_from, requires
+from lib._runtime import Globals, run, stderr
 
-DEV_UP_DEFAULT_SERVICES = ["api", "postgres", "elasticsearch"]
-DEV_UP_OPTIONAL_SERVICES = ["foreman"]
-DEV_UP_ALL_SERVICES = sorted(set(DEV_UP_DEFAULT_SERVICES) | set(DEV_UP_OPTIONAL_SERVICES))
+WORKER_IMAGES = [
+    "affymetrix",
+    "agilent",
+    "compendia",
+    "downloaders",
+    "illumina",
+    "no_op",
+    "salmon",
+    "smasher",
+    "transcriptome",
+]
+
+JOB_SUBCOMMANDS = ["run_downloader_job", "run_processor_job"]
 
 
-def cmd_dev_up(argv):
+# Maps processor job names to the worker image that handles them. Keep in sync
+# with workers/data_refinery_workers/processors/management/commands/run_processor_job.py.
+_PROCESSOR_JOB_IMAGE = {
+    "AFFY_TO_PCL": "affymetrix",
+    "AGILENT_TWOCOLOR_TO_PCL": "affymetrix",
+    "SALMON": "salmon",
+    "ILLUMINA_TO_PCL": "illumina",
+    "TRANSCRIPTOME_INDEX_LONG": "transcriptome",
+    "TRANSCRIPTOME_INDEX_SHORT": "transcriptome",
+    "NO_OP": "no_op",
+}
+
+
+@requires(tools=["docker"])
+def cmd_dev_pipeline(argv):
     p = argparse.ArgumentParser(
-        prog="rbio dev:up",
-        description="Start the local dev stack.",
-        epilog=(
-            "services:\n"
-            f"  default:   {', '.join(DEV_UP_DEFAULT_SERVICES)}\n"
-            f"  optional:  {', '.join(DEV_UP_OPTIONAL_SERVICES)}\n"
-            "\n"
-            "  workers are not part of dev:up — they're ephemeral job\n"
-            "  containers, started on demand by other commands.\n"
-            "\n"
-            "wraps: docker compose up -d <services>"
-        ),
-        formatter_class=argparse.RawDescriptionHelpFormatter,
-    )
-    p.add_argument(
-        "-s",
-        "--service",
-        dest="services",
-        action="append",
-        default=[],
-        metavar="SERVICE",
-        choices=DEV_UP_ALL_SERVICES,
-        help="service to start (repeatable). default: the full default stack.",
-    )
-    p.add_argument(
-        "--wait", action="store_true", help="block until services pass their healthchecks"
-    )
-    args = p.parse_args(argv)
-
-    services = list(args.services) if args.services else list(DEV_UP_DEFAULT_SERVICES)
-
-    if not Globals.dry_run:
-        missing = check_missing_local_images(services)
-        if missing:
-            stderr("rbio dev:up: missing local image(s):")
-            for img in sorted(missing):
-                stderr(f"  {img}")
-            stderr("")
-            stderr("build them first:  rbio build")
-            return 1
-
-    cmd = ["docker", "compose", "up", "-d"]
-    if args.wait:
-        cmd.append("--wait")
-    cmd.extend(services)
-    return run(cmd)
-
-
-def check_missing_local_images(services):
-    """Return refinebio-built images that compose needs but aren't in the local daemon."""
-    cfg = subprocess.run(
-        ["docker", "compose", "config", "--format", "json"],
-        capture_output=True,
-        text=True,
-        cwd=str(REPO_ROOT),
-    )
-    if cfg.returncode != 0:
-        return []
-    try:
-        config = json.loads(cfg.stdout)
-    except json.JSONDecodeError:
-        return []
-    needed = [config.get("services", {}).get(s, {}).get("image", "") for s in services]
-    needed = [i for i in needed if "/dr_" in i]
-    if not needed:
-        return []
-    ls = subprocess.run(
-        ["docker", "image", "ls", "--format", "{{.Repository}}:{{.Tag}}"],
-        capture_output=True,
-        text=True,
-    )
-    local = set(ls.stdout.splitlines()) if ls.returncode == 0 else set()
-    return [i for i in needed if i not in local]
-
-
-def cmd_dev_down(argv):
-    p = argparse.ArgumentParser(
-        prog="rbio dev:down",
+        prog="rbio dev:pipeline",
         description=(
-            "Stop the local dev stack. Volumes are preserved by default — "
-            "your postgres data is safe."
+            "Survey an accession locally, then drain the resulting downloader "
+            "and processor jobs one at a time against the local stack."
         ),
-        epilog="wraps: docker compose down",
+        epilog=epilog_from(
+            cmd_dev_pipeline,
+            "wraps:\n"
+            "  docker compose run --rm foreman python3 manage.py survey_all --accession ACC\n"
+            "  (loop) docker compose run --rm foreman python3 manage.py get_job_to_be_run\n"
+            "  (loop) docker compose run --rm <worker> python3 manage.py run_{processor,downloader}_job ...",
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    p.add_argument("accession_code", help="experiment accession to survey")
+    args = p.parse_args(argv)
+
+    if (
+        rc := run(
+            [
+                "docker",
+                "compose",
+                "run",
+                "--rm",
+                "foreman",
+                "python3",
+                "manage.py",
+                "survey_all",
+                "--accession",
+                args.accession_code,
+            ]
+        )
+    ) != 0:
+        return rc
+
+    while True:
+        job = _get_job_to_run()
+        if not job:
+            return 0
+        if (rc := _run_job(job)) != 0:
+            return rc
+
+
+def _get_job_to_run():
+    if Globals.dry_run:
+        return None
+    # The management command prints the JSON as its last non-empty stdout line.
+    result = subprocess.run(
+        [
+            "docker",
+            "compose",
+            "run",
+            "--rm",
+            "foreman",
+            "python3",
+            "manage.py",
+            "get_job_to_be_run",
+        ],
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        return None
+    lines = [ln for ln in result.stdout.splitlines() if ln.strip()]
+    if not lines:
+        return None
+    try:
+        return json.loads(lines[-1])
+    except json.JSONDecodeError:
+        return None
+
+
+def _run_job(job):
+    job_name = job["job_name"]
+    job_id = job["job_id"]
+    print(f"Running {job_name} Job with id {job_id}!")
+
+    if job["job_type"] == "DownloaderJob":
+        subcommand = "run_downloader_job"
+        image = "downloaders"
+    else:
+        subcommand = "run_processor_job"
+        image = _PROCESSOR_JOB_IMAGE.get(job_name, "downloaders")
+
+    return run(
+        [
+            "docker",
+            "compose",
+            "run",
+            "--rm",
+            image,
+            "python3",
+            "manage.py",
+            subcommand,
+            f"--job-name={job_name}",
+            f"--job-id={job_id}",
+        ]
+    )
+
+
+@requires(tools=["docker"])
+def cmd_dev_job(argv):
+    p = argparse.ArgumentParser(
+        prog="rbio dev:job",
+        description="Run a single downloader/processor job in a worker container.",
+        epilog=epilog_from(
+            cmd_dev_job,
+            "examples:\n"
+            "  rbio dev:job downloaders run_downloader_job --job-name=SRA --job-id=12345\n"
+            "  rbio dev:job affymetrix run_processor_job --job-name=AFFY_TO_PCL --job-id=54321\n"
+            "\n"
+            "agilent uses the affymetrix image (same binary).\n"
+            "\n"
+            "wraps: docker compose run --rm <image> python3 manage.py <subcommand> <args>",
+        ),
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
     p.add_argument(
-        "-v",
-        "--volumes",
-        action="store_true",
-        help="also remove volumes (DESTRUCTIVE — wipes the db)",
+        "image",
+        choices=WORKER_IMAGES,
+        help="worker image to run the job in",
     )
-    p.add_argument("--rmi", action="store_true", help="remove images built by compose")
+    p.add_argument(
+        "subcommand",
+        choices=JOB_SUBCOMMANDS,
+        help="management command to run",
+    )
+    p.add_argument(
+        "manage_args",
+        nargs=argparse.REMAINDER,
+        help="forwarded to manage.py (e.g. --job-name=SRA --job-id=12345)",
+    )
     args = p.parse_args(argv)
 
-    cmd = ["docker", "compose", "down"]
-    if args.volumes:
-        cmd.append("--volumes")
-    if args.rmi:
-        cmd.extend(["--rmi", "local"])
-    return run(cmd)
+    # agilent and affymetrix share the affymetrix image.
+    image = "affymetrix" if args.image == "agilent" else args.image
+
+    return run(
+        [
+            "docker",
+            "compose",
+            "run",
+            "--rm",
+            image,
+            "python3",
+            "manage.py",
+            args.subcommand,
+            *args.manage_args,
+        ]
+    )
+
+
+@requires(tools=["docker"])
+def cmd_dev_janitor(argv):
+    p = argparse.ArgumentParser(
+        prog="rbio dev:janitor",
+        description="Run the janitor (cleanup) management command in a smasher container.",
+        epilog=epilog_from(
+            cmd_dev_janitor,
+            "wraps: docker compose run --rm smasher python3 manage.py run_janitor",
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    p.parse_args(argv)
+    return run(
+        [
+            "docker",
+            "compose",
+            "run",
+            "--rm",
+            "smasher",
+            "python3",
+            "manage.py",
+            "run_janitor",
+        ]
+    )
 
 
 COMMANDS = [
-    ("dev:up", cmd_dev_up, "start the dev stack"),
-    ("dev:down", cmd_dev_down, "stop the dev stack"),
+    ("dev:pipeline", cmd_dev_pipeline, "survey an accession + drain its job queue locally"),
+    ("dev:job", cmd_dev_job, "run a single downloader/processor job"),
+    ("dev:janitor", cmd_dev_janitor, "run the janitor cleanup command in a smasher container"),
 ]

--- a/bin/lib/test/__init__.py
+++ b/bin/lib/test/__init__.py
@@ -1,6 +1,7 @@
-"""test:* — per-subproject test runners (api / common / foreman / workers)."""
+"""test:* — per-subproject test runners (api / common / foreman / workers) + test:all."""
 
+from lib.test.all import COMMANDS as _ALL_COMMANDS
 from lib.test.subprojects import COMMANDS as _SUBPROJECT_COMMANDS
 from lib.test.workers import COMMANDS as _WORKER_COMMANDS
 
-COMMANDS = [*_SUBPROJECT_COMMANDS, *_WORKER_COMMANDS]
+COMMANDS = [*_SUBPROJECT_COMMANDS, *_WORKER_COMMANDS, *_ALL_COMMANDS]

--- a/bin/lib/test/all.py
+++ b/bin/lib/test/all.py
@@ -1,0 +1,55 @@
+"""test:all — orchestrate every project test suite sequentially."""
+
+import argparse
+
+from lib._docker import require_services
+from lib._requirements import epilog_from, requires
+from lib._runtime import REPO_ROOT
+from lib.common import cmd_common_update
+from lib.test.subprojects import cmd_test_api, cmd_test_common, cmd_test_foreman
+from lib.test.workers import cmd_test_workers
+
+
+@requires(tools=["docker"])
+def cmd_test_all(argv):
+    p = argparse.ArgumentParser(
+        prog="rbio test:all",
+        description="Run every project test suite (api, common, foreman, workers).",
+        epilog=epilog_from(
+            cmd_test_all,
+            "wraps:\n"
+            "  rbio common:update           (apply migrations, rebuild common sdist)\n"
+            "  rbio test:api\n"
+            "  rbio test:common\n"
+            "  rbio test:foreman\n"
+            "  rbio test:workers\n"
+            "\n"
+            "Suites run sequentially against the same local postgres + ES.\n"
+            "First failure short-circuits the chain.",
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    p.parse_args(argv)
+
+    if (rc := require_services("test:all", {"postgres": "drdb", "elasticsearch": "dres"})) != 0:
+        return rc
+
+    test_volume = REPO_ROOT / "test_volume"
+    test_volume.mkdir(exist_ok=True)
+    test_volume.chmod(0o777)
+
+    for fn in [
+        cmd_common_update,
+        cmd_test_api,
+        cmd_test_common,
+        cmd_test_foreman,
+        cmd_test_workers,
+    ]:
+        if (rc := fn([])) != 0:
+            return rc
+    return 0
+
+
+COMMANDS = [
+    ("test:all", cmd_test_all, "run every test suite sequentially"),
+]

--- a/bin/rbio
+++ b/bin/rbio
@@ -6,13 +6,13 @@ from pathlib import Path
 # Make `from lib import ...` work when this script is invoked directly.
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 
-from lib import build, common, db, dev, es, test
+from lib import build, common, compose, db, dev, es, test
 from lib._runtime import Globals, stderr
 
 # Each namespace module exports a COMMANDS list of (name, fn, help) tuples;
 # concatenating them gives the single registry that drives both dispatch and
 # the top-level help block. Adding a namespace is one line in NAMESPACES.
-NAMESPACES = [build, common, db, dev, es, test]
+NAMESPACES = [build, common, compose, db, dev, es, test]
 
 COMMAND_REGISTRY = [entry for ns in NAMESPACES for entry in ns.COMMANDS]
 


### PR DESCRIPTION
## Issue Number

#3572

## Purpose/Implementation Notes

- bin/lib/compose.py (new) - wraps docker compose for the local stack. Takes ownership of the rename: compose:up / compose:down replace dev:up / dev:down (which are removed). compose:manage is new - runs a Django management command in a named service container; collapses what would have been separate "manage" + "shell" commands since shell is itself a manage.py subcommand.
- bin/lib/dev.py (rewrite) - higher-level local workflows. Replaces the old cmd_dev_up/down (moved to compose.py) with three orchestration commands:
    * dev:pipeline - survey an accession, drain its job queue locally (port of scripts/run_full_pipeline.py, talks to compose directly)
    * dev:job - run a single downloader/processor job in a worker container (replaces workers/run_job.sh, image as positional arg so no implicit default-to-downloaders surprise)
    * dev:janitor - run cleanup logic in a smasher container (replaces workers/run_janitor.sh; no memory cap — local does not mirror Batch limits, Batch has its own)

- bin/lib/test/all.py (new) - test:all chains common:update + each
  test:* sequentially. Matches scripts/run_all_tests.sh behavior.

- bin/lib/test/__init__.py - register test:all in the aggregated COMMANDS.

- bin/rbio - register the compose namespace.


## Methods

N/A

## Types of changes

- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Functional tests

rbio smoketesting

## Checklist

- [x] Lint and unit tests pass locally with my changes

## Screenshots

N/A
