### PR TITLE
ci: pin DEPLOY_USER to circleci; add DEPLOY_NOTIFIER for Slack

### DIFF
--- a/.github/scripts/slackpost_deploy.sh
+++ b/.github/scripts/slackpost_deploy.sh
@@ -21,7 +21,7 @@ if [[ $username == "" ]]; then
 fi
 
 # ------------
-text="New deployment! Woo! $DEPLOY_USER: $BRANCH $DEPLOY_TAG"
+text="New deployment! Woo! $DEPLOY_NOTIFIER: $BRANCH $DEPLOY_TAG"
 
 escapedText=$(echo "$text" | sed 's/"/\"/g' | sed "s/'/\'/g")
 

--- a/.github/workflows/config.yml
+++ b/.github/workflows/config.yml
@@ -671,7 +671,13 @@ jobs:
   deploy:
     name: Deploy
     env:
-      DEPLOY_USER: ${{ github.actor }}
+      # DEPLOY_USER is the Terraform stack identity: it names every resource and
+      # selects the remote state file (see TF_VAR_user). Keep it "circleci" to
+      # match the existing stacks — it was hardcoded under CircleCI, and if it
+      # became the pushing user (github.actor) every deploy would fork a new stack.
+      DEPLOY_USER: circleci
+      # Who actually triggered the deploy; shown in the Slack notification.
+      DEPLOY_NOTIFIER: ${{ github.actor }}
     if: startsWith(github.ref, 'refs/tags/v') && ! endsWith(github.ref, '-hotfix')
     needs:
       - determine_branch
@@ -743,7 +749,13 @@ jobs:
   deploy_hotfix:
     name: Deploy Hotfix
     env:
-      DEPLOY_USER: ${{ github.actor }}
+      # DEPLOY_USER is the Terraform stack identity: it names every resource and
+      # selects the remote state file (see TF_VAR_user). Keep it "circleci" to
+      # match the existing stacks — it was hardcoded under CircleCI, and if it
+      # became the pushing user (github.actor) every deploy would fork a new stack.
+      DEPLOY_USER: circleci
+      # Who actually triggered the deploy; shown in the Slack notification.
+      DEPLOY_NOTIFIER: ${{ github.actor }}
     if: startsWith(github.ref, 'refs/tags/v') && endsWith(github.ref, '-hotfix')
     needs:
       - determine_branch


### PR DESCRIPTION
## Issue Number

Include an issue number if applicable.

## Purpose/Implementation Notes

This pull request updates the deployment workflow to better distinguish between the identity used for Terraform deployments and the user who actually triggered the deployment. The main improvements are to environment variable handling and Slack notification messaging.

**Workflow environment variable changes:**

* `DEPLOY_USER` is now always set to `circleci` to ensure Terraform stacks remain consistent and do not fork for each user who pushes a deploy. This matches the legacy behavior from CircleCI. (`.github/workflows/config.yml`) [[1]](diffhunk://#diff-33cc4c925f7fd36575f5e5b61d1e9c942fea5189e2c67d09720d714e19151404L674-R680) [[2]](diffhunk://#diff-33cc4c925f7fd36575f5e5b61d1e9c942fea5189e2c67d09720d714e19151404L746-R758)
* A new `DEPLOY_NOTIFIER` variable is introduced, set to the actual GitHub user who triggered the deploy, for use in notifications. (`.github/workflows/config.yml`) [[1]](diffhunk://#diff-33cc4c925f7fd36575f5e5b61d1e9c942fea5189e2c67d09720d714e19151404L674-R680) [[2]](diffhunk://#diff-33cc4c925f7fd36575f5e5b61d1e9c942fea5189e2c67d09720d714e19151404L746-R758)

**Notification messaging:**

* The Slack deployment notification now uses `DEPLOY_NOTIFIER` instead of `DEPLOY_USER`, so it shows who actually triggered the deployment rather than the Terraform stack identity. (`.github/scripts/slackpost_deploy.sh`)

## Methods


## Types of changes

What types of changes does your code introduce?
- Bugfix (non-breaking change which fixes an issue)

## Functional tests

N/A

## Checklist

- [x] Lint and unit tests pass locally with my changes

## Screenshots

N/A
