### PR TITLE
migrage drf-yasg OpenAPI2-> drf-spectacular OpenAPI3

### DIFF
--- a/api/data_refinery_api/settings.py
+++ b/api/data_refinery_api/settings.py
@@ -51,13 +51,12 @@ INSTALLED_APPS = [
     "django.contrib.staticfiles",
     # 3rd Party
     "rest_framework",
-    "coreapi",
     "django_filters",
     "corsheaders",
     "raven.contrib.django.raven_compat",
     "django_elasticsearch_dsl",
     "django_elasticsearch_dsl_drf",
-    "drf_yasg",
+    "drf_spectacular",
     # Local
     "data_refinery_common",
     "data_refinery_api",
@@ -184,12 +183,37 @@ REST_FRAMEWORK = {
     "DEFAULT_PAGINATION_CLASS": "data_refinery_api.pagination.LimitedLimitOffsetPagination",
     "PAGE_SIZE": 25,
     "DEFAULT_VERSIONING_CLASS": "rest_framework.versioning.URLPathVersioning",
+    "DEFAULT_SCHEMA_CLASS": "drf_spectacular.openapi.AutoSchema",
     "EXCEPTION_HANDLER": "data_refinery_api.exceptions.custom_exception_handler",
     "DEFAULT_THROTTLE_CLASSES": [
         "rest_framework.throttling.AnonRateThrottle",
         "rest_framework.throttling.UserRateThrottle",
     ],
     "DEFAULT_THROTTLE_RATES": {"anon": "10/second", "user": "10/second"},
+}
+
+SPECTACULAR_SETTINGS = {
+    "TITLE": "Refine.bio API",
+    "VERSION": "v1",
+    "DESCRIPTION": """
+refine.bio is a multi-organism collection of genome-wide transcriptome or gene expression data that has been obtained from publicly available repositories and uniformly processed and normalized. refine.bio allows biologists, clinicians, and machine learning researchers to search for experiments from different source repositories all in one place and build custom data sets for their questions of interest.
+
+The swagger-ui view can be found [here](https://api.refine.bio/swagger/).
+
+The ReDoc view can be found [here](https://api.refine.bio/).
+
+Additional documentation can be found at [docs.refine.bio](https://docs.refine.bio/en/latest/).
+
+### Questions/Feedback?
+
+If you have a question or comment, please [file an issue on GitHub](https://github.com/AlexsLemonade/refinebio/issues) or send us an email at [requests@ccdatalab.org](mailto:requests@ccdatalab.org).
+        """,
+    "TOS": "https://www.refine.bio/terms",
+    "CONTACT": {"email": "requests@ccdatalab.org"},
+    "LICENSE": {"name": "BSD License"},
+    "SERVERS": [{"url": "https://api.refine.bio"}],
+    # Keep the schema endpoint pointed at v1 and don't split by version.
+    "SERVE_INCLUDE_SCHEMA": False,
 }
 
 SWAGGER_SETTINGS = {

--- a/api/data_refinery_api/urls.py
+++ b/api/data_refinery_api/urls.py
@@ -5,10 +5,8 @@ from django.contrib import admin
 from django.http import JsonResponse
 from django.urls import include, path, re_path
 from django.views.generic import RedirectView
-from rest_framework import permissions
 
-from drf_yasg import openapi
-from drf_yasg.views import get_schema_view
+from drf_spectacular.views import SpectacularAPIView, SpectacularRedocView, SpectacularSwaggerView
 
 from data_refinery_api.views import (
     AboutStats,
@@ -87,32 +85,6 @@ class AccessUser:
 
 if settings.DEBUG:
     admin.site.has_permission = lambda r: setattr(r, "user", AccessUser()) or True
-
-schema_view = get_schema_view(
-    openapi.Info(
-        title="Refine.bio API",
-        default_version="v1",
-        description="""
-refine.bio is a multi-organism collection of genome-wide transcriptome or gene expression data that has been obtained from publicly available repositories and uniformly processed and normalized. refine.bio allows biologists, clinicians, and machine learning researchers to search for experiments from different source repositories all in one place and build custom data sets for their questions of interest.
-
-The swagger-ui view can be found [here](http://api.refine.bio/swagger/).
-
-The ReDoc view can be found [here](http://api.refine.bio/).
-
-Additional documentation can be found at [docs.refine.bio](http://docs.refine.bio/en/latest/).
-
-### Questions/Feedback?
-
-If you have a question or comment, please [file an issue on GitHub](https://github.com/AlexsLemonade/refinebio/issues) or send us an email at [requests@ccdatalab.org](mailto:requests@ccdatalab.org).
-        """,
-        terms_of_service="https://www.refine.bio/terms",
-        contact=openapi.Contact(email="requests@ccdatalab.org"),
-        license=openapi.License(name="BSD License"),
-    ),
-    public=True,
-    permission_classes=(permissions.AllowAny,),
-    url="https://api.refine.bio",
-)
 
 urlpatterns = [
     re_path(
@@ -264,12 +236,17 @@ urlpatterns = [
                     name="compendium_result",
                 ),
                 # v1 api docs
+                re_path(r"^schema/$", SpectacularAPIView.as_view(), name="schema"),
                 re_path(
                     r"^swagger/$",
-                    schema_view.with_ui("swagger", cache_timeout=0),
+                    SpectacularSwaggerView.as_view(url="/v1/schema/"),
                     name="schema_swagger_ui",
                 ),
-                re_path(r"^$", schema_view.with_ui("redoc", cache_timeout=0), name="schema_redoc"),
+                re_path(
+                    r"^$",
+                    SpectacularRedocView.as_view(url="/v1/schema/"),
+                    name="schema_redoc",
+                ),
             ]
         ),
     ),

--- a/api/data_refinery_api/views/api_token.py
+++ b/api/data_refinery_api/views/api_token.py
@@ -5,7 +5,7 @@
 from django.utils.decorators import method_decorator
 from rest_framework import mixins, serializers, viewsets
 
-from drf_yasg.utils import swagger_auto_schema
+from drf_spectacular.utils import extend_schema
 
 from data_refinery_common.models import APIToken
 
@@ -23,8 +23,8 @@ class APITokenSerializer(serializers.ModelSerializer):
 
 @method_decorator(
     name="create",
-    decorator=swagger_auto_schema(
-        operation_description="""
+    decorator=extend_schema(
+        description="""
     This endpoint can be used to create and activate tokens. These tokens can be used
     in requests that provide urls to download computed files. Setting `is_activated` to
     true indicates agreement with refine.bio's [Terms of Use](https://www.refine.bio/terms)
@@ -49,14 +49,14 @@ class APITokenSerializer(serializers.ModelSerializer):
 )
 @method_decorator(
     name="retrieve",
-    decorator=swagger_auto_schema(
-        operation_description="Return details about a specific token.",
+    decorator=extend_schema(
+        description="Return details about a specific token.",
     ),
 )
 @method_decorator(
     name="update",
-    decorator=swagger_auto_schema(
-        operation_description="""
+    decorator=extend_schema(
+        description="""
     This can be used to activate a specific token by sending `is_activated: true`.
     Setting `is_activated` to true indicates agreement with refine.bio's
     [Terms of Use](https://www.refine.bio/terms) and

--- a/api/data_refinery_api/views/compendium_result.py
+++ b/api/data_refinery_api/views/compendium_result.py
@@ -9,8 +9,8 @@ from django.utils.decorators import method_decorator
 from rest_framework import filters, generics, serializers
 
 from django_filters.rest_framework import DjangoFilterBackend
-from drf_yasg import openapi
-from drf_yasg.utils import swagger_auto_schema
+from drf_spectacular.types import OpenApiTypes
+from drf_spectacular.utils import OpenApiParameter, extend_schema
 
 from data_refinery_api.exceptions import InvalidFilters
 from data_refinery_api.utils import check_filters
@@ -67,18 +67,18 @@ class CompendiumResultWithUrlSerializer(serializers.ModelSerializer):
 
 @method_decorator(
     name="get",
-    decorator=swagger_auto_schema(
-        manual_parameters=[
-            openapi.Parameter(
+    decorator=extend_schema(
+        parameters=[
+            OpenApiParameter(
                 name="latest_version",
-                in_=openapi.IN_QUERY,
-                type=openapi.TYPE_BOOLEAN,
+                location=OpenApiParameter.QUERY,
+                type=OpenApiTypes.BOOL,
                 description="`True` will only return the highest `compendium_version` for each primary_organism.",
             ),
-            openapi.Parameter(
+            OpenApiParameter(
                 name="quant_sf_only",
-                in_=openapi.IN_QUERY,
-                type=openapi.TYPE_BOOLEAN,
+                location=OpenApiParameter.QUERY,
+                type=OpenApiTypes.BOOL,
                 description="`True` for RNA-seq Sample Compendium results or `False` for quantile normalized.",
             ),
         ]

--- a/api/data_refinery_api/views/dataset.py
+++ b/api/data_refinery_api/views/dataset.py
@@ -10,8 +10,8 @@ from django.utils.decorators import method_decorator
 from rest_framework import mixins, serializers, viewsets
 from rest_framework.exceptions import APIException
 
-from drf_yasg import openapi
-from drf_yasg.utils import swagger_auto_schema
+from drf_spectacular.types import OpenApiTypes
+from drf_spectacular.utils import OpenApiParameter, extend_schema
 
 from data_refinery_api.exceptions import BadRequest, InvalidData
 from data_refinery_common.enums import ProcessorPipeline
@@ -313,13 +313,13 @@ class DatasetSerializer(serializers.ModelSerializer):
 
 @method_decorator(
     name="retrieve",
-    decorator=swagger_auto_schema(
-        operation_description="View a single Dataset.",
-        manual_parameters=[
-            openapi.Parameter(
+    decorator=extend_schema(
+        description="View a single Dataset.",
+        parameters=[
+            OpenApiParameter(
                 name="details",
-                in_=openapi.IN_QUERY,
-                type=openapi.TYPE_BOOLEAN,
+                location=OpenApiParameter.QUERY,
+                type=OpenApiTypes.BOOL,
                 description="When set to `True`, additional fields will be included in the response with details about the experiments in the dataset. This is used mostly on the dataset page in www.refine.bio",
             )
         ],
@@ -327,8 +327,8 @@ class DatasetSerializer(serializers.ModelSerializer):
 )
 @method_decorator(
     name="update",
-    decorator=swagger_auto_schema(
-        operation_description="""
+    decorator=extend_schema(
+        description="""
 Modify an existing Dataset.
 
 In order to begin smashing, an activated API key must be provided in the `API-KEY` header field of the request.

--- a/api/data_refinery_api/views/experiment_document.py
+++ b/api/data_refinery_api/views/experiment_document.py
@@ -22,8 +22,8 @@ from django_elasticsearch_dsl_drf.filter_backends import (
 from django_elasticsearch_dsl_drf.pagination import LimitOffsetPagination as ESLimitOffsetPagination
 from django_elasticsearch_dsl_drf.serializers import DocumentSerializer
 from django_elasticsearch_dsl_drf.viewsets import DocumentViewSet
-from drf_yasg import openapi
-from drf_yasg.utils import swagger_auto_schema
+from drf_spectacular.types import OpenApiTypes
+from drf_spectacular.utils import OpenApiParameter, extend_schema
 from elasticsearch_dsl import TermsFacet
 from six import iteritems
 
@@ -153,46 +153,46 @@ class ExperimentDocumentSerializer(DocumentSerializer):
 
 @method_decorator(
     name="list",
-    decorator=swagger_auto_schema(
-        manual_parameters=[
-            openapi.Parameter(
+    decorator=extend_schema(
+        parameters=[
+            OpenApiParameter(
                 name="accession_code",
-                in_=openapi.IN_QUERY,
-                type=openapi.TYPE_STRING,
+                location=OpenApiParameter.QUERY,
+                type=OpenApiTypes.STR,
                 description="Allows filtering the results by accession code, can have multiple values. Eg: `?accession_code=microarray&accession_code=rna-seq`",
             ),
-            openapi.Parameter(
+            OpenApiParameter(
                 name="technology",
-                in_=openapi.IN_QUERY,
-                type=openapi.TYPE_STRING,
+                location=OpenApiParameter.QUERY,
+                type=OpenApiTypes.STR,
                 description="Allows filtering the results by technology, can have multiple values. Eg: `?technology=microarray&technology=rna-seq`",
             ),
-            openapi.Parameter(
+            OpenApiParameter(
                 name="has_publication",
-                in_=openapi.IN_QUERY,
-                type=openapi.TYPE_STRING,
+                location=OpenApiParameter.QUERY,
+                type=OpenApiTypes.STR,
                 description="Filter the results that have associated publications with `?has_publication=true`",
             ),
-            openapi.Parameter(
+            OpenApiParameter(
                 name="platform",
-                in_=openapi.IN_QUERY,
-                type=openapi.TYPE_STRING,
+                location=OpenApiParameter.QUERY,
+                type=OpenApiTypes.STR,
                 description="Allows filtering the results by platform, this parameter can have multiple values.",
             ),
-            openapi.Parameter(
+            OpenApiParameter(
                 name="organism",
-                in_=openapi.IN_QUERY,
-                type=openapi.TYPE_STRING,
+                location=OpenApiParameter.QUERY,
+                type=OpenApiTypes.STR,
                 description="Allows filtering the results by organism, this parameter can have multiple values.",
             ),
-            openapi.Parameter(
+            OpenApiParameter(
                 name="num_processed_samples",
-                in_=openapi.IN_QUERY,
-                type=openapi.TYPE_NUMBER,
+                location=OpenApiParameter.QUERY,
+                type=OpenApiTypes.NUMBER,
                 description="Use ElasticSearch queries to specify the number of processed samples of the results",
             ),
         ],
-        operation_description="""
+        description="""
 Use this endpoint to search among the experiments.
 
 This is powered by ElasticSearch, information regarding advanced usages of the
@@ -380,7 +380,7 @@ class ExperimentDocumentView(DocumentViewSet):
     # Define a separate post method so that we can hide it in the
     # documentation. Otherwise, the auto-generated documentation for the post
     # method is incorrect
-    @swagger_auto_schema(auto_schema=None)
+    @extend_schema(auto_schema=None)
     def post(self, request, *args, **kwargs):
         return self.list(request, *args, **kwargs)
 

--- a/api/data_refinery_api/views/experiment_document.py
+++ b/api/data_refinery_api/views/experiment_document.py
@@ -380,7 +380,7 @@ class ExperimentDocumentView(DocumentViewSet):
     # Define a separate post method so that we can hide it in the
     # documentation. Otherwise, the auto-generated documentation for the post
     # method is incorrect
-    @extend_schema(auto_schema=None)
+    @extend_schema(exclude=True)
     def post(self, request, *args, **kwargs):
         return self.list(request, *args, **kwargs)
 

--- a/api/data_refinery_api/views/jobs/downloader_job.py
+++ b/api/data_refinery_api/views/jobs/downloader_job.py
@@ -7,8 +7,8 @@ from rest_framework import filters, generics, serializers
 
 import boto3
 from django_filters.rest_framework import DjangoFilterBackend
-from drf_yasg import openapi
-from drf_yasg.utils import swagger_auto_schema
+from drf_spectacular.types import OpenApiTypes
+from drf_spectacular.utils import OpenApiParameter, extend_schema
 
 from data_refinery_api.exceptions import InvalidFilters
 from data_refinery_api.utils import check_filters
@@ -55,12 +55,12 @@ class DownloaderJobSerializer(serializers.ModelSerializer):
 
 @method_decorator(
     name="get",
-    decorator=swagger_auto_schema(
-        manual_parameters=[
-            openapi.Parameter(
+    decorator=extend_schema(
+        parameters=[
+            OpenApiParameter(
                 name="sample_accession_code",
-                in_=openapi.IN_QUERY,
-                type=openapi.TYPE_STRING,
+                location=OpenApiParameter.QUERY,
+                type=OpenApiTypes.STR,
                 description="List the downloader jobs associated with a sample",
             ),
         ]

--- a/api/data_refinery_api/views/jobs/processor_job.py
+++ b/api/data_refinery_api/views/jobs/processor_job.py
@@ -7,8 +7,8 @@ from rest_framework import filters, generics, serializers
 
 import boto3
 from django_filters.rest_framework import DjangoFilterBackend
-from drf_yasg import openapi
-from drf_yasg.utils import swagger_auto_schema
+from drf_spectacular.types import OpenApiTypes
+from drf_spectacular.utils import OpenApiParameter, extend_schema
 
 from data_refinery_api.exceptions import InvalidFilters
 from data_refinery_api.utils import check_filters
@@ -56,12 +56,12 @@ class ProcessorJobSerializer(serializers.ModelSerializer):
 
 @method_decorator(
     name="get",
-    decorator=swagger_auto_schema(
-        manual_parameters=[
-            openapi.Parameter(
+    decorator=extend_schema(
+        parameters=[
+            OpenApiParameter(
                 name="sample_accession_code",
-                in_=openapi.IN_QUERY,
-                type=openapi.TYPE_STRING,
+                location=OpenApiParameter.QUERY,
+                type=OpenApiTypes.STR,
                 description="List the processor jobs associated with a sample",
             ),
         ]

--- a/api/data_refinery_api/views/qn_targets.py
+++ b/api/data_refinery_api/views/qn_targets.py
@@ -6,8 +6,8 @@ from django.utils.decorators import method_decorator
 from rest_framework import generics, serializers
 from rest_framework.exceptions import NotFound
 
-from drf_yasg import openapi
-from drf_yasg.utils import swagger_auto_schema
+from drf_spectacular.types import OpenApiTypes
+from drf_spectacular.utils import OpenApiParameter, OpenApiResponse, extend_schema
 
 from data_refinery_api.views.relation_serializers import (
     ComputationalResultNoFilesRelationSerializer,
@@ -51,16 +51,16 @@ class QNTargetsAvailable(generics.ListAPIView):
 
 @method_decorator(
     name="get",
-    decorator=swagger_auto_schema(
-        manual_parameters=[
-            openapi.Parameter(
+    decorator=extend_schema(
+        parameters=[
+            OpenApiParameter(
                 name="organism_name",
-                in_=openapi.IN_PATH,
-                type=openapi.TYPE_STRING,
+                location=OpenApiParameter.PATH,
+                type=OpenApiTypes.STR,
                 description="Eg `DANIO_RERIO`, `MUS_MUSCULUS`",
             )
         ],
-        responses={404: "QN Target not found for the given organism."},
+        responses={404: OpenApiResponse(description="QN Target not found for the given organism.")},
     ),
 )
 class QNTargetsDetailView(generics.RetrieveAPIView):

--- a/api/data_refinery_api/views/sample.py
+++ b/api/data_refinery_api/views/sample.py
@@ -9,8 +9,8 @@ from django.utils.decorators import method_decorator
 from rest_framework import filters, generics, serializers
 
 from django_filters.rest_framework import DjangoFilterBackend
-from drf_yasg import openapi
-from drf_yasg.utils import swagger_auto_schema
+from drf_spectacular.types import OpenApiTypes
+from drf_spectacular.utils import OpenApiParameter, extend_schema
 
 from data_refinery_api.exceptions import InvalidFilters
 from data_refinery_api.utils import check_filters
@@ -116,24 +116,24 @@ class DetailedSampleSerializer(serializers.ModelSerializer):
 
 @method_decorator(
     name="get",
-    decorator=swagger_auto_schema(
-        manual_parameters=[
-            openapi.Parameter(
+    decorator=extend_schema(
+        parameters=[
+            OpenApiParameter(
                 name="dataset_id",
-                in_=openapi.IN_QUERY,
-                type=openapi.TYPE_STRING,
+                location=OpenApiParameter.QUERY,
+                type=OpenApiTypes.STR,
                 description="Filters the result and only returns samples that are added to a dataset.",
             ),
-            openapi.Parameter(
+            OpenApiParameter(
                 name="experiment_accession_code",
-                in_=openapi.IN_QUERY,
-                type=openapi.TYPE_STRING,
+                location=OpenApiParameter.QUERY,
+                type=OpenApiTypes.STR,
                 description="Filters the result and only returns only the samples associated with an experiment accession code.",
             ),
-            openapi.Parameter(
+            OpenApiParameter(
                 name="accession_codes",
-                in_=openapi.IN_QUERY,
-                type=openapi.TYPE_STRING,
+                location=OpenApiParameter.QUERY,
+                type=OpenApiTypes.STR,
                 description="Provide a list of sample accession codes separated by commas and the endpoint will only return information about these samples.",
             ),
         ]

--- a/api/data_refinery_api/views/stats.py
+++ b/api/data_refinery_api/views/stats.py
@@ -20,8 +20,8 @@ from rest_framework.response import Response
 from rest_framework.views import APIView
 
 import boto3
-from drf_yasg import openapi
-from drf_yasg.utils import swagger_auto_schema
+from drf_spectacular.types import OpenApiTypes
+from drf_spectacular.utils import OpenApiParameter, extend_schema
 
 from data_refinery_common.logging import get_and_configure_logger
 from data_refinery_common.models import (
@@ -186,12 +186,12 @@ def get_batch_jobs_breakdown(force=False):
 class Stats(APIView):
     """Statistics about the health of the system."""
 
-    @swagger_auto_schema(
-        manual_parameters=[
-            openapi.Parameter(
+    @extend_schema(
+        parameters=[
+            OpenApiParameter(
                 name="range",
-                in_=openapi.IN_QUERY,
-                type=openapi.TYPE_STRING,
+                location=OpenApiParameter.QUERY,
+                type=OpenApiTypes.STR,
                 description="Specify a range from which to calculate the possible options",
                 enum=("day", "week", "month", "year"),
             )
@@ -393,12 +393,12 @@ class Stats(APIView):
 
 
 class FailedDownloaderJobStats(APIView):
-    @swagger_auto_schema(
-        manual_parameters=[
-            openapi.Parameter(
+    @extend_schema(
+        parameters=[
+            OpenApiParameter(
                 name="range",
-                in_=openapi.IN_QUERY,
-                type=openapi.TYPE_STRING,
+                location=OpenApiParameter.QUERY,
+                type=OpenApiTypes.STR,
                 description="Specify a range from which to calculate the possible options",
                 enum=("day", "week", "month", "year"),
             )
@@ -427,12 +427,12 @@ class FailedDownloaderJobStats(APIView):
 
 
 class FailedProcessorJobStats(APIView):
-    @swagger_auto_schema(
-        manual_parameters=[
-            openapi.Parameter(
+    @extend_schema(
+        parameters=[
+            OpenApiParameter(
                 name="range",
-                in_=openapi.IN_QUERY,
-                type=openapi.TYPE_STRING,
+                location=OpenApiParameter.QUERY,
+                type=OpenApiTypes.STR,
                 description="Specify a range from which to calculate the possible options",
                 enum=("day", "week", "month", "year"),
             )

--- a/api/data_refinery_api/views/transcriptome_index.py
+++ b/api/data_refinery_api/views/transcriptome_index.py
@@ -6,8 +6,8 @@ from django.utils.decorators import method_decorator
 from rest_framework import filters, generics, serializers
 
 from django_filters.rest_framework import DjangoFilterBackend
-from drf_yasg import openapi
-from drf_yasg.utils import swagger_auto_schema
+from drf_spectacular.types import OpenApiTypes
+from drf_spectacular.utils import OpenApiParameter, extend_schema
 
 from data_refinery_api.exceptions import InvalidFilters
 from data_refinery_api.utils import check_filters
@@ -45,30 +45,30 @@ class OrganismIndexSerializer(serializers.ModelSerializer):
 
 @method_decorator(
     name="get",
-    decorator=swagger_auto_schema(
-        manual_parameters=[
-            openapi.Parameter(
+    decorator=extend_schema(
+        parameters=[
+            OpenApiParameter(
                 name="organism__name",
-                in_=openapi.IN_QUERY,
-                type=openapi.TYPE_STRING,
+                location=OpenApiParameter.QUERY,
+                type=OpenApiTypes.STR,
                 description="Organism name. Eg. `MUS_MUSCULUS`",
             ),
-            openapi.Parameter(
+            OpenApiParameter(
                 name="length",
-                in_=openapi.IN_QUERY,
-                type=openapi.TYPE_STRING,
+                location=OpenApiParameter.QUERY,
+                type=OpenApiTypes.STR,
                 description="Short hand for `index_type` Eg. `short` or `long`",
             ),
-            openapi.Parameter(
+            OpenApiParameter(
                 name="salmon_version",
-                in_=openapi.IN_QUERY,
-                type=openapi.TYPE_STRING,
+                location=OpenApiParameter.QUERY,
+                type=OpenApiTypes.STR,
                 description="Eg. `salmon 0.13.1`",
             ),
-            openapi.Parameter(
+            OpenApiParameter(
                 name="index_type",
-                in_=openapi.IN_QUERY,
-                type=openapi.TYPE_STRING,
+                location=OpenApiParameter.QUERY,
+                type=OpenApiTypes.STR,
                 description="Eg. `TRANSCRIPTOME_LONG`",
             ),
         ]
@@ -123,12 +123,12 @@ class TranscriptomeIndexListView(generics.ListAPIView):
 
 @method_decorator(
     name="get",
-    decorator=swagger_auto_schema(
-        manual_parameters=[
-            openapi.Parameter(
+    decorator=extend_schema(
+        parameters=[
+            OpenApiParameter(
                 name="id",
-                in_=openapi.IN_PATH,
-                type=openapi.TYPE_NUMBER,
+                location=OpenApiParameter.PATH,
+                type=OpenApiTypes.NUMBER,
                 description="Transcriptome Index Id eg `1`",
             ),
         ]

--- a/api/requirements.in
+++ b/api/requirements.in
@@ -10,14 +10,13 @@ markupsafe>=1.1
 djangorestframework<3.14.0
 django-cors-headers
 django-filter
-coreapi
 # For ElasticSearch support:
 django-elasticsearch-dsl-drf
 # Can't go above 6.X without upgrading elasticsearch
 django-elasticsearch-dsl==6.5.0
 elasticsearch-dsl<7.0.0
 six
-drf_yasg>=1.20.0
+drf-spectacular
 apscheduler
 django-computedfields>=0.1.5
 pyyaml>=5.4

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -6,14 +6,13 @@
 #
 apscheduler==3.10.0       # via -r requirements.in
 asgiref==3.6.0            # via django
+attrs==26.1.0             # via jsonschema, referencing
 boto3==1.26.68            # via -r requirements.in
 botocore==1.29.68         # via boto3, s3transfer
 certifi==2023.7.22        # via -r requirements.in, requests
 charset-normalizer==3.0.1  # via requests
-coreapi==2.3.3            # via -r requirements.in, drf-yasg
-coreschema==0.0.4         # via coreapi, drf-yasg
 coverage==7.1.0           # via -r requirements.in
-django==3.2.17            # via -r requirements.in, django-computedfields, django-cors-headers, django-fast-update, django-filter, django-nine, djangorestframework, drf-yasg
+django==3.2.17            # via -r requirements.in, django-computedfields, django-cors-headers, django-fast-update, django-filter, django-nine, djangorestframework, drf-spectacular
 django-computedfields==0.2.1  # via -r requirements.in
 django-cors-headers==3.13.0  # via -r requirements.in
 django-elasticsearch-dsl==6.5.0  # via -r requirements.in, django-elasticsearch-dsl-drf
@@ -21,32 +20,33 @@ django-elasticsearch-dsl-drf==0.22.5  # via -r requirements.in
 django-fast-update==0.2.1  # via django-computedfields
 django-filter==22.1       # via -r requirements.in
 django-nine==0.2.7        # via django-elasticsearch-dsl-drf
-djangorestframework==3.13.1  # via -r requirements.in, django-elasticsearch-dsl-drf, drf-yasg
-drf-yasg==1.21.5          # via -r requirements.in
+djangorestframework==3.13.1  # via -r requirements.in, django-elasticsearch-dsl-drf, drf-spectacular
+drf-spectacular==0.29.0   # via -r requirements.in
 elasticsearch==6.8.2      # via django-elasticsearch-dsl-drf, elasticsearch-dsl
 elasticsearch-dsl==6.4.0  # via -r requirements.in, django-elasticsearch-dsl, django-elasticsearch-dsl-drf
 idna==3.4                 # via requests
-inflection==0.5.1         # via drf-yasg
-itypes==1.2.0             # via coreapi
-jinja2==3.1.2             # via -r requirements.in, coreschema
+inflection==0.5.1         # via drf-spectacular
+jinja2==3.1.2             # via -r requirements.in
 jmespath==1.0.1           # via boto3, botocore
+jsonschema==4.26.0        # via drf-spectacular
+jsonschema-specifications==2025.9.1  # via jsonschema
 markupsafe==2.1.2         # via -r requirements.in, jinja2
-packaging==23.0           # via django-nine, drf-yasg
+packaging==23.0           # via django-nine
 psycopg2-binary==2.9.5    # via -r requirements.in
 python-dateutil==2.8.2    # via botocore, elasticsearch-dsl
-pytz==2022.7.1            # via apscheduler, django, djangorestframework, drf-yasg
+pytz==2022.7.1            # via apscheduler, django, djangorestframework
 pytz-deprecation-shim==0.1.0.post0  # via tzlocal
-pyyaml==6.0               # via -r requirements.in
-requests==2.28.2          # via -r requirements.in, coreapi
-ruamel-yaml==0.17.21      # via drf-yasg
-ruamel-yaml-clib==0.2.7   # via ruamel-yaml
+pyyaml==6.0               # via -r requirements.in, drf-spectacular
+referencing==0.37.0       # via jsonschema, jsonschema-specifications
+requests==2.28.2          # via -r requirements.in
+rpds-py==0.30.0           # via jsonschema, referencing
 s3transfer==0.6.0         # via boto3
 six==1.16.0               # via -r requirements.in, apscheduler, django-elasticsearch-dsl, django-elasticsearch-dsl-drf, elasticsearch-dsl, python-dateutil
 sqlparse==0.4.3           # via -r requirements.in, django
-typing-extensions==4.4.0  # via django-computedfields
+typing-extensions==4.4.0  # via django-computedfields, referencing
 tzdata==2022.7            # via pytz-deprecation-shim
 tzlocal==4.2              # via apscheduler
-uritemplate==4.1.1        # via coreapi, drf-yasg
+uritemplate==4.1.1        # via drf-spectacular
 urllib3==1.26.14          # via -r requirements.in, botocore, elasticsearch, requests
 
 # The following packages are considered to be unsafe in a requirements file:


### PR DESCRIPTION
## Issue Number

#3596 

## Purpose/Implementation Notes

Ahead of the upgrade to django 4.x we need to drop coreapi. This PR does that by migrating the only dependency of that package drf-yasg. There will be a new schema hosted at `/v1/schema` but otherwise besides the structural change (OpenAPI 2 -> 3) in the response this should have parity with what already was served.


This pull request migrates the API documentation tooling from `drf_yasg` to `drf_spectacular`, updating both the dependencies and all related code for schema generation and documentation. It also refactors API URL routing to use `re_path` instead of the deprecated `url`, and updates all schema decorators and parameters to use the new library's types and utilities. The changes improve maintainability, future-proof the API documentation, and ensure compatibility with current best practices.

**Migration to drf_spectacular and API Documentation Updates:**
- Removed `drf_yasg`, `coreapi`, and `rest_framework_hstore` from `INSTALLED_APPS` and added `drf_spectacular`. Updated REST framework settings to use `drf_spectacular` for schema generation and added `SPECTACULAR_SETTINGS` for OpenAPI documentation metadata. (`api/data_refinery_api/settings.py`) [[1]](diffhunk://#diff-67743db573ca00234f6d00f35364ccb07022ac4ae92f843a6557365bf06bea29L54-R59) [[2]](diffhunk://#diff-67743db573ca00234f6d00f35364ccb07022ac4ae92f843a6557365bf06bea29R186) [[3]](diffhunk://#diff-67743db573ca00234f6d00f35364ccb07022ac4ae92f843a6557365bf06bea29R195-R218)

- Updated all schema decorators and parameter definitions in API views from `swagger_auto_schema`/`openapi.Parameter` to `extend_schema`/`OpenApiParameter` and related types from `drf_spectacular`. This affects views such as `api_token.py`, `compendium_result.py`, `dataset.py`, and `experiment_document.py`. (`api/data_refinery_api/views/api_token.py`, `api/data_refinery_api/views/compendium_result.py`, `api/data_refinery_api/views/dataset.py`, `api/data_refinery_api/views/experiment_document.py`) [[1]](diffhunk://#diff-5bbf4764c1135bcf4cd9d4eb77143ac79a7ffb0d7149e801718898077ee35c11L8-R8) [[2]](diffhunk://#diff-5bbf4764c1135bcf4cd9d4eb77143ac79a7ffb0d7149e801718898077ee35c11L26-R27) [[3]](diffhunk://#diff-5bbf4764c1135bcf4cd9d4eb77143ac79a7ffb0d7149e801718898077ee35c11L52-R59) [[4]](diffhunk://#diff-07464774bc1616d297e5d3ff2f9458d2dbe513af43a55d254a28d531de31ea29L12-R13) [[5]](diffhunk://#diff-07464774bc1616d297e5d3ff2f9458d2dbe513af43a55d254a28d531de31ea29L70-R81) [[6]](diffhunk://#diff-f74af0ce7de90a94a7adb2bd51775996c021cbcfe57313a36620992d65106a4dL13-R14) [[7]](diffhunk://#diff-f74af0ce7de90a94a7adb2bd51775996c021cbcfe57313a36620992d65106a4dL316-R331) [[8]](diffhunk://#diff-744285c7d6e5f5f62f2b1cafec57f7749ad3f810862cea15a90f56a5dfad45c7L25-R26) [[9]](diffhunk://#diff-744285c7d6e5f5f62f2b1cafec57f7749ad3f810862cea15a90f56a5dfad45c7L156-R195)

**URL Routing and Schema View Refactor:**
- Replaced all usage of `url` with `re_path` in `urls.py`. Removed the old `drf_yasg` schema view and replaced it with `SpectacularAPIView`, `SpectacularSwaggerView`, and `SpectacularRedocView` from `drf_spectacular` for API documentation endpoints. (`api/data_refinery_api/urls.py`) [[1]](diffhunk://#diff-71795c5458ccf2f11accdcc1235e1299503b5791c749d31513c5525c64703f39L4-R9) [[2]](diffhunk://#diff-71795c5458ccf2f11accdcc1235e1299503b5791c749d31513c5525c64703f39L92-R174) [[3]](diffhunk://#diff-71795c5458ccf2f11accdcc1235e1299503b5791c749d31513c5525c64703f39L215-R257)

These changes collectively modernize the API documentation stack and ensure all endpoints are properly documented and accessible using current OpenAPI tools.

## Methods

N/A

## Types of changes

- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Functional tests

N/A

## Checklist
- [x] Lint and unit tests pass locally with my changes

## Screenshots

N/A
