### PR TITLE
api: migrate serve scripts to rbio build + refinebio_default network

### DIFF
--- a/api/serve.sh
+++ b/api/serve.sh
@@ -10,10 +10,10 @@ script_directory="$(
 )"
 cd "$script_directory" || exit
 
-# Run from the repo root so prepare_image.sh and compose.yml resolve.
+# Run from the repo root so bin/rbio and compose.yml resolve.
 cd ..
 
-./scripts/prepare_image.sh -i api_local -s api
+./bin/rbio build api_local
 
 exec docker compose run --rm --service-ports api \
     python3 manage.py runserver 0.0.0.0:8000 "$@"

--- a/api/serve_production.sh
+++ b/api/serve_production.sh
@@ -1,6 +1,10 @@
 #!/bin/sh
 
-# Script for executing Django PyUnit tests within a Docker container.
+# Run the production API server locally using the uwsgi prod image
+# (dr_api). Mirrors what runs on the production API EC2 box.
+#
+# Requires: rbio compose:up postgres
+# (so the refinebio_default network and the `database` alias exist)
 
 # This script should always run as if it were being called from
 # the directory it lives in.
@@ -14,19 +18,15 @@ cd "$script_directory" || exit
 # move up a level.
 cd ..
 
-./scripts/prepare_image.sh -i api -s api
+./bin/rbio build api
 
-. ./scripts/common.sh
-
-DB_HOST_IP=$(get_docker_db_ip_address)
 STATIC_VOLUMES=/tmp/volumes_static
 
 docker run \
-    --add-host=database:"$DB_HOST_IP" \
     --detach \
     --env-file api/environments/local \
     --interactive \
-    --link drdb:postgres \
+    --network refinebio_default \
     --platform linux/amd64 \
     --publish 8081:8081 \
     --tty \


### PR DESCRIPTION
## Issue Number

#3572

## Purpose/Implementation Notes

- api/serve.sh: swap scripts/prepare_image.sh → ./bin/rbio build api_local. Behavior unchanged; image is built before compose runs runserver as before.

- api/serve_production.sh:
    * swap scripts/prepare_image.sh → ./bin/rbio build api
    * drop the scripts/common.sh source and DB_HOST_IP computation
    * replace --add-host=database:$DB_HOST_IP + --link drdb:postgres with --network refinebio_default
    * fix the misleading top-of-file comment (the script serves the production uwsgi API locally; it has never executed PyUnit tests)
    * add an explicit precondition note: requires `rbio compose:up postgres` so the refinebio_default network and the `database` service alias exist before this script tries to attach.

The --link mechanism is also Docker-deprecated; --network refinebio_default is both more correct and forward-compatible. The compose network's `aliases: [database]` on the postgres service provides the same hostname resolution that --add-host was hardcoding from a docker inspect.

## Methods

N/A

## Types of changes

- New feature (non-breaking change which adds functionality)

## Functional tests

N/A

## Checklist

- [x] Lint and unit tests pass locally with my changes

## Screenshots

N/A
