### PR TITLE
Production Deploy: Pin deploy user to circleci

### DIFF
--- a/.github/scripts/slackpost_deploy.sh
+++ b/.github/scripts/slackpost_deploy.sh
@@ -21,7 +21,7 @@ if [[ $username == "" ]]; then
 fi
 
 # ------------
-text="New deployment! Woo! $DEPLOY_USER: $BRANCH $DEPLOY_TAG"
+text="New deployment! Woo! $DEPLOY_NOTIFIER: $BRANCH $DEPLOY_TAG"
 
 escapedText=$(echo "$text" | sed 's/"/\"/g' | sed "s/'/\'/g")
 

--- a/.github/workflows/config.yml
+++ b/.github/workflows/config.yml
@@ -671,7 +671,13 @@ jobs:
   deploy:
     name: Deploy
     env:
-      DEPLOY_USER: ${{ github.actor }}
+      # DEPLOY_USER is the Terraform stack identity: it names every resource and
+      # selects the remote state file (see TF_VAR_user). Keep it "circleci" to
+      # match the existing stacks — it was hardcoded under CircleCI, and if it
+      # became the pushing user (github.actor) every deploy would fork a new stack.
+      DEPLOY_USER: circleci
+      # Who actually triggered the deploy; shown in the Slack notification.
+      DEPLOY_NOTIFIER: ${{ github.actor }}
     if: startsWith(github.ref, 'refs/tags/v') && ! endsWith(github.ref, '-hotfix')
     needs:
       - determine_branch
@@ -743,7 +749,13 @@ jobs:
   deploy_hotfix:
     name: Deploy Hotfix
     env:
-      DEPLOY_USER: ${{ github.actor }}
+      # DEPLOY_USER is the Terraform stack identity: it names every resource and
+      # selects the remote state file (see TF_VAR_user). Keep it "circleci" to
+      # match the existing stacks — it was hardcoded under CircleCI, and if it
+      # became the pushing user (github.actor) every deploy would fork a new stack.
+      DEPLOY_USER: circleci
+      # Who actually triggered the deploy; shown in the Slack notification.
+      DEPLOY_NOTIFIER: ${{ github.actor }}
     if: startsWith(github.ref, 'refs/tags/v') && endsWith(github.ref, '-hotfix')
     needs:
       - determine_branch


### PR DESCRIPTION
This pull request updates the deployment workflow to distinguish between the identity used for Terraform resources and the user who actually triggered the deployment. The changes ensure that the Terraform stack identity remains consistent across deployments, while the Slack notification correctly attributes the deploy to the triggering user.

**Deployment environment variable changes:**

* The `DEPLOY_USER` environment variable is now hardcoded as `circleci` in both the `deploy` and `deploy_hotfix` jobs to maintain consistent Terraform stack naming and state management. [[1]](diffhunk://#diff-33cc4c925f7fd36575f5e5b61d1e9c942fea5189e2c67d09720d714e19151404L674-R680) [[2]](diffhunk://#diff-33cc4c925f7fd36575f5e5b61d1e9c942fea5189e2c67d09720d714e19151404L746-R758)
* A new environment variable, `DEPLOY_NOTIFIER`, is introduced to capture the actual user who triggered the deployment (`github.actor`). This value is now used in Slack notifications. [[1]](diffhunk://#diff-33cc4c925f7fd36575f5e5b61d1e9c942fea5189e2c67d09720d714e19151404L674-R680) [[2]](diffhunk://#diff-33cc4c925f7fd36575f5e5b61d1e9c942fea5189e2c67d09720d714e19151404L746-R758)

**Slack notification update:**

* The Slack deployment message in `.github/scripts/slackpost_deploy.sh` now uses `DEPLOY_NOTIFIER` instead of `DEPLOY_USER` to correctly display the deploy triggerer.