### PR TITLE
Add retention_in_days to CloudWatch Log Groups

### DIFF
--- a/infrastructure/logging.tf
+++ b/infrastructure/logging.tf
@@ -35,6 +35,7 @@ resource "aws_cloudtrail" "data_refinery_s3_cloudtrail" {
 # This is the group. All of the streams belong to this.
 resource "aws_cloudwatch_log_group" "data_refinery_log_group" {
   name = "data-refinery-log-group-${var.user}-${var.stage}"
+  retention_in_days = 14
 
   tags = merge(
     var.default_tags,
@@ -91,6 +92,7 @@ resource "aws_cloudwatch_log_stream" "log_stream_api_nginx_error" {
 # Must start with `/aws/events` in order to connect to a cloudwatch_event_target.
 resource "aws_cloudwatch_log_group" "compendia_object_metrics_log_group" {
   name = "/aws/events/data-refinery-compendia-log-group-${var.user}-${var.stage}"
+  retention_in_days = 14
 
   tags = var.default_tags
 }


### PR DESCRIPTION
## Issue Number

N/A

## Purpose/Implementation Notes

This PR adds a `retention_in_days` value of **14 days** to the two existing CloudWatch Log Groups defined in `infrastructure/logging.tf`.

Previously, these log groups had no retention policy configured, causing logs to be retained indefinitely by default. Setting a retention period helps reduce unnecessary CloudWatch storage costs while preserving recent operational logs.

This change is based on an issue identified by **InfraScan** as part of the infrastructure analysis introduced in PR #3602.

## Methods

Updated the following Terraform resources by adding:

```hcl
retention_in_days = 14
```

to:

- `aws_cloudwatch_log_group.data_refinery_log_group`
- `aws_cloudwatch_log_group.compendia_object_metrics_log_group`

No other infrastructure resources or application behavior were modified.

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

- Reviewed the Terraform changes to ensure only the two CloudWatch Log Groups were modified.
- Verified that both resources now define `retention_in_days = 14`.
- Confirmed the change is limited to `infrastructure/logging.tf`.

## Checklist

_Put an `x` in the boxes that apply._

- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots

Not applicable.