### PR TITLE
infra/deploy.sh: drop scripts/common.sh source, inline its consumers

### DIFF
--- a/infrastructure/deploy.sh
+++ b/infrastructure/deploy.sh
@@ -93,15 +93,14 @@ if [[ -z $SYSTEM_VERSION ]]; then
     exit 1
 fi
 
-# Load $ALL_IMAGES and helper functions.
-# shellcheck disable=SC1091
-. ../scripts/common.sh
+ALL_IMAGES="base api_base api foreman smasher compendia illumina affymetrix salmon transcriptome no_op downloaders"
 
 if [[ -z $TF_VAR_dockerhub_repo ]]; then
+    # ccdlstaging hosts -dev images for staging; ccdl hosts the prod tag.
     if [[ $SYSTEM_VERSION == *"-dev" ]]; then
-        TF_VAR_dockerhub_repo=$(get_deploy_repo dev)
+        TF_VAR_dockerhub_repo=ccdlstaging
     else
-        TF_VAR_dockerhub_repo=$(get_deploy_repo master)
+        TF_VAR_dockerhub_repo=ccdl
     fi
     export TF_VAR_dockerhub_repo
 fi


### PR DESCRIPTION
## Issue Number

#3572

## Purpose/Implementation Notes

- infrastructure/deploy.sh only used two things from scripts/common.sh:
  - the $ALL_IMAGES list (consumed by the for-loop that builds per-image TF_VAR_*_docker_image vars) and get_deploy_repo (a two-line case mapping branch → Dockerhub namespace). Both are inlined now so this file no longer depends on scripts/.
- ALL_IMAGES is now a local string literal, matching the expansion of common.sh's `base api_base api foreman $WORKER_IMAGES`.
- get_deploy_repo is replaced with the two literal repo names (ccdlstaging / ccdl) at the only call site, with a comment naming what each is for.

## Methods

N/A

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

N/A

## Checklist

- [x] Lint and unit tests pass locally with my changes

## Screenshots

N/A
